### PR TITLE
fix(input): await async event registration on iOS

### DIFF
--- a/core/src/utils/input-shims/input-shims.ts
+++ b/core/src/utils/input-shims/input-shims.ts
@@ -11,7 +11,7 @@ const SCROLL_ASSIST = true;
 const SCROLL_PADDING = true;
 const HIDE_CARET = true;
 
-export const startInputShims = (config: Config) => {
+export const startInputShims = async (config: Config) => {
   const doc = document;
   const keyboardHeight = config.getNumber('keyboardHeight', 290);
   const scrollAssist = config.getBoolean('scrollAssist', true);
@@ -77,11 +77,11 @@ export const startInputShims = (config: Config) => {
   // At this point we need to look for all of the inputs not registered yet
   // and register them.
   for (const input of inputs) {
-    registerInput(input);
+    await registerInput(input);
   }
 
-  doc.addEventListener('ionInputDidLoad', ((ev: InputEvent) => {
-    registerInput(ev.detail);
+  doc.addEventListener('ionInputDidLoad', (async (ev: InputEvent) => {
+    await registerInput(ev.detail);
   }) as any);
 
   doc.addEventListener('ionInputDidUnload', ((ev: InputEvent) => {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
To trigger a `(click)` event on an `ion-item`, several clicks were necessary. For further information see the issue below.

Issue Number: #21871 

## What is the new behavior?

Now you only need to click once to trigger the `(click)` event on an `ion-item`. async methods are now awaited and the event listeners get registered properly.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Please have a look at issue #21871.
