### PR TITLE
fix(radio-group): pressing space no longer jumps screen to bottom of page

### DIFF
--- a/core/src/components/radio-group/radio-group.tsx
+++ b/core/src/components/radio-group/radio-group.tsx
@@ -145,6 +145,10 @@ export class RadioGroup implements ComponentInterface {
       // to radios in a select popover)
       if (['Space'].includes(ev.code)) {
         this.value = current.value;
+
+        // Prevent browsers from jumping
+        // to the bottom of the screen
+        ev.preventDefault();
       }
     }
   }

--- a/core/src/components/radio-group/radio-group.tsx
+++ b/core/src/components/radio-group/radio-group.tsx
@@ -148,7 +148,6 @@ export class RadioGroup implements ComponentInterface {
 
         // Prevent browsers from jumping
         // to the bottom of the screen
-        // pls run tests
         ev.preventDefault();
       }
     }

--- a/core/src/components/radio-group/radio-group.tsx
+++ b/core/src/components/radio-group/radio-group.tsx
@@ -148,6 +148,7 @@ export class RadioGroup implements ComponentInterface {
 
         // Prevent browsers from jumping
         // to the bottom of the screen
+        // pls run tests
         ev.preventDefault();
       }
     }


### PR DESCRIPTION
Tested on Chrome macOS, Safari macOS, and Chrome Windows

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/22716


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- prevent browser's default behavior when pressing space bar 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
