### PR TITLE
fix(): scroll assist no longer prevents first click event from firing

### DIFF
--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -1,4 +1,4 @@
-import { pointerCoord } from '../../helpers';
+import { pointerCoord, raf } from '../../helpers';
 
 import { isFocused, relocateInput } from './common';
 import { getScrollData } from './scroll-data';
@@ -26,7 +26,6 @@ export const enableScrollAssist = (
     // focus this input if the pointer hasn't moved XX pixels
     // and the input doesn't already have focus
     if (!hasPointerMoved(6, coord, endCoord) && !isFocused(inputEl)) {
-      ev.preventDefault();
       ev.stopPropagation();
 
       // begin the input focus process
@@ -88,6 +87,13 @@ const jsSetFocus = async (
 
       // ensure this is the focused input
       inputEl.focus();
+
+      /**
+       * Relocating/Focusing input causes the
+       * click event to be cancelled, so
+       * manually fire one here.
+       */
+      raf(() => componentEl.click());
     };
 
     const doubleKeyboardEventListener = () => {

--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -64,6 +64,13 @@ const jsSetFocus = async (
   relocateInput(componentEl, inputEl, true, scrollData.inputSafeY);
   inputEl.focus();
 
+  /**
+   * Relocating/Focusing input causes the
+   * click event to be cancelled, so
+   * manually fire one here.
+   */
+  raf(() => componentEl.click());
+
   /* tslint:disable-next-line */
   if (typeof window !== 'undefined') {
     let scrollContentTimeout: any;
@@ -87,13 +94,6 @@ const jsSetFocus = async (
 
       // ensure this is the focused input
       inputEl.focus();
-
-      /**
-       * Relocating/Focusing input causes the
-       * click event to be cancelled, so
-       * manually fire one here.
-       */
-      raf(() => componentEl.click());
     };
 
     const doubleKeyboardEventListener = () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #21871


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Moving the input/focusing during touchstart seems to cancel the first click event, so we need to manually fire it ourselves. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
