### PR TITLE
fix(virtual-scroll): allow null in items prop

### DIFF
--- a/angular/src/directives/virtual-scroll/virtual-scroll.ts
+++ b/angular/src/directives/virtual-scroll/virtual-scroll.ts
@@ -71,7 +71,7 @@ export declare interface IonVirtualScroll {
    * entire virtual scroll is reset, which is an expensive operation and
    * should be avoided if possible.
    */
-  items?: any[];
+  items?: any[] | null;
 
   /**
    * An optional function that maps each item within their height.


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Using the async pipe is considered best practice for angular projects.

When using the `async` pipe with `<ion-virtual-scroll>` with `strictTemplates` set to `true` in `tsconfig.json` we get this error `Type 'null' is not assignable to type 'any[] | undefined'.` during the build phase.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

When setting `angularCompilerOptions.strictTemplates=true` in `tsconfig.json` the build fails because there is a type mismatch between async & [items]. This is because the return type of async can be `any[] | null` whereas [items] only accepts `any[] | undefined`. Adding null to the allowed types fixes the issue and allows async to be used with virtual scroll.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
