### PR TITLE
fix(react): tabs no longer errors when a new tab button is added dynamically

### DIFF
--- a/packages/react/src/components/navigation/IonTabBar.tsx
+++ b/packages/react/src/components/navigation/IonTabBar.tsx
@@ -61,7 +61,7 @@ class IonTabBarUnwrapped extends React.PureComponent<Props, State> {
     React.Children.forEach((props as any).children, (child: any) => {
       if (child != null && typeof child === 'object' && child.props && child.type === IonTabButton) {
         const tab = tabs[child.props.tab];
-        if (tab.originalHref !== child.props.href) {
+        if (tab === undefined || tab.originalHref !== child.props.href) {
           tabs[child.props.tab] = {
             originalHref: child.props.href,
             currentHref: child.props.href

--- a/packages/react/src/components/navigation/IonTabBar.tsx
+++ b/packages/react/src/components/navigation/IonTabBar.tsx
@@ -61,7 +61,7 @@ class IonTabBarUnwrapped extends React.PureComponent<Props, State> {
     React.Children.forEach((props as any).children, (child: any) => {
       if (child != null && typeof child === 'object' && child.props && child.type === IonTabButton) {
         const tab = tabs[child.props.tab];
-        if (tab === undefined || tab.originalHref !== child.props.href) {
+        if (!tab || tab.originalHref !== child.props.href) {
           tabs[child.props.tab] = {
             originalHref: child.props.href,
             currentHref: child.props.href


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In IonTabBar, there is code that updates the state of the tabs as their href changes, but it does not handle the case where a new tab is added. When that happens, it would try to get the `originalHref` of `undefined`. Instead, what it should do is add a new entry for the tab, which it can do by just checking that the tab exists in the test.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

When looping over the children as the props change, if a tab in the state is not found for one of them, add an entry to it.

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I have not tried to make a simple app reproducing this problem because it seems pretty straightforward, but if you need one then I should be able to put it together.