### PR TITLE
fix(progress-bar): use correct theme colors in dark mode

### DIFF
--- a/core/src/components/progress-bar/progress-bar.scss
+++ b/core/src/components/progress-bar/progress-bar.scss
@@ -54,8 +54,10 @@
 
 // Extend a bit to overflow. The size of animated distance.
 .buffer-circles {
+  /* stylelint-disable property-blacklist */
   left: -10px;
   right: -10px;
+  /* stylelint-enable property-blacklist */
 }
 
 // Determinate progress bar

--- a/core/src/components/progress-bar/progress-bar.scss
+++ b/core/src/components/progress-bar/progress-bar.scss
@@ -10,7 +10,7 @@
   * @prop --progress-background: Color of the progress bar
   * @prop --buffer-background: Color of the buffer bar
   */
-  --background: #{ion-color(primary, base, 0.2)};
+  --background: #{ion-color(primary, base, 0.3)};
   --progress-background: #{ion-color(primary, base)};
   --buffer-background: var(--background);
   display: block;
@@ -27,7 +27,7 @@
 
 :host(.ion-color) {
   --progress-background: #{current-color(base)};
-  --buffer-background: #{current-color(base, 0.2)};
+  --buffer-background: #{current-color(base, 0.3)};
 }
 
 // indeterminate has no progress-buffer-bar, so it will be added to the host

--- a/core/src/components/progress-bar/progress-bar.scss
+++ b/core/src/components/progress-bar/progress-bar.scss
@@ -39,26 +39,33 @@
 .progress-indeterminate,
 .indeterminate-bar-primary,
 .indeterminate-bar-secondary,
