### PR TITLE
docs(ripple-effect): add React and Angular live examples

### DIFF
--- a/core/src/components/ripple-effect/readme.md
+++ b/core/src/components/ripple-effect/readme.md
@@ -183,6 +183,7 @@ export default defineComponent({
 </script>
 ```
 
+You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-angular-ripple-effect) and in React [here](https://stackblitz.com/edit/ionic-react-ripple-effect).
 
 
 ## Properties


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

The ripple-effect documentation only contains code examples.

## What is the new behavior?

There are live previews for Angular and React code examples.

Angular - https://stackblitz.com/edit/ionic-angular-ripple-effect
React - https://stackblitz.com/edit/ionic-react-ripple-effect

## Does this introduce a breaking change?

- [ ] Yes
- [x] No