### PR TITLE
feat(datetime): add styles for placeholders

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -348,6 +348,9 @@ ion-datetime,css-prop,--padding-end
 ion-datetime,css-prop,--padding-start
 ion-datetime,css-prop,--padding-top
 ion-datetime,css-prop,--placeholder-color
+ion-datetime,css-prop,--placeholder-font-style
+ion-datetime,css-prop,--placeholder-font-weight
+ion-datetime,css-prop,--placeholder-opacity
 ion-datetime,part,placeholder
 ion-datetime,part,text
 

--- a/core/src/components/datetime/datetime.scss
+++ b/core/src/components/datetime/datetime.scss
@@ -11,6 +11,9 @@
    * @prop --padding-start: Left padding if direction is left-to-right, and right padding if direction is right-to-left of the datetime
    *
    * @prop --placeholder-color: Color of the datetime placeholder
+   * @prop --placeholder-font-style: Font style of the datetime placeholder
+   * @prop --placeholder-font-weight: Font weight of the datetime placeholder
+   * @prop --placeholder-opacity: Opacity of the datetime placeholder
    */
   @include padding(var(--padding-top), var(--padding-end), var(--padding-bottom), var(--padding-start));
 
@@ -36,6 +39,10 @@
 
 :host(.datetime-placeholder) {
   color: var(--placeholder-color);
+  font-style:var(--placeholder-font-style);
+  font-family: inherit;
+  font-weight: var(--placeholder-font-weight);
+  opacity: var(--placeholder-opacity);
 }
 
 :host(.datetime-disabled) {

--- a/core/src/components/datetime/readme.md
+++ b/core/src/components/datetime/readme.md
@@ -852,13 +852,16 @@ Type: `Promise<void>`
 
 ## CSS Custom Properties
 
-| Name                  | Description                                                                                                 |
-| --------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `--padding-bottom`    | Bottom padding of the datetime                                                                              |
-| `--padding-end`       | Right padding if direction is left-to-right, and left padding if direction is right-to-left of the datetime |
-| `--padding-start`     | Left padding if direction is left-to-right, and right padding if direction is right-to-left of the datetime |
-| `--padding-top`       | Top padding of the datetime                                                                                 |
-| `--placeholder-color` | Color of the datetime placeholder                                                                           |
+| Name                        | Description                                                                                                 |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `--padding-bottom`          | Bottom padding of the datetime                                                                              |
+| `--padding-end`             | Right padding if direction is left-to-right, and left padding if direction is right-to-left of the datetime |
+| `--padding-start`           | Left padding if direction is left-to-right, and right padding if direction is right-to-left of the datetime |
+| `--padding-top`             | Top padding of the datetime                                                                                 |
+| `--placeholder-color`       | Color of the datetime placeholder                                                                           |
+| `--placeholder-font-style`  | Font style of the datetime placeholder                                                                      |
+| `--placeholder-font-weight` | Font weight of the datetime placeholder                                                                     |
+| `--placeholder-opacity`     | Opacity of the datetime placeholder                                                                         |
 
 
 ----------------------------------------------


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Previously `ion-datetime` would only take `color` as a placeholder SCSS prop. 

## What is the new behavior?
This has been expanded to now include `opacity`, `font-weight`, and `font-style`.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No