### PR TITLE
fix(anim): prevent swipe back animation getting stuck / not completing

### DIFF
--- a/core/src/components/router-outlet/route-outlet.tsx
+++ b/core/src/components/router-outlet/route-outlet.tsx
@@ -64,7 +64,7 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
   private endSwipeBackGestureAnimation(shouldComplete: boolean, step: number, dur: number) {
     if (this.ani) {
       this.animationEnabled = false;
-      
+
       this.ani.onFinish(() => {
         this.animationEnabled = true;
 


### PR DESCRIPTION
closes #22895

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #22895 

While debugging the swipe back gesture I noticed that there are some race conditions where the animation is never stopped. The endlessly running animation blocks all further animations/routing of the entire app (e.g. back-button, tabs, ...).

This happens when the swipe back gesture is performed very fast (not fast in the sense of quickly performing the gesture multiple times like in issue #15154, but instead only performing it once which a fast finger movement). This can especially be reproduced in about 50% of cases when trying to perform the gesture with as little time and horizontal movement of your finger as possible on the far left side of the page/device. 

Debugging actually shows, that the gesture ends (```onEndHandler``` called in ```swipe-back.ts```)  BEFORE the animation actually started and the reference to the animation ```ani``` in ```route-outlet.tsx``` is set. Since the animation is progress-based and is only ever stopped by calling ```progressEnd```, this leads to the endlessly running animation.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The supplied fix handles this edge case where the swipe gesture should be stopped, but the animation reference is not yet set. In that case the result params are temporary stored within the route-outlet and as soon as the animation reference is set, the animation will be stopped gracefully.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I have tested it in our apps in combination with PR https://github.com/ionic-team/ionic-framework/pull/23125 and its working very well. The app always stays responsive and routing always works even after performing the wildest swipe animations.