### PR TITLE
picker-column detect pressed

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -14890,7 +14890,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.4.1.tgz",
       "integrity": "sha512-B4urIlIb+I95NkKeCt3Ygpor1D0x5RMezuFyCFp6DYXshUaT1TbiJcW1FgA+gfwlquNzT1AMvEbi96YLnsOg3w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@stylelint/postcss-css-in-js": {
       "version": "0.37.2",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The picker's pull movement incorrectly calculates the drag speed. After dragging the mouse or finger, after holding down and stopping, the picker does not take the stop into account and calculates de speed incorrectly.

Issue Number: #23034


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

After dragging the mouse or finger, after holding down and stopping,  the picker must take the stop into account and calculate a lower drag speed

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
