### PR TITLE
fix(react): support React refs (object and callback)

### DIFF
--- a/packages/react/src/components/IonIcon.tsx
+++ b/packages/react/src/components/IonIcon.tsx
@@ -22,7 +22,7 @@ interface IonIconProps {
 }
 
 type InternalProps = IonIconProps & {
-  forwardedRef?: React.RefObject<HTMLIonIconElement>;
+  forwardedRef?: React.ForwardedRef<HTMLIonIconElement>;
 };
 
 class IonIconContainer extends React.PureComponent<InternalProps> {

--- a/packages/react/src/components/IonPage.tsx
+++ b/packages/react/src/components/IonPage.tsx
@@ -9,7 +9,7 @@ import { createForwardRef } from './utils';
 interface IonPageProps extends IonicReactProps {}
 
 interface IonPageInternalProps extends IonPageProps {
-  forwardedRef?: React.RefObject<HTMLDivElement>;
+  forwardedRef?: React.ForwardedRef<HTMLDivElement>;
 }
 
 class IonPageInternal extends React.Component<IonPageInternalProps> {

--- a/packages/react/src/components/IonRouterOutlet.tsx
+++ b/packages/react/src/components/IonRouterOutlet.tsx
@@ -10,12 +10,12 @@ import { createForwardRef } from './utils';
 
 type Props = LocalJSX.IonRouterOutlet & {
   basePath?: string;
-  ref?: React.RefObject<any>;
+  ref?: React.Ref<any>;
   ionPage?: boolean;
 };
 
 interface InternalProps extends Props {
-  forwardedRef?: React.RefObject<HTMLIonRouterOutletElement>;
+  forwardedRef?: React.ForwardedRef<HTMLIonRouterOutletElement>;
 }
 
 interface InternalState {}

--- a/packages/react/src/components/__tests__/createComponent.spec.tsx
+++ b/packages/react/src/components/__tests__/createComponent.spec.tsx
@@ -27,13 +27,23 @@ describe('createComponent - events', () => {
 });
 
 describe('createComponent - ref', () => {
-  test('should pass ref on to web component instance', () => {
+  test('should pass ref on to web component instance (RefObject)', () => {
     const ionButtonRef: React.RefObject<any> = React.createRef();
     const IonButton = createReactComponent<JSX.IonButton, HTMLIonButtonElement>('ion-button');
 
     const { getByText } = render(<IonButton ref={ionButtonRef}>ButtonNameA</IonButton>);
     const ionButtonItem = getByText('ButtonNameA');
     expect(ionButtonRef.current).toEqual(ionButtonItem);
+  });
+
+  test('should pass ref on to web component instance (RefCallback)', () => {
+    let current
+    const ionButtonRef: React.RefCallback<any> = value => current = value;
+    const IonButton = createReactComponent<JSX.IonButton, HTMLIonButtonElement>('ion-button');
+
+    const { getByText } = render(<IonButton ref={ionButtonRef}>ButtonNameA</IonButton>);
+    const ionButtonItem = getByText('ButtonNameA');
+    expect(current).toEqual(ionButtonItem);
   });
 });
 

--- a/packages/react/src/components/createControllerComponent.tsx
+++ b/packages/react/src/components/createControllerComponent.tsx
@@ -1,7 +1,7 @@
 import { OverlayEventDetail } from '@ionic/core';
 import React from 'react';
 
-import { attachProps } from './utils';
+import { attachProps, setRef } from './utils';
 
 interface OverlayBase extends HTMLElement {
   present: () => Promise<void>;
@@ -30,7 +30,7 @@ export const createControllerComponent = <
 
   type Props = OptionsType &
     ReactControllerProps & {
-      forwardedRef?: React.RefObject<OverlayType>;
+      forwardedRef?: React.ForwardedRef<OverlayType>;
     };
 
   class Overlay extends React.Component<Props> {
@@ -73,9 +73,7 @@ export const createControllerComponent = <
       if (this.props.onDidDismiss) {
         this.props.onDidDismiss(event);
       }
-      if (this.props.forwardedRef) {
-        (this.props.forwardedRef as any).current = undefined;
-      }
+      setRef(this.props.forwardedRef, null)
     }
 
     async present(prevProps?: Props) {
@@ -106,9 +104,7 @@ export const createControllerComponent = <
       // Check isOpen again since the value could have changed during the async call to controller.create
       // It's also possible for the component to have become unmounted.
       if (this.props.isOpen === true && this.isUnmounted === false) {
-        if (this.props.forwardedRef) {
-          (this.props.forwardedRef as any).current = this.overlay;
-        }
+        setRef(this.props.forwardedRef, this.overlay)
         await this.overlay.present();
       }
     }

--- a/packages/react/src/components/createOverlayComponent.tsx
+++ b/packages/react/src/components/createOverlayComponent.tsx
@@ -2,7 +2,7 @@ import { OverlayEventDetail } from '@ionic/core';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { attachProps } from './utils';
+import { attachProps, setRef } from './utils';
 
 interface OverlayElement extends HTMLElement {
   present: () => Promise<void>;
@@ -32,7 +32,7 @@ export const createOverlayComponent = <
 
   type Props = OverlayComponent &
     ReactOverlayProps & {
-      forwardedRef?: React.RefObject<OverlayType>;
+      forwardedRef?: React.ForwardedRef<OverlayType>;
     };
 
   let isDismissing = false;
@@ -69,9 +69,7 @@ export const createOverlayComponent = <
       if (this.props.onDidDismiss) {
         this.props.onDidDismiss(event);
       }
-      if (this.props.forwardedRef) {
-        (this.props.forwardedRef as any).current = undefined;
-      }
+      setRef(this.props.forwardedRef, null)
     }
 
     shouldComponentUpdate(nextProps: Props) {
@@ -125,10 +123,7 @@ export const createOverlayComponent = <
         componentProps: {},
       });
 
-      if (this.props.forwardedRef) {
-        (this.props.forwardedRef as any).current = this.overlay;
-      }
-
+      setRef(this.props.forwardedRef, this.overlay);
       attachProps(this.overlay, elementProps, prevProps);
 
       await this.overlay.present();

--- a/packages/react/src/components/inner-proxies.ts
+++ b/packages/react/src/components/inner-proxies.ts
@@ -18,7 +18,7 @@ export const IonBackButtonInner = /*@__PURE__*/ createReactComponent<
 export const IonRouterOutletInner = /*@__PURE__*/ createReactComponent<
   JSX.IonRouterOutlet & {
     setRef?: (val: HTMLIonRouterOutletElement) => void;
-    forwardedRef?: React.RefObject<HTMLIonRouterOutletElement>;
+    forwardedRef?: React.ForwardedRef<HTMLIonRouterOutletElement>;
   },
   HTMLIonRouterOutletElement
 >('ion-router-outlet');

--- a/packages/react/src/components/navigation/IonBackButton.tsx
+++ b/packages/react/src/components/navigation/IonBackButton.tsx
@@ -13,7 +13,7 @@ type Props = Omit<LocalJSX.IonBackButton, 'icon'> &
           md: string;
         }
       | string;
-    ref?: React.RefObject<HTMLIonBackButtonElement>;
+    ref?: React.Ref<HTMLIonBackButtonElement>;
   };
 
 export const IonBackButton = /*@__PURE__*/ (() =>

--- a/packages/react/src/components/navigation/IonTabBar.tsx
+++ b/packages/react/src/components/navigation/IonTabBar.tsx
@@ -18,7 +18,7 @@ type IonTabBarProps = LocalJSX.IonTabBar &
   };
 
 interface InternalProps extends IonTabBarProps {
-  forwardedRef?: React.RefObject<HTMLIonIconElement>;
+  forwardedRef?: React.ForwardedRef<HTMLIonIconElement>;
   onSetCurrentTab: (tab: string, routeInfo: RouteInfo) => void;
   routeInfo: RouteInfo;
 }

--- a/packages/react/src/components/navigation/IonTabButton.tsx
+++ b/packages/react/src/components/navigation/IonTabButton.tsx
@@ -8,7 +8,7 @@ import { IonTabButtonInner } from '../inner-proxies';
 type Props = LocalJSX.IonTabButton &
   IonicReactProps & {
     routerOptions?: RouterOptions;
-    ref?: React.RefObject<HTMLIonTabButtonElement>;
+    ref?: React.Ref<HTMLIonTabButtonElement>;
     onClick?: (e: any) => void;
   };
 

--- a/packages/react/src/components/utils/index.tsx
+++ b/packages/react/src/components/utils/index.tsx
@@ -18,13 +18,32 @@ export const createForwardRef = <PropType, ElementType>(
 ) => {
   const forwardRef = (
     props: IonicReactExternalProps<PropType, ElementType>,
-    ref: React.Ref<ElementType>
+    ref: React.ForwardedRef<ElementType>
   ) => {
     return <ReactComponent {...props} forwardedRef={ref} />;
   };
   forwardRef.displayName = displayName;
 
   return React.forwardRef(forwardRef);
+};
+
+export const setRef = (ref: React.ForwardedRef<any> | React.Ref<any> | undefined, value: any) => {
+  if (typeof ref === 'function') {
+    ref(value)
+  } else if (ref != null) {
+    // Cast as a MutableRef so we can assign current
+    (ref as React.MutableRefObject<any>).current = value
+  }
+};
+
+export const mergeRefs = (
+  ...refs: (React.ForwardedRef<any> | React.Ref<any> | undefined)[]
+): React.RefCallback<any> => {
+  return (value: any) => {
+    refs.forEach(ref => {
+      setRef(ref, value)
+    })
+  }
 };
 
 export * from './attachProps';

--- a/packages/react/src/routing/OutletPageManager.tsx
+++ b/packages/react/src/routing/OutletPageManager.tsx
@@ -8,7 +8,7 @@ import { StackContext } from './StackContext';
 
 interface OutletPageManagerProps {
   className?: string;
-  forwardedRef?: React.RefObject<HTMLIonRouterOutletElement>;
+  forwardedRef?: React.ForwardedRef<HTMLIonRouterOutletElement>;
   routeInfo?: RouteInfo;
   StackManager: any;
 }

--- a/packages/react/src/routing/PageManager.tsx
+++ b/packages/react/src/routing/PageManager.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { mergeRefs } from '../components/utils';
 import { IonLifeCycleContext } from '../contexts/IonLifeCycleContext';
 import { RouteInfo } from '../models';
 
@@ -7,7 +8,7 @@ import { StackContext } from './StackContext';
 
 interface PageManagerProps {
   className?: string;
-  forwardedRef?: React.RefObject<HTMLDivElement>;
+  forwardedRef?: React.ForwardedRef<HTMLDivElement>;
   routeInfo?: RouteInfo;
 }
 
@@ -15,10 +16,13 @@ export class PageManager extends React.PureComponent<PageManagerProps> {
   ionLifeCycleContext!: React.ContextType<typeof IonLifeCycleContext>;
   context!: React.ContextType<typeof StackContext>;
   ionPageElementRef: React.RefObject<HTMLDivElement>;
+  stableMergedRefs: React.RefCallback<HTMLDivElement>
 
   constructor(props: PageManagerProps) {
     super(props);
-    this.ionPageElementRef = this.props.forwardedRef || React.createRef();
+    this.ionPageElementRef = React.createRef();
+    // React refs must be stable (not created inline).
+    this.stableMergedRefs = mergeRefs(this.ionPageElementRef, this.props.forwardedRef)
   }
 
   componentDidMount() {
@@ -95,7 +99,7 @@ export class PageManager extends React.PureComponent<PageManagerProps> {
               className={
                 className ? `${className} ion-page` : `ion-page`
               }
-              ref={this.ionPageElementRef}
+              ref={this.stableMergedRefs}
               {...props}
             >
               {children}


### PR DESCRIPTION
React refs can be an object, or a callback - callbacks are
commonly used by 3rd party libraries for combining multiple refs.
https://reactjs.org/docs/refs-and-the-dom.html#callback-refs

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #23153

Providing a callback ref breaks internal assumptions that forwardedRefs will always be in the object format.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Internal ref usage has been decoupled from forwardedRefs.
- Refs may be provided in object or callback format.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
