### PR TITLE
feat(vue): web-types support

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -5,11 +5,12 @@
   "scripts": {
     "lint": "echo add linter",
     "test": "jest",
-    "build": "npm run clean && npm run copy && npm run copy.overlays && npm run compile && npm run bundle",
+    "build": "npm run clean && npm run copy && npm run copy.overlays && npm run compile && npm run bundle && npm run build.web-types",
     "bundle": "rollup --config rollup.config.js",
     "clean": "rimraf dist dist-transpiled",
     "compile": "npm run tsc",
     "tsc": "tsc -p .",
+    "build.web-types": "node ./scripts/build-web-types.js",
     "copy": "node ./scripts/copy-css.js",
     "copy.overlays": "node ./scripts/copy-overlays.js"
   },
@@ -56,5 +57,6 @@
   "dependencies": {
     "@ionic/core": "5.4.1",
     "ionicons": "^5.1.2"
-  }
+  },
+  "web-types": "dist/web-types.json"
 }

--- a/packages/vue/scripts/build-web-types.js
+++ b/packages/vue/scripts/build-web-types.js
@@ -1,0 +1,83 @@
+const fs = require("fs")
+
+// Web-types build require docs to be built first
+const docs = require("../../../docs/core.json")
+
+const components = []
+
+function toCamelCase(name) {
+  return name.split("-").map(n => n[0].toUpperCase() + n.substr(1)).join("")
+}
+
+for (const component of docs.components) {
+  if (!component.usage.vue) continue
+  const attributes = []
+  const slots = []
+  const events = []
+  const componentName = toCamelCase(component.tag)
+  const docUrl = "https://ionicframework.com/docs/api/" + component.tag.substr(4)
+
+  for (const prop of component.props || []) {
+    attributes.push({
+      name: prop.attr || prop.name,
+      description: prop.docs,
+      required: prop.required,
+      default: prop.default,
+      value: {
+        kind: "expression",
+        type: prop.type
+      }
+    })
+  }
+
+  for (const event of component.events || []) {
+    let eventName = event.event;
+    if (eventName.toLowerCase().startsWith(componentName.toLowerCase())) {
+      eventName = "on" + eventName.substr(componentName.length);
+    }
+    events.push({
+      name: eventName,
+      description: event.docs,
+      arguments: [{
+        name: "detail",
+        type: event.detail
+      }]
+    })
+  }
+
+  for (const slot of component.slots || []) {
+    slots.push({
+      name: slot.name === "" ? "default" : slot.name,
+      description: slot.docs
+    })
+  }
+
+  components.push({
+    name: componentName,
+    "doc-url": docUrl,
+    description: component.docs,
+    source: {
+      module: "@ionic/core/" + component.filePath.replace("./src/", "dist/types/").replace(".tsx", ".d.ts"),
+      symbol: componentName.substr(3)
+    },
+    attributes,
+    slots,
+    events
+  })
+}
+
+const webTypes = {
+  $schema: "http://json.schemastore.org/web-types",
+  framework: "vue",
+  name: "@ionic/vue",
+  version: require("../package.json").version,
+  contributions: {
+    html: {
+      "types-syntax": "typescript",
+      "description-markup": "markdown",
+      tags: components
+    }
+  }
+}
+
+fs.writeFileSync("dist/web-types.json", JSON.stringify(webTypes, null, 2))

--- a/packages/vue/scripts/build-web-types.js
+++ b/packages/vue/scripts/build-web-types.js
@@ -1,7 +1,7 @@
 const fs = require("fs")
 
 // Web-types build require docs to be built first
-const docs = require("../../../docs/core.json")
+const docs = require("@ionic/core/dist/docs.json")
 
 const components = []
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves #19522 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR introduces bundling of web-types with `@ionic/vue` for in-editor documentation support. The web-types standard is an open source standard supported so far only by WebStorm and is bundled with various other Vue libraries, like `vuetify`, `bootstrap-vue` or `quasar`. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
