### PR TITLE
fix(vue): give name to Vue components

### DIFF
--- a/packages/vue/src/vue-component-lib/utils.ts
+++ b/packages/vue/src/vue-component-lib/utils.ts
@@ -48,7 +48,9 @@ export const defineContainer = <Props>(name: string, componentProps: string[] = 
   * Note: The `props` here are not all properties on a component.
   * They refer to whatever properties are set on an instance of a component.
   */
-  const Container = defineComponent<Props & InputProps>((props, { attrs, slots, emit }) => {
+  const Container = defineComponent<Props & InputProps>({
+    name: name,
+    setup(props, { attrs, slots, emit }) {
     let modelPropValue = (props as any)[modelProp];
     const containerRef = ref<HTMLElement>();
     const classes = new Set(getComponentClasses(attrs.class));
@@ -127,7 +129,7 @@ export const defineContainer = <Props>(name: string, componentProps: string[] = 
 
       return h(name, propsToAdd, slots.default && slots.default());
     }
-  });
+  }});
 
   Container.displayName = name;
   Container.props = [...componentProps, ROUTER_LINK_VALUE];


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

Issue Number: #23073 


## What is the new behavior?
Now, in Vue3-Devtools the components are named correctly.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


## Other information
