### PR TITLE
fix(refresher): resolve progressEnd errors in native MD refresher

### DIFF
--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -307,6 +307,7 @@ export class Refresher implements ComponentInterface {
       canStart: () => this.state !== RefresherState.Refreshing && this.state !== RefresherState.Completing && this.scrollEl!.scrollTop === 0,
       onStart: (ev: GestureDetail) => {
         ev.data = { animation: undefined, didStart: false, cancelled: false };
+        this.state = RefresherState.Pulling;
       },
       onMove: (ev: GestureDetail) => {
         if ((ev.velocityY < 0 && this.progress === 0 && !ev.data.didStart) || ev.data.cancelled) {
@@ -317,19 +318,14 @@ export class Refresher implements ComponentInterface {
         if (!ev.data.didStart) {
           ev.data.didStart = true;
 
-          this.state = RefresherState.Pulling;
+          writeTask(() => this.scrollEl!.style.setProperty('--overflow', 'hidden'));
 
-          writeTask(() => {
-            const animationType = getRefresherAnimationType(contentEl);
-            const animation = createPullingAnimation(animationType, pullingRefresherIcon);
-            ev.data.animation = animation;
-
-            this.scrollEl!.style.setProperty('--overflow', 'hidden');
-
-            animation.progressStart(false, 0);
-            this.ionStart.emit();
-            this.animations.push(animation);
-          });
+          const animationType = getRefresherAnimationType(contentEl);
+          const animation = createPullingAnimation(animationType, pullingRefresherIcon);
+          ev.data.animation = animation;
+          animation.progressStart(false, 0);
+          this.ionStart.emit();
+          this.animations.push(animation);
 
           return;
         }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Since `ev.data.animation = animation` is set asynchronously, it was possible for `onEnd` to fire before that async task completed resulting in `ev.data.animation` being undefined.

In addition, we need to make sure that `this.state = RefresherState.Pulling;` is set at the beginning of the gesture otherwise dimensions will be incorrect when creating this animation synchronously.

Note: `onMove` is fired in an raf from the gesture utility, so firing something "Synchronously" refers to within the context of the callback function.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR ensures that `ev.data.animation` is set synchronously so the undefined error never happens.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
