### PR TITLE
fix(refresher): correctly detect spinner when using native refresher

### DIFF
--- a/core/src/components/refresher/refresher.utils.ts
+++ b/core/src/components/refresher/refresher.utils.ts
@@ -172,8 +172,8 @@ export const shouldUseNativeRefresher = async (referenceEl: HTMLIonRefresherElem
 
   await refresherContent.componentOnReady();
 
-  const pullingSpinner = refresherContent.querySelector('.refresher-pulling ion-spinner');
-  const refreshingSpinner = refresherContent.querySelector('.refresher-refreshing ion-spinner');
+  const pullingSpinner = referenceEl.querySelector('ion-refresher-content .refresher-pulling ion-spinner');
+  const refreshingSpinner = referenceEl.querySelector('ion-refresher-content .refresher-refreshing ion-spinner');
 
   return (
     pullingSpinner !== null &&

--- a/core/src/components/refresher/test/basic/index.html
+++ b/core/src/components/refresher/test/basic/index.html
@@ -21,7 +21,11 @@
 
     <ion-content>
       <ion-refresher id="refresher" slot="fixed">
-        <ion-refresher-content pulling-text="Pull to refresh..." refreshing-text="Refreshing...">
+        <ion-refresher-content
+          pulling-icon="arrow-down-outline"
+          pulling-text="Pull to refresh..."
+          refreshing-text="Refreshing..."
+          refreshing-spinner="circles">
         </ion-refresher-content>
       </ion-refresher>
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/22706


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Revert to old query. Though not really sure why doing `ion-refresher-content .pulling-icon ion-spinner` works but doing `refresherContentRef.querySelector('.pulling-icon ion-spinner')` does not.
- Also both refresher tests were using the native refresher which is why we did not catch this. Reverted the basic test to using the old refresher.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
