### PR TITLE
IonFab and IonProgressBar fixes.

### DIFF
--- a/core/src/components/fab/fab.scss
+++ b/core/src/components/fab/fab.scss
@@ -35,7 +35,7 @@
 // --------------------------------------------------
 
 :host(.fab-vertical-top) {
-  top: $fab-content-margin;
+  top: max(#{$fab-content-margin}, var(--ion-safe-area-top, 0px));
 }
 
 :host(.fab-vertical-top.fab-edge) {
@@ -44,7 +44,7 @@
 
 
 :host(.fab-vertical-bottom) {
-  bottom: $fab-content-margin;
+  bottom: max(#{$fab-content-margin}, var(--ion-safe-area-bottom, 0px));
 }
 
 :host(.fab-vertical-bottom.fab-edge) {

--- a/core/src/components/progress-bar/progress-bar.scss
+++ b/core/src/components/progress-bar/progress-bar.scss
@@ -67,7 +67,7 @@
 .progress,
 .progress-indeterminate {
   background: var(--progress-background);
-
+  border-radius: var(--progress-border-radius);
   z-index: 2;
 }
 

--- a/core/src/components/progress-bar/progress-bar.scss
+++ b/core/src/components/progress-bar/progress-bar.scss
@@ -66,8 +66,11 @@
 
 .progress,
 .progress-indeterminate {
-  background: var(--progress-background);
+  /* stylelint-disable-next-line property-blacklist */
   border-radius: var(--progress-border-radius);
+
+  background: var(--progress-background);
+
   z-index: 2;
 }
 

--- a/core/src/components/progress-bar/progress-bar.tsx
+++ b/core/src/components/progress-bar/progress-bar.tsx
@@ -89,7 +89,7 @@ const renderProgress = (value: number, buffer: number) => {
   const finalBuffer = clamp(0, buffer, 1);
 
   return [
-    <div class="progress" style={{ transform: `scaleX(${finalValue})` }}></div>,
+    <div class="progress" style={{ width: `calc(${finalValue}) * 100%` }}></div>,
     finalBuffer !== 1 && <div class="buffer-circles"></div>,
     <div class="progress-buffer-bar" style={{ transform: `scaleX(${finalBuffer})` }}></div>,
   ];


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #21728, #21346 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- for the fab-button replaced fixed bottom position of 10px to adjust according on mobile devices
- for progess-bar user can set a --progress-border-radius variable for border-radius and other can apply custom style without getting them scaled down.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
