### PR TITLE
fix(progress-bar): use correct theme colors

### DIFF
--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -278,8 +278,8 @@ export class IonHeader {
 }
 export declare interface IonIcon extends Components.IonIcon {
 }
-@ProxyCmp({ inputs: ["ariaLabel", "color", "flipRtl", "icon", "ios", "lazy", "md", "mode", "name", "size", "src"] })
-@Component({ selector: "ion-icon", changeDetection: ChangeDetectionStrategy.OnPush, template: "<ng-content></ng-content>", inputs: ["ariaLabel", "color", "flipRtl", "icon", "ios", "lazy", "md", "mode", "name", "size", "src"] })
+@ProxyCmp({ inputs: ["ariaHidden", "ariaLabel", "color", "flipRtl", "icon", "ios", "lazy", "md", "mode", "name", "sanitize", "size", "src"] })
+@Component({ selector: "ion-icon", changeDetection: ChangeDetectionStrategy.OnPush, template: "<ng-content></ng-content>", inputs: ["ariaHidden", "ariaLabel", "color", "flipRtl", "icon", "ios", "lazy", "md", "mode", "name", "sanitize", "size", "src"] })
 export class IonIcon {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {

--- a/core/src/components/progress-bar/progress-bar.scss
+++ b/core/src/components/progress-bar/progress-bar.scss
@@ -10,7 +10,7 @@
   * @prop --progress-background: Color of the progress bar
   * @prop --buffer-background: Color of the buffer bar
   */
-  --background: #{ion-color(primary, base, 0.2)};
+  --background: #{ion-color(primary, base, 0.3)};
   --progress-background: #{ion-color(primary, base)};
   --buffer-background: var(--background);
   display: block;
@@ -27,7 +27,7 @@
 
 :host(.ion-color) {
   --progress-background: #{current-color(base)};
-  --buffer-background: #{current-color(base, 0.2)};
+  --buffer-background: #{current-color(base, 0.3)};
 }
 
 // indeterminate has no progress-buffer-bar, so it will be added to the host
@@ -72,17 +72,10 @@
 }
 
 .progress-buffer-bar {
-  // It's currently here because --buffer-background has an alpha
-  // Otherwise the buffer circles would be seen through
-  background: #fff;
+  background: var(--buffer-background);
 
-  z-index: 1; // Make it behind the progress
-
-  &:before {
-    background: var(--buffer-background);
-
-    content: "";
-  }
+  // Make it behind the progress
+  z-index: 1;
 }
 
 // MD based animation on indeterminate type
@@ -109,7 +102,7 @@
   top: 0;
   right: 0;
   bottom: 0;
-  left:  -54.888891%;
+  left: -54.888891%;
   /* stylelint-enable property-blacklist */
 
   animation: secondary-indeterminate-translate 2s infinite linear;
@@ -123,8 +116,26 @@
 // Buffer style
 // --------------------------------------------------
 
+.buffer-circles.buffer-circles-reversed {
+  /* stylelint-disable property-blacklist */
+  right: unset;
+  left: 0;
+
+  background-position: right;
+  /* stylelint-enable property-blacklist */
+}
+
 .buffer-circles {
-  background: radial-gradient(ellipse at center, var(--buffer-background) 0%, var(--buffer-background) 30%, transparent 30%) repeat-x 5px center;
+  /* stylelint-disable property-blacklist */
+  right: 0;
+
+  left: unset;
+  /* stylelint-enable property-blacklist */
+
+  background: radial-gradient(ellipse at center, var(--buffer-background) 0%, var(--buffer-background) 30%, transparent 30%) repeat-x 5px;
+
+  /* stylelint-disable-next-line property-blacklist */
+  background-position: left;
   background-size: 10px 10px;
 
   z-index: 0;

--- a/core/src/components/progress-bar/progress-bar.tsx
+++ b/core/src/components/progress-bar/progress-bar.tsx
@@ -54,6 +54,7 @@ export class ProgressBar implements ComponentInterface {
     const { color, type, reversed, value, buffer } = this;
     const paused = config.getBoolean('_testing');
     const mode = getIonMode(this);
+    const isReversed = document.dir === 'rtl' ? !reversed : reversed;
     return (
       <Host
         role="progressbar"
@@ -64,12 +65,12 @@ export class ProgressBar implements ComponentInterface {
           [mode]: true,
           [`progress-bar-${type}`]: true,
           'progress-paused': paused,
-          'progress-bar-reversed': document.dir === 'rtl' ? !reversed : reversed
+          'progress-bar-reversed': isReversed
         })}
       >
         {type === 'indeterminate'
           ? renderIndeterminate()
-          : renderProgress(value, buffer)
+          : renderProgress(value, buffer, isReversed)
         }
       </Host>
     );
@@ -83,13 +84,13 @@ const renderIndeterminate = () => {
   ];
 };
 
