### PR TITLE
fix(back-button): truncate long texts

### DIFF
--- a/core/src/components/back-button/back-button.scss
+++ b/core/src/components/back-button/back-button.scss
@@ -242,3 +242,17 @@ ion-icon {
 :host(.in-toolbar:not(.in-toolbar-color)) {
   color: #{var(--ion-toolbar-color, var(--color))};
 }
+
+// Back Button Text: Truncate long Texts
+
+.button-text {
+  flex: 1;
+
+  min-width: 1px;
+
+  text-overflow: ellipsis;
+
+  white-space: nowrap;
+
+  overflow: hidden;
+}

--- a/core/src/components/back-button/test/toolbar/index.html
+++ b/core/src/components/back-button/test/toolbar/index.html
@@ -91,7 +91,21 @@
         </ion-buttons>
         <ion-title>Success</ion-title>
       </ion-toolbar>
+
+      <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-back-button default-href="/" text="Go back with long description text" style="max-width: 50vw;">
+          </ion-back-button>
+        </ion-buttons>
+        <ion-buttons slot="end">
+          <ion-button color="secondary" fill="outline" class="ion-activated">
+            <ion-icon slot="icon-only" name="person-circle"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+
     </ion-content>
+
   </ion-app>
 
   <script>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Setting a (max)-width on back-button creates an inccorect view of that button. See last row in image

![before](https://user-images.githubusercontent.com/3854502/80797387-026ecc80-8ba2-11ea-88a3-54a925b58ba9.png)


Issue Number: #21146


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Text in back-button is truncated with `text-overflow: ellipsis` if consumer restricts the button's width. Again see last row in image.

![after](https://user-images.githubusercontent.com/3854502/80797443-229e8b80-8ba2-11ea-9526-3b58249a96c8.png)


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This is related to #21146. It doesn't fix it entirely, but at least allows the developer to truncate text if necessary. 

If more changes are required (e.g. in the docs) let me know.

PS: I was wondering why `npm run build` did not create any change even tho there was a code change in a scss file. Maybe one can enlight me.