### PR TITLE
fix(angular): Remove Ionic Angular has initialized warning.

### DIFF
--- a/angular/src/app-initialize.ts
+++ b/angular/src/app-initialize.ts
@@ -10,10 +10,7 @@ let didInitialize = false;
 export const appInitialize = (config: Config, doc: Document, zone: NgZone) => {
   return (): any => {
     const win: IonicWindow | undefined = doc.defaultView as any;
-    if (win && typeof (window as any) !== 'undefined') {
-      if (didInitialize) {
-        console.warn('Ionic Angular was already initialized. Make sure IonicModule.forRoot() is just called once.');
-      }
+    if (!didInitialize && win && typeof (window as any) !== 'undefined') {
       didInitialize = true;
       const Ionic = win.Ionic = win.Ionic || {};
 


### PR DESCRIPTION
Remove the warning and initialize app only if it did not get initialized before. Fix #19926.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Show lots of warning message, `Ionic Angular was already initialized. Make sure IonicModule.forRoot() is just called once.`, when running `ng test`.

Issue Number: #19926


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Remove the unnecessary warning and initialize app only if it did not get initialized before.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
