### PR TITLE
fix(nav): prevent swipe back when task is running

### DIFF
--- a/angular/src/directives/navigation/ion-router-outlet.ts
+++ b/angular/src/directives/navigation/ion-router-outlet.ts
@@ -52,7 +52,7 @@ export class IonRouterOutlet implements OnDestroy, OnInit {
     this._swipeGesture = swipe;
 
     this.nativeEl.swipeHandler = swipe ? {
-      canStart: () => this.stackCtrl.canGoBack(1),
+      canStart: () => this.stackCtrl.canGoBack(1) && !this.stackCtrl.hasRunningTask(),
       onStart: () => this.stackCtrl.startBackTransition(),
       onEnd: shouldContinue => this.stackCtrl.endBackTransition(shouldContinue)
     } : undefined;

--- a/angular/src/directives/navigation/stack-controller.ts
+++ b/angular/src/directives/navigation/stack-controller.ts
@@ -232,6 +232,10 @@ export class StackController {
     return this.activeView ? this.activeView.stackId : undefined;
   }
 
+  hasRunningTask(): boolean {
+    return this.runningTask !== undefined;
+  }
+
   destroy() {
     this.containerEl = undefined!;
     this.views.forEach(destroyView);
@@ -294,6 +298,7 @@ export class StackController {
       this.runningTask = undefined;
     }
     const promise = this.runningTask = task();
+    promise.finally(() => this.runningTask = undefined);
     return promise;
   }
 }


### PR DESCRIPTION
closes #15154

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #15154


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- the swipe back gesture on the angular ion-router-outlet checks if another navigation task of the stack controller is currently running and if so prevents the swipe back animation to start

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