-const renderProgress = (value: number, buffer: number) => {
+const renderProgress = (value: number, buffer: number, reversed: boolean) => {
   const finalValue = clamp(0, value, 1);
   const finalBuffer = clamp(0, buffer, 1);
 
   return [
     <div class="progress" style={{ transform: `scaleX(${finalValue})` }}></div>,
-    finalBuffer !== 1 && <div class="buffer-circles"></div>,
+    finalBuffer !== 1 && <div class={{ 'buffer-circles': true, 'buffer-circles-reversed': reversed }} style={{ width: `calc(${(1 - finalBuffer) * 100}% + 4px)` }}></div>,
     <div class="progress-buffer-bar" style={{ transform: `scaleX(${finalBuffer})` }}></div>,
   ];
 };

--- a/core/src/components/progress-bar/test/basic/index.html
+++ b/core/src/components/progress-bar/test/basic/index.html
@@ -9,7 +9,9 @@
   <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
   <script src="../../../../../scripts/testing/scripts.js"></script>
   <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
-  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>  <style>
+  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+
+  <style>
     .custom-bar-background {
       --buffer-background: red;
     }
@@ -126,13 +128,26 @@
         </ion-list-header>
         <ion-progress-bar color="tertiary" buffer="0"></ion-progress-bar>
 
+        <ion-list-header>
+          <ion-label>
+            Buffer (change buffer with slider)
+          </ion-label>
+        </ion-list-header>
+        <ion-progress-bar class="progressBarBuffer" value="0.20" buffer="0.4"></ion-progress-bar>
+        <ion-progress-bar class="progressBarBuffer" value="0.20" buffer="0.4" reversed="true"></ion-progress-bar>
+
+        <ion-item>
+          <ion-range pin="true" value="0" id="progressValueBuffer">
+            <ion-label slot="start">0</ion-label>
+            <ion-label slot="end">100</ion-label>
+          </ion-range>
+        </ion-item>
       </ion-list>
-
     </ion-content>
-
   </ion-app>
 
   <script>
+    // Progress Bar Value
     const progressValue = document.getElementById('progressValue');
     const progressBar = document.getElementById('progressBar');
 
@@ -140,6 +155,13 @@
       progressBar.value = ev.detail.value / 100;
     });
 
+    // Progress Bar Buffer
+    const progressValueBuffer = document.getElementById('progressValueBuffer');
+    const progressBarBuffer = document.querySelectorAll('.progressBarBuffer');
+
+    progressValueBuffer.addEventListener('ionChange', function (ev) {
+      progressBarBuffer.forEach(ele => ele.buffer = ev.detail.value / 100);
+    });
   </script>
 </body>
 

--- a/core/src/themes/test/css-variables/index.html
+++ b/core/src/themes/test/css-variables/index.html
@@ -52,6 +52,9 @@
       font-size: 48px;
     }
 
+    ion-progress-bar {
+      margin-bottom: 10px;
+    }
   </style>
 </head>
 
@@ -620,10 +623,6 @@
             <section>
               <p>
                 <ion-toolbar>
-                  <ion-title>Default</ion-title>
-                </ion-toolbar>
-
-                <ion-toolbar>
                   <ion-buttons slot="start">
                     <ion-button color="danger">
                       <ion-icon slot="icon-only" name="add"></ion-icon>
@@ -758,6 +757,18 @@
                   </ion-buttons>
                   <ion-title>Dark</ion-title>
                 </ion-toolbar>
