### PR TITLE
Fix typos in textarea docs (IonLabe -> IonLabel)

### DIFF
--- a/core/src/components/textarea/readme.md
+++ b/core/src/components/textarea/readme.md
@@ -253,11 +253,11 @@ export class TextareaExample {
 </template>
 
 <script>
-import { IonItem, IonLabe, IonTextarea } from '@ionic/vue';
+import { IonItem, IonLabel, IonTextarea } from '@ionic/vue';
 import { defineComponent } from 'vue';
 
 export default defineComponent({
-  components: { IonItem, IonLabe, IonTextarea }
+  components: { IonItem, IonLabel, IonTextarea }
 });
 </script>
 ```

--- a/core/src/components/textarea/usage/vue.md
+++ b/core/src/components/textarea/usage/vue.md
@@ -38,11 +38,11 @@
 </template>
 
 <script>
-import { IonItem, IonLabe, IonTextarea } from '@ionic/vue';
+import { IonItem, IonLabel, IonTextarea } from '@ionic/vue';
 import { defineComponent } from 'vue';
 
 export default defineComponent({
-  components: { IonItem, IonLabe, IonTextarea }
+  components: { IonItem, IonLabel, IonTextarea }
 });
 </script>
 ```


### PR DESCRIPTION
## Pull request type

- [X] Documentation content changes

##

Current docs have code examples that will not work. `IonLabe` is written instead of `IonLabel`. This PR fixes those.