### PR TITLE
fix(ssr): Only set events in render function when running in browser

### DIFF
--- a/packages/react/src/components/createComponent.tsx
+++ b/packages/react/src/components/createComponent.tsx
@@ -50,10 +50,11 @@ export const createReactComponent = <PropType, ElementType>(
     render() {
       const { children, forwardedRef, style, className, ref, ...cProps } = this.props;
 
+      const isRunningInBrowser = typeof document !== 'undefined';
       const propsToPass = Object.keys(cProps).reduce((acc, name) => {
         if (name.indexOf('on') === 0 && name[2] === name[2].toUpperCase()) {
           const eventName = name.substring(2).toLowerCase();
-          if (isCoveredByReact(eventName)) {
+          if (isRunningInBrowser && isCoveredByReact(eventName)) {
             (acc as any)[name] = (cProps as any)[name];
           }
         } else if (typeof (cProps as any)[name] === 'string') {
@@ -68,7 +69,7 @@ export const createReactComponent = <PropType, ElementType>(
         style
       };
 
-      if (routerLinkComponent) {
+      if (isRunningInBrowser && routerLinkComponent) {
         if (this.props.routerLink && !this.props.href) {
           newProps.href = this.props.routerLink;
         }

--- a/packages/react/src/components/createComponent.tsx
+++ b/packages/react/src/components/createComponent.tsx
@@ -50,6 +50,7 @@ export const createReactComponent = <PropType, ElementType>(
     render() {
       const { children, forwardedRef, style, className, ref, ...cProps } = this.props;
 
+      // tslint:disable-next-line:strict-type-predicates
       const isRunningInBrowser = typeof document !== 'undefined';
       const propsToPass = Object.keys(cProps).reduce((acc, name) => {
         if (name.indexOf('on') === 0 && name[2] === name[2].toUpperCase()) {

--- a/packages/react/src/components/createOverlayComponent.tsx
+++ b/packages/react/src/components/createOverlayComponent.tsx
@@ -106,6 +106,10 @@ export const createOverlayComponent = <OverlayComponent extends object, OverlayT
     }
 
     render() {
+      if (this.el === undefined) {
+        return null;
+      }
+
       return ReactDOM.createPortal(
         this.props.isOpen ? this.props.children : null,
         this.el

--- a/packages/react/src/components/navigation/IonTabs.tsx
+++ b/packages/react/src/components/navigation/IonTabs.tsx
@@ -8,7 +8,7 @@ import { IonRouterOutlet } from '../IonRouterOutlet';
 import { IonTabBar } from './IonTabBar';
 import { IonTabsContext, IonTabsContextState } from './IonTabsContext';
 
-if (window && window.customElements) {
+if (typeof window !== 'undefined' && window.customElements) {
   class IonTabsElement extends HTMLElement {
     constructor() {
       super();

--- a/packages/react/src/components/navigation/IonTabs.tsx
+++ b/packages/react/src/components/navigation/IonTabs.tsx
@@ -8,13 +8,13 @@ import { IonRouterOutlet } from '../IonRouterOutlet';
 import { IonTabBar } from './IonTabBar';
 import { IonTabsContext, IonTabsContextState } from './IonTabsContext';
 
-class IonTabsElement extends HTMLElement {
-  constructor() {
-    super();
-  }
-}
-
 if (window && window.customElements) {
+  class IonTabsElement extends HTMLElement {
+    constructor() {
+      super();
+    }
+  }
+
   const element = customElements.get('ion-tabs');
   if (!element) {
     customElements.define('ion-tabs', IonTabsElement);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #19975 
Rendering any Ionic component wrapped by `createComponent` on the server will cause an error:
```
ReferenceError: document is not defined
    at isCoveredByReact (\node_modules\@ionic\react\dist\index.js:267:50)
```
This makes Ionic incompatible with frameworks such as Gatsby or Next.js

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- isCoveredByReact is only called if the code is running in the browser.
- No events are passed to the web component if the renderer is not running in the browser.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This fix mirrors a commit on the `stencil-ds-plugins` repository: https://github.com/ionic-team/stencil-ds-plugins/commit/b7b69ee2d3d97b3e375e1bbdcde50421020d89fe

The ReactDOMServer passes the source code of an event handler as a string to the client if it does not recognize the element id. Therefore, an extra check for the onClick handler of routerLinkComponents was added. Without this check, this is the HTML sent to the client:
```
<ion-item onClick="(e) =&gt; {
    const { routerLink, routerDirection } = this.props;
    if (routerLink !== undefined) {
        e.preventDefault();
        this.context.navigate(routerLink, routerDirection);
    }
}">
```
The client side ReactDOM does not do this and can deal with onClick just fine. This was an interesting finding.
