### PR TITLE
fix(refresher): end pointer event if pulling farther than pullMax

### DIFF
--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -612,8 +612,9 @@ export class Refresher implements ComponentInterface {
     }
 
     if (deltaY > this.pullMax) {
-      // they pulled farther than the max, so kick off the refresh
-      this.beginRefresh();
+      // they pulled farther than the max, so end the related gesture, which will kick off the refresh
+      this.state = RefresherState.Ready;
+      this.gesture?.end();
       return;
     }
 

--- a/core/src/utils/gesture/index.ts
+++ b/core/src/utils/gesture/index.ts
@@ -231,6 +231,9 @@ export const createGesture = (config: GestureConfig): Gesture => {
     destroy() {
       gesture.destroy();
       pointerEvents.destroy();
+    },
+    end() {
+      pointerUp(undefined);
     }
   };
 };
@@ -305,6 +308,7 @@ export type GestureCallback = (detail: GestureDetail) => boolean | void;
 export interface Gesture {
   enable(enable?: boolean): void;
   destroy(): void;
+  end(): void;
 }
 
 export interface GestureConfig {


### PR DESCRIPTION
closes #22819

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #22819 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Refresher doesn't call `beginRefresh` anymore if refresher is pulled farther than pullMax, instead state is set and gesture is finished manually. This results in the same refreshing behavior as pulling between pullMin and pullMax and additionally ends the gesture correctly.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
