### PR TITLE
feat(vue): add hook to access Ionic Vue router

### DIFF
--- a/packages/vue/src/hooks.ts
+++ b/packages/vue/src/hooks.ts
@@ -1,6 +1,11 @@
 import { BackButtonEvent } from '@ionic/core';
+import { inject } from 'vue';
 
 type Handler = (processNextHandler: () => void) => Promise<any> | void | null;
+
+export interface IonRouter {
+  canGoBack: (deep: number) => boolean;
+}
 
 export const useHardwareBackButton = (priority: number, handler: Handler) => {
   const callback = (ev: BackButtonEvent) => ev.detail.register(priority, handler);
@@ -9,4 +14,12 @@ export const useHardwareBackButton = (priority: number, handler: Handler) => {
   document.addEventListener('ionBackButton', callback);
 
   return { unregister };
+}
+
+export const useIonRouter = (): IonRouter => {
+  const { canGoBack } = inject('navManager') as any;
+
+  return {
+    canGoBack
+  } as IonRouter
 }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -11,7 +11,7 @@ export { IonTabButton } from './components/IonTabButton';
 export { IonTabs } from './components/IonTabs';
 export { IonTabBar } from './components/IonTabBar';
 
-export { useHardwareBackButton } from './hardware-back-button';
+export { IonRouter, useHardwareBackButton, useIonRouter } from './hooks';
 
 export {
   // Overlay Controllers


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We need a way to determine if users "canGoBack" when listening to hardware back button events.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Expose a hook that users can use to access the router. This also allows us to selectively expose methods on the Ionic Vue router while keeping other methods accessible for internal component usage.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
