### PR TITLE
feat(range): add support for custom pin text

### DIFF
--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -562,13 +562,14 @@ export declare interface IonRange extends Components.IonRange {
 @Component({ selector: "ion-range", changeDetection: ChangeDetectionStrategy.OnPush, template: "<ng-content></ng-content>", inputs: ["color", "debounce", "disabled", "dualKnobs", "max", "min", "mode", "name", "pin", "snaps", "step", "ticks", "value"] })
 export class IonRange {
   ionChange!: EventEmitter<CustomEvent>;
+  ionRawChange!: EventEmitter<CustomEvent>;
   ionFocus!: EventEmitter<CustomEvent>;
   ionBlur!: EventEmitter<CustomEvent>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ["ionChange", "ionFocus", "ionBlur"]);
+    proxyOutputs(this, this.el, ["ionChange", "ionRawChange", "ionFocus", "ionBlur"]);
   }
 }
 export declare interface IonRefresher extends Components.IonRefresher {

--- a/core/api.txt
+++ b/core/api.txt
@@ -883,6 +883,7 @@ ion-range,prop,value,number | { lower: number; upper: number; },0,false,false
 ion-range,event,ionBlur,void,true
 ion-range,event,ionChange,RangeChangeEventDetail,true
 ion-range,event,ionFocus,void,true
+ion-range,event,ionRawChange,RangeChangeEventDetail,true
 ion-range,css-prop,--bar-background
 ion-range,css-prop,--bar-background-active
 ion-range,css-prop,--bar-border-radius

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -5036,13 +5036,17 @@ declare namespace LocalJSX {
          */
         "onIonBlur"?: (event: CustomEvent<void>) => void;
         /**
-          * Emitted when the value property has changed.
+          * Emitted when the value property has changed. This event is debounced when the `debounce` property is set.
          */
         "onIonChange"?: (event: CustomEvent<RangeChangeEventDetail>) => void;
         /**
           * Emitted when the range has focus.
          */
         "onIonFocus"?: (event: CustomEvent<void>) => void;
+        /**
+          * Emitted when the value property has changed. This event is not debounced. It is typically used to set a custom pin label.
+         */
+        "onIonRawChange"?: (event: CustomEvent<RangeChangeEventDetail>) => void;
         /**
           * Emitted when the styles change.
          */

--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -10,6 +10,7 @@ import { createColorClasses, hostContext } from '../../utils/theme';
  *
  * @slot start - Content is placed to the left of the range slider in LTR, and to the right in RTL.
  * @slot end - Content is placed to the right of the range slider in LTR, and to the left in RTL.
+ * @slot pin - Content is used as the pin label. It defaults to `Math.round(value)`.
  *
  * @part tick - An inactive tick mark.
  * @part tick-active - An active tick mark.
@@ -140,6 +141,7 @@ export class Range implements ComponentInterface {
     value = this.ensureValueInBounds(value);
 
     this.ionChange.emit({ value });
+    this.ionRawChange.emit({ value });
   }
 
   private clampBounds = (value: any): number => {
@@ -159,8 +161,16 @@ export class Range implements ComponentInterface {
 
   /**
    * Emitted when the value property has changed.
+   * This event is debounced when the `debounce` property is set.
    */
   @Event() ionChange!: EventEmitter<RangeChangeEventDetail>;
+
+  /**
+   * Emitted when the value property has changed.
+   * This event is not debounced. It is typically used to set a custom pin
+   * label.
+   */
+  @Event() ionRawChange!: EventEmitter<RangeChangeEventDetail>;
 
   /**
    * Emitted when the styles change.
@@ -555,7 +565,7 @@ const renderKnob = (isRTL: boolean, { knob, value, ratio, min, max, disabled, pr
       aria-disabled={disabled ? 'true' : null}
       aria-valuenow={value}
     >
-      {pin && <div class="range-pin" role="presentation" part="pin">{Math.round(value)}</div>}
+      {pin && <div class="range-pin" role="presentation" part="pin"><slot name="pin">{Math.round(value)}</slot></div>}
       <div class="range-knob" role="presentation" part="knob" />
     </div>
   );

--- a/core/src/components/range/readme.md
+++ b/core/src/components/range/readme.md
@@ -288,11 +288,12 @@ export default defineComponent({
 
 ## Events
 
-| Event       | Description                                  | Type                                  |
-| ----------- | -------------------------------------------- | ------------------------------------- |
-| `ionBlur`   | Emitted when the range loses focus.          | `CustomEvent<void>`                   |
-| `ionChange` | Emitted when the value property has changed. | `CustomEvent<RangeChangeEventDetail>` |
-| `ionFocus`  | Emitted when the range has focus.            | `CustomEvent<void>`                   |
+| Event          | Description                                                                                                               | Type                                  |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `ionBlur`      | Emitted when the range loses focus.                                                                                       | `CustomEvent<void>`                   |
+| `ionChange`    | Emitted when the value property has changed. This event is debounced when the `debounce` property is set.                 | `CustomEvent<RangeChangeEventDetail>` |
+| `ionFocus`     | Emitted when the range has focus.                                                                                         | `CustomEvent<void>`                   |
+| `ionRawChange` | Emitted when the value property has changed. This event is not debounced. It is typically used to set a custom pin label. | `CustomEvent<RangeChangeEventDetail>` |
 
 
 ## Slots
@@ -300,6 +301,7 @@ export default defineComponent({
 | Slot      | Description                                                                        |
 | --------- | ---------------------------------------------------------------------------------- |
 | `"end"`   | Content is placed to the right of the range slider in LTR, and to the left in RTL. |
+| `"pin"`   | Content is used as the pin label. It defaults to `Math.round(value)`.              |
 | `"start"` | Content is placed to the left of the range slider in LTR, and to the right in RTL. |
 
 

--- a/core/src/components/range/test/basic/index.html
+++ b/core/src/components/range/test/basic/index.html
@@ -177,6 +177,18 @@
           <ion-range min="0" value="50" max="100" id="targetRange"></ion-range>
         </ion-item>
       </ion-list>
+
+      <ion-list>
+        <ion-list-header>
+          <ion-label>
+            Custom pin label
+          </ion-label>
+        </ion-list-header>
+        <ion-item>
+          <ion-range pin min="1" step="0.1" max="2" id="customLabel"><span slot="pin"></slot></ion-range>
+        </ion-item>
+      </ion-list>
+  
     </ion-content>
 
   </ion-app>
@@ -264,6 +276,12 @@
       lower: '-100',
       upper: '100'
     }
+
+    const customLabel = document.getElementById('customLabel');
+    const pinSlot = customLabel.querySelector('[slot=pin]');
+    customLabel.addEventListener('ionRawChange', function(ev) {
+      pinSlot.innerText = ev.detail.value.toFixed(1);
+    })    
   </script>
 </body>
 

--- a/packages/vue/src/proxies.ts
+++ b/packages/vue/src/proxies.ts
@@ -480,6 +480,7 @@ export const IonRange = /*@__PURE__*/ defineContainer<JSX.IonRange>('ion-range',
   'disabled',
   'value',
   'ionChange',
+  'ionRawChange',
   'ionStyle',
   'ionFocus',
   'ionBlur'


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #22864

The pin text is fixed and set to `Math.round(value)`

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a `"pin"` slot to customize the pin text, i.e. `<span slot=pin>{format(value)}</slot>`.
- Added a `ionRawChange` event on top of the existing `ionChange` event as you want the pin text to immediately update to the current value. 

My use case is to display 1 fractional digit as in the added example (i.e. "1.3").
It could also be useful to format currency ("$123") or percentage ("42%").

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

No:
- The pin slot defaults to the text before this CL (`Math.round(value)`),
- The `ionRawChange` is purely additional.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This could also be implemented in a simpler manner by using a `formatPin: (number) => string` property.

It would be a little simpler both to implement and to use. It might be a little less flexible but would probably be sufficient. Let me know if you want me to implement that instead.

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
