### PR TITLE
fix(overlays): prevent focus from being stolen when presenting another overlay from within a modal

### DIFF
--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -138,6 +138,8 @@ const trapKeyboardFocus = (ev: Event, doc: Document) => {
      * wrapper element as the traps live outside of the wrapper.
      */
     const overlayRoot = getElementRoot(lastOverlay);
+    if (!overlayRoot.contains(target)) { return; }
+
     const overlayWrapper = overlayRoot.querySelector('.ion-overlay-wrapper');
 
     if (!overlayWrapper) { return; }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes https://github.com/ionic-team/ionic-framework/issues/21840


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- New accessibility improvements for focus trapping did not account for overlays being presented from a modal, so focus was always being stolen from them
- Added a check to see if the focused element is inside the top-most overlay. If it is not, do not try to steal focus away.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
