### PR TITLE
docs(vue): fix skeleton-text usage example

### DIFF
--- a/core/src/components/skeleton-text/readme.md
+++ b/core/src/components/skeleton-text/readme.md
@@ -736,7 +736,7 @@ export class SkeletonTextExample {
   </div>
 
   <!-- Skeleton screen -->
-  <div *ngIf="!data">
+  <div v-if="!data">
     <div class="ion-padding custom-skeleton">
       <ion-skeleton-text animated style="width: 60%"></ion-skeleton-text>
       <ion-skeleton-text animated></ion-skeleton-text>
@@ -819,12 +819,12 @@ import {
   IonItem, 
   IonLabel, 
   IonList, 
-  IonListheader,
+  IonListHeader,
   IonSkeletonText,
   IonThumbnail
 } from '@ionic/vue';
 import { call } from 'ionicons/icons';
-import { defineComponent } from 'vue';
+import { defineComponent, ref } from 'vue';
 
 export default defineComponent({
   components: {
@@ -833,7 +833,7 @@ export default defineComponent({
     IonItem, 
     IonLabel, 
     IonList, 
-    IonListheader,
+    IonListHeader,
     IonSkeletonText,
     IonThumbnail
   },

--- a/core/src/components/skeleton-text/usage/vue.md
+++ b/core/src/components/skeleton-text/usage/vue.md
@@ -62,7 +62,7 @@
   </div>
 
   <!-- Skeleton screen -->
-  <div *ngIf="!data">
+  <div v-if="!data">
     <div class="ion-padding custom-skeleton">
       <ion-skeleton-text animated style="width: 60%"></ion-skeleton-text>
       <ion-skeleton-text animated></ion-skeleton-text>
@@ -145,12 +145,12 @@ import {
   IonItem, 
   IonLabel, 
   IonList, 
-  IonListheader,
+  IonListHeader,
   IonSkeletonText,
   IonThumbnail
 } from '@ionic/vue';
 import { call } from 'ionicons/icons';
-import { defineComponent } from 'vue';
+import { defineComponent, ref } from 'vue';
 
 export default defineComponent({
   components: {
@@ -159,7 +159,7 @@ export default defineComponent({
     IonItem, 
     IonLabel, 
     IonList, 
-    IonListheader,
+    IonListHeader,
     IonSkeletonText,
     IonThumbnail
   },


### PR DESCRIPTION
Fix skeleton-text component vue usage example

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The skeleton-text usage example is broken.

Issue Number: N/A


## What is the new behavior?
The skeleton-text vue use example now works correctly.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information