### PR TITLE
fix(refresher): ios native refresher now works in side menu

### DIFF
--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -165,7 +165,15 @@ export class Refresher implements ComponentInterface {
   private async setupiOSNativeRefresher(pullingSpinner: HTMLIonSpinnerElement, refreshingSpinner: HTMLIonSpinnerElement) {
     this.elementToTransform = this.scrollEl!;
     const ticks = pullingSpinner.shadowRoot!.querySelectorAll('svg');
-    const MAX_PULL = this.scrollEl!.clientHeight * 0.16;
+    const height = this.scrollEl!.clientHeight;
+
+    /**
+     * If the scroll element is hidden, then height will be zero.
+     * In that case, just assign a reasonable value for pulling down.
+     * The most common scenario of this happening is when using the
+     * refreshing in a menu that is initially hidden.
+     */
+    const MAX_PULL = (height === 0) ? 80 : height * 0.16;
     const NUM_TICKS = ticks.length;
 
     writeTask(() => ticks.forEach(el => el.style.setProperty('animation', 'none')));

--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -258,7 +258,7 @@ export class Refresher implements ComponentInterface {
              * will be 0. When the gesture starts, the content
              * will be visible, so try to get the correct
              * client height again. This is most common when
-             * using the refresher in the side menu.
+             * using the refresher in an ion-menu.
              */
             if (MAX_PULL === 0) {
               MAX_PULL = this.scrollEl!.clientHeight * 0.16;

--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -165,15 +165,7 @@ export class Refresher implements ComponentInterface {
   private async setupiOSNativeRefresher(pullingSpinner: HTMLIonSpinnerElement, refreshingSpinner: HTMLIonSpinnerElement) {
     this.elementToTransform = this.scrollEl!;
     const ticks = pullingSpinner.shadowRoot!.querySelectorAll('svg');
-    const height = this.scrollEl!.clientHeight;
-
-    /**
-     * If the scroll element is hidden, then height will be zero.
-     * In that case, just assign a reasonable value for pulling down.
-     * The most common scenario of this happening is when using the
-     * refreshing in a menu that is initially hidden.
-     */
-    const MAX_PULL = (height === 0) ? 80 : height * 0.16;
+    let MAX_PULL = this.scrollEl!.clientHeight * 0.16;
     const NUM_TICKS = ticks.length;
 
     writeTask(() => ticks.forEach(el => el.style.setProperty('animation', 'none')));
@@ -258,6 +250,18 @@ export class Refresher implements ComponentInterface {
 
             if (!this.didRefresh) {
               translateElement(this.elementToTransform, '0px');
+            }
+
+            /**
+             * If the content had `display: none` when
+             * the refresher was initialized, its clientHeight
+             * will be 0. When the gesture starts, the content
+             * will be visible, so try to get the correct
+             * client height again. This is most common when
+             * using the refresher in the side menu.
+             */
+            if (MAX_PULL === 0) {
+              MAX_PULL = this.scrollEl!.clientHeight * 0.16;
             }
           },
           onMove: ev => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Sometimes the scrollEl's clientHeight is zero because the containing element is hidden. This results in the refresher firing too early.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a default MAX_PULL value in the event the content height is 0.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
