### PR TITLE
fix(vue): ionChange events now propagate correctly

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -16393,8 +16393,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.3.0.tgz",
       "integrity": "sha512-uiBe+o7M+NU0gMRgJfrlepxLPBXK0lX4TL2jIPwhBfxYw++pbtg7BLRO2HxE69GR0nxw+7Uf3uJzOGbMsl+ZUQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@stylelint/postcss-css-in-js": {
       "version": "0.37.2",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -17,7 +17,7 @@
         "@rollup/plugin-virtual": "^2.0.3",
         "@stencil/core": "2.1.2",
         "@stencil/sass": "1.3.2",
-        "@stencil/vue-output-target": "0.2.5",
+        "@stencil/vue-output-target": "0.3.0",
         "@types/jest": "^26.0.10",
         "@types/node": "^14.6.0",
         "@types/puppeteer": "3.0.1",
@@ -1657,9 +1657,9 @@
       "dev": true
     },
     "node_modules/@stencil/vue-output-target": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.2.5.tgz",
-      "integrity": "sha512-EnCZbJDD7y2nTnaFXo4PJrEgP9CNvJARZQrnvz93rMDKCzm+19C9goU4D6A1ysblLVvZSTm3wELKSM1auRUm0Q==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.3.0.tgz",
+      "integrity": "sha512-uiBe+o7M+NU0gMRgJfrlepxLPBXK0lX4TL2jIPwhBfxYw++pbtg7BLRO2HxE69GR0nxw+7Uf3uJzOGbMsl+ZUQ==",
       "dev": true,
       "peerDependencies": {
         "@stencil/core": ">=1.8.0"
@@ -16390,10 +16390,11 @@
       "dev": true
     },
     "@stencil/vue-output-target": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.2.5.tgz",
-      "integrity": "sha512-EnCZbJDD7y2nTnaFXo4PJrEgP9CNvJARZQrnvz93rMDKCzm+19C9goU4D6A1ysblLVvZSTm3wELKSM1auRUm0Q==",
-      "dev": true
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.3.0.tgz",
+      "integrity": "sha512-uiBe+o7M+NU0gMRgJfrlepxLPBXK0lX4TL2jIPwhBfxYw++pbtg7BLRO2HxE69GR0nxw+7Uf3uJzOGbMsl+ZUQ==",
+      "dev": true,
+      "requires": {}
     },
     "@stylelint/postcss-css-in-js": {
       "version": "0.37.2",

--- a/core/package.json
+++ b/core/package.json
@@ -38,7 +38,7 @@
     "@rollup/plugin-virtual": "^2.0.3",
     "@stencil/core": "2.1.2",
     "@stencil/sass": "1.3.2",
-    "@stencil/vue-output-target": "0.2.5",
+    "@stencil/vue-output-target": "0.3.0",
     "@types/jest": "^26.0.10",
     "@types/node": "^14.6.0",
     "@types/puppeteer": "3.0.1",

--- a/core/stencil.config.ts
+++ b/core/stencil.config.ts
@@ -91,12 +91,14 @@ export const config: Config = {
         {
           elements: ['ion-checkbox', 'ion-toggle'],
           targetAttr: 'checked',
-          event: 'ionChange'
+          event: 'v-ionChange',
+          externalEvent: 'ionChange'
         },
         {
           elements: ['ion-datetime', 'ion-input', 'ion-radio-group', 'ion-radio', 'ion-range', 'ion-searchbar', 'ion-segment', 'ion-segment-button', 'ion-select', 'ion-textarea'],
           targetAttr: 'value',
-          event: 'ionChange'
+          event: 'v-ionChange',
+          externalEvent: 'ionChange'
         }
       ],
     }),

--- a/packages/vue/src/ionic-vue.ts
+++ b/packages/vue/src/ionic-vue.ts
@@ -2,8 +2,17 @@ import { App, Plugin } from 'vue';
 import { IonicConfig, setupConfig } from '@ionic/core';
 import { applyPolyfills, defineCustomElements } from '@ionic/core/loader';
 
