### PR TITLE
chore(github): add pull request labeler for packages

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -130,22 +130,6 @@ noReproduction:
   lock: true
   dryRun: false
 
-labelPullRequest:
-  labels:
-    - label: "package: angular"
-      branch: master
-      path: ^angular
-    - label: "package: core"
-      branch: master
-      path: ^core
-    - label: "package: react"
-      branch: master
-      path: ^react
-    - label: "package: vue"
-      branch: master
-      path: ^vue
-  dryRun: false
-
 wrongRepo:
   repos:
     - label: "ionitron: capacitor"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,22 @@
+# This is used with the label workflow which
+# will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# For more information, see:
+# https://github.com/actions/labeler
+
+'package: core':
+  - core/**/*
+
+'package: angular':
+  - angular/**/*
+  - packages/angular-server/**/*
+
+'package: react':
+  - packages/react/**/*
+  - packages/react-router/**/*
+
+'package: vue':
+  - vue/**/*
+  - packages/vue/**/*
+  - packages/vue-router/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,13 +10,12 @@
 
 'package: angular':
   - angular/**/*
-  - packages/angular-server/**/*
+  - packages/angular-*/**/*
 
 'package: react':
   - packages/react/**/*
-  - packages/react-router/**/*
+  - packages/react-*/**/*
 
 'package: vue':
-  - vue/**/*
   - packages/vue/**/*
-  - packages/vue-router/**/*
+  - packages/vue-*/**/*

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,19 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true


### PR DESCRIPTION
This adds the Github workflow to automatically label PRs based on the files changed, removing the code that is done by ionitron. I have tested it out in a sample repository here: https://github.com/brandyscarney/testing-labeler/pull/3

It seems to be behaving as desired, removing labels when the changes are reverted and adding them based on the file path.

<img width="906" alt="Screen Shot 2020-09-30 at 1 23 23 PM" src="https://user-images.githubusercontent.com/6577830/94718711-1f115b00-0320-11eb-912e-df53bb5f8b08.png">
