### PR TITLE
breaking(config): remove experimentalTransitionShadow config option

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -4,9 +4,23 @@ This is a comprehensive list of the breaking changes introduced in the major ver
 
 ## Versions
 
+- [Version 6.x](#version-6x)
 - [Version 5.x](#version-5x)
 - [Version 4.x](#version-4x)
 - [Legacy](#legacy)
+
+
+## Version 6.x
+
+- [Config](#config)
+  * [Transition Shadow](#transition-shadow)
+
+
+### Config
+
+#### Transition Shadow
+
+The `experimentalTransitionShadow` config option has been removed. The transition shadow is now enabled when running in `ios` mode.
 
 
 ## Version 5.x

--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -1,6 +1,5 @@
 import { Component, ComponentInterface, Element, Event, EventEmitter, Host, Listen, Method, Prop, forceUpdate, h, readTask } from '@stencil/core';
 
-import { config } from '../../global/config';
 import { getIonMode } from '../../global/ionic-global';
 import { Color, ScrollBaseDetail, ScrollDetail } from '../../interface';
 import { isPlatform } from '../../utils/platform';
@@ -307,7 +306,7 @@ export class Content implements ComponentInterface {
     const { scrollX, scrollY } = this;
     const mode = getIonMode(this);
     const forceOverscroll = this.shouldForceOverscroll();
-    const transitionShadow = (mode === 'ios' && config.getBoolean('experimentalTransitionShadow', true));
+    const transitionShadow = mode === 'ios';
 
     this.resize();
 

--- a/core/src/utils/config.ts
+++ b/core/src/utils/config.ts
@@ -171,11 +171,6 @@ export interface IonicConfig {
   pickerLeave?: AnimationBuilder;
 
   /**
-   * EXPERIMENTAL: Adds a page shadow to transitioning pages on iOS. Disabled by default.
-   */
-  experimentalTransitionShadow?: boolean;
-
-  /**
    * If `true`, Ionic will enable a basic DOM sanitizer on component properties that accept custom HTML.
    */
   sanitizerEnabled?: boolean;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The transition shadow has not been considered experimental since v5, but we forgot to remove the config option.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The `experimentalTransitionShadow` config option has been removed, and the transition shadow is always visible on `ios` mode.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
