### PR TITLE
feat(select): add optional generic typings

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -1069,7 +1069,7 @@ ion-select,prop,value,any,undefined,false,false
 ion-select,method,open,open(event?: UIEvent | undefined) => Promise<any>
 ion-select,event,ionBlur,void,true
 ion-select,event,ionCancel,void,true
-ion-select,event,ionChange,SelectChangeEventDetail,true
+ion-select,event,ionChange,SelectChangeEventDetail<any>,true
 ion-select,event,ionFocus,void,true
 ion-select,css-prop,--padding-bottom
 ion-select,css-prop,--padding-end

--- a/core/src/components/select/readme.md
+++ b/core/src/components/select/readme.md
@@ -1225,12 +1225,12 @@ export class SelectExample {
 
 ## Events
 
-| Event       | Description                              | Type                                   |
-| ----------- | ---------------------------------------- | -------------------------------------- |
-| `ionBlur`   | Emitted when the select loses focus.     | `CustomEvent<void>`                    |
-| `ionCancel` | Emitted when the selection is cancelled. | `CustomEvent<void>`                    |
-| `ionChange` | Emitted when the value has changed.      | `CustomEvent<SelectChangeEventDetail>` |
-| `ionFocus`  | Emitted when the select has focus.       | `CustomEvent<void>`                    |
+| Event       | Description                              | Type                                        |
+| ----------- | ---------------------------------------- | ------------------------------------------- |
+| `ionBlur`   | Emitted when the select loses focus.     | `CustomEvent<void>`                         |
+| `ionCancel` | Emitted when the selection is cancelled. | `CustomEvent<void>`                         |
+| `ionChange` | Emitted when the value has changed.      | `CustomEvent<SelectChangeEventDetail<any>>` |
+| `ionFocus`  | Emitted when the select has focus.       | `CustomEvent<void>`                         |
 
 
 ## Methods

--- a/core/src/components/select/select-interface.ts
+++ b/core/src/components/select/select-interface.ts
@@ -2,6 +2,6 @@ export type SelectInterface = 'action-sheet' | 'popover' | 'alert';
 
 export type SelectCompareFn = (currentValue: any, compareValue: any) => boolean;
 
-export interface SelectChangeEventDetail {
-  value: any | any[] | undefined | null;
+export interface SelectChangeEventDetail<T = any> {
+  value: T;
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

`SelectChangeEventDetail` is not generic and `value` has type `any | any[] | undefined | null` (which basically boils down to `any`).

Issue Number: Closes #20220.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `SelectChangeEventDetail` is now generic so that `value` can be strongly typed, e. g. `CustomEvent<SelectChangeEventDetail<number>>` for a change handler when the values are numbers. By default (if not specified) the generic type is `any` which means that it's fully backwards compatible.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
