### PR TITLE
fix(range): gesture is now properly re-created on connectedCallback

### DIFF
--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -265,8 +265,6 @@ export class Range implements ComponentInterface {
     const rect = this.rect = this.rangeSlider!.getBoundingClientRect() as any;
     const currentX = detail.currentX;
 
-    console.log('on start', detail)
-
     // figure out which knob they started closer to
     let ratio = clamp(0, (currentX - rect.left) / rect.width, 1);
     if (document.dir === 'rtl') {

--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -198,7 +198,7 @@ export class Range implements ComponentInterface {
     this.didLoad = true;
   }
 
-  async connectedCallback() {
+  connectedCallback() {
     this.updateRatio();
     this.debounceChanged();
     this.disabledChanged();


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/22335


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- disconnectedCallback destroyed the range gesture, but it was never re-created on connectedCallback. Added extra code to recreate the gesture

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
