### PR TITLE
Return refs when creating overlay and controller components

### DIFF
--- a/packages/react/src/components/createControllerComponent.tsx
+++ b/packages/react/src/components/createControllerComponent.tsx
@@ -1,7 +1,7 @@
 import { OverlayEventDetail } from '@ionic/core';
 import React from 'react';
 
-import { attachProps } from './utils';
+import { attachProps, createForwardRef, dashToPascalCase } from './utils';
 
 interface OverlayBase extends HTMLElement {
   present: () => Promise<void>;
@@ -21,7 +21,7 @@ export const createControllerComponent = <OptionsType extends object, OverlayTyp
 
   type Props = OptionsType & ReactControllerProps;
 
-  return class extends React.Component<Props> {
+  const ReactComponent = class extends React.Component<Props> {
     overlay?: OverlayType;
     isUnmounted = false;
 
@@ -73,4 +73,5 @@ export const createControllerComponent = <OptionsType extends object, OverlayTyp
       return null;
     }
   };
+  return createForwardRef<Props, OverlayType>(ReactComponent, dashToPascalCase(displayName));
 };

--- a/packages/react/src/components/createOverlayComponent.tsx
+++ b/packages/react/src/components/createOverlayComponent.tsx
@@ -2,7 +2,7 @@ import { OverlayEventDetail } from '@ionic/core';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { attachProps } from './utils';
+import { attachProps, createForwardRef, dashToPascalCase } from './utils';
 
 interface OverlayElement extends HTMLElement {
   present: () => Promise<void>;
@@ -23,7 +23,7 @@ export const createOverlayComponent = <T extends object, OverlayType extends Ove
 
   type Props = T & ReactOverlayProps;
 
-  return class extends React.Component<Props> {
+  const ReactComponent = class extends React.Component<Props> {
     overlay?: OverlayType;
     el: HTMLDivElement;
 
@@ -80,4 +80,5 @@ export const createOverlayComponent = <T extends object, OverlayType extends Ove
       );
     }
   };
+  return createForwardRef<Props, OverlayType>(ReactComponent, dashToPascalCase(displayName));
 };


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #19924 

As described in the issue above, it's currently not possible to pass a ref to any components created with createControllerComponent or createOverlayComponent.

## What is the new behavior?
This changes those functions to returns refs, like createComponent does, which should fix the problem, although I'm struggling with how to verify that. Since there's not really a test suite at the moment, how do you verify that changes like this have the desired effect?

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
