### PR TITLE
fix(datetime): remove the automatic switching from am to pm and vice versa

### DIFF
--- a/core/src/components/datetime/datetime-util.ts
+++ b/core/src/components/datetime/datetime-util.ts
@@ -326,24 +326,6 @@ export const updateDate = (existingData: DatetimeData, newData: any, displayTime
       // newData is from the datetime picker's selected values
       // update the existing datetimeValue with the new values
       if (newData.ampm !== undefined && newData.hour !== undefined) {
-        // If the date we came from exists, we need to change the meridiem value when
-        // going to and from 12
-        if (existingData.ampm !== undefined && existingData.hour !== undefined) {
-          // If the existing meridiem is am, we want to switch to pm if it is either
-          // A) coming from 0 (12 am)
-          // B) going to 12 (12 pm)
-          if (existingData.ampm === 'am' && (existingData.hour === 0 || newData.hour.value === 12)) {
-            newData.ampm.value = 'pm';
-          }
-
-          // If the existing meridiem is pm, we want to switch to am if it is either
-          // A) coming from 12 (12 pm)
-          // B) going to 12 (12 am)
-          if (existingData.ampm === 'pm' && (existingData.hour === 12 || newData.hour.value === 12)) {
-            newData.ampm.value = 'am';
-          }
-        }
-
         // change the value of the hour based on whether or not it is am or pm
         // if the meridiem is pm and equal to 12, it remains 12
         // otherwise we add 12 to the hour value


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

It was previously thought to be the intended behavior to switch from am -> pm and vice versa when going from 12 am / pm to another number but I've discovered this was never how it worked.

Issue Number: fixes #18924 fixes #22171 fixes #22199


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- No longer automatically switch between AM/PM when going from or to 12

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
