### PR TITLE
fix(ios): contenteditable elements are now selectable on iOS

### DIFF
--- a/core/src/components/app/app.scss
+++ b/core/src/components/app/app.scss
@@ -3,6 +3,16 @@ html.plt-mobile ion-app {
   user-select: none;
 }
 
+/**
+ * This works around a WebKit issue
+ * where user-select: none was causing
+ * contenteditable to not be selectable,
+ * even though inputs and textareas are selectable.
+ */
+html.plt-mobile ion-app [contenteditable] {
+  user-select: text;
+}
+
 ion-app.force-statusbar-padding {
   --ion-safe-area-top: 20px;
 }


### PR DESCRIPTION
TODO give co-author credit from https://github.com/ionic-team/ionic-framework/pull/18369
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`user-select: none` causes contenteditable to be non-selectable in WebKit but input and textarea work fine. This issue does not affect Chromium.
Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/18368


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added user-select: text to contenteditable

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