-const ael = (el: any, eventName: string, cb: any, opts: any) => el.addEventListener(eventName.toLowerCase(), cb, opts);
-const rel = (el: any, eventName: string, cb: any, opts: any) => el.removeEventListener(eventName.toLowerCase(), cb, opts);
+/**
+ * We need to make sure that the web component fires an event
+ * that will not conflict with the user's @ionChange binding,
+ * otherwise the binding's callback will fire before any
+ * v-model values have been updated.
+ */
+const transformEventName = (eventName: string) => {
+  return eventName === 'ionChange' ? 'v-ionchange' : eventName.toLowerCase();
+}
+const ael = (el: any, eventName: string, cb: any, opts: any) => el.addEventListener(transformEventName(eventName), cb, opts);
+const rel = (el: any, eventName: string, cb: any, opts: any) => el.removeEventListener(transformEventName(eventName), cb, opts);
 
 export const IonicVue: Plugin = {
 
@@ -17,7 +26,7 @@ export const IonicVue: Plugin = {
       await applyPolyfills();
       await defineCustomElements(window, {
         exclude: ['ion-tabs'],
-        ce: (eventName: string, opts: any) => new CustomEvent(eventName.toLowerCase(), opts),
+        ce: (eventName: string, opts: any) => new CustomEvent(transformEventName(eventName), opts),
         ael,
         rel
       } as any);

--- a/packages/vue/src/proxies.ts
+++ b/packages/vue/src/proxies.ts
@@ -97,7 +97,8 @@ export const IonCheckbox = /*@__PURE__*/ defineContainer<JSX.IonCheckbox>('ion-c
 ],
 {
   "modelProp": "checked",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "v-ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -180,7 +181,8 @@ export const IonDatetime = /*@__PURE__*/ defineContainer<JSX.IonDatetime>('ion-d
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "v-ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -294,7 +296,8 @@ export const IonInput = /*@__PURE__*/ defineContainer<JSX.IonInput>('ion-input',
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "v-ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -445,7 +448,8 @@ export const IonRadio = /*@__PURE__*/ defineContainer<JSX.IonRadio>('ion-radio',
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "v-ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -457,7 +461,8 @@ export const IonRadioGroup = /*@__PURE__*/ defineContainer<JSX.IonRadioGroup>('i
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "v-ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -481,7 +486,8 @@ export const IonRange = /*@__PURE__*/ defineContainer<JSX.IonRange>('ion-range',
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "v-ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -551,7 +557,8 @@ export const IonSearchbar = /*@__PURE__*/ defineContainer<JSX.IonSearchbar>('ion
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "v-ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -567,7 +574,8 @@ export const IonSegment = /*@__PURE__*/ defineContainer<JSX.IonSegment>('ion-seg
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "v-ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -579,7 +587,8 @@ export const IonSegmentButton = /*@__PURE__*/ defineContainer<JSX.IonSegmentButt
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "v-ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -603,7 +612,8 @@ export const IonSelect = /*@__PURE__*/ defineContainer<JSX.IonSelect>('ion-selec
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "v-ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -695,7 +705,8 @@ export const IonTextarea = /*@__PURE__*/ defineContainer<JSX.IonTextarea>('ion-t
 ],
 {
   "modelProp": "value",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "v-ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 
@@ -722,7 +733,8 @@ export const IonToggle = /*@__PURE__*/ defineContainer<JSX.IonToggle>('ion-toggl
 ],
 {
   "modelProp": "checked",
-  "modelUpdateEvent": "ionChange"
+  "modelUpdateEvent": "v-ionChange",
+  "externalModelUpdateEvent": "ionChange"
 });
 
 

--- a/packages/vue/src/vue-component-lib/utils.ts
+++ b/packages/vue/src/vue-component-lib/utils.ts
@@ -17,6 +17,7 @@ interface NavManager<T = any> {
 interface ComponentOptions {
   modelProp?: string;
   modelUpdateEvent?: string;
+  externalModelUpdateEvent?: string;
 }
 
 const getComponentClasses = (classes: unknown) => {
@@ -40,7 +41,7 @@ const getElementClasses = (ref: Ref<HTMLElement | undefined>, componentClasses: 
 * integrations.
 */
 export const defineContainer = <Props>(name: string, componentProps: string[] = [], componentOptions: ComponentOptions = {}) => {
-  const { modelProp, modelUpdateEvent } = componentOptions;
+  const { modelProp, modelUpdateEvent, externalModelUpdateEvent } = componentOptions;
 
   /**
   * Create a Vue component wrapper around a Web Component.
@@ -66,8 +67,7 @@ export const defineContainer = <Props>(name: string, componentProps: string[] = 
            * native web component, but the v-model will
            * not have been updated yet.
            */
-          emit(modelUpdateEvent, e);
-          e.stopImmediatePropagation();
+          emit(externalModelUpdateEvent, e);
         });
       }
     };
@@ -112,7 +112,7 @@ export const defineContainer = <Props>(name: string, componentProps: string[] = 
         ref: containerRef,
         class: getElementClasses(containerRef, classes),
         onClick: handleClick,
-        onVnodeBeforeMount: (modelUpdateEvent) ? onVnodeBeforeMount : undefined
+        onVnodeBeforeMount: (modelUpdateEvent && externalModelUpdateEvent) ? onVnodeBeforeMount : undefined
       };
 
       if (modelProp) {
@@ -130,7 +130,7 @@ export const defineContainer = <Props>(name: string, componentProps: string[] = 
   Container.props = [...componentProps, ROUTER_LINK_VALUE];
   if (modelProp) {
     Container.props.push(MODEL_VALUE);
-    Container.emits = [UPDATE_VALUE_EVENT, modelUpdateEvent];
+    Container.emits = [UPDATE_VALUE_EVENT, externalModelUpdateEvent];
   }
 
   return Container;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves #22870

The problem here is that when you do `@ionChange="myFn()"`, Vue does an `addEventListener` for `ionchange`. Since the underlying Web Component fires `ionchange` too, `myFn()` is being called before an `v-model` sync has happened (I.e. before the Vue wrappers have had a chance to react). This causes `v-model` to not be the correct value at the time `myFn` is called.

I previously worked around this by re-emitting the event from the Vue wrappers and calling `stopImmediatePropagation`. This had the unintended side effect of breaking components like `ion-radio` and `ion-radio-group` that rely on the `ionChange` event emitted from other components.

This PR should resolve the first issue in a way that does not introduce the second issue. The Web Components now emit and listen for `v-ionchange`, but the Vue wrapper will emit `ionchange` to the developer's app. Since developers have `@ionChange`, their event handler will only fire once `v-model` has been updated.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added external event name via output targets

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