+              </p>
+
+              <p>
+                <ion-progress-bar value="0.5"></ion-progress-bar>
+                <ion-progress-bar value="0.5" color="secondary"></ion-progress-bar>
+                <ion-progress-bar value="0.5" color="tertiary"></ion-progress-bar>
+                <ion-progress-bar type="indeterminate" color="danger"></ion-progress-bar>
+                <ion-progress-bar type="indeterminate" color="warning"></ion-progress-bar>
+                <ion-progress-bar value="0.2" buffer="0.3" color="success"></ion-progress-bar>
+                <ion-progress-bar value="0.5" color="light"></ion-progress-bar>
+                <ion-progress-bar value="0.5" color="medium"></ion-progress-bar>
+                <ion-progress-bar value="0.2" buffer="0.3" color="dark"></ion-progress-bar>
               </p>
             </section>
           </div>
@@ -921,22 +932,31 @@
       // create component to open
       const element = document.createElement('div');
       element.innerHTML = `
-      <ion-header>
+      <ion-header translucent="true">
         <ion-toolbar>
           <ion-title>Super Modal</ion-title>
         </ion-toolbar>
       </ion-header>
-      <ion-content>
-        <h1>Content of doom</h1>
-        <div>Here's some more content</div>
-        <ion-button class="dismiss">Dismiss Modal</ion-button>
+      <ion-content fullscreen="true">
+        <ion-header collapse="condense">
+          <ion-toolbar>
+            <ion-title size="large">Super Modal</ion-title>
+          </ion-toolbar>
+        </ion-header>
+        <div class="ion-padding">
+          <h1>Content of doom</h1>
+          <div>Here's some more content</div>
+          <ion-button class="dismiss">Dismiss Modal</ion-button>
+        </div>
       </ion-content>
       `;
 
 
       // present the modal
       const modalElement = Object.assign(document.createElement('ion-modal'), {
-        component: element
+        component: element,
+        swipeToClose: true,
+        presentingElement: document.querySelector('ion-tabs')
       });
 
       // listen for close event

--- a/packages/vue/src/proxies.ts
+++ b/packages/vue/src/proxies.ts
@@ -3,7 +3,7 @@
 /* auto-generated vue proxies */
 import { defineContainer } from './vue-component-lib/utils';
 
-import { JSX } from '@ionic/core';
+import type { JSX } from '@ionic/core';
 
 
 
@@ -42,10 +42,7 @@ export const IonButton = /*@__PURE__*/ defineContainer<JSX.IonButton>('ion-butto
   'type',
   'ionFocus',
   'ionBlur'
-],
-{
-  "routerLinkComponent": true
-});
+]);
 
 
 export const IonButtons = /*@__PURE__*/ defineContainer<JSX.IonButtons>('ion-buttons', [
@@ -64,10 +61,7 @@ export const IonCard = /*@__PURE__*/ defineContainer<JSX.IonCard>('ion-card', [
   'routerDirection',
   'routerAnimation',
   'target'
-],
-{
-  "routerLinkComponent": true
-});
+]);
 
 
 export const IonCardContent = /*@__PURE__*/ defineContainer<JSX.IonCardContent>('ion-card-content');
