### PR TITLE
fix(vue): canGoBack now returns correct result with initial load redirect

### DIFF
--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -31,15 +31,6 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
   // TODO types
   let historyChangeListeners: any[] = [];
 
-  const currentRoute = router.currentRoute.value;
-  currentRouteInfo = {
-    id: generateId('routeInfo'),
-    pathname: currentRoute.path,
-    search: currentRoute.fullPath.split('?')[1] || '',
-    params: currentRoute.params
-  }
-  locationHistory.add(currentRouteInfo)
-
   if (typeof (document as any) !== 'undefined') {
     document.addEventListener('ionBackButton', (ev: Event) => {
       (ev as any).detail.register(0, (processNextHandler: () => void) => {
@@ -103,6 +94,13 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
       }
     } else {
       leavingLocationInfo = locationHistory.current();
+    }
+
+    if (!leavingLocationInfo) {
+      leavingLocationInfo = {
+        pathname: '',
+        search: ''
+      }
     }
 
     const leavingUrl = leavingLocationInfo.pathname + leavingLocationInfo.search;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Previously, we set an initial location history view item no matter the path. This was to work around some undefined errors when on the initial page (if there was no previous page). This was wrong as it set a location history item even for an initial page redirect. This results in canGoBack being wrong as there were always 2+ items in the history stack.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- No longer set initial route, let that happen naturally by listening to the data vue router gives us.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
