### PR TITLE
fix(refresher): force content to be ready before saving the scrollEl

### DIFF
--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -371,8 +371,6 @@ export class Refresher implements ComponentInterface {
     const pullingSpinner = this.el.querySelector('ion-refresher-content .refresher-pulling ion-spinner') as HTMLIonSpinnerElement;
     const refreshingSpinner = this.el.querySelector('ion-refresher-content .refresher-refreshing ion-spinner') as HTMLIonSpinnerElement;
 
-    await contentEl.componentOnReady();
-
     if (getIonMode(this) === 'ios') {
       this.setupiOSNativeRefresher(pullingSpinner, refreshingSpinner);
     } else {
@@ -395,6 +393,8 @@ export class Refresher implements ComponentInterface {
       console.error('<ion-refresher> must be used inside an <ion-content>');
       return;
     }
+
+    await contentEl.componentOnReady();
 
     this.scrollEl = await contentEl.getScrollElement();
     this.backgroundContentEl = getElementRoot(contentEl).querySelector('#background-content') as HTMLElement;


### PR DESCRIPTION
closes #22256 

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Issue Number: #22256 

Like wrote in the linked Issue, the Refresher sometimes starts too early / buggy when used in iOS card style modal. I debugged this today and saw, that the ScrollElement's **offsetHeight** could be zero here:
https://github.com/ionic-team/ionic-framework/blob/c1455a839a25e3e23b7c9e7b7d930055b24c2ecb/core/src/components/refresher/refresher.tsx#L399

This cause the `setupiOSNativeRefresher` to not work properly, as **MAX_PULL** is zero then as well.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Before loading the ScrollElement from the Content Element, wait for the Content's Component to be ready

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
