### PR TITLE
fix(checkbox): internal-button-not-accessible

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -357,6 +357,10 @@ export namespace Components {
     }
     interface IonCheckbox {
         /**
+          * Sets the aria-label of the inside button of the checkox. Accessibility feature.
+         */
+        "ariaLabel": string;
+        /**
           * If `true`, the checkbox is selected.
          */
         "checked": boolean;
@@ -3600,6 +3604,10 @@ declare namespace LocalJSX {
         "mode"?: "ios" | "md";
     }
     interface IonCheckbox {
+        /**
+          * Sets the aria-label of the inside button of the checkox. Accessibility feature.
+         */
+        "ariaLabel"?: string;
         /**
           * If `true`, the checkbox is selected.
          */

--- a/core/src/components/checkbox/checkbox.tsx
+++ b/core/src/components/checkbox/checkbox.tsx
@@ -54,6 +54,12 @@ export class Checkbox implements ComponentInterface {
   @Prop() disabled = false;
 
   /**
+   * Sets the aria-label of the inside button of the checkox.
+   * Accessibility feature.
+   */
+  @Prop() ariaLabel = '';
+
+  /**
    * The value of the toggle does not mean if it's checked or not, use the `checked`
    * property for that.
    *
@@ -169,6 +175,7 @@ export class Checkbox implements ComponentInterface {
           {path}
         </svg>
         <button
+          aria-label={this.ariaLabel}
           type="button"
           onFocus={this.onFocus}
           onBlur={this.onBlur}

--- a/core/src/components/checkbox/test/standalone/index.html
+++ b/core/src/components/checkbox/test/standalone/index.html
@@ -75,6 +75,9 @@
   <ion-checkbox class="custom-transition"></ion-checkbox>
   <ion-checkbox class="custom-transition" checked></ion-checkbox>
 
+  <h1>Accessibility</h1>
+  <ion-checkbox aria-label="ion-checkbox" checked></ion-checkbox>
+
   <style>
     .custom {
       --background: #444;


### PR DESCRIPTION
Bug https://github.com/ionic-team/ionic/issues/17796
The issue creator mentiones that there is an option missing to create an aria-label for the button.
Add an ariaLabel prop to the checkbox and delegate it to the button for accessibility.

closes  #17796

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

Issue Number: 17796


## What is the new behavior?

- ` Prop() ariaLabel: string` prop has been added to checkbox component
- Accessibility headline has been added to test/basic

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

First contribution, want to start contributing, will see how it goes. Might need some guidance on how to properly do it and how to resolve the screenshot tests. Also happy to get feedback on how to create better pull requests or improve the code. I hope that this isn't too bad, I'm happy to change it if it is.

HTML after the change (chrome dev tools):
![Capture2](https://user-images.githubusercontent.com/23557370/80797513-51b4fd00-8ba2-11ea-8f6c-ab03e56e11c8.PNG)
