### PR TITLE
fix(vue): quickly swiping back no longer causes transition to get stuck

### DIFF
--- a/core/src/components/router-outlet/route-outlet.tsx
+++ b/core/src/components/router-outlet/route-outlet.tsx
@@ -20,7 +20,6 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
   private gesture?: Gesture;
   private ani?: Animation;
   private animationEnabled = true;
-  private isTransitioning = false;
 
   @Element() el!: HTMLElement;
 
@@ -64,7 +63,7 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
   async connectedCallback() {
     this.gesture = (await import('../../utils/gesture/swipe-back')).createSwipeBackGesture(
       this.el,
-      () => !this.isTransitioning && !!this.swipeHandler && this.swipeHandler.canStart() && this.animationEnabled,
+      () => !!this.swipeHandler && this.swipeHandler.canStart() && this.animationEnabled,
       () => this.swipeHandler && this.swipeHandler.onStart(),
       step => this.ani && this.ani.progressStep(step),
       (shouldComplete, step, dur) => {
@@ -185,8 +184,6 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
     const animated = this.animated && config.getBoolean('animated', true);
     const animationBuilder = this.animation || opts.animationBuilder || config.get('navAnimation');
 
-    this.isTransitioning = true;
-
     await transition({
       mode,
       animated,
@@ -200,8 +197,6 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
       ...opts,
       animationBuilder,
     });
-
-    this.isTransitioning = false;
 
     // emit nav changed event
     this.ionNavDidChange.emit();

--- a/core/src/components/router-outlet/route-outlet.tsx
+++ b/core/src/components/router-outlet/route-outlet.tsx
@@ -20,6 +20,7 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
   private gesture?: Gesture;
   private ani?: Animation;
   private animationEnabled = true;
+  private isTransitioning = false;
 
   @Element() el!: HTMLElement;
 
@@ -63,7 +64,7 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
   async connectedCallback() {
     this.gesture = (await import('../../utils/gesture/swipe-back')).createSwipeBackGesture(
       this.el,
-      () => !!this.swipeHandler && this.swipeHandler.canStart() && this.animationEnabled,
+      () => !this.isTransitioning && !!this.swipeHandler && this.swipeHandler.canStart() && this.animationEnabled,
       () => this.swipeHandler && this.swipeHandler.onStart(),
       step => this.ani && this.ani.progressStep(step),
       (shouldComplete, step, dur) => {
@@ -184,6 +185,8 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
     const animated = this.animated && config.getBoolean('animated', true);
     const animationBuilder = this.animation || opts.animationBuilder || config.get('navAnimation');
 
+    this.isTransitioning = true;
+
     await transition({
       mode,
       animated,
@@ -197,6 +200,8 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
       ...opts,
       animationBuilder,
     });
+
+    this.isTransitioning = false;
 
     // emit nav changed event
     this.ionNavDidChange.emit();

--- a/core/src/utils/transition/ios.transition.ts
+++ b/core/src/utils/transition/ios.transition.ts
@@ -243,11 +243,11 @@ export const iosTransitionAnimation = (navEl: HTMLElement, opts: TransitionOptio
          * when double tapping the ion-back-button.
          */
         enteringEl.style.setProperty('pointer-events', 'none');
-        leavingEl.style.setProperty('pointer-events', 'none');
+        leavingEl?.style.setProperty('pointer-events', 'none');
       })
       .afterAddWrite(() => {
         enteringEl.style.removeProperty('pointer-events');
-        leavingEl.style.removeProperty('pointer-events');
+        leavingEl?.style.removeProperty('pointer-events');
       });
 
     if (leavingEl && navEl) {

--- a/core/src/utils/transition/ios.transition.ts
+++ b/core/src/utils/transition/ios.transition.ts
@@ -233,7 +233,22 @@ export const iosTransitionAnimation = (navEl: HTMLElement, opts: TransitionOptio
       .duration(opts.duration || DURATION)
       .easing(opts.easing || EASING)
       .fill('both')
-      .beforeRemoveClass('ion-page-invisible');
+      .beforeRemoveClass('ion-page-invisible')
+      .beforeAddWrite(() => {
+        /**
+         * When transitioning, the page should not
+         * respond to click events. This resolves small
+         * issues like users trying to swipe to
+         * go back while the page is transitioning in and
+         * when double tapping the ion-back-button.
+         */
+        enteringEl.style.setProperty('pointer-events', 'none');
+        leavingEl.style.setProperty('pointer-events', 'none');
+      })
+      .afterAddWrite(() => {
+        enteringEl.style.removeProperty('pointer-events');
+        leavingEl.style.removeProperty('pointer-events');
+      });
 
     if (leavingEl && navEl) {
       const navDecorAnimation = createAnimation();

--- a/core/src/utils/transition/md.transition.ts
+++ b/core/src/utils/transition/md.transition.ts
@@ -17,7 +17,22 @@ export const mdTransitionAnimation = (_: HTMLElement, opts: TransitionOptions): 
   rootTransition
     .addElement(ionPageElement)
     .fill('both')
-    .beforeRemoveClass('ion-page-invisible');
+    .beforeRemoveClass('ion-page-invisible')
+    .beforeAddWrite(() => {
+      /**
+       * When transitioning, the page should not
+       * respond to click events. This resolves small
+       * issues like users trying to swipe to
+       * go back while the page is transitioning in and
+       * when double tapping the ion-back-button.
+       */
+      enteringEl.style.setProperty('pointer-events', 'none');
+      leavingEl.style.setProperty('pointer-events', 'none');
+    })
+    .afterAddWrite(() => {
+      enteringEl.style.removeProperty('pointer-events');
+      leavingEl.style.removeProperty('pointer-events');
+    });
 
   // animate the component itself
   if (backDirection) {

--- a/core/src/utils/transition/md.transition.ts
+++ b/core/src/utils/transition/md.transition.ts
@@ -27,11 +27,11 @@ export const mdTransitionAnimation = (_: HTMLElement, opts: TransitionOptions): 
        * when double tapping the ion-back-button.
        */
       enteringEl.style.setProperty('pointer-events', 'none');
-      leavingEl.style.setProperty('pointer-events', 'none');
+      leavingEl?.style.setProperty('pointer-events', 'none');
     })
     .afterAddWrite(() => {
       enteringEl.style.removeProperty('pointer-events');
-      leavingEl.style.removeProperty('pointer-events');
+      leavingEl?.style.removeProperty('pointer-events');
     });
 
   // animate the component itself


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/22895


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- If a transition is currently in progress, a new one can no longer be created. This fixes issues where users quickly tap the back button or swipe back while a page is transitioning in.
- 
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