-.progress-buffer-bar,
-.progress-buffer-bar:before,
-.buffer-circles {
+.progress-buffer-bar {
   @include position(0, 0, 0, 0);
-
   position: absolute;
-
   width: 100%;
   height: 100%;
+}
+
+.buffer-circles-container,
+.buffer-circles {
+  @include position(0, 0, 0, 0);
+  position: absolute;
+}
+
+// Extend a bit to overflow. The size of animated distance.
+.buffer-circles {
+  left: -10px;
+  right: -10px;
 }
 
 // Determinate progress bar
 // --------------------------------------------------
 
 .progress,
-.progress-buffer-bar {
-  /* stylelint-disable-next-line property-blacklist */
-  transform-origin: left top;
-
+.progress-buffer-bar,
+.buffer-circles-container {
   transition: transform 150ms linear;
+  transform-origin: left top;
 }
 
 // Progress and background bar
@@ -67,21 +74,19 @@
 .progress,
 .progress-indeterminate {
   background: var(--progress-background);
-
   z-index: 2;
 }
 
 .progress-buffer-bar {
-  // It's currently here because --buffer-background has an alpha
-  // Otherwise the buffer circles would be seen through
-  background: #fff;
+  background: var(--buffer-background);
+  z-index: 1;
+}
 
-  z-index: 1; // Make it behind the progress
-
-  &:before {
-    background: var(--buffer-background);
-
-    content: "";
+.buffer-circles-container {
+  overflow: hidden;
+  &.hidden {
+    // Moved from tsx due to transition issue.
+    display: none;
   }
 }
 
@@ -109,7 +114,7 @@
   top: 0;
   right: 0;
   bottom: 0;
-  left:  -54.888891%;
+  left: -54.888891%;
   /* stylelint-enable property-blacklist */
 
   animation: secondary-indeterminate-translate 2s infinite linear;
@@ -136,18 +141,7 @@
 // --------------------------------------------------
 
 :host(.progress-bar-reversed) {
-  .progress,
-  .progress-buffer-bar {
-    /* stylelint-disable-next-line property-blacklist */
-    transform-origin: right top;
-  }
-
-  .buffer-circles,
-  .indeterminate-bar-primary,
-  .indeterminate-bar-secondary,
-  .progress-indeterminate {
-    animation-direction: reverse;
-  }
+  transform: scaleX(-1);
 }
 
 // Progress paused

--- a/core/src/components/progress-bar/progress-bar.scss
+++ b/core/src/components/progress-bar/progress-bar.scss
@@ -65,6 +65,7 @@
 .progress-buffer-bar,
 .buffer-circles-container {
   transition: transform 150ms linear;
+  /* stylelint-disable-next-line property-blacklist */
   transform-origin: left top;
 }
 

--- a/core/src/components/progress-bar/progress-bar.scss
+++ b/core/src/components/progress-bar/progress-bar.scss
@@ -91,10 +91,6 @@
 
 .buffer-circles-container {
   overflow: hidden;
-  &.hidden {
-    // Moved from tsx due to transition issue.
-    display: none;
-  }
 }
 
 // MD based animation on indeterminate type

--- a/core/src/components/progress-bar/progress-bar.scss
+++ b/core/src/components/progress-bar/progress-bar.scss
@@ -42,6 +42,7 @@
 .progress-buffer-bar {
   @include position(0, 0, 0, 0);
   position: absolute;
+
   width: 100%;
   height: 100%;
 }
@@ -55,8 +56,8 @@
 // Extend a bit to overflow. The size of animated distance.
 .buffer-circles {
   /* stylelint-disable property-blacklist */
-  left: -10px;
   right: -10px;
+  left: -10px;
   /* stylelint-enable property-blacklist */
 }
 
@@ -66,9 +67,10 @@
 .progress,
 .progress-buffer-bar,
 .buffer-circles-container {
-  transition: transform 150ms linear;
   /* stylelint-disable-next-line property-blacklist */
   transform-origin: left top;
+
+  transition: transform 150ms linear;
 }
 
 // Progress and background bar
@@ -77,11 +79,13 @@
 .progress,
 .progress-indeterminate {
   background: var(--progress-background);
+
   z-index: 2;
 }
 
 .progress-buffer-bar {
   background: var(--buffer-background);
+
   z-index: 1;
 }
 

--- a/core/src/components/progress-bar/progress-bar.scss
+++ b/core/src/components/progress-bar/progress-bar.scss
@@ -10,7 +10,7 @@
   * @prop --progress-background: Color of the progress bar
   * @prop --buffer-background: Color of the buffer bar
   */
-  --background: #{ion-color(primary, base, 0.3)};
+  --background: #{ion-color(primary, base, 0.2)};
   --progress-background: #{ion-color(primary, base)};
   --buffer-background: var(--background);
   display: block;
@@ -27,7 +27,7 @@
 
 :host(.ion-color) {
   --progress-background: #{current-color(base)};
-  --buffer-background: #{current-color(base, 0.3)};
+  --buffer-background: #{current-color(base, 0.2)};
 }
 
 // indeterminate has no progress-buffer-bar, so it will be added to the host
@@ -72,10 +72,17 @@
 }
 
 .progress-buffer-bar {
-  background: var(--buffer-background);
+  // It's currently here because --buffer-background has an alpha
+  // Otherwise the buffer circles would be seen through
+  background: #fff;
 
-  // Make it behind the progress
-  z-index: 1;
+  z-index: 1; // Make it behind the progress
+
+  &:before {
+    background: var(--buffer-background);
+
+    content: "";
+  }
 }
 
 // MD based animation on indeterminate type
@@ -102,7 +109,7 @@
   top: 0;
   right: 0;
   bottom: 0;
-  left: -54.888891%;
+  left:  -54.888891%;
   /* stylelint-enable property-blacklist */
 
   animation: secondary-indeterminate-translate 2s infinite linear;
@@ -116,26 +123,8 @@
 // Buffer style
 // --------------------------------------------------
 
-.buffer-circles.buffer-circles-reversed {
-  /* stylelint-disable property-blacklist */
-  right: unset;
-  left: 2px;
-
-  background-position: right;
-  /* stylelint-enable property-blacklist */
-}
-
 .buffer-circles {
-  /* stylelint-disable property-blacklist */
-  right: -8px;
-
-  left: unset;
-  /* stylelint-enable property-blacklist */
-
-  background: radial-gradient(ellipse at center, var(--buffer-background) 0%, var(--buffer-background) 30%, transparent 30%) repeat-x 5px;
-
-  /* stylelint-disable-next-line property-blacklist */
-  background-position: left;
+  background: radial-gradient(ellipse at center, var(--buffer-background) 0%, var(--buffer-background) 30%, transparent 30%) repeat-x 5px center;
   background-size: 10px 10px;
 
   z-index: 0;

--- a/core/src/components/progress-bar/progress-bar.tsx
+++ b/core/src/components/progress-bar/progress-bar.tsx
@@ -90,24 +90,12 @@ const renderProgress = (value: number, buffer: number) => {
   return [
     <div class="progress" style={{ transform: `scaleX(${finalValue})` }}></div>,
     // Buffer circles with two container to move the circles behind the buffer progress with respecting the animation.
-    <div
-      class={{'buffer-circles-container': true, hidden: finalBuffer === 1}}
-      style={{
-        transform: `translateX(${finalBuffer * 100}%)`,
-      }}
-    >
-      <div
-        class="buffer-circles-container"
-        style={{
-          transform: `translateX(-${finalBuffer * 100}%)`,
-        }}
-      >
+    <div class={{ 'buffer-circles-container': true, hidden: finalBuffer === 1 }} style={{ transform: `translateX(${finalBuffer * 100}%)` }}>
+      <div class="buffer-circles-container" style={{ transform: `translateX(-${finalBuffer * 100}%)` }}>
         <div class="buffer-circles"></div>
       </div>
     </div>,
-    <div
-      class="progress-buffer-bar"
-      style={{ transform: `scaleX(${finalBuffer})` }}
+    <div class="progress-buffer-bar" style={{ transform: `scaleX(${finalBuffer})` }}
     ></div>,
   ];
 };

--- a/core/src/components/progress-bar/progress-bar.tsx
+++ b/core/src/components/progress-bar/progress-bar.tsx
@@ -95,7 +95,6 @@ const renderProgress = (value: number, buffer: number) => {
         <div class="buffer-circles"></div>
       </div>
     </div>,
-    <div class="progress-buffer-bar" style={{ transform: `scaleX(${finalBuffer})` }}
-    ></div>,
+    <div class="progress-buffer-bar" style={{ transform: `scaleX(${finalBuffer})` }}></div>,
   ];
 };

--- a/core/src/components/progress-bar/progress-bar.tsx
+++ b/core/src/components/progress-bar/progress-bar.tsx
@@ -54,7 +54,6 @@ export class ProgressBar implements ComponentInterface {
     const { color, type, reversed, value, buffer } = this;
     const paused = config.getBoolean('_testing');
     const mode = getIonMode(this);
-    const isReversed = document.dir === 'rtl' ? !reversed : reversed;
     return (
       <Host
         role="progressbar"
@@ -65,12 +64,12 @@ export class ProgressBar implements ComponentInterface {
           [mode]: true,
           [`progress-bar-${type}`]: true,
           'progress-paused': paused,
-          'progress-bar-reversed': isReversed
+          'progress-bar-reversed': document.dir === 'rtl' ? !reversed : reversed
         })}
       >
         {type === 'indeterminate'
           ? renderIndeterminate()
-          : renderProgress(value, buffer, isReversed)
+          : renderProgress(value, buffer)
         }
       </Host>
     );
@@ -84,13 +83,13 @@ const renderIndeterminate = () => {
   ];
 };
 
