### PR TITLE
docs(select): Fix broken link to select-option

### DIFF
--- a/core/src/components/select/readme.md
+++ b/core/src/components/select/readme.md
@@ -118,7 +118,7 @@ Customizing the interface dialog should be done by following the Customization s
 - [Action Sheet Customization](../action-sheet#customization)
 - [Popover Customization](../popover#customization)
 
-However, the Select Option does set a class for easier styling and allows for the ability to pass a class to the overlay option, see the [Select Options documentation](./select-option) for usage examples of customizing options.
+However, the Select Option does set a class for easier styling and allows for the ability to pass a class to the overlay option, see the [Select Options documentation](../select-option) for usage examples of customizing options.
 
 <!-- Auto Generated Below -->
 


### PR DESCRIPTION
Fix broken link to the select-option page. The broken link can be seen here https://ionicframework.com/docs/api/select#styling-select-interface when clicking on "Select Options documentation"

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The link "Select Options documentation" on the "Styling Select Interface" paragraph on [this page](https://ionicframework.com/docs/api/select#styling-select-interface) is broken.

Issue Number: N/A


## What is the new behavior?
The link open the page as expected.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
