### PR TITLE
fix(vue): adding non tab button elements inside ion-tab-bar no longer causes errors

### DIFF
--- a/packages/vue/src/components/IonTabBar.ts
+++ b/packages/vue/src/components/IonTabBar.ts
@@ -24,6 +24,7 @@ export const IonTabBar = defineComponent({
         tabs: {}
     };
     const currentInstance = getCurrentInstance();
+    const isTabButton = (child: any) => child.type?.name === 'IonTabButton';
     /**
      * For each tab, we need to keep track of its
      * base href as well as any child page that
@@ -33,7 +34,7 @@ export const IonTabBar = defineComponent({
      */
     const children = (currentInstance.subTree.children || []) as VNode[];
     children.forEach((child: VNode) => {
-      if (child.type && (child.type as any).name === 'IonTabButton') {
+      if (isTabButton(child)) {
         tabState.tabs[child.props.tab] = {
           originalHref: child.props.href,
           currentHref: child.props.href,
@@ -65,7 +66,7 @@ export const IonTabBar = defineComponent({
        * it in the tabs state.
        */
       childNodes.forEach((child: VNode) => {
-        if (child.type && (child.type as any).name === 'IonTabButton') {
+        if (isTabButton(child)) {
           const tab = tabs[child.props.tab];
           if (!tab || (tab.originalHref !== child.props.href)) {
 
@@ -106,7 +107,7 @@ export const IonTabBar = defineComponent({
         }
       }
 
-      const activeChild = childNodes.find((child: VNode) => child.props.tab === activeTab);
+      const activeChild = childNodes.find((child: VNode) => isTabButton(child) && child.props?.tab === activeTab);
       const tabBar = this.$refs.ionTabBar;
       const tabDidChange = activeTab !== prevActiveTab;
       if (activeChild && tabBar) {

--- a/packages/vue/test-app/tests/unit/tab-bar.spec.ts
+++ b/packages/vue/test-app/tests/unit/tab-bar.spec.ts
@@ -102,4 +102,38 @@ describe('ion-tab-bar', () => {
     const innerHTML = wrapper.find('ion-tabs').html();
     expect(innerHTML).toContain(`<div class="tabs-inner" style="position: relative; flex: 1; contain: layout size style;"><ion-router-outlet tabs="true"></ion-router-outlet></div><ion-tab-bar></ion-tab-bar></ion-tabs>`)
   });
+
+  // Verifies the fix for https://github.com/ionic-team/ionic-framework/issues/22642
+  it('should not fail on non tab button elements', async () => {
+    const Tabs = {
+      components: { IonPage, IonTabs, IonTabBar },
+      template: `
+        <ion-page>
+          <ion-tabs>
+            <ion-tab-bar>
+              <!-- my comment -->
+            </ion-tab-bar>
+          </ion-tabs>
+        </ion-page>
+      `,
+    }
+
+    const router = createRouter({
+      history: createWebHistory(process.env.BASE_URL),
+      routes: [
+        { path: '/', component: Tabs }
+      ]
+    });
+
+    router.push('/');
+    await router.isReady();
+    const wrapper = mount(App, {
+      global: {
+        plugins: [router, IonicVue]
+      }
+    });
+
+    const innerHTML = wrapper.find('ion-tabs').html();
+    expect(innerHTML).toContain(`><ion-tab-bar><!-- my comment --></ion-tab-bar>`)
+  })
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/22642


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a check to make sure we are looking at a tab button and that the element has a tab prop

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
