### PR TITLE
fix(react): onIonTabsWillChange and onIonTabsDidChange event handlers are now properly bound to IonTabs

### DIFF
--- a/packages/react/src/components/navigation/IonTabs.tsx
+++ b/packages/react/src/components/navigation/IonTabs.tsx
@@ -85,6 +85,7 @@ export class IonTabs extends React.Component<Props> {
   render() {
     let outlet: React.ReactElement<{}> | undefined;
     let tabBar: React.ReactElement | undefined;
+    const { className, onIonTabsDidChange, onIonTabsWillChange, ...props } = this.props;
 
     const children =
       typeof this.props.children === 'function'
@@ -101,7 +102,7 @@ export class IonTabs extends React.Component<Props> {
         outlet = child.props.children[0];
       }
       if (child.type === IonTabBar || child.type.isTabBar) {
-        const { onIonTabsDidChange, onIonTabsWillChange } = this.props;
+
         tabBar = React.cloneElement(child, {
           onIonTabsDidChange,
           onIonTabsWillChange,
@@ -111,7 +112,7 @@ export class IonTabs extends React.Component<Props> {
         child.type === Fragment &&
         (child.props.children[1].type === IonTabBar || child.props.children[1].type.isTabBar)
       ) {
-        const { onIonTabsDidChange, onIonTabsWillChange } = this.props;
+
         tabBar = React.cloneElement(child.props.children[1], {
           onIonTabsDidChange,
           onIonTabsWillChange,
@@ -126,8 +127,6 @@ export class IonTabs extends React.Component<Props> {
     if (!tabBar) {
       throw new Error('IonTabs needs a IonTabBar');
     }
-
-    const { className, ...props } = this.props;
 
     return (
       <IonTabsContext.Provider value={this.ionTabContextState}>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves #21827

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Correctly pass event handler props

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
