### PR TITLE
chore(): revert old segment fix in favor of new one

### DIFF
--- a/core/src/components/segment-button/segment-button.ios.scss
+++ b/core/src/components/segment-button/segment-button.ios.scss
@@ -38,7 +38,7 @@
   min-height: #{$segment-button-ios-min-height};
 
   // Necessary for the z-index to work properly
-  transform: translate(0, 0);
+  transform: translate3d(0, 0, 0);
 
   font-size: #{$segment-button-ios-font-size};
 
@@ -62,6 +62,8 @@
 
   content: "";
   opacity: 1;
+
+  will-change: opacity;
 }
 
 :host(:first-of-type)::before {

--- a/core/src/components/segment-button/segment-button.scss
+++ b/core/src/components/segment-button/segment-button.scss
@@ -81,7 +81,7 @@
   @include text-inherit();
   @include margin(var(--margin-top), var(--margin-end), var(--margin-bottom), var(--margin-start));
   @include padding(var(--padding-top), var(--padding-end), var(--padding-bottom), var(--padding-start));
-  @include transform(translate(0,0));
+  @include transform(translate3d(0,0,0));
 
   display: flex;
   position: relative;
@@ -269,6 +269,8 @@ ion-ripple-effect {
   opacity: 0;
 
   box-sizing: border-box;
+
+  will-change: transform, opacity;
 
   pointer-events: none;
 }

--- a/core/src/components/segment/segment.tsx
+++ b/core/src/components/segment/segment.tsx
@@ -260,7 +260,7 @@ export class Segment implements ComponentInterface {
 
     // Scale the indicator width to match the previous indicator width
     // and translate it on top of the previous indicator
-    const transform = `translate(${xPosition}px, 0) scaleX(${widthDelta})`;
+    const transform = `translate3d(${xPosition}px, 0, 0) scaleX(${widthDelta})`;
 
     writeTask(() => {
       // Remove the transition before positioning on top of the previous indicator


### PR DESCRIPTION
This reverts commit 68afc49e9ed27acffb0b765b7be6b03e8574850d in favor of https://github.com/ionic-team/ionic-framework/commit/9f44966d8572a27d8296b38ae4f3e689c76c2e44.

The new fix was supposed to revert this commit, but I must have forgotten to do it. The new fix is a more universal fix that should help us in other scenarios when using translate3d

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
