### PR TITLE
fix(vue): pass props to component when using modal and popover controller

### DIFF
--- a/packages/vue/src/framework-delegate.ts
+++ b/packages/vue/src/framework-delegate.ts
@@ -6,7 +6,7 @@ export const VueDelegate = () => {
      * Ionic Framework passes in modal and popover element
      * refs as props, but if these are not defined
      * on the Vue component instance as props, Vue will
-     * throw a warning
+     * warn the user.
      */
     delete componentProps['modal'];
     delete componentProps['popover'];

--- a/packages/vue/src/framework-delegate.ts
+++ b/packages/vue/src/framework-delegate.ts
@@ -1,8 +1,16 @@
 import { createVNode, render } from 'vue';
 
 export const VueDelegate = () => {
-  const attachViewToDom = (parentElement: HTMLElement, component: any, _: any, classes?: string[]) => {
-    const vueInstance = createVNode(component);
+  const attachViewToDom = (parentElement: HTMLElement, component: any, componentProps: any, classes?: string[]) => {
+    /**
+     * Ionic Framework passes in modal and popover element
+     * refs as props, but if these are not defined
+     * on the Vue component instance as props, Vue will
+     * throw a warning
+     */
+    delete componentProps['modal'];
+    delete componentProps['popover'];
+    const vueInstance = createVNode(component, componentProps);
 
     const div = document.createElement('div');
     classes && div.classList.add(...classes);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/22189


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Controllers did not pass props to component, so I updated VueDelegate to do this. Overlay components in template were not affected.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
