### PR TITLE
fix(vue): overlay events can now be listened for without the "on" prefix

### DIFF
--- a/core/src/components/action-sheet/readme.md
+++ b/core/src/components/action-sheet/readme.md
@@ -418,7 +418,7 @@ Developers can also use this component directly in their template:
     header="Albums"
     css-class="my-custom-class"
     :buttons="buttons"
-    @onDidDismiss="setOpen(false)"
+    @didDismiss="setOpen(false)"
   >
   </ion-action-sheet>
 </template>

--- a/core/src/components/action-sheet/usage/vue.md
+++ b/core/src/components/action-sheet/usage/vue.md
@@ -76,7 +76,7 @@ Developers can also use this component directly in their template:
     header="Albums"
     css-class="my-custom-class"
     :buttons="buttons"
-    @onDidDismiss="setOpen(false)"
+    @didDismiss="setOpen(false)"
   >
   </ion-action-sheet>
 </template>

--- a/core/src/components/alert/readme.md
+++ b/core/src/components/alert/readme.md
@@ -1664,7 +1664,7 @@ Developers can also use this component directly in their template:
     message="This is an alert message."
     css-class="my-custom-class"
     :buttons="buttons"
-    @onDidDismiss="setOpen(false)"
+    @didDismiss="setOpen(false)"
   >
   </ion-alert>
 </template>

--- a/core/src/components/alert/usage/vue.md
+++ b/core/src/components/alert/usage/vue.md
@@ -315,7 +315,7 @@ Developers can also use this component directly in their template:
     message="This is an alert message."
     css-class="my-custom-class"
     :buttons="buttons"
-    @onDidDismiss="setOpen(false)"
+    @didDismiss="setOpen(false)"
   >
   </ion-alert>
 </template>

--- a/core/src/components/loading/readme.md
+++ b/core/src/components/loading/readme.md
@@ -312,7 +312,7 @@ Developers can also use this component directly in their template:
     cssClass="my-custom-class"
     message="Please wait..."
     :duration="timeout"
-    @onDidDismiss="setOpen(false)"
+    @didDismiss="setOpen(false)"
   >
   </ion-loading>
 </template>

--- a/core/src/components/loading/usage/vue.md
+++ b/core/src/components/loading/usage/vue.md
@@ -63,7 +63,7 @@ Developers can also use this component directly in their template:
     cssClass="my-custom-class"
     message="Please wait..."
     :duration="timeout"
-    @onDidDismiss="setOpen(false)"
+    @didDismiss="setOpen(false)"
   >
   </ion-loading>
 </template>

--- a/core/src/components/modal/readme.md
+++ b/core/src/components/modal/readme.md
@@ -717,7 +717,7 @@ Developers can also use this component directly in their template:
   <ion-modal
     :is-open="isOpenRef"
     css-class="my-custom-class"
-    @onDidDismiss="setOpen(false)"
+    @didDismiss="setOpen(false)"
   >
     <Modal :data="data"></Modal>
   </ion-modal>

--- a/core/src/components/modal/usage/vue.md
+++ b/core/src/components/modal/usage/vue.md
@@ -69,7 +69,7 @@ Developers can also use this component directly in their template:
   <ion-modal
     :is-open="isOpenRef"
     css-class="my-custom-class"
-    @onDidDismiss="setOpen(false)"
+    @didDismiss="setOpen(false)"
   >
     <Modal :data="data"></Modal>
   </ion-modal>

--- a/core/src/components/popover/readme.md
+++ b/core/src/components/popover/readme.md
@@ -330,7 +330,7 @@ Developers can also use this component directly in their template:
     css-class="my-custom-class"
     :event="event"
     :translucent="true"
-    @onDidDismiss="setOpen(false)"
+    @didDismiss="setOpen(false)"
   >
     <Popover></Popover>
   </ion-popover>

--- a/core/src/components/popover/usage/vue.md
+++ b/core/src/components/popover/usage/vue.md
@@ -60,7 +60,7 @@ Developers can also use this component directly in their template:
     css-class="my-custom-class"
     :event="event"
     :translucent="true"
-    @onDidDismiss="setOpen(false)"
+    @didDismiss="setOpen(false)"
   >
     <Popover></Popover>
   </ion-popover>

--- a/core/src/components/toast/readme.md
+++ b/core/src/components/toast/readme.md
@@ -334,7 +334,7 @@ Developers can also use this component directly in their template:
     :is-open="isOpenRef"
     message="Your settings have been saved."
     :duration="2000"
-    @onDidDismiss="setOpen(false)"
+    @didDismiss="setOpen(false)"
   >
   </ion-toast>
 </template>

--- a/core/src/components/toast/usage/vue.md
+++ b/core/src/components/toast/usage/vue.md
@@ -64,7 +64,7 @@ Developers can also use this component directly in their template:
     :is-open="isOpenRef"
     message="Your settings have been saved."
     :duration="2000"
-    @onDidDismiss="setOpen(false)"
+    @didDismiss="setOpen(false)"
   >
   </ion-toast>
 </template>

--- a/packages/vue/test-app/src/views/Overlays.vue
+++ b/packages/vue/test-app/src/views/Overlays.vue
@@ -76,7 +76,7 @@
       <ion-action-sheet
         :is-open="isActionSheetOpen"
         :buttons="actionSheetButtons"
-        @onDidDismiss="setActionSheetRef(false)"
+        @didDismiss="setActionSheetRef(false)"
       >
       </ion-action-sheet>
 
@@ -84,7 +84,7 @@
         :is-open="isAlertOpen"
         header="Alert!"
         :buttons="alertButtons"
-        @onDidDismiss="setAlertRef(false)"
+        @didDismiss="setAlertRef(false)"
       >
       </ion-alert>
 
@@ -93,17 +93,17 @@
         :duration="2000"
         message="Loading"
         :backdrop-dismiss="true"
-        @onDidDismiss="setLoadingRef(false)"
+        @didDismiss="setLoadingRef(false)"
       >
       </ion-loading>
 
       <ion-modal
         :is-open="isModalOpen"
         :componentProps="overlayProps"
-        @onWillPresent="onModalWillPresent"
-        @onDidPresent="onModalDidPresent"
-        @onWillDismiss="onModalWillDismiss"
-        @onDidDismiss="onModalDidDismiss"
+        @willPresent="onModalWillPresent"
+        @didPresent="onModalDidPresent"
+        @willDismiss="onModalWillDismiss"
+        @didDismiss="onModalDidDismiss"
       >
         <ModalContent></ModalContent>
       </ion-modal>
@@ -112,7 +112,7 @@
         :is-open="isPopoverOpen"
         :componentProps="overlayProps"
         :event="popoverEvent"
-        @onDidDismiss="setPopoverRef(false)"
+        @didDismiss="setPopoverRef(false)"
       >
         <PopoverContent></PopoverContent>
       </ion-popover>
@@ -122,7 +122,7 @@
         :duration="2000"
         message="Toast"
         :buttons="toastButtons"
-        @onDidDismiss="setToastRef(false)"
+        @didDismiss="setToastRef(false)"
       >
       </ion-toast>
     </ion-content>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently Vue users need to listen to overlay events using an `on` prefix which is not very Vue-like. This syntax was carried over from Ionic React, but the `on` prefix is more suitable in a React environment.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Users can now do `@didPresent` instead of `@onDidPresent`
- Deprecated `@onDid` and `@onWill` events

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Only impacts overlay components
