### PR TITLE
fix(alert): correctly position alert when keyboard is open

### DIFF
--- a/core/src/components/alert/alert.scss
+++ b/core/src/components/alert/alert.scss
@@ -27,7 +27,7 @@
   @include position(0, 0, 0, 0);
 
   display: flex;
-  position: fixed;
+  position: absolute;
 
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
TODO: Give co-author credit when merging

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic-framework/pull/17776
The alert was not inheriting the height of `ion-app` because it had `position: fixed`. As a result, it was still being sized/positioned relative to the viewport.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Changing to `position: absolute` now causes ion-alert to inherit the height from ion-app

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
