### PR TITLE
fix(react, vue): tab buttons no longer throw an error if href is undefined

### DIFF
--- a/packages/react-router/src/ReactRouter/IonRouter.tsx
+++ b/packages/react-router/src/ReactRouter/IonRouter.tsx
@@ -76,7 +76,9 @@ class IonRouterInner extends React.PureComponent<IonRouteProps, IonRouteState> {
     };
   }
 
-  handleChangeTab(tab: string, path: string, routeOptions?: any) {
+  handleChangeTab(tab: string, path?: string, routeOptions?: any) {
+    if (!path) { return; }
+
     const routeInfo = this.locationHistory.getCurrentRouteInfoForTab(tab);
     const [pathname, search] = path.split('?');
     if (routeInfo) {

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -252,7 +252,9 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
     }
   }
 
-  const changeTab = (tab: string, path: string) => {
+  const changeTab = (tab: string, path?: string) => {
+    if (!path) return;
+
     const routeInfo = locationHistory.getCurrentRouteInfoForTab(tab);
     const [pathname] = path.split('?');
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/22997

It's currently impossible to do custom click handlers right now because the `href` always takes priority. Leaving the `href` off will cause the click handler to fire, but it causes errors. The underlying WC for tab button allows an undefined href without crashing, so we need to here as well.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Check if `path` is defined before attempting to switch tabs.
- The `path` prop is optional on the regular web component ion-tab-button, so we should expect it to be undefined here as well. Also allows devs to override the default tab button behavior and add their own click handler.
- I did not apply this same logic to `tab` because even though it defaults to `undefined` it is a required prop according to the docs.
- More work is likely need to be fully consistent across all the framework integrations, but this at least doesn't cause an error for users now.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
