### PR TITLE
fix(vue): improve compatibility with route guards

### DIFF
--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -1,7 +1,6 @@
 import {
   Router,
-  RouteLocationNormalized,
-  NavigationGuardNext
+  RouteLocationNormalized
 } from 'vue-router';
 import { createLocationHistory } from './locationHistory';
 import { generateId } from './utils';
@@ -19,13 +18,20 @@ import { AnimationBuilder } from '@ionic/core';
 export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => {
   let currentNavigationInfo: NavigationInformation = { direction: undefined, action: undefined };
 
-  router.beforeEach((to: RouteLocationNormalized, _: RouteLocationNormalized, next: NavigationGuardNext) => {
+  /**
+   * Ionic Vue should only react to navigation
+   * changes once they have been confirmed and should
+   * never affect the outcome of navigation (with the
+   * exception of going back or selecting a tab).
+   * As a result, we should do our work in afterEach
+   * which is fired once navigation is confirmed
+   * and any user guards have run.
+   */
+  router.afterEach((to: RouteLocationNormalized, _: RouteLocationNormalized) => {
     const { direction, action } = currentNavigationInfo;
     handleHistoryChange(to, action, direction);
 
     currentNavigationInfo = { direction: undefined, action: undefined };
-
-    next();
   });
 
   const locationHistory = createLocationHistory();

--- a/packages/vue/test-app/src/guards/Delay.ts
+++ b/packages/vue/test-app/src/guards/Delay.ts
@@ -6,8 +6,8 @@ import {
 
 export const DelayGuard = async (_: RouteLocationNormalized, _x: RouteLocationNormalized, next: NavigationGuardNext) => {
   const loading = await loadingController.create({
-    message: 'Waiting 1000ms...',
-    duration: 1000
+    message: 'Waiting 500ms...',
+    duration: 500
   });
 
   await loading.present();

--- a/packages/vue/test-app/src/guards/Delay.ts
+++ b/packages/vue/test-app/src/guards/Delay.ts
@@ -1,0 +1,18 @@
+import { loadingController } from '@ionic/vue';
+import {
+  NavigationGuardNext,
+  RouteLocationNormalized
+} from 'vue-router';
+
+export const DelayGuard = async (_: RouteLocationNormalized, _x: RouteLocationNormalized, next: NavigationGuardNext) => {
+  const loading = await loadingController.create({
+    message: 'Waiting 1000ms...',
+    duration: 1000
+  });
+
+  await loading.present();
+
+  await loading.onDidDismiss();
+
+  next({ path: '/routing' });
+}

--- a/packages/vue/test-app/src/router/index.ts
+++ b/packages/vue/test-app/src/router/index.ts
@@ -1,10 +1,16 @@
 import { createRouter, createWebHistory } from '@ionic/vue-router';
 import { RouteRecordRaw } from 'vue-router';
-import Home from '../views/Home.vue'
+import Home from '@/views/Home.vue'
+import { DelayGuard } from '@/guards/Delay';
 
 const routes: Array<RouteRecordRaw> = [
   {
     path: '/',
+    component: Home
+  },
+  {
+    path: '/delayed-redirect',
+    beforeEnter: DelayGuard,
     component: Home
   },
   {

--- a/packages/vue/test-app/src/router/index.ts
+++ b/packages/vue/test-app/src/router/index.ts
@@ -89,6 +89,9 @@ const routes: Array<RouteRecordRaw> = [
       },
       {
         path: 'tab3',
+        beforeEnter: (to, from, next) => {
+          next({ path: '/tabs/tab1' });
+        },
         component: () => import('@/views/Tab3.vue')
       }
     ]
@@ -120,6 +123,6 @@ const routes: Array<RouteRecordRaw> = [
 const router = createRouter({
   history: createWebHistory(process.env.BASE_URL),
   routes
-})
+});
 
 export default router

--- a/packages/vue/test-app/src/views/Home.vue
+++ b/packages/vue/test-app/src/views/Home.vue
@@ -44,6 +44,9 @@
         <ion-item router-link="/lifecycle" id="lifecycle">
           <ion-label>Lifecycle</ion-label>
         </ion-item>
+        <ion-item router-link="/delayed-redirect" id="delayed-redirect">
+          <ion-label>Delayed Redirect</ion-label>
+        </ion-item>
       </ion-list>
 
     </ion-content>

--- a/packages/vue/test-app/tests/e2e/specs/routing.js
+++ b/packages/vue/test-app/tests/e2e/specs/routing.js
@@ -62,7 +62,23 @@ describe('Routing', () => {
 
     cy.ionPageDoesNotExist('routingparameter');
     cy.ionPageVisible('routing');
-  })
+  });
+
+  // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/22359
+  it('should work properly with async navigation guards', () => {
+    cy.visit('http://localhost:8080');
+    cy.get('#delayed-redirect').click();
+
+    cy.get('ion-loading').should('exist');
+
+    cy.ionPageVisible('routing');
+    cy.ionPageHidden('home');
+
+    cy.ionBackClick('routing');
+
+    cy.ionPageVisible('home');
+    cy.ionPageDoesNotExist('routing');
+  });
 });
 
 describe('Routing - Swipe to Go Back', () => {

--- a/packages/vue/test-app/tests/e2e/specs/tabs.js
+++ b/packages/vue/test-app/tests/e2e/specs/tabs.js
@@ -113,6 +113,15 @@ describe('Tabs', () => {
     cy.get('ion-tab-button#tab-button-tab2').click();
     cy.ionPageVisible('tab2');
   });
+
+  // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/22344
+  it('should show tab 1 when redirecting from tab 3', () => {
+    cy.visit('http://localhost:8080/tabs/tab3');
+
+    cy.ionPageVisible('tab1');
+    cy.ionPageDoesNotExist('tab3');
+    cy.ionPageVisible('tabs');
+  });
 })
 
 describe('Tabs - Swipe to Go Back', () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/22344


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Ionic Vue was reacting too soon to navigation changes by its use of `router.beforeEach`. This would cause transitions to happen before navigation was confirmed, leading to unexpected behaviors.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
