### PR TITLE
refactor(ios): update toolbar and tabbar default background colors

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -12,6 +12,9 @@ This is a comprehensive list of the breaking changes introduced in the major ver
 
 ## Version 6.x
 
+- [Components](#components)
+  * [Tab Bar](#tab-bar)
+  * [Toolbar](#toolbar)
 - [Config](#config)
   * [Transition Shadow](#transition-shadow)
 
@@ -21,6 +24,25 @@ This is a comprehensive list of the breaking changes introduced in the major ver
 #### Transition Shadow
 
 The `experimentalTransitionShadow` config option has been removed. The transition shadow is now enabled when running in `ios` mode.
+
+
+### Components
+
+#### Tab Bar
+
+The default iOS tab bar background color has been updated to better reflect the latest iOS styles. The new default value is:
+
+```css
+var(--ion-tab-bar-background, var(--ion-color-step-50, #f6f6f6));
+```
+
+#### Toolbar
+
+The default iOS toolbar background color has been updated to better reflect the latest iOS styles. The new default value is:
+
+```css
+var(--ion-toolbar-background, var(--ion-color-step-50, #f6f6f6));
+```
 
 
 ## Version 5.x

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -41,7 +41,7 @@ ion-header.header-collapse-condense ion-toolbar:last-of-type {
 The default iOS tab bar background color has been updated to better reflect the latest iOS styles. The new default value is:
 
 ```css
-var(--ion-tab-bar-background, var(--ion-color-step-50, #f6f6f6));
+var(--ion-tab-bar-background, var(--ion-color-step-50, #f7f7f7));
 ```
 
 #### Toast
@@ -53,7 +53,7 @@ The `--white-space` CSS variable now defaults to `normal` instead of `pre-wrap`.
 The default iOS toolbar background color has been updated to better reflect the latest iOS styles. The new default value is:
 
 ```css
-var(--ion-toolbar-background, var(--ion-color-step-50, #f6f6f6));
+var(--ion-toolbar-background, var(--ion-color-step-50, #f7f7f7));
 ```
 
 

--- a/core/src/themes/ionic.theme.default.ios.scss
+++ b/core/src/themes/ionic.theme.default.ios.scss
@@ -13,7 +13,7 @@ $overlay-ios-background-color:              var(--ion-overlay-background-color, 
 
 // iOS Tabs & Tab bar
 // --------------------------------------------------
-$tabbar-ios-background:                     var(--ion-tab-bar-background, $background-color) !default;
+$tabbar-ios-background:                     var(--ion-tab-bar-background, var(--ion-color-step-50, #f6f6f6)) !default;
 $tabbar-ios-background-focused:             var(--ion-tab-bar-background-focused, get-color-shade(#fff)) !default;
 $tabbar-ios-border-color:                   var(--ion-tab-bar-border-color, var(--ion-border-color, var(--ion-color-step-150, rgba(0, 0, 0, .2)))) !default;
 $tabbar-ios-color:                          var(--ion-tab-bar-color, $text-color-step-600) !default;
@@ -21,7 +21,7 @@ $tabbar-ios-color-selected:                 var(--ion-tab-bar-color-selected, io
 
 // iOS Toolbar
 // --------------------------------------------------
-$toolbar-ios-background:                    var(--ion-toolbar-background, var(--ion-color-step-50, #fff)) !default;
+$toolbar-ios-background:                    var(--ion-toolbar-background, var(--ion-color-step-50, #f6f6f6)) !default;
 $toolbar-ios-border-color:                  var(--ion-toolbar-border-color, var(--ion-border-color, var(--ion-color-step-150, rgba(0, 0, 0, .2)))) !default;
 $toolbar-ios-color:                         var(--ion-toolbar-color, $text-color) !default;
 

--- a/core/src/themes/ionic.theme.default.ios.scss
+++ b/core/src/themes/ionic.theme.default.ios.scss
@@ -13,7 +13,7 @@ $overlay-ios-background-color:              var(--ion-overlay-background-color, 
 
 // iOS Tabs & Tab bar
 // --------------------------------------------------
-$tabbar-ios-background:                     var(--ion-tab-bar-background, var(--ion-color-step-50, #f6f6f6)) !default;
+$tabbar-ios-background:                     var(--ion-tab-bar-background, var(--ion-color-step-50, #f7f7f7)) !default;
 $tabbar-ios-background-focused:             var(--ion-tab-bar-background-focused, get-color-shade(#fff)) !default;
 $tabbar-ios-border-color:                   var(--ion-tab-bar-border-color, var(--ion-border-color, var(--ion-color-step-150, rgba(0, 0, 0, .2)))) !default;
 $tabbar-ios-color:                          var(--ion-tab-bar-color, $text-color-step-600) !default;
@@ -21,7 +21,7 @@ $tabbar-ios-color-selected:                 var(--ion-tab-bar-color-selected, io
 
 // iOS Toolbar
 // --------------------------------------------------
-$toolbar-ios-background:                    var(--ion-toolbar-background, var(--ion-color-step-50, #f6f6f6)) !default;
+$toolbar-ios-background:                    var(--ion-toolbar-background, var(--ion-color-step-50, #f7f7f7)) !default;
 $toolbar-ios-border-color:                  var(--ion-toolbar-border-color, var(--ion-border-color, var(--ion-color-step-150, rgba(0, 0, 0, .2)))) !default;
 $toolbar-ios-color:                         var(--ion-toolbar-color, $text-color) !default;
 


### PR DESCRIPTION
Starters: https://github.com/ionic-team/starters/pull/1670
Docs: https://github.com/ionic-team/ionic-docs/pull/1835

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/22780


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updated toolbar and tab bar default background colors (fallback values)

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
