### PR TITLE
refactor(toast): whitespace variable now defaults to normal

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -12,8 +12,18 @@ This is a comprehensive list of the breaking changes introduced in the major ver
 
 ## Version 6.x
 
+- [Components](#components)
+  * [Toast](#toast)
 - [Config](#config)
   * [Transition Shadow](#transition-shadow)
+
+
+
+### Components
+
+#### Toast
+
+The `--white-space` CSS variable now defaults to `normal` instead of `pre-wrap`.
 
 
 ### Config

--- a/core/src/components/toast/toast.scss
+++ b/core/src/components/toast/toast.scss
@@ -39,7 +39,7 @@
   --min-height: auto;
   --height: auto;
   --max-height: auto;
-  --white-space: pre-wrap;
+  --white-space: normal;
 
   @include position(0, null, null, 0);
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/21486


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `--white-space: normal` is the new default on `ion-toast`.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