-const renderProgress = (value: number, buffer: number, reversed: boolean) => {
+const renderProgress = (value: number, buffer: number) => {
   const finalValue = clamp(0, value, 1);
   const finalBuffer = clamp(0, buffer, 1);
 
   return [
     <div class="progress" style={{ transform: `scaleX(${finalValue})` }}></div>,
-    finalBuffer !== 1 && <div class={{ 'buffer-circles': true, 'buffer-circles-reversed': reversed }} style={{ width: `calc(${(1 - finalBuffer) * 100}%)` }}></div>,
+    finalBuffer !== 1 && <div class="buffer-circles"></div>,
     <div class="progress-buffer-bar" style={{ transform: `scaleX(${finalBuffer})` }}></div>,
   ];
 };

--- a/core/src/components/progress-bar/progress-bar.tsx
+++ b/core/src/components/progress-bar/progress-bar.tsx
@@ -89,8 +89,14 @@ const renderProgress = (value: number, buffer: number) => {
 
   return [
     <div class="progress" style={{ transform: `scaleX(${finalValue})` }}></div>,
-    // Buffer circles with two container to move the circles behind the buffer progress with respecting the animation.
-    <div class={{ 'buffer-circles-container': true, hidden: finalBuffer === 1 }} style={{ transform: `translateX(${finalBuffer * 100}%)` }}>
+    /**
+     * Buffer circles with two container to move
+     * the circles behind the buffer progress
+     * with respecting the animation.
+     * When finalBuffer === 1, we use display: none
+     * instead of removing the element to avoid flickering.
+     */
+    <div class={{ 'buffer-circles-container': true, 'ion-hide': finalBuffer === 1 }} style={{ transform: `translateX(${finalBuffer * 100}%)` }}>
       <div class="buffer-circles-container" style={{ transform: `translateX(-${finalBuffer * 100}%)` }}>
         <div class="buffer-circles"></div>
       </div>

--- a/core/src/components/progress-bar/progress-bar.tsx
+++ b/core/src/components/progress-bar/progress-bar.tsx
@@ -89,7 +89,25 @@ const renderProgress = (value: number, buffer: number) => {
 
   return [
     <div class="progress" style={{ transform: `scaleX(${finalValue})` }}></div>,
-    finalBuffer !== 1 && <div class="buffer-circles"></div>,
-    <div class="progress-buffer-bar" style={{ transform: `scaleX(${finalBuffer})` }}></div>,
+    // Buffer circles with two container to move the circles behind the buffer progress with respecting the animation.
+    <div
+      class={{'buffer-circles-container': true, hidden: finalBuffer === 1}}
+      style={{
+        transform: `translateX(${finalBuffer * 100}%)`,
+      }}
+    >
+      <div
+        class="buffer-circles-container"
+        style={{
+          transform: `translateX(-${finalBuffer * 100}%)`,
+        }}
+      >
+        <div class="buffer-circles"></div>
+      </div>
+    </div>,
+    <div
+      class="progress-buffer-bar"
+      style={{ transform: `scaleX(${finalBuffer})` }}
+    ></div>,
   ];
 };


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

This fixes the previous. attempts of fixes. This pull-request should be the final fix. (Hopefully)

![](https://user-images.githubusercontent.com/28209992/108900409-e1d49f00-7619-11eb-8a12-3047481c73eb.gif)
![](https://user-images.githubusercontent.com/28209992/108901192-de8de300-761a-11eb-9b1e-e8ec4bf44a4b.gif)

Issue Number: resolves #20098.
Could replace the pull-request: #22964

## What is the new behavior?

Now the component uses the Ionic theme colors and the buffer progress works correctly.
I made some changes like flip the component if reverted, instead of handle each child element separately. 
I hope it makes it less prone to error.

![](https://user-images.githubusercontent.com/28209992/100153281-32662000-2ea4-11eb-9377-8ddb8f48da9f.gif)

![demo-light](https://user-images.githubusercontent.com/28209992/108927234-2ecb6c00-7640-11eb-8d53-ea998cd9df8c.gif)
![demo-dark](https://user-images.githubusercontent.com/28209992/108927235-2f640280-7640-11eb-9ef7-cd2c92612d46.gif)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

