### PR TITLE
fix(input): only focus the first input / textarea when clicking on the parent item

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -2440,6 +2440,10 @@ export namespace Components {
          */
         "enterkeyhint"?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send';
         /**
+          * This is required for a WebKit bug which requires us to blur and focus an input to properly focus the input in an item with delegatesFocus. It will no longer be needed with iOS 14.
+         */
+        "fireFocusEvents": boolean;
+        /**
           * Returns the native `<textarea>` element used under the hood.
          */
         "getInputElement": () => Promise<HTMLTextAreaElement>;
@@ -2480,7 +2484,11 @@ export namespace Components {
          */
         "rows"?: number;
         /**
-          * Sets focus on the specified `ion-textarea`. Use this method instead of the global `input.focus()`.
+          * Sets blur on the native `textarea` in `ion-textarea`. Use this method instead of the global `textarea.blur()`.
+         */
+        "setBlur": () => Promise<void>;
+        /**
+          * Sets focus on the native `textarea` in `ion-textarea`. Use this method instead of the global `textarea.focus()`.
          */
         "setFocus": () => Promise<void>;
         /**
@@ -5738,6 +5746,10 @@ declare namespace LocalJSX {
           * A hint to the browser for which enter key to display. Possible values: `"enter"`, `"done"`, `"go"`, `"next"`, `"previous"`, `"search"`, and `"send"`.
          */
         "enterkeyhint"?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send';
+        /**
+          * This is required for a WebKit bug which requires us to blur and focus an input to properly focus the input in an item with delegatesFocus. It will no longer be needed with iOS 14.
+         */
+        "fireFocusEvents"?: boolean;
         /**
           * A hint to the browser for which keyboard to display. Possible values: `"none"`, `"text"`, `"tel"`, `"url"`, `"email"`, `"numeric"`, `"decimal"`, and `"search"`.
          */

--- a/core/src/components/item/item.tsx
+++ b/core/src/components/item/item.tsx
@@ -177,9 +177,9 @@ export class Item implements ComponentInterface, AnchorInterface, ButtonInterfac
     return (this.isClickable() || this.hasCover());
   }
 
-  private hasInputs(): boolean {
-    const inputs = this.el.querySelectorAll('ion-input');
-    return inputs.length > 0;
+  private getFirstInput(): HTMLIonInputElement | HTMLIonTextareaElement {
+    const inputs = this.el.querySelectorAll('ion-input, ion-textarea') as NodeListOf<HTMLIonInputElement | HTMLIonTextareaElement>;
+    return inputs[0];
   }
 
   // This is needed for WebKit due to a delegatesFocus bug where
@@ -187,17 +187,19 @@ export class Item implements ComponentInterface, AnchorInterface, ButtonInterfac
   // but is opening the keyboard. It will no longer be needed with
   // iOS 14.
   @Listen('click')
-  delegateFocus() {
-    if (this.hasInputs()) {
-      const input = this.el.querySelector('ion-input');
-      if (input) {
-        input.fireFocusEvents = false;
-        input.setBlur();
-        input.setFocus();
-        raf(() => {
-          input.fireFocusEvents = true;
-        });
-      }
+  delegateFocus(ev: Event) {
+    const clickedItem = (ev.target as HTMLElement).tagName === 'ION-ITEM';
+    const input = this.getFirstInput();
+
+    // Only focus the first input if we clicked on an ion-item
+    // and the first input exists
+    if (clickedItem && input) {
+      input.fireFocusEvents = false;
+      input.setBlur();
+      input.setFocus();
+      raf(() => {
+        input.fireFocusEvents = true;
+      });
     }
   }
 

--- a/core/src/components/item/item.tsx
+++ b/core/src/components/item/item.tsx
@@ -190,10 +190,18 @@ export class Item implements ComponentInterface, AnchorInterface, ButtonInterfac
   delegateFocus(ev: Event) {
     const clickedItem = (ev.target as HTMLElement).tagName === 'ION-ITEM';
     const input = this.getFirstInput();
+    let firstActive = false;
+
+    // If the first input is the same as the active element we need
+    // to focus the first input again, but if the active element
+    // is another input inside of the item we shouldn't switch focus
+    if (input && document.activeElement) {
+      firstActive = input.querySelector('input, textarea') === document.activeElement;
+    }
 
     // Only focus the first input if we clicked on an ion-item
     // and the first input exists
-    if (clickedItem && input) {
+    if (clickedItem && input && firstActive) {
       input.fireFocusEvents = false;
       input.setBlur();
       input.setFocus();

--- a/core/src/components/item/test/inputs/index.html
+++ b/core/src/components/item/test/inputs/index.html
@@ -124,6 +124,27 @@
       </ion-list-header>
       <ion-list class="multiple">
         <ion-item>
+          <ion-label>Multiple inputs</ion-label>
+          <ion-input placeholder="Input 1"></ion-input>
+          <ion-input placeholder="Input 2"></ion-input>
+          <ion-input placeholder="Input 3"></ion-input>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Multiple textareas</ion-label>
+          <ion-textarea placeholder="Textarea 1"></ion-textarea>
+          <ion-textarea placeholder="Textarea 2"></ion-textarea>
+          <ion-textarea placeholder="Textarea 3"></ion-textarea>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Multiple input/textareas</ion-label>
+          <ion-textarea placeholder="Textarea 1"></ion-textarea>
+          <ion-input placeholder="Input 2"></ion-input>
+          <ion-textarea placeholder="Textarea 3"></ion-textarea>
+        </ion-item>
+
+        <ion-item>
           <ion-checkbox slot="start" id="checkbox-start"></ion-checkbox>
           <ion-label>Multiple inputs w/ cover</ion-label>
           <ion-datetime placeholder="startTime" display-format="HH:mm" id="datetime-end"></ion-datetime>

--- a/core/src/components/item/test/inputs/index.html
+++ b/core/src/components/item/test/inputs/index.html
@@ -200,7 +200,7 @@
       clickableItem.color = color === undefined ? 'primary' : undefined;
     });
 
-    const inputs = document.querySelectorAll('ion-input');
+    const inputs = document.querySelectorAll('ion-input, ion-textarea');
 
     for (var i = 0; i < inputs.length; i++) {
       const input = inputs[i];

--- a/core/src/components/textarea/readme.md
+++ b/core/src/components/textarea/readme.md
@@ -306,8 +306,8 @@ Type: `Promise<HTMLTextAreaElement>`
 
 ### `setFocus() => Promise<void>`
 
-Sets focus on the specified `ion-textarea`. Use this method instead of the global
-`input.focus()`.
+Sets focus on the native `textarea` in `ion-textarea`. Use this method instead of the global
+`textarea.focus()`.
 
 #### Returns
 

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -23,6 +23,16 @@ export class Textarea implements ComponentInterface {
   private didBlurAfterEdit = false;
   private textareaWrapper?: HTMLElement;
 
+  /**
+   * This is required for a WebKit bug which requires us to
+   * blur and focus an input to properly focus the input in
+   * an item with delegatesFocus. It will no longer be needed
+   * with iOS 14.
+   *
+   * @internal
+   */
+  @Prop() fireFocusEvents = true;
+
   @Element() el!: HTMLElement;
 
   @State() hasFocus = false;
@@ -220,13 +230,25 @@ export class Textarea implements ComponentInterface {
   }
 
   /**
-   * Sets focus on the specified `ion-textarea`. Use this method instead of the global
-   * `input.focus()`.
+   * Sets focus on the native `textarea` in `ion-textarea`. Use this method instead of the global
+   * `textarea.focus()`.
    */
   @Method()
   async setFocus() {
     if (this.nativeInput) {
       this.nativeInput.focus();
+    }
+  }
+
+  /**
+   * Sets blur on the native `textarea` in `ion-textarea`. Use this method instead of the global
+   * `textarea.blur()`.
+   * @internal
+   */
+  @Method()
+  async setBlur() {
+    if (this.nativeInput) {
+      this.nativeInput.blur();
     }
   }
 
@@ -296,14 +318,18 @@ export class Textarea implements ComponentInterface {
     this.hasFocus = true;
     this.focusChange();
 
-    this.ionFocus.emit(ev);
+    if (this.fireFocusEvents) {
+      this.ionFocus.emit(ev);
+    }
   }
 
   private onBlur = (ev: FocusEvent) => {
     this.hasFocus = false;
     this.focusChange();
 
-    this.ionBlur.emit(ev);
+    if (this.fireFocusEvents) {
+      this.ionBlur.emit(ev);
+    }
   }
 
   private onKeyDown = () => {


### PR DESCRIPTION
:warning: dev build: `5.4.0-dev.202009081606.5ddd37f` :warning:
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes #22037 resolves #22032


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Check if the event target is an ion-item before focusing the first input, thus if another input exists it won't change focus
- Add support for focusing ion-textarea if that exists as the first input

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
