### PR TITLE
chore(build): set stencil extras config

### DIFF
--- a/core/stencil.config.ts
+++ b/core/stencil.config.ts
@@ -121,6 +121,14 @@ export const config: Config = {
       ]
     }
   ],
+  extras: {
+    cssVarsShim: true,
+    dynamicImportShim: true,
+    initializeNextTick: true,
+    safari10: true,
+    scriptDataOpts: true,
+    shadowDomShim: true,
+  },
   testing: {
     allowableMismatchedPixels: 200,
     pixelmatchThreshold: 0.05,


### PR DESCRIPTION
Stencil 2 will update the extras defaults to not include many of the polyfills and shims by default. Setting the configs here ensures they stay enabled so there isn't a breaking change for Ionic v5 users.