### PR TITLE
feat(card): expose global card css variable

### DIFF
--- a/core/src/components/card/card.ios.scss
+++ b/core/src/components/card/card.ios.scss
@@ -6,7 +6,7 @@
 
 :host {
   --background: #{$card-ios-background};
-  --color: #{$card-ios-text-color};
+  --color: #{$card-ios-color};
 
   @include margin($card-ios-margin-top, $card-ios-margin-end, $card-ios-margin-bottom, $card-ios-margin-start);
   @include border-radius($card-ios-border-radius);

--- a/core/src/components/card/card.ios.scss
+++ b/core/src/components/card/card.ios.scss
@@ -5,7 +5,7 @@
 // --------------------------------------------------
 
 :host {
-  --background: #{$item-ios-background};
+  --background: #{$card-ios-background};
   --color: #{$card-ios-text-color};
 
   @include margin($card-ios-margin-top, $card-ios-margin-end, $card-ios-margin-bottom, $card-ios-margin-start);

--- a/core/src/components/card/card.ios.vars.scss
+++ b/core/src/components/card/card.ios.vars.scss
@@ -15,9 +15,6 @@ $card-ios-margin-bottom:               $card-ios-margin-top !default;
 /// @prop - Margin start of the card
 $card-ios-margin-start:                16px !default;
 
-/// @prop - Background color of the card
-$card-ios-background-color:            $item-ios-background !default;
-
 /// @prop - Box shadow color of the card
 $card-ios-box-shadow-color:            rgba(0, 0, 0, .12) !default;
 

--- a/core/src/components/card/card.ios.vars.scss
+++ b/core/src/components/card/card.ios.vars.scss
@@ -27,9 +27,6 @@ $card-ios-border-radius:               8px !default;
 /// @prop - Font size of the card
 $card-ios-font-size:                   14px !default;
 
-/// @prop - Color of the card text
-$card-ios-text-color:                  $text-color-step-400 !default;
-
 /// @prop - Transition timing function of the card
 $card-ios-transition-timing-function:  cubic-bezier(0.12, 0.72, 0.29, 1) !default;
 

--- a/core/src/components/card/card.md.scss
+++ b/core/src/components/card/card.md.scss
@@ -5,7 +5,7 @@
 // --------------------------------------------------
 
 :host {
-  --background: #{$item-md-background};
+  --background: #{$card-md-background};
   --color: #{$card-md-text-color};
 
   @include margin($card-md-margin-top, $card-md-margin-end, $card-md-margin-bottom, $card-md-margin-start);

--- a/core/src/components/card/card.md.scss
+++ b/core/src/components/card/card.md.scss
@@ -6,7 +6,7 @@
 
 :host {
   --background: #{$card-md-background};
-  --color: #{$card-md-text-color};
+  --color: #{$card-md-color};
 
   @include margin($card-md-margin-top, $card-md-margin-end, $card-md-margin-bottom, $card-md-margin-start);
   @include border-radius($card-md-border-radius);

--- a/core/src/components/card/card.md.vars.scss
+++ b/core/src/components/card/card.md.vars.scss
@@ -15,9 +15,6 @@ $card-md-margin-bottom:               10px !default;
 /// @prop - Margin start of the card
 $card-md-margin-start:                10px !default;
 
-/// @prop - Background color of the card
-$card-md-background-color:            $item-md-background !default;
-
 /// @prop - Box shadow of the card
 $card-md-box-shadow:                  0 3px 1px -2px rgba(0,0,0,.2), 0 2px 2px 0 rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12) !default;
 

--- a/core/src/components/card/card.md.vars.scss
+++ b/core/src/components/card/card.md.vars.scss
@@ -26,6 +26,3 @@ $card-md-font-size:                   14px !default;
 
 /// @prop - Line height of the card
 $card-md-line-height:                 1.5 !default;
-
-/// @prop - Color of the card text
-$card-md-text-color:                  $text-color-step-450 !default;

--- a/core/src/themes/ionic.theme.default.ios.scss
+++ b/core/src/themes/ionic.theme.default.ios.scss
@@ -31,6 +31,6 @@ $item-ios-background:                       var(--ion-item-background, $backgrou
 $item-ios-border-color:                     var(--ion-item-border-color, var(--ion-border-color, var(--ion-color-step-250, #c8c7cc))) !default;
 $item-ios-color:                            var(--ion-item-color, $text-color) !default;
 
-// Material Design Card
+// iOS Card
 // --------------------------------------------------
 $card-ios-background:                        var(--ion-card-background, $background-color) !default;

--- a/core/src/themes/ionic.theme.default.ios.scss
+++ b/core/src/themes/ionic.theme.default.ios.scss
@@ -33,4 +33,5 @@ $item-ios-color:                            var(--ion-item-color, $text-color) !
 
 // iOS Card
 // --------------------------------------------------
-$card-ios-background:                        var(--ion-card-background, $background-color) !default;
+$card-ios-background:                        var(--ion-card-background, $item-ios-background) !default;
+$card-ios-color:                             var(--ion-card-color, $text-color-step-400) !default;

--- a/core/src/themes/ionic.theme.default.ios.scss
+++ b/core/src/themes/ionic.theme.default.ios.scss
@@ -30,3 +30,7 @@ $toolbar-ios-color:                         var(--ion-toolbar-color, $text-color
 $item-ios-background:                       var(--ion-item-background, $background-color) !default;
 $item-ios-border-color:                     var(--ion-item-border-color, var(--ion-border-color, var(--ion-color-step-250, #c8c7cc))) !default;
 $item-ios-color:                            var(--ion-item-color, $text-color) !default;
+
+// Material Design Card
+// --------------------------------------------------
+$card-ios-background:                        var(--ion-card-background, $background-color) !default;

--- a/core/src/themes/ionic.theme.default.ios.scss
+++ b/core/src/themes/ionic.theme.default.ios.scss
@@ -34,4 +34,4 @@ $item-ios-color:                            var(--ion-item-color, $text-color) !
 // iOS Card
 // --------------------------------------------------
 $card-ios-background:                        var(--ion-card-background, $item-ios-background) !default;
-$card-ios-color:                             var(--ion-card-color, $text-color-step-400) !default;
+$card-ios-color:                             var(--ion-card-color, var(--ion-item-color, $text-color-step-400)) !default;

--- a/core/src/themes/ionic.theme.default.md.scss
+++ b/core/src/themes/ionic.theme.default.md.scss
@@ -31,3 +31,7 @@ $toolbar-md-color:                          var(--ion-toolbar-color, var(--ion-t
 $item-md-background:                        var(--ion-item-background, $background-color) !default;
 $item-md-border-color:                      var(--ion-item-border-color, var(--ion-border-color, var(--ion-color-step-150, rgba(0, 0, 0, .13)))) !default;
 $item-md-color:                             var(--ion-item-color, $text-color) !default;
+
+// Material Design Card
+// --------------------------------------------------
+$card-md-background:                        var(--ion-card-background, $background-color) !default;

--- a/core/src/themes/ionic.theme.default.md.scss
+++ b/core/src/themes/ionic.theme.default.md.scss
@@ -34,4 +34,5 @@ $item-md-color:                             var(--ion-item-color, $text-color) !
 
 // Material Design Card
 // --------------------------------------------------
-$card-md-background:                        var(--ion-card-background, $background-color) !default;
+$card-md-background:                        var(--ion-card-background, $item-md-background) !default;
+$card-md-color:                             var(--ion-card-color, $text-color-step-450) !default;

--- a/core/src/themes/ionic.theme.default.md.scss
+++ b/core/src/themes/ionic.theme.default.md.scss
@@ -35,4 +35,4 @@ $item-md-color:                             var(--ion-item-color, $text-color) !
 // Material Design Card
 // --------------------------------------------------
 $card-md-background:                        var(--ion-card-background, $item-md-background) !default;
-$card-md-color:                             var(--ion-card-color, $text-color-step-450) !default;
+$card-md-color:                             var(--ion-card-color, var(--ion-item-color, $text-color-step-450)) !default;


### PR DESCRIPTION
Docs PR: https://github.com/ionic-team/ionic-docs/pull/1542
Starters PR: https://github.com/ionic-team/starters/pull/1393

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/21694


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The card bg color on dark mode was wrong because it follows `ion-item`'s background color
- I exposed a `--ion-card-background` global variable so we can separate the two and properly set the background color for the card.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
