### PR TITLE
fix(select): properly align label with select in item in md

### DIFF
--- a/core/src/components/select/select.md.vars.scss
+++ b/core/src/components/select/select.md.vars.scss
@@ -11,7 +11,7 @@ $select-md-padding-top:         $item-md-padding-top !default;
 $select-md-padding-end:         0 !default;
 
 /// @prop - Padding bottom of the select
-$select-md-padding-bottom:      $item-md-padding-bottom !default;
+$select-md-padding-bottom:      $select-md-padding-top !default;
 
 /// @prop - Padding start of the select
 $select-md-padding-start:       $item-md-padding-start !default;

--- a/core/src/components/select/select.scss
+++ b/core/src/components/select/select.scss
@@ -76,7 +76,7 @@ button {
 
 .select-icon-inner {
   @include position(50%, null, null, 5px);
-  @include margin(-3px, null, null, null);
+  @include margin(-2px, null, null, null);
 
   position: absolute;
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Label & select placeholder / label are not aligned

Issue Number: fixes #19887

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Properly align

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


| Before | After |
| ---| ---|
| ![before](https://user-images.githubusercontent.com/6577830/96159077-3a649480-0ee2-11eb-92f3-c9f68ba98961.png) | ![after](https://user-images.githubusercontent.com/6577830/96157422-47808400-0ee0-11eb-9b2a-1c28627347fc.png) |