### PR TITLE
fix(vue): going back with query params now goes to correct view

### DIFF
--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -59,7 +59,7 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
      */
     currentNavigationInfo = {
       action: info.type,
-      direction: info.direction === '' ? 'none' : info.direction
+      direction: info.direction === '' ? 'forward' : info.direction
     };
   });
 

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -1,7 +1,7 @@
 import {
   Router,
   RouteLocationNormalized,
-  NavigationGuardNext,
+  NavigationGuardNext
 } from 'vue-router';
 import { createLocationHistory } from './locationHistory';
 import { generateId } from './utils';

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -1,7 +1,7 @@
 import {
   Router,
   RouteLocationNormalized,
-  NavigationGuardNext
+  NavigationGuardNext,
 } from 'vue-router';
 import { createLocationHistory } from './locationHistory';
 import { generateId } from './utils';
@@ -11,14 +11,20 @@ import {
   RouteParams,
   RouteAction,
   RouteDirection,
-  IonicVueRouterOptions
+  IonicVueRouterOptions,
+  NavigationInformation
 } from './types';
 import { AnimationBuilder } from '@ionic/core';
 
 export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => {
+  let currentNavigationInfo: NavigationInformation = { direction: undefined, action: undefined };
 
   router.beforeEach((to: RouteLocationNormalized, _: RouteLocationNormalized, next: NavigationGuardNext) => {
-    handleHistoryChange(to);
+    const { direction, action } = currentNavigationInfo;
+    handleHistoryChange(to, action, direction);
+
+    currentNavigationInfo = { direction: undefined, action: undefined };
+
     next();
   });
 
@@ -39,8 +45,23 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
     })
   }
 
-  //   NavigationCallback
-  opts.history.listen((to: any, _: any, info: any) => handleHistoryChange({ path: to }, info.type, info.direction));
+  opts.history.listen((_: any, _x: any, info: any) => {
+    /**
+     * history.listen only fires on certain
+     * event such as when the user clicks the
+     * browser back button. It also gives us
+     * additional information as to the type
+     * of navigation (forward, backward, etc).
+     *
+     * We can use this to better handle the
+     * `handleHistoryChange` call in
+     * router.beforeEach
+     */
+    currentNavigationInfo = {
+      action: info.type,
+      direction: info.direction === '' ? 'none' : info.direction
+    };
+  });
 
   const handleNavigateBack = (defaultHref?: string, routerAnimation?: AnimationBuilder) => {
     // todo grab default back button href from config

--- a/packages/vue-router/src/types.ts
+++ b/packages/vue-router/src/types.ts
@@ -51,3 +51,8 @@ export interface ExternalNavigationOptions {
   routerDirection?: RouteDirection;
   routerAnimation?: AnimationBuilder;
 }
+
+export interface NavigationInformation {
+  action?: RouteAction;
+  direction?: RouteDirection;
+}

--- a/packages/vue/test-app/src/router/index.ts
+++ b/packages/vue/test-app/src/router/index.ts
@@ -35,6 +35,10 @@ const routes: Array<RouteRecordRaw> = [
     component: () => import('@/views/RoutingChild.vue')
   },
   {
+    path: '/routing/item/:id/view',
+    component: () => import('@/views/RoutingParameter.vue')
+  },
+  {
     path: '/navigation',
     component: () => import('@/views/Navigation.vue')
   },

--- a/packages/vue/test-app/src/views/Routing.vue
+++ b/packages/vue/test-app/src/views/Routing.vue
@@ -23,6 +23,10 @@
       <ion-item button router-link="/routing/child" id="child">
         <ion-label>Go to Child Page</ion-label>
       </ion-item>
+
+      <ion-item button router-link="/routing/item/123/view" id="item">
+        <ion-label>Go to Parameterized Route</ion-label>
+      </ion-item>
     </ion-content>
   </ion-page>
 </template>

--- a/packages/vue/test-app/src/views/RoutingParameter.vue
+++ b/packages/vue/test-app/src/views/RoutingParameter.vue
@@ -1,0 +1,49 @@
+<template>
+  <ion-page data-pageid="routingparameter">
+    <ion-header :translucent="true">
+      <ion-toolbar>
+        <ion-buttons>
+          <ion-back-button></ion-back-button>
+        </ion-buttons>
+        <ion-title>Routing Parameter</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content :fullscreen="true">
+      <ion-header collapse="condense">
+        <ion-toolbar>
+          <ion-title size="large">Routing Parameter</ion-title>
+        </ion-toolbar>
+      </ion-header>
+
+      <div class="ion-padding">
+        Routing Parameter Page: {{ $route.params.id }}
+      </div>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script lang="ts">
+import {
+  IonBackButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonPage,
+  IonTitle,
+  IonToolbar
+} from '@ionic/vue';
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  components: {
+    IonBackButton,
+    IonButtons,
+    IonContent,
+    IonHeader,
+    IonPage,
+    IonTitle,
+    IonToolbar
+  }
+});
+</script>

--- a/packages/vue/test-app/tests/e2e/specs/routing.js
+++ b/packages/vue/test-app/tests/e2e/specs/routing.js
@@ -46,6 +46,22 @@ describe('Routing', () => {
     cy.ionPageVisible('home');
     cy.ionPageDoesNotExist('routing');
     cy.ionPageDoesNotExist('routingchild')
+  });
+
+  // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/22324
+  it('should show correct view when navigating back from parameterized page to query string page', () => {
+    cy.visit('http://localhost:8080');
+    cy.get('#routing').click();
+    cy.get('#route-params').click();
+    cy.get('#item').click();
+
+    cy.ionPageVisible('routingparameter');
+    cy.ionPageHidden('routing');
+
+    cy.ionBackClick('routingparameter');
+
+    cy.ionPageDoesNotExist('routingparameter');
+    cy.ionPageVisible('routing');
   })
 });
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/22324


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Use the history listener to just grab the action/direction since it fires before `router.beforeEach` and let the `router.beforeEach` callback handle calling the ion router method.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
