### PR TITLE
fix(defineCustomElements): remove window reference

### DIFF
--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -50,4 +50,4 @@ addIcons({
 
 // TODO: defineCustomElements() is asyncronous
 // We need to use the promise
-defineCustomElements(window);
+defineCustomElements();


### PR DESCRIPTION
Removing this reference will allow ionic to be imported in non-browser environments and makes it easier to integrate ionic in frameworks such as Next.js. This contributes a partial fix towards #19975

The parameter `window` is no longer required as per stencil documentation (https://stenciljs.com/docs/react). In fact, the parameter to this function is currently ignored in the generated bundle.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #19975 
Due to the reference to `window` in the module's root, the ionic library cannot be imported in server side environments. This causes issues for libraries such as Next.js, which will load the Ionic library on the server side, crashing the server.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- No visible changes in behavior on supported environments has been introduced.
- Ionic can now be imported in a server side environment without errors.

Note: Using Ionic components for server-side rendering still causes causes issues. This does not make Ionic React compatible with server side rendering. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

To use Ionic with Next.js after this fix, install `react-no-ssr`, then update your `pages/_app.js` to use it:
```js
import NoSSR from 'react-no-ssr';

export default ({ Component, pageProps }) => {
  return (
    <NoSSR>
      <Component {...pageProps} />
    </NoSSR>
  );
};
```

[Previous](https://github.com/ionic-team/ionic/issues/19975) [solutions](https://github.com/ionic-team/ionic/issues/17591#issuecomment-485510454) have required using dynamic imports, which has performance implications.