### PR TITLE
fix(select): announce placeholder, hide select text from screenreaders

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -105,7 +105,7 @@ export namespace Components {
         /**
           * The main title in the heading of the alert.
          */
-        "header"?: string;
+        "header"?: string | null;
         /**
           * Array of input to show in the alert.
          */
@@ -3404,7 +3404,7 @@ declare namespace LocalJSX {
         /**
           * The main title in the heading of the alert.
          */
-        "header"?: string;
+        "header"?: string | null;
         /**
           * Array of input to show in the alert.
          */

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -105,7 +105,7 @@ export namespace Components {
         /**
           * The main title in the heading of the alert.
          */
-        "header"?: string | null;
+        "header"?: string;
         /**
           * Array of input to show in the alert.
          */
@@ -3404,7 +3404,7 @@ declare namespace LocalJSX {
         /**
           * The main title in the heading of the alert.
          */
-        "header"?: string | null;
+        "header"?: string;
         /**
           * Array of input to show in the alert.
          */

--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -384,9 +384,11 @@ export class Alert implements ComponentInterface, OverlayInterface {
   private renderCheckbox(labelledby: string | undefined) {
     const inputs = this.processedInputs;
     const mode = getIonMode(this);
+
     if (inputs.length === 0) {
       return null;
     }
+
     return (
       <div class="alert-checkbox-group" aria-labelledby={labelledby}>
         { inputs.map(i => (
@@ -424,9 +426,11 @@ export class Alert implements ComponentInterface, OverlayInterface {
 
   private renderRadio(labelledby: string | undefined) {
     const inputs = this.processedInputs;
+
     if (inputs.length === 0) {
       return null;
     }
+
     return (
       <div class="alert-radio-group" role="radiogroup" aria-labelledby={labelledby} aria-activedescendant={this.activeId}>
         { inputs.map(i => (
@@ -553,7 +557,8 @@ export class Alert implements ComponentInterface, OverlayInterface {
     const msgId = `alert-${overlayIndex}-msg`;
 
     let labelledById: string | undefined;
-    if (header !== undefined) {
+
+    if (header !== null) {
       labelledById = hdrId;
     } else if (subHeader !== undefined) {
       labelledById = subHdrId;

--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -65,7 +65,7 @@ export class Alert implements ComponentInterface, OverlayInterface {
   /**
    * The main title in the heading of the alert.
    */
-  @Prop() header?: string;
+  @Prop() header?: string | null;
 
   /**
    * The subtitle in the heading of the alert. Displayed under the title.

--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -65,7 +65,7 @@ export class Alert implements ComponentInterface, OverlayInterface {
   /**
    * The main title in the heading of the alert.
    */
-  @Prop() header?: string | null;
+  @Prop() header?: string;
 
   /**
    * The subtitle in the heading of the alert. Displayed under the title.
@@ -373,15 +373,15 @@ export class Alert implements ComponentInterface, OverlayInterface {
     return values;
   }
 
-  private renderAlertInputs(labelledBy: string | undefined) {
+  private renderAlertInputs() {
     switch (this.inputType) {
-      case 'checkbox': return this.renderCheckbox(labelledBy);
-      case 'radio': return this.renderRadio(labelledBy);
-      default: return this.renderInput(labelledBy);
+      case 'checkbox': return this.renderCheckbox();
+      case 'radio': return this.renderRadio();
+      default: return this.renderInput();
     }
   }
 
-  private renderCheckbox(labelledby: string | undefined) {
+  private renderCheckbox() {
     const inputs = this.processedInputs;
     const mode = getIonMode(this);
 
@@ -390,7 +390,7 @@ export class Alert implements ComponentInterface, OverlayInterface {
     }
 
     return (
-      <div class="alert-checkbox-group" aria-labelledby={labelledby}>
+      <div class="alert-checkbox-group">
         { inputs.map(i => (
           <button
             type="button"
@@ -424,7 +424,7 @@ export class Alert implements ComponentInterface, OverlayInterface {
     );
   }
 
-  private renderRadio(labelledby: string | undefined) {
+  private renderRadio() {
     const inputs = this.processedInputs;
 
     if (inputs.length === 0) {
@@ -432,7 +432,7 @@ export class Alert implements ComponentInterface, OverlayInterface {
     }
 
     return (
-      <div class="alert-radio-group" role="radiogroup" aria-labelledby={labelledby} aria-activedescendant={this.activeId}>
+      <div class="alert-radio-group" role="radiogroup" aria-activedescendant={this.activeId}>
         { inputs.map(i => (
           <button
             type="button"
@@ -463,13 +463,13 @@ export class Alert implements ComponentInterface, OverlayInterface {
     );
   }
 
-  private renderInput(labelledby: string | undefined) {
+  private renderInput() {
     const inputs = this.processedInputs;
     if (inputs.length === 0) {
       return null;
     }
     return (
-      <div class="alert-input-group" aria-labelledby={labelledby}>
+      <div class="alert-input-group">
         { inputs.map(i => {
           if (i.type === 'textarea') {
             return (
@@ -556,14 +556,6 @@ export class Alert implements ComponentInterface, OverlayInterface {
     const subHdrId = `alert-${overlayIndex}-sub-hdr`;
     const msgId = `alert-${overlayIndex}-msg`;
 
-    let labelledById: string | undefined;
-
-    if (header !== null) {
-      labelledById = hdrId;
-    } else if (subHeader !== undefined) {
-      labelledById = subHdrId;
-    }
-
     return (
       <Host
         role="dialog"
@@ -594,7 +586,7 @@ export class Alert implements ComponentInterface, OverlayInterface {
 
           <div id={msgId} class="alert-message" innerHTML={sanitizeDOMString(this.message)}></div>
 
-          {this.renderAlertInputs(labelledById)}
+          {this.renderAlertInputs()}
           {this.renderAlertButtons()}
 
         </div>

--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -462,7 +462,7 @@ export class Select implements ComponentInterface {
     // nicely when the screen reader announces it, otherwise just
     // announce the value / placeholder
     const displayLabel = labelText !== undefined
-      ? `${selectText}, ${labelText}`
+      ? (selectText !== '' ? `${selectText}, ${labelText}` : labelText)
       : selectText;
 
     return (

--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -458,8 +458,9 @@ export class Select implements ComponentInterface {
     const textPart = addPlaceholderClass ? 'placeholder' : 'text';
 
     // If there is a label then we need to concatenate it with the
-    // current value and a comma so it separates nicely when the screen reader
-    // announces it, otherwise just announce the value
+    // current value (or placeholder) and a comma so it separates
+    // nicely when the screen reader announces it, otherwise just
+    // announce the value / placeholder
     const displayLabel = labelText !== undefined
       ? `${selectText}, ${labelText}`
       : selectText;

--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -461,8 +461,8 @@ export class Select implements ComponentInterface {
     // current value and a comma so it separates nicely when the screen reader
     // announces it, otherwise just announce the value
     const displayLabel = labelText !== undefined
-      ? `${displayValue}, ${labelText}`
-      : displayValue;
+      ? `${selectText}, ${labelText}`
+      : selectText;
 
     return (
       <Host
@@ -477,7 +477,7 @@ export class Select implements ComponentInterface {
           'select-disabled': disabled,
         }}
       >
-        <div class={selectTextClasses} part={textPart}>
+        <div aria-hidden class={selectTextClasses} part={textPart}>
           {selectText}
         </div>
         <div class="select-icon" role="presentation" part="icon">

--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -478,7 +478,7 @@ export class Select implements ComponentInterface {
           'select-disabled': disabled,
         }}
       >
-        <div aria-hidden class={selectTextClasses} part={textPart}>
+        <div aria-hidden="true" class={selectTextClasses} part={textPart}>
           {selectText}
         </div>
         <div class="select-icon" role="presentation" part="icon">

--- a/core/src/components/select/test/a11y/index.html
+++ b/core/src/components/select/test/a11y/index.html
@@ -54,7 +54,7 @@
         <ion-item>
           <ion-label>Favorite Pet</ion-label>
 
-          <ion-select id="ionic-select">
+          <ion-select>
             <ion-select-option value="dog">Dog</ion-select-option>
             <ion-select-option value="cat">Cat</ion-select-option>
             <ion-select-option value="hamster">Hamster</ion-select-option>
@@ -101,7 +101,7 @@
         <ion-item>
           <label for="ionic-select">Favorite Pet</label>
 
-          <ion-select>
+          <ion-select id="ionic-select">
             <ion-select-option value="dog">Dog</ion-select-option>
             <ion-select-option value="cat">Cat</ion-select-option>
             <ion-select-option value="hamster">Hamster</ion-select-option>

--- a/core/src/components/select/test/a11y/index.html
+++ b/core/src/components/select/test/a11y/index.html
@@ -31,7 +31,7 @@
         </ion-list-header>
 
         <div class="native-select-wrapper">
-          <label for="pet-select">Choose a Pet</label>
+          <label for="pet-select">Favorite Pet</label>
 
           <select name="pets" id="pet-select">
             <option value="dog">Dog</option>
@@ -52,9 +52,35 @@
         </ion-list-header>
 
         <ion-item>
-          <ion-label>Choose a Pet</ion-label>
+          <ion-label>Favorite Pet</ion-label>
 
           <ion-select>
+            <ion-select-option value="dog">Dog</ion-select-option>
+            <ion-select-option value="cat">Cat</ion-select-option>
+            <ion-select-option value="hamster">Hamster</ion-select-option>
+            <ion-select-option value="parrot">Parrot</ion-select-option>
+            <ion-select-option value="spider">Spider</ion-select-option>
+            <ion-select-option value="goldfish">Goldfish</ion-select-option>
+          </ion-select>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Favorite Pet</ion-label>
+
+          <ion-select placeholder="Select a Pet">
+            <ion-select-option value="dog">Dog</ion-select-option>
+            <ion-select-option value="cat">Cat</ion-select-option>
+            <ion-select-option value="hamster">Hamster</ion-select-option>
+            <ion-select-option value="parrot">Parrot</ion-select-option>
+            <ion-select-option value="spider">Spider</ion-select-option>
+            <ion-select-option value="goldfish">Goldfish</ion-select-option>
+          </ion-select>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Favorite Pet</ion-label>
+
+          <ion-select value="spider">
             <ion-select-option value="dog">Dog</ion-select-option>
             <ion-select-option value="cat">Cat</ion-select-option>
             <ion-select-option value="hamster">Hamster</ion-select-option>
@@ -73,7 +99,7 @@
         </ion-list-header>
 
         <ion-item>
-          <label for="ionic-select">Choose a Pet</label>
+          <label for="ionic-select">Favorite Pet</label>
 
           <ion-select id="ionic-select">
             <ion-select-option value="dog">Dog</ion-select-option>
@@ -94,7 +120,7 @@
         </ion-list-header>
 
         <ion-item>
-          <ion-label>Choose a Pet</ion-label>
+          <ion-label>Favorite Pet</ion-label>
 
           <ion-select interface="popover">
             <ion-select-option value="dog">Dog</ion-select-option>
@@ -115,7 +141,7 @@
         </ion-list-header>
 
         <ion-item>
-          <ion-label>Choose a Pet</ion-label>
+          <ion-label>Favorite Pet</ion-label>
 
           <ion-select interface="action-sheet">
             <ion-select-option value="dog">Dog</ion-select-option>


### PR DESCRIPTION
Fixes:
- [x] Hides select text from screen readers so it isn't announced twice (Android talkback needs this)
- [x] Adds the placeholder text to be announced if there is no value
- [x] Don't add a comma if there is no value/placeholder (NVDA speech viewer)
- [x] Don't announce alert label twice