### PR TITLE
fix(react): add improved method for not unmounting component until overlay is dismissed

### DIFF
--- a/packages/react/src/components/createOverlayComponent.tsx
+++ b/packages/react/src/components/createOverlayComponent.tsx
@@ -35,6 +35,8 @@ export const createOverlayComponent = <
       forwardedRef?: React.RefObject<OverlayType>;
     };
 
+  let isDismissing = false;
+
   class Overlay extends React.Component<Props> {
     overlay?: OverlayType;
     el!: HTMLDivElement;
@@ -72,6 +74,15 @@ export const createOverlayComponent = <
       }
     }
 
+    shouldComponentUpdate(nextProps: Props) {
+      // Check if the overlay component is about to dismiss
+      if (this.overlay && nextProps.isOpen !== this.props.isOpen && nextProps.isOpen === false) {
+        isDismissing = true;
+      }
+
+      return true;
+    }
+
     async componentDidUpdate(prevProps: Props) {
       if (this.overlay) {
         attachProps(this.overlay, this.props, prevProps);
@@ -82,6 +93,7 @@ export const createOverlayComponent = <
       }
       if (this.overlay && prevProps.isOpen !== this.props.isOpen && this.props.isOpen === false) {
         await this.overlay.dismiss();
+        isDismissing = false;
       }
     }
 
@@ -123,7 +135,12 @@ export const createOverlayComponent = <
     }
 
     render() {
-      return ReactDOM.createPortal(this.props.children, this.el);
+      /**
+       * Continue to render the component even when
+       * overlay is dismissing otherwise component
+       * will be hidden before animation is done.
+       */
+      return ReactDOM.createPortal(this.props.isOpen || isDismissing ? this.props.children : null, this.el);
     }
   }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves a regression in https://github.com/ionic-team/ionic-framework/commit/14e8441706c230da4669afaaf0028aaeaf4dbe0e by adding a better fix for https://github.com/ionic-team/ionic-framework/issues/22761


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Overlay now only unmounts component if overlay is not open or if overlay is in process of dismissing.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
