### PR TITLE
Fix IonTabButton onClick props not work

### DIFF
--- a/packages/react/src/components/navigation/IonTabBar.tsx
+++ b/packages/react/src/components/navigation/IonTabBar.tsx
@@ -189,7 +189,7 @@ class IonTabBarUnwrapped extends React.PureComponent<InternalProps, IonTabBarSta
         return React.cloneElement(child, {
           href,
           routeOptions,
-          onClick: this.onTabButtonClick
+          onClick: () => {child.props.onClick?(); this.onTabButtonClick();}
         });
       }
       return null;


### PR DESCRIPTION
Fix IonTabButton onClick props not work

- [√ ] Bugfix