### PR TITLE
fix(react): IonTabs props undefined in hot-reload

### DIFF
--- a/react/src/components/navigation/IonTabs.tsx
+++ b/react/src/components/navigation/IonTabs.tsx
@@ -35,12 +35,23 @@ export default class IonTabs extends Component<Props> {
       if (child == null || typeof child !== 'object' || !child.hasOwnProperty('type')) {
         return;
       }
-      if (child.type === IonRouterOutlet) {
-        outlet = child;
+
+      if(outlet === undefined && child.type.hasOwnProperty('displayName')) {
+        const childType = child.type as any;
+        const displayName = childType.displayName as string;
+        if(displayName === IonRouterOutlet.displayName){
+          outlet = child;
+        }
       }
-      if (child.type === IonTabBar) {
-        tabBar = child;
+
+      if(tabBar === undefined && child.type.hasOwnProperty('displayName')) {
+        const childType = child.type as any;
+        const displayName = childType.displayName as string;
+        if(displayName === IonTabBar.displayName){
+          tabBar = child;
+        }
       }
+
     });
 
     return (


### PR DESCRIPTION

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
#18301 

I am having problems when I try to try a hot update in a typescript project that uses @ionic/react. As follow:

![image](https://user-images.githubusercontent.com/26819913/57941799-6dc47d80-7902-11e9-8a24-8a37af3deac9.png)

![image](https://user-images.githubusercontent.com/26819913/57941537-cc3d2c00-7901-11e9-9ac8-7bee01a72c7b.png)

![image](https://user-images.githubusercontent.com/26819913/57941563-e1b25600-7901-11e9-82c2-9ac9fb27cf50.png)

example [https://github.com/NaccOll/ionic-react-conference-app/tree/try-hot-reload](https://github.com/NaccOll/ionic-react-conference-app/tree/try-hot-reload)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

no change.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Using a component with the same name will cause an error。