@@ -103,7 +97,8 @@ export const IonCheckbox = /*@__PURE__*/ defineContainer<JSX.IonCheckbox>('ion-c
 ],
 {
   "modelProp": "checked",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -186,7 +181,8 @@ export const IonDatetime = /*@__PURE__*/ defineContainer<JSX.IonDatetime>('ion-d
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -195,10 +191,7 @@ export const IonFab = /*@__PURE__*/ defineContainer<JSX.IonFab>('ion-fab', [
   'vertical',
   'edge',
   'activated'
-],
-{
-  "routerLinkComponent": true
-});
+]);
 
 
 export const IonFabButton = /*@__PURE__*/ defineContainer<JSX.IonFabButton>('ion-fab-button', [
@@ -218,10 +211,7 @@ export const IonFabButton = /*@__PURE__*/ defineContainer<JSX.IonFabButton>('ion
   'closeIcon',
   'ionFocus',
   'ionBlur'
-],
-{
-  "routerLinkComponent": true
-});
+]);
 
 
 export const IonFabList = /*@__PURE__*/ defineContainer<JSX.IonFabList>('ion-fab-list', [
@@ -306,7 +296,8 @@ export const IonInput = /*@__PURE__*/ defineContainer<JSX.IonInput>('ion-input',
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -324,10 +315,7 @@ export const IonItem = /*@__PURE__*/ defineContainer<JSX.IonItem>('ion-item', [
   'routerDirection',
   'target',
   'type'
-],
-{
-  "routerLinkComponent": true
-});
+]);
 
 
 export const IonItemDivider = /*@__PURE__*/ defineContainer<JSX.IonItemDivider>('ion-item-divider', [
@@ -460,7 +448,8 @@ export const IonRadio = /*@__PURE__*/ defineContainer<JSX.IonRadio>('ion-radio',
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -472,7 +461,8 @@ export const IonRadioGroup = /*@__PURE__*/ defineContainer<JSX.IonRadioGroup>('i
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -496,7 +486,8 @@ export const IonRange = /*@__PURE__*/ defineContainer<JSX.IonRange>('ion-range',
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -566,7 +557,8 @@ export const IonSearchbar = /*@__PURE__*/ defineContainer<JSX.IonSearchbar>('ion
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -582,7 +574,8 @@ export const IonSegment = /*@__PURE__*/ defineContainer<JSX.IonSegment>('ion-seg
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -594,7 +587,8 @@ export const IonSegmentButton = /*@__PURE__*/ defineContainer<JSX.IonSegmentButt
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -618,7 +612,8 @@ export const IonSelect = /*@__PURE__*/ defineContainer<JSX.IonSelect>('ion-selec
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -710,7 +705,8 @@ export const IonTextarea = /*@__PURE__*/ defineContainer<JSX.IonTextarea>('ion-t
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -737,7 +733,8 @@ export const IonToggle = /*@__PURE__*/ defineContainer<JSX.IonToggle>('ion-toggl
 ],
 {
   "modelProp": "checked",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 

--- a/packages/vue/src/vue-component-lib/utils.ts
+++ b/packages/vue/src/vue-component-lib/utils.ts
@@ -1,4 +1,4 @@
-import { VNode, defineComponent, h, inject, ref, Ref } from 'vue';
+import { VNode, defineComponent, getCurrentInstance, h, inject, ref, Ref } from 'vue';
 
 export interface InputProps extends Object {
   modelValue: string | boolean;
@@ -17,7 +17,7 @@ interface NavManager<T = any> {
 interface ComponentOptions {
   modelProp?: string;
   modelUpdateEvent?: string;
-  routerLinkComponent?: boolean;
+  externalModelUpdateEvent?: string;
 }
 
 const getComponentClasses = (classes: unknown) => {
@@ -41,7 +41,7 @@ const getElementClasses = (ref: Ref<HTMLElement | undefined>, componentClasses: 
 * integrations.
 */
 export const defineContainer = <Props>(name: string, componentProps: string[] = [], componentOptions: ComponentOptions = {}) => {
-  const { modelProp, modelUpdateEvent, routerLinkComponent } = componentOptions;
+  const { modelProp, modelUpdateEvent, externalModelUpdateEvent } = componentOptions;
 
   /**
   * Create a Vue component wrapper around a Web Component.
@@ -49,29 +49,46 @@ export const defineContainer = <Props>(name: string, componentProps: string[] = 
   * They refer to whatever properties are set on an instance of a component.
   */
   const Container = defineComponent<Props & InputProps>((props, { attrs, slots, emit }) => {
+    let modelPropValue = (props as any)[modelProp];
     const containerRef = ref<HTMLElement>();
     const classes = new Set(getComponentClasses(attrs.class));
     const onVnodeBeforeMount = (vnode: VNode) => {
       // Add a listener to tell Vue to update the v-model
       if (vnode.el) {
         vnode.el.addEventListener(modelUpdateEvent.toLowerCase(), (e: Event) => {
-          emit(UPDATE_VALUE_EVENT, (e?.target as any)[modelProp]);
+          modelPropValue = (e?.target as any)[modelProp];
+          emit(UPDATE_VALUE_EVENT, modelPropValue);
+
+          /**
+           * We need to emit the change event here
+           * rather than on the web component to ensure
+           * that any v-model bindings have been updated.
+           * Otherwise, the developer will listen on the
+           * native web component, but the v-model will
+           * not have been updated yet.
+           */
+          emit(externalModelUpdateEvent, e);
         });
       }
     };
 
-    let handleClick: (ev: Event) => void;
-    if (routerLinkComponent) {
-      const navManager: NavManager = inject(NAV_MANAGER);
-      handleClick = (ev: Event) => {
-        const routerProps = Object.keys(props).filter(p => p.startsWith(ROUTER_PROP_REFIX));
-        if (routerProps.length === 0) return;
+    const currentInstance = getCurrentInstance();
+    const hasRouter = currentInstance?.appContext?.provides[NAV_MANAGER];
+    const navManager: NavManager | undefined = hasRouter ? inject(NAV_MANAGER) : undefined;
+    const handleRouterLink = (ev: Event) => {
+      const { routerLink } = props as any;
+      if (!routerLink) return;
 
+      const routerProps = Object.keys(props).filter(p => p.startsWith(ROUTER_PROP_REFIX));
+
+      if (navManager !== undefined) {
         let navigationPayload: any = { event: ev };
         routerProps.forEach(prop => {
           navigationPayload[prop] = (props as any)[prop];
         });
         navManager.navigate(navigationPayload);
+      } else {
+        console.warn('Tried to navigate, but no router was found. Make sure you have mounted Vue Router.');
       }
     }
 
@@ -80,28 +97,28 @@ export const defineContainer = <Props>(name: string, componentProps: string[] = 
         classes.add(value);
       });
 
+      const oldClick = (props as any).onClick;
+      const handleClick = (ev: Event) => {
+        if (oldClick !== undefined) {
+          oldClick(ev);
+        }
+        if (!ev.defaultPrevented) {
+          handleRouterLink(ev);
+        }
+      }
+
       let propsToAdd = {
         ...props,
         ref: containerRef,
         class: getElementClasses(containerRef, classes),
-        onClick: (routerLinkComponent) ? handleClick : (props as any).onClick,
-        onVnodeBeforeMount: (modelUpdateEvent) ? onVnodeBeforeMount : undefined
+        onClick: handleClick,
+        onVnodeBeforeMount: (modelUpdateEvent && externalModelUpdateEvent) ? onVnodeBeforeMount : undefined
       };
-
-      if ((props as any).onClick) {
-        const oldClick = (props as any).onClick;
-        propsToAdd.onClick = (ev: Event) => {
-            oldClick(ev);
-            if (!ev.defaultPrevented) {
-                handleClick(ev);
-            }
-        };
-      }
 
       if (modelProp) {
         propsToAdd = {
           ...propsToAdd,
-          [modelProp]: props.hasOwnProperty('modelValue') ? props.modelValue : (props as any)[modelProp]
+          [modelProp]: props.hasOwnProperty('modelValue') ? props.modelValue : modelPropValue
         }
       }
 
@@ -110,13 +127,10 @@ export const defineContainer = <Props>(name: string, componentProps: string[] = 
   });
 
   Container.displayName = name;
-  Container.props = componentProps;
+  Container.props = [...componentProps, ROUTER_LINK_VALUE];
   if (modelProp) {
     Container.props.push(MODEL_VALUE);
-    Container.emits = [UPDATE_VALUE_EVENT];
-  }
-  if (routerLinkComponent) {
-    Container.props.push(ROUTER_LINK_VALUE);
+    Container.emits = [UPDATE_VALUE_EVENT, externalModelUpdateEvent];
   }
 
   return Container;


### PR DESCRIPTION
# Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features) (no changes needed)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features) (no changes needed)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

Issue Number: resolves #20098 


## What is the new behavior?
The buffering animation is now cropped by a wrapper. It's now not under the the semi-transparent buffer progress bar anymore. No need for solid color. This was the problem. Please see the related issue. ... Never use fixed solid colors. Always use theme colors / variables.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other informations:

I also added a dark mode for the test page to validate the correct use of theme variables. But feel free to remove it ([cf131f3](https://github.com/ionic-team/ionic-framework/pull/22562/commits/cf131f3b67afb48901d615b6ae697d73e9641a7b)). But consider to implement a dark theme for the while tests and docs page in the future.

### Before

![current](https://user-images.githubusercontent.com/60390085/99792742-d445df80-2b27-11eb-80c4-a23a28004b5c.png)

See the solid white color. If we use the `--buffer-background` with alpha value we have the problem of the buffer circles would be seen through. See:

![demo-dark](https://user-images.githubusercontent.com/28209992/99861787-b7e18b80-2b97-11eb-8997-98c195aaefbe.gif)

![demo-light](https://user-images.githubusercontent.com/28209992/99862324-88cc1980-2b99-11eb-9aeb-c9603e293241.gif)


### After

This pull-request will fix it:
![fixed](https://user-images.githubusercontent.com/28209992/100153281-32662000-2ea4-11eb-9377-8ddb8f48da9f.gif)