### PR TITLE
fix(ion-radio-group) Add disabled attribute on radio-group

### DIFF
--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -587,7 +587,7 @@ export class IonRadio {
 proxyInputs(IonRadio, ['checked', 'color', 'disabled', 'mode', 'name', 'value']);
 
 export declare interface IonRadioGroup extends Components.IonRadioGroup {}
-@Component({ selector: 'ion-radio-group', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['allowEmptySelection', 'name', 'value'] })
+@Component({ selector: 'ion-radio-group', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['allowEmptySelection', 'disabled', 'name', 'value'] })
 export class IonRadioGroup {
   ionChange!: EventEmitter<CustomEvent>;
   protected el: HTMLElement;
@@ -597,7 +597,7 @@ export class IonRadioGroup {
     proxyOutputs(this, this.el, ['ionChange']);
   }
 }
-proxyInputs(IonRadioGroup, ['allowEmptySelection', 'name', 'value']);
+proxyInputs(IonRadioGroup, ['allowEmptySelection', 'disabled', 'name', 'value']);
 
 export declare interface IonRange extends Components.IonRange {}
 @Component({ selector: 'ion-range', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['color', 'debounce', 'disabled', 'dualKnobs', 'max', 'min', 'mode', 'name', 'pin', 'snaps', 'step', 'ticks', 'value'] })

--- a/core/api.txt
+++ b/core/api.txt
@@ -851,6 +851,7 @@ ion-radio,css-prop,--color-checked
 
 ion-radio-group,none
 ion-radio-group,prop,allowEmptySelection,boolean,false,false,false
+ion-radio-group,prop,disabled,boolean,false,false,false
 ion-radio-group,prop,name,string,this.inputId,false,false
 ion-radio-group,prop,value,any,undefined,false,false
 ion-radio-group,event,ionChange,RadioGroupChangeEventDetail,true

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -1933,6 +1933,10 @@ export namespace Components {
     */
     'allowEmptySelection': boolean;
     /**
+    * If `true`, the user cannot interact with the radio.
+    */
+    'disabled': boolean;
+    /**
     * The name of the control, which is submitted with the form data.
     */
     'name': string;
@@ -5228,6 +5232,10 @@ declare namespace LocalJSX {
     * If `true`, the radios can be deselected.
     */
     'allowEmptySelection'?: boolean;
+    /**
+    * If `true`, the user cannot interact with the radio.
+    */
+    'disabled'?: boolean;
     /**
     * The name of the control, which is submitted with the form data.
     */

--- a/core/src/components/radio-group/radio-group.tsx
+++ b/core/src/components/radio-group/radio-group.tsx
@@ -26,6 +26,11 @@ export class RadioGroup implements ComponentInterface {
   @Prop() name: string = this.inputId;
 
   /**
+   * If `true`, the user cannot interact with the radio.
+   */
+  @Prop() disabled = false;
+
+  /**
    * the value of the radio group.
    */
   @Prop({ mutable: true }) value?: any | null;
@@ -34,6 +39,11 @@ export class RadioGroup implements ComponentInterface {
   valueChanged(value: any | undefined) {
     this.updateRadios();
     this.ionChange.emit({ value });
+  }
+
+  @Watch('disabled')
+  disabledChanged() {
+    this.getRadios().then(radios => radios.forEach(radio => radio.disabled = this.disabled));
   }
 
   /**
@@ -73,6 +83,7 @@ export class RadioGroup implements ComponentInterface {
       }
     });
     this.updateRadios();
+    this.disabledChanged();
   }
 
   disconnectedCallback() {

--- a/core/src/components/radio-group/readme.md
+++ b/core/src/components/radio-group/readme.md
@@ -140,6 +140,7 @@ export const RadioGroupExample: React.FC = () => (
 | Property              | Attribute               | Description                                                     | Type      | Default        |
 | --------------------- | ----------------------- | --------------------------------------------------------------- | --------- | -------------- |
 | `allowEmptySelection` | `allow-empty-selection` | If `true`, the radios can be deselected.                        | `boolean` | `false`        |
+| `disabled`            | `disabled`              | If `true`, the user cannot interact with the radio.             | `boolean` | `false`        |
 | `name`                | `name`                  | The name of the control, which is submitted with the form data. | `string`  | `this.inputId` |
 | `value`               | `value`                 | the value of the radio group.                                   | `any`     | `undefined`    |
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

Issue Number: #19520


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add the disabled attribute to a ion-radio-group
- See that the child ion-radio elements get disabled
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
It seems disabled functionality did exist once but was removed in https://github.com/ionic-team/ionic/pull/16071 not sure why