### PR TITLE
Feat ion toggle toggle event

### DIFF
--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -909,13 +909,14 @@ export declare interface IonToggle extends Components.IonToggle {}
 @Component({ selector: 'ion-toggle', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['checked', 'color', 'disabled', 'mode', 'name', 'value'] })
 export class IonToggle {
   ionChange!: EventEmitter<CustomEvent>;
+  ionToggle!: EventEmitter<CustomEvent>;
   ionFocus!: EventEmitter<CustomEvent>;
   ionBlur!: EventEmitter<CustomEvent>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionChange', 'ionFocus', 'ionBlur']);
+    proxyOutputs(this, this.el, ['ionChange', 'ionToggle', 'ionFocus', 'ionBlur']);
   }
 }
 proxyInputs(IonToggle, ['checked', 'color', 'disabled', 'mode', 'name', 'value']);

--- a/core/api.txt
+++ b/core/api.txt
@@ -1264,6 +1264,7 @@ ion-toggle,prop,value,null | string | undefined,'on',false,false
 ion-toggle,event,ionBlur,void,true
 ion-toggle,event,ionChange,ToggleChangeEventDetail,true
 ion-toggle,event,ionFocus,void,true
+ion-toggle,event,ionToggle,ToggleChangeEventDetail,true
 ion-toggle,css-prop,--background
 ion-toggle,css-prop,--background-checked
 ion-toggle,css-prop,--handle-background

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -6148,6 +6148,10 @@ declare namespace LocalJSX {
     */
     'onIonFocus'?: (event: CustomEvent<void>) => void;
     /**
+    * Emitted when the toggle is being toggled manually.
+    */
+    'onIonToggle'?: (event: CustomEvent<ToggleChangeEventDetail>) => void;
+    /**
     * The value of the toggle does not mean if it's checked or not, use the `checked` property for that.  The value of a toggle is analogous to the value of a `<input type="checkbox">`, it's only used when the toggle participates in a native `<form>`.
     */
     'value'?: string | null;

--- a/core/src/components/toggle/readme.md
+++ b/core/src/components/toggle/readme.md
@@ -189,11 +189,12 @@ export const ToggleExample: React.FC = () => (
 
 ## Events
 
-| Event       | Description                                  | Type                                   |
-| ----------- | -------------------------------------------- | -------------------------------------- |
-| `ionBlur`   | Emitted when the toggle loses focus.         | `CustomEvent<void>`                    |
-| `ionChange` | Emitted when the value property has changed. | `CustomEvent<ToggleChangeEventDetail>` |
-| `ionFocus`  | Emitted when the toggle has focus.           | `CustomEvent<void>`                    |
+| Event       | Description                                        | Type                                   |
+| ----------- | -------------------------------------------------- | -------------------------------------- |
+| `ionBlur`   | Emitted when the toggle loses focus.               | `CustomEvent<void>`                    |
+| `ionChange` | Emitted when the value property has changed.       | `CustomEvent<ToggleChangeEventDetail>` |
+| `ionFocus`  | Emitted when the toggle has focus.                 | `CustomEvent<void>`                    |
+| `ionToggle` | Emitted when the toggle is being toggled manually. | `CustomEvent<ToggleChangeEventDetail>` |
 
 
 ## CSS Custom Properties

--- a/core/src/components/toggle/toggle.tsx
+++ b/core/src/components/toggle/toggle.tsx
@@ -65,6 +65,11 @@ export class Toggle implements ComponentInterface {
   @Event() ionChange!: EventEmitter<ToggleChangeEventDetail>;
 
   /**
+   * Emitted when the toggle is being toggled manually.
+   */
+  @Event() ionToggle!: EventEmitter<ToggleChangeEventDetail>;
+
+  /**
    * Emitted when the toggle has focus.
    */
   @Event() ionFocus!: EventEmitter<void>;
@@ -161,6 +166,11 @@ export class Toggle implements ComponentInterface {
   private onClick = () => {
     if (this.lastDrag + 300 < Date.now()) {
       this.checked = !this.checked;
+
+      this.ionToggle.emit({
+        checked: this.checked,
+        value: this.value
+      });
     }
   }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

The `ionChange` event will be emitted as soon as the toggle's value changes, whether that is because the toggle is being toggled manually or the value changes otherwise, programatically for example. At the moment from the `ionChange` event there is no way to determine if the value change happened manually or automatically.
This is basically the same issue as mentioned in PR #19097 for ion-checkbox.

## What is the new behavior?

This PR adds the `ionToggle` event which is only emitted when the toggle actually is being toggled by the user.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

--
