### PR TITLE
feat(slides): add container slot

### DIFF
--- a/core/src/components/slides/readme.md
+++ b/core/src/components/slides/readme.md
@@ -429,15 +429,16 @@ const slideOpts = {
 };
 ```
 
-## Container slot
-Swiper allows to add non slide children, which can be used to add additional functionality (e.g. pagination) - to add that kind of child element use named slot "container".
+## Container slots
+Swiper allows to add non slide children, which can be used to add additional functionality (e.g. pagination) - to add that kind of child element use named slot "top" or "bottom".
 ```html
 <ion-slides>
+  <div slot="top">...</div>
   <ion-slide>a</ion-slide>
   <ion-slide>b</ion-slide>
   <ion-slide>c</ion-slide>
   <ion-slide>d</ion-slide>
-  <div slot="container">...</div>
+  <div slot="bottom">...</div>
 </ion-slides>
 ```
 

--- a/core/src/components/slides/readme.md
+++ b/core/src/components/slides/readme.md
@@ -429,6 +429,18 @@ const slideOpts = {
 };
 ```
 
+## Container slot
+Swiper allows to add non slide children, which can be used to add additional functionality (e.g. pagination) - to add that kind of child element use named slot "container".
+```html
+<ion-slides>
+  <ion-slide>a</ion-slide>
+  <ion-slide>b</ion-slide>
+  <ion-slide>c</ion-slide>
+  <ion-slide>d</ion-slide>
+  <div slot="container">...</div>
+</ion-slides>
+```
+
 <!-- Auto Generated Below -->
 
 

--- a/core/src/components/slides/slides.tsx
+++ b/core/src/components/slides/slides.tsx
@@ -521,6 +521,9 @@ export class Slides implements ComponentInterface {
         <div class="swiper-wrapper">
           <slot></slot>
         </div>
+        
+        <slot name="container"></slot>
+        
         {this.pager && <div class="swiper-pagination" ref={el => this.paginationEl = el}></div>}
         {this.scrollbar && <div class="swiper-scrollbar" ref={el => this.scrollbarEl = el}></div>}
       </Host>

--- a/core/src/components/slides/slides.tsx
+++ b/core/src/components/slides/slides.tsx
@@ -6,6 +6,10 @@ import { SwiperInterface, SwiperOptions } from './swiper/swiper-interface';
 
 /**
  * @virtualProp {"ios" | "md"} mode - The mode determines which platform styles to use.
+ *
+ * @slot - Default slot for adding children of .swiper-wrapper, so all ion-slide should use this slot.
+ * @slot top - Content is placed within .swiper-container, before .swiper-wrapper.
+ * @slot bottom - Content is placed within .swiper-container, after .swiper-wrapper.
  */
 @Component({
   tag: 'ion-slides',

--- a/core/src/components/slides/slides.tsx
+++ b/core/src/components/slides/slides.tsx
@@ -518,11 +518,13 @@ export class Slides implements ComponentInterface {
           'swiper-container': true
         }}
       >
+        <slot name="top"></slot>
+        
         <div class="swiper-wrapper">
           <slot></slot>
         </div>
         
-        <slot name="container"></slot>
+        <slot name="bottom"></slot>
         
         {this.pager && <div class="swiper-pagination" ref={el => this.paginationEl = el}></div>}
         {this.scrollbar && <div class="swiper-scrollbar" ref={el => this.scrollbarEl = el}></div>}

--- a/core/src/components/slides/test/basic/index.html
+++ b/core/src/components/slides/test/basic/index.html
@@ -23,6 +23,7 @@
 
     <ion-content id="content">
       <ion-slides style="background: black" id="slides" pager>
+        <div slot="top">content before slides</div>
         <ion-slide style="background: rgb(0, 200, 0); color: white;">
           <h1>Slide 1</h1>
         </ion-slide>
@@ -32,7 +33,9 @@
         <ion-slide style="background: blue; color: white;">
           <h1>Slide 3</h1>
         </ion-slide>
+        <div slot="bottom">content after slides</div>
       </ion-slides>
+      
       <ion-button expand="block" onclick="addSlide()">Add slide</ion-button>
       <ion-button expand="block" onclick="removeSlide()">Remove slide</ion-button>
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
All child elements of ion-slides are placed within swiper-wrapper - that is correct for ion-slide, but it makes impossible to add elements like custom pagination or other swiper plugins, which should be placed directly within swiper-container.

Issue Number:
#19250
#15330

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
If elements other than ion-slide must be added to ion-slides, then it should be placed in "container" slot.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
