### PR TITLE
fix(datetime, input, textarea): remove aria-labelledby when there is no adjacent ion-label

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -641,7 +641,7 @@ export class Datetime implements ComponentInterface {
         aria-disabled={disabled ? 'true' : null}
         aria-expanded={`${isExpanded}`}
         aria-haspopup="true"
-        aria-labelledby={labelId}
+        aria-labelledby={label ? labelId : null}
         class={{
           [mode]: true,
           'datetime-disabled': disabled,

--- a/core/src/components/datetime/test/a11y/datetime.spec.ts
+++ b/core/src/components/datetime/test/a11y/datetime.spec.ts
@@ -4,26 +4,27 @@ import { Item } from '../../../item/item';
 import { Label } from '../../../label/label';
 
 describe('Datetime a11y', () => {
-    it('does not set a default aria-labelledby when there is not a neighboring ion-label', async () => {
-        const page = await newSpecPage({
-            components: [Datetime, Item, Label],
-            html: `<ion-datetime></ion-datetime>`
-        })
+  it('does not set a default aria-labelledby when there is not a neighboring ion-label', async () => {
+    const page = await newSpecPage({
+      components: [Datetime, Item, Label],
+      html: `<ion-datetime></ion-datetime>`
+    })
 
-        const ariaLabelledBy = page.root.getAttribute('aria-labelledby');
-        expect(ariaLabelledBy).toBe(null);
-    });
+    const ariaLabelledBy = page.root.getAttribute('aria-labelledby');
+    expect(ariaLabelledBy).toBe(null);
+  });
 
-    it('set a default aria-labelledby when a neighboring ion-label exists', async () => {
-        const page = await newSpecPage({
-            components: [Datetime, Item, Label],
-            html: `<ion-item>
-                <ion-label>A11y Test</ion-label>
-                <ion-datetime></ion-datetime>
-            </ion-item>`
-        })
+  it('set a default aria-labelledby when a neighboring ion-label exists', async () => {
+    const page = await newSpecPage({
+      components: [Datetime, Item, Label],
+      html: `<ion-item>
+        <ion-label>A11y Test</ion-label>
+        <ion-datetime></ion-datetime>
+      </ion-item>`
+    })
 
-        const ariaLabelledBy = page.body.querySelector('ion-datetime').getAttribute('aria-labelledby');
-        expect(ariaLabelledBy).toBe('ion-dt-1-lbl');
-    });
+    const label = page.body.querySelector('ion-label');
+    const ariaLabelledBy = page.body.querySelector('ion-datetime').getAttribute('aria-labelledby');
+    expect(ariaLabelledBy).toBe(label.id);
+  });
 });

--- a/core/src/components/datetime/test/a11y/datetime.spec.ts
+++ b/core/src/components/datetime/test/a11y/datetime.spec.ts
@@ -20,7 +20,7 @@ describe('Datetime a11y', () => {
             html: `<ion-item>
                 <ion-label>A11y Test</ion-label>
                 <ion-datetime></ion-datetime>
-            </ion-item`
+            </ion-item>`
         })
 
         const ariaLabelledBy = page.body.querySelector('ion-datetime').getAttribute('aria-labelledby');

--- a/core/src/components/datetime/test/a11y/datetime.spec.ts
+++ b/core/src/components/datetime/test/a11y/datetime.spec.ts
@@ -1,0 +1,29 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { Datetime } from '../../datetime';
+import { Item } from '../../../item/item';
+import { Label } from '../../../label/label';
+
+describe('Datetime a11y', () => {
+    it('does not set a default aria-labelledby when there is not a neighboring ion-label', async () => {
+        const page = await newSpecPage({
+            components: [Datetime, Item, Label],
+            html: `<ion-datetime></ion-datetime>`
+        })
+
+        const ariaLabelledBy = page.root.getAttribute('aria-labelledby');
+        expect(ariaLabelledBy).toBe(null);
+    });
+
+    it('set a default aria-labelledby when a neighboring ion-label exists', async () => {
+        const page = await newSpecPage({
+            components: [Datetime, Item, Label],
+            html: `<ion-item>
+                <ion-label>A11y Test</ion-label>
+                <ion-datetime></ion-datetime>
+            </ion-item`
+        })
+
+        const ariaLabelledBy = page.body.querySelector('ion-datetime').getAttribute('aria-labelledby');
+        expect(ariaLabelledBy).toBe('ion-dt-1-lbl');
+    });
+});

--- a/core/src/components/datetime/test/standalone/index.html
+++ b/core/src/components/datetime/test/standalone/index.html
@@ -12,6 +12,6 @@
   <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script></head>
 
 <body>
-  <ion-datetime id="basic" display-format="MMMM" value="2012-12-15T13:47:20.789"></ion-datetime>
+  <ion-datetime id="basic" display-format="MMMM" value="2012-12-15T13:47:20.789" aria-label="datetime picker"></ion-datetime>
 </body>
 </html>

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -408,7 +408,7 @@ export class Input implements ComponentInterface {
         <input
           class="native-input"
           ref={input => this.nativeInput = input}
-          aria-labelledby={labelId}
+          aria-labelledby={label ? labelId : null}
           disabled={this.disabled}
           accept={this.accept}
           autoCapitalize={this.autocapitalize}

--- a/core/src/components/input/test/a11y/input.spec.ts
+++ b/core/src/components/input/test/a11y/input.spec.ts
@@ -4,26 +4,27 @@ import { Item } from '../../../item/item';
 import { Label } from '../../../label/label';
 
 describe('Input a11y', () => {
-    it('does not set a default aria-labelledby when there is not a neighboring ion-label', async () => {
-        const page = await newSpecPage({
-            components: [Input, Item, Label],
-            html: `<ion-input></ion-input>`
-        })
+  it('does not set a default aria-labelledby when there is not a neighboring ion-label', async () => {
+    const page = await newSpecPage({
+      components: [Input, Item, Label],
+      html: `<ion-input></ion-input>`
+    })
+ 
+    const ariaLabelledBy = page.body.querySelector('ion-input > input').getAttribute('aria-labelledby');
+    expect(ariaLabelledBy).toBe(null);
+  });
 
-        const ariaLabelledBy = page.body.querySelector('ion-input > input').getAttribute('aria-labelledby');
-        expect(ariaLabelledBy).toBe(null);
-    });
+  it('set a default aria-labelledby when a neighboring ion-label exists', async () => {
+    const page = await newSpecPage({
+      components: [Input, Item, Label],
+      html: `<ion-item>
+        <ion-label>A11y Test</ion-label>
+        <ion-input></ion-input>
+      </ion-item>`
+    })
 
-    it('set a default aria-labelledby when a neighboring ion-label exists', async () => {
-        const page = await newSpecPage({
-            components: [Input, Item, Label],
-            html: `<ion-item>
-                <ion-label>A11y Test</ion-label>
-                <ion-input></ion-input>
-            </ion-item>`
-        })
-
-        const ariaLabelledBy = page.body.querySelector('ion-input > input').getAttribute('aria-labelledby');
-        expect(ariaLabelledBy).toBe('ion-input-1-lbl');
-    });
+    const label = page.body.querySelector('ion-label'); 
+    const ariaLabelledBy = page.body.querySelector('ion-input > input').getAttribute('aria-labelledby');
+    expect(ariaLabelledBy).toBe(label.id);
+  });
 });

--- a/core/src/components/input/test/a11y/input.spec.ts
+++ b/core/src/components/input/test/a11y/input.spec.ts
@@ -20,7 +20,7 @@ describe('Input a11y', () => {
             html: `<ion-item>
                 <ion-label>A11y Test</ion-label>
                 <ion-input></ion-input>
-            </ion-item`
+            </ion-item>`
         })
 
         const ariaLabelledBy = page.body.querySelector('ion-input > input').getAttribute('aria-labelledby');

--- a/core/src/components/input/test/a11y/input.spec.ts
+++ b/core/src/components/input/test/a11y/input.spec.ts
@@ -1,0 +1,29 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { Input } from '../../input';
+import { Item } from '../../../item/item';
+import { Label } from '../../../label/label';
+
+describe('Input a11y', () => {
+    it('does not set a default aria-labelledby when there is not a neighboring ion-label', async () => {
+        const page = await newSpecPage({
+            components: [Input, Item, Label],
+            html: `<ion-input></ion-input>`
+        })
+
+        const ariaLabelledBy = page.body.querySelector('ion-input > input').getAttribute('aria-labelledby');
+        expect(ariaLabelledBy).toBe(null);
+    });
+
+    it('set a default aria-labelledby when a neighboring ion-label exists', async () => {
+        const page = await newSpecPage({
+            components: [Input, Item, Label],
+            html: `<ion-item>
+                <ion-label>A11y Test</ion-label>
+                <ion-input></ion-input>
+            </ion-item`
+        })
+
+        const ariaLabelledBy = page.body.querySelector('ion-input > input').getAttribute('aria-labelledby');
+        expect(ariaLabelledBy).toBe('ion-input-1-lbl');
+    });
+});

--- a/core/src/components/input/test/attributes/index.html
+++ b/core/src/components/input/test/attributes/index.html
@@ -46,6 +46,10 @@
           <ion-input id="input3" value="inputs"></ion-input>
         </ion-item>
 
+        <ion-item>
+          <ion-input id="input4" placeholder="No Label" aria-label="input4"></ion-input>
+        </ion-item>
+
         <ion-list>
           <ion-item>
             Number Test&nbsp;
@@ -58,6 +62,10 @@
           <ion-item>
             Default Test&nbsp;
             <span id="defaultInputResult"></span>
+          </ion-item>
+          <ion-item>
+            No Label Test&nbsp;
+            <span id="noLabelInputResult"></span>
           </ion-item>
         </ion-list>
 
@@ -73,6 +81,9 @@
 
       var defaultInput = checkInput('input3');
       updateResult(defaultInput, 'defaultInputResult');
+
+      var noLabelInput = checkInput('input4');
+      updateResult(noLabelInput, 'noLabelInputResult');
 
       // Update results of input
       function updateResult(result, resultId) {
@@ -121,6 +132,14 @@
             value: 'inputs',
             readonly: undefined,
             disabled: undefined
+          });
+        } else if (id === 'input4') {
+          return testAttributes(el, inputEl, {
+            id: 'input4',
+            type: undefined,
+            readonly: undefined,
+            disabled: undefined,
+            'aria-label': 'input4'
           });
         }
         return false;

--- a/core/src/components/textarea/test/a11y/textarea.spec.ts
+++ b/core/src/components/textarea/test/a11y/textarea.spec.ts
@@ -20,7 +20,7 @@ describe('Textarea a11y', () => {
             html: `<ion-item>
                 <ion-label>A11y Test</ion-label>
                 <ion-textarea></ion-textarea>
-            </ion-item`
+            </ion-item>`
         })
 
         const ariaLabelledBy = page.body.querySelector('ion-textarea textarea').getAttribute('aria-labelledby');

--- a/core/src/components/textarea/test/a11y/textarea.spec.ts
+++ b/core/src/components/textarea/test/a11y/textarea.spec.ts
@@ -1,0 +1,29 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { Textarea } from '../../textarea';
+import { Item } from '../../../item/item';
+import { Label } from '../../../label/label';
+
+describe('Textarea a11y', () => {
+    it('does not set a default aria-labelledby when there is not a neighboring ion-label', async () => {
+        const page = await newSpecPage({
+            components: [Textarea, Item, Label],
+            html: `<ion-textarea></ion-textarea>`
+        })
+
+        const ariaLabelledBy = page.body.querySelector('ion-textarea textarea').getAttribute('aria-labelledby');
+        expect(ariaLabelledBy).toBe(null);
+    });
+
+    it('set a default aria-labelledby when a neighboring ion-label exists', async () => {
+        const page = await newSpecPage({
+            components: [Textarea, Item, Label],
+            html: `<ion-item>
+                <ion-label>A11y Test</ion-label>
+                <ion-textarea></ion-textarea>
+            </ion-item`
+        })
+
+        const ariaLabelledBy = page.body.querySelector('ion-textarea textarea').getAttribute('aria-labelledby');
+        expect(ariaLabelledBy).toBe('ion-textarea-1-lbl');
+    });
+});

--- a/core/src/components/textarea/test/a11y/textarea.spec.ts
+++ b/core/src/components/textarea/test/a11y/textarea.spec.ts
@@ -4,26 +4,27 @@ import { Item } from '../../../item/item';
 import { Label } from '../../../label/label';
 
 describe('Textarea a11y', () => {
-    it('does not set a default aria-labelledby when there is not a neighboring ion-label', async () => {
-        const page = await newSpecPage({
-            components: [Textarea, Item, Label],
-            html: `<ion-textarea></ion-textarea>`
-        })
+  it('does not set a default aria-labelledby when there is not a neighboring ion-label', async () => {
+    const page = await newSpecPage({
+      components: [Textarea, Item, Label],
+      html: `<ion-textarea></ion-textarea>`
+    })
 
-        const ariaLabelledBy = page.body.querySelector('ion-textarea textarea').getAttribute('aria-labelledby');
-        expect(ariaLabelledBy).toBe(null);
-    });
+    const ariaLabelledBy = page.body.querySelector('ion-textarea textarea').getAttribute('aria-labelledby');
+    expect(ariaLabelledBy).toBe(null);
+  });
 
-    it('set a default aria-labelledby when a neighboring ion-label exists', async () => {
-        const page = await newSpecPage({
-            components: [Textarea, Item, Label],
-            html: `<ion-item>
-                <ion-label>A11y Test</ion-label>
-                <ion-textarea></ion-textarea>
-            </ion-item>`
-        })
+  it('set a default aria-labelledby when a neighboring ion-label exists', async () => {
+    const page = await newSpecPage({
+      components: [Textarea, Item, Label],
+      html: `<ion-item>
+        <ion-label>A11y Test</ion-label>
+        <ion-textarea></ion-textarea>
+      </ion-item>`
+    })
 
-        const ariaLabelledBy = page.body.querySelector('ion-textarea textarea').getAttribute('aria-labelledby');
-        expect(ariaLabelledBy).toBe('ion-textarea-1-lbl');
-    });
+    const label = page.body.querySelector('ion-label');
+    const ariaLabelledBy = page.body.querySelector('ion-textarea textarea').getAttribute('aria-labelledby');
+    expect(ariaLabelledBy).toBe(label.id);
+  });
 });

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -363,7 +363,7 @@ export class Textarea implements ComponentInterface {
         >
           <textarea
             class="native-textarea"
-            aria-labelledby={labelId}
+            aria-labelledby={label ? labelId : null}
             ref={el => this.nativeInput = el}
             autoCapitalize={this.autocapitalize}
             autoFocus={this.autofocus}


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves #23182 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Datetime, input, and textarea no longer generate a default aria-labelledby attribute when there is no adjacent ion-label

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

