### PR TITLE
refactor(vue): drop support for "on" prefixed overlay events and bump minimum required version of vue to 3.0.6

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -24,6 +24,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
 - [Vue](#vue)
   * [Tabs Config](#tabs-config)
   * [Overlay Events](#overlay-events)
+  * [Minimum Required Version](#minimum-required-version)
 
 
 
@@ -188,6 +189,14 @@ This applies to the following components: `ion-action-sheet`, `ion-alert`, `ion-
 >
   ...
 </ion-modal>
+```
+
+#### Minimum Required Version
+
+Vue v3.0.6 or newer is required.
+
+```
+npm install vue@next
 ```
 
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -23,6 +23,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
   * [Config Provider](#config-provider)
 - [Vue](#vue)
   * [Tabs Config](#tabs-config)
+  * [Overlay Events](#overlay-events)
 
 
 
@@ -156,6 +157,38 @@ const routes: Array<RouteRecordRaw> = [
 ```
 
 In the example above `tabs/tab1/view` has been rewritten has a sibling route to `tabs/tab1`. The `path` field now includes the `tab1` prefix.
+
+#### Overlay Events
+
+Overlay events `onWillPresent`, `onDidPresent`, `onWillDismiss`, and `onDidDismiss` have been removed in favor of `willPresent`, `didPresent`, `willDismiss`, and `didDismiss`.
+
+This applies to the following components: `ion-action-sheet`, `ion-alert`, `ion-loading`, `ion-modal`, `ion-picker`, `ion-popover`, and `ion-toast`.
+
+**Old**
+```html
+<ion-modal
+  :is-open="modalOpenRef"
+  @onWillPresent="onModalWillPresentHandler"
+  @onDidPresent="onModalDidPresentHandler"
+  @onWillDismiss="onModalWillDismissHandler"
+  @onDidDismiss="onModalDidDismissHandler"
+>
+  ...
+</ion-modal>
+```
+
+**New**
+```html
+<ion-modal
+  :is-open="modalOpenRef"
+  @willPresent="onModalWillPresentHandler"
+  @didPresent="onModalDidPresentHandler"
+  @willDismiss="onModalWillDismissHandler"
+  @didDismiss="onModalDidDismissHandler"
+>
+  ...
+</ion-modal>
+```
 
 
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -196,7 +196,7 @@ This applies to the following components: `ion-action-sheet`, `ion-alert`, `ion-
 Vue v3.0.6 or newer is required.
 
 ```
-npm install vue@next
+npm install vue@3
 ```
 
 

--- a/packages/vue/src/ionic-vue.ts
+++ b/packages/vue/src/ionic-vue.ts
@@ -1,7 +1,6 @@
 import { App, Plugin } from 'vue';
 import { IonicConfig, setupConfig } from '@ionic/core';
 import { applyPolyfills, defineCustomElements } from '@ionic/core/loader';
-import { needsKebabCase } from './utils';
 
 /**
 * We need to make sure that the web component fires an event
@@ -9,31 +8,22 @@ import { needsKebabCase } from './utils';
 * otherwise the binding's callback will fire before any
 * v-model values have been updated.
 */
-const toLowerCase = (eventName: string) => eventName === 'ionChange' ? 'v-ionchange' : eventName.toLowerCase();
 const toKebabCase = (eventName: string) => eventName === 'ionChange' ? 'v-ion-change' : eventName.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase();
 
-/**
- * Vue 3.0.6 fixed a bug where events on custom elements
- * were always converted to lower case, so "ionRefresh"
- * became "ionRefresh". We need to account for the old
- * issue as well as the new behavior where "ionRefresh"
- * is converted to "ion-refresh".
- * See https://github.com/vuejs/vue-next/pull/2847
- */
-const getHelperFunctions = (needsKebabCase: boolean = true) => {
-  const conversionFn = (needsKebabCase) ? toKebabCase : toLowerCase;
+
+const getHelperFunctions = () => {
   return {
-      ael: (el: any, eventName: string, cb: any, opts: any) => el.addEventListener(conversionFn(eventName), cb, opts),
-      rel: (el: any, eventName: string, cb: any, opts: any) => el.removeEventListener(conversionFn(eventName), cb, opts),
-      ce: (eventName: string, opts: any) => new CustomEvent(conversionFn(eventName), opts)
+      ael: (el: any, eventName: string, cb: any, opts: any) => el.addEventListener(toKebabCase(eventName), cb, opts),
+      rel: (el: any, eventName: string, cb: any, opts: any) => el.removeEventListener(toKebabCase(eventName), cb, opts),
+      ce: (eventName: string, opts: any) => new CustomEvent(toKebabCase(eventName), opts)
   };
 };
 
 export const IonicVue: Plugin = {
 
-  async install(app: App, config: IonicConfig = {}) {
+  async install(_: App, config: IonicConfig = {}) {
     if (typeof (window as any) !== 'undefined') {
-      const { ael, rel, ce } = getHelperFunctions(needsKebabCase(app.version));
+      const { ael, rel, ce } = getHelperFunctions();
       setupConfig({
         ...config,
         _ael: ael,

--- a/packages/vue/src/utils.ts
+++ b/packages/vue/src/utils.ts
@@ -57,5 +57,3 @@ export const getConfig = (): CoreConfig | null => {
   }
   return null;
 };
-
-export const needsKebabCase = (version: string) => !['3.0.0', '3.0.1', '3.0.2', '3.0.3', '3.0.4', '3.0.5'].includes(version);

--- a/packages/vue/src/vue-component-lib/overlays.ts
+++ b/packages/vue/src/vue-component-lib/overlays.ts
@@ -1,41 +1,8 @@
-import { defineComponent, h, ref, VNode, getCurrentInstance, ComponentInternalInstance } from 'vue';
+import { defineComponent, h, ref, VNode, getCurrentInstance } from 'vue';
 import { needsKebabCase } from '../utils';
 
 export interface OverlayProps {
   isOpen?: boolean;
-}
-
-/**
- * Make sure we only
- * warn user about each
- * event at most once.
- */
-let willPresentWarn = false;
-let didPresentWarn = false;
-let willDismissWarn = false;
-let didDismissWarn = false;
-
-const checkForDeprecatedListeners = (instance: ComponentInternalInstance) => {
-  const props = instance.vnode.props;
-  if (!willPresentWarn && props.onOnWillPresent !== undefined) {
-    console.warn('[@ionic/vue Deprecation]: @onWillPresent has been deprecated in favor of @willPresent and will be removed in Ionic Vue v6.0.');
-    willPresentWarn = true;
-  }
-
-  if (!didPresentWarn && props.onOnDidPresent !== undefined) {
-    console.warn('[@ionic/vue Deprecation]: @onDidPresent has been deprecated in favor of @didPresent and will be removed in Ionic Vue v6.0.');
-    didPresentWarn = true;
-  }
-
-  if (!willDismissWarn && props.onOnWillDismiss !== undefined) {
-    console.warn('[@ionic/vue Deprecation]: @onWillDismiss has been deprecated in favor of @willDismiss and will be removed in Ionic Vue v6.0.');
-    willDismissWarn = true;
-  }
-
-  if (!didDismissWarn && props.onOnDidDismiss !== undefined) {
-    console.warn('[@ionic/vue Deprecation]: @onDidDismiss has been deprecated in favor of @didDismiss and will be removed in Ionic Vue v6.0.');
-    didDismissWarn = true;
-  }
 }
 
 export const defineOverlayContainer = <Props extends object>(name: string, componentProps: string[] = [], controller: any) => {
@@ -49,23 +16,21 @@ export const defineOverlayContainer = <Props extends object>(name: string, compo
    */
   const eventPrefix = name.toLowerCase().split('-').join('');
   const lowerCaseListeners = [
-    { componentEv: `${eventPrefix}willpresent`, frameworkEv: 'willPresent', deprecatedEv: 'onWillPresent' },
-    { componentEv: `${eventPrefix}didpresent`, frameworkEv: 'didPresent', deprecatedEv: 'onDidPresent' },
-    { componentEv: `${eventPrefix}willdismiss`, frameworkEv: 'willDismiss', deprecatedEv: 'onWillDismiss' },
-    { componentEv: `${eventPrefix}diddismiss`, frameworkEv: 'didDismiss', deprecatedEv: 'onDidDismiss' },
+    { componentEv: `${eventPrefix}willpresent`, frameworkEv: 'willPresent' },
+    { componentEv: `${eventPrefix}didpresent`, frameworkEv: 'didPresent' },
+    { componentEv: `${eventPrefix}willdismiss`, frameworkEv: 'willDismiss' },
+    { componentEv: `${eventPrefix}diddismiss`, frameworkEv: 'didDismiss' },
   ];
   const kebabCaseListeners = [
-    { componentEv: `${name}-will-present`, frameworkEv: 'willPresent', deprecatedEv: 'onWillPresent' },
-    { componentEv: `${name}-did-present`, frameworkEv: 'didPresent', deprecatedEv: 'onDidPresent' },
-    { componentEv: `${name}-will-dismiss`, frameworkEv: 'willDismiss', deprecatedEv: 'onWillDismiss'  },
-    { componentEv: `${name}-did-dismiss`, frameworkEv: 'didDismiss', deprecatedEv: 'onDidDismiss' },
+    { componentEv: `${name}-will-present`, frameworkEv: 'willPresent' },
+    { componentEv: `${name}-did-present`, frameworkEv: 'didPresent' },
+    { componentEv: `${name}-will-dismiss`, frameworkEv: 'willDismiss' },
+    { componentEv: `${name}-did-dismiss`, frameworkEv: 'didDismiss' },
   ];
 
   const Container = defineComponent<Props & OverlayProps>((props, { slots, emit }) => {
     const instance = getCurrentInstance();
     const adjustedEventListeners = needsKebabCase(instance.appContext.app.version) ? kebabCaseListeners : lowerCaseListeners;
-
-    checkForDeprecatedListeners(instance);
 
     const overlay = ref();
     const onVnodeMounted = async () => {
@@ -120,21 +85,9 @@ export const defineOverlayContainer = <Props extends object>(name: string, compo
         return;
       }
 
-      /**
-       * When supporting both the "on" prefixed and non-"on" prefixed
-       * events, there seems to be an issue where the handlers are
-       * getting passed as props. This should be resolved when we drop
-       * support for the "on" prefixed listeners.
-       */
-      const restOfProps = { ...(props as any) };
-      delete restOfProps.onWillPresent;
-      delete restOfProps.onDidPresent;
-      delete restOfProps.onWillDismiss;
-      delete restOfProps.onDidDismiss;
-
       const component = slots.default && slots.default()[0];
       overlay.value = controller.create({
-        ...restOfProps,
+        ...props,
         component
       });
 
@@ -143,7 +96,6 @@ export const defineOverlayContainer = <Props extends object>(name: string, compo
       adjustedEventListeners.forEach(eventListener => {
         overlay.value.addEventListener(eventListener.componentEv, () => {
           emit(eventListener.frameworkEv);
-          emit(eventListener.deprecatedEv);
         });
       })
 
@@ -166,10 +118,7 @@ export const defineOverlayContainer = <Props extends object>(name: string, compo
 
   Container.displayName = name;
   Container.props = [...componentProps, 'isOpen'];
-  Container.emits = [
-    'willPresent', 'didPresent', 'willDismiss', 'didDismiss',
-    'onWillPresent', 'onDidPresent', 'onWillDismiss', 'onDidDismiss'
-  ];
+  Container.emits = ['willPresent', 'didPresent', 'willDismiss', 'didDismiss'];
 
   return Container;
 }

--- a/packages/vue/src/vue-component-lib/overlays.ts
+++ b/packages/vue/src/vue-component-lib/overlays.ts
@@ -1,27 +1,11 @@
-import { defineComponent, h, ref, VNode, getCurrentInstance } from 'vue';
-import { needsKebabCase } from '../utils';
+import { defineComponent, h, ref, VNode } from 'vue';
 
 export interface OverlayProps {
   isOpen?: boolean;
 }
 
 export const defineOverlayContainer = <Props extends object>(name: string, componentProps: string[] = [], controller: any) => {
-  /**
-   * Vue 3.0.6 fixed a bug where events on custom elements
-   * were always converted to lower case, so "ionRefresh"
-   * became "ionrefresh". We need to account for the old
-   * issue as well as the new behavior where "ionRefresh"
-   * is converted to "ion-refresh".
-   * See https://github.com/vuejs/vue-next/pull/2847
-   */
-  const eventPrefix = name.toLowerCase().split('-').join('');
-  const lowerCaseListeners = [
-    { componentEv: `${eventPrefix}willpresent`, frameworkEv: 'willPresent' },
-    { componentEv: `${eventPrefix}didpresent`, frameworkEv: 'didPresent' },
-    { componentEv: `${eventPrefix}willdismiss`, frameworkEv: 'willDismiss' },
-    { componentEv: `${eventPrefix}diddismiss`, frameworkEv: 'didDismiss' },
-  ];
-  const kebabCaseListeners = [
+  const eventListeners = [
     { componentEv: `${name}-will-present`, frameworkEv: 'willPresent' },
     { componentEv: `${name}-did-present`, frameworkEv: 'didPresent' },
     { componentEv: `${name}-will-dismiss`, frameworkEv: 'willDismiss' },
@@ -29,9 +13,6 @@ export const defineOverlayContainer = <Props extends object>(name: string, compo
   ];
 
   const Container = defineComponent<Props & OverlayProps>((props, { slots, emit }) => {
-    const instance = getCurrentInstance();
-    const adjustedEventListeners = needsKebabCase(instance.appContext.app.version) ? kebabCaseListeners : lowerCaseListeners;
-
     const overlay = ref();
     const onVnodeMounted = async () => {
       const isOpen = props.isOpen;
@@ -103,7 +84,7 @@ export const defineOverlayContainer = <Props extends object>(name: string, compo
 
       overlay.value = await overlay.value;
 
-      adjustedEventListeners.forEach(eventListener => {
+      eventListeners.forEach(eventListener => {
         overlay.value.addEventListener(eventListener.componentEv, () => {
           emit(eventListener.frameworkEv);
         });

--- a/packages/vue/src/vue-component-lib/overlays.ts
+++ b/packages/vue/src/vue-component-lib/overlays.ts
@@ -85,9 +85,19 @@ export const defineOverlayContainer = <Props extends object>(name: string, compo
         return;
       }
 
+      /**
+       * These are getting passed as props.
+       * Potentially a Vue bug with Web Components?
+       */
+      const restOfProps = { ...(props as any) };
+      delete restOfProps.onWillPresent;
+      delete restOfProps.onDidPresent;
+      delete restOfProps.onWillDismiss;
+      delete restOfProps.onDidDismiss;
+
       const component = slots.default && slots.default()[0];
       overlay.value = controller.create({
-        ...props,
+        ...restOfProps,
         component
       });
 

--- a/packages/vue/test-app/package-lock.json
+++ b/packages/vue/test-app/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "@ionic/vue": "5.6.3",
         "@ionic/vue-router": "5.6.3",
-        "vue": "^3.0.0-0",
+        "vue": "^3.0.11",
         "vue-router": "^4.0.0-rc.4"
       },
       "devDependencies": {
@@ -4456,6 +4456,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.2.tgz",
       "integrity": "sha512-GOlEMTlC/OdzBkKaKOniYErbkjoKxkBOmulxGmMR10I2JJX6TvXd/peaO/kla2xhpliV/M6Z4TLJp0yjAvRIAw==",
+      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.12.0",
         "@babel/types": "^7.12.0",
@@ -4468,6 +4469,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4476,6 +4478,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.2.tgz",
       "integrity": "sha512-jvaL4QF2yXBJVD+JLbM2YA3e5fNfflJnfQ+GtfYk46ENGsEetqbkZqcX7fO+RHdG8tZBo7LCNBvgD0QLr+V4sg==",
+      "dev": true,
       "dependencies": {
         "@vue/compiler-core": "3.0.2",
         "@vue/shared": "3.0.2"
@@ -4605,36 +4608,52 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.2.tgz",
-      "integrity": "sha512-GdRloNcBar4yqWGXOcba1t//j/WizwfthfPUYkjcIPHjYnA/vTEQYp0C9+ZjPdinv1WRK1BSMeN/xj31kQES4A==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.11.tgz",
+      "integrity": "sha512-SKM3YKxtXHBPMf7yufXeBhCZ4XZDKP9/iXeQSC8bBO3ivBuzAi4aZi0bNoeE2IF2iGfP/AHEt1OU4ARj4ao/Xw==",
       "dependencies": {
-        "@vue/shared": "3.0.2"
+        "@vue/shared": "3.0.11"
       }
+    },
+    "node_modules/@vue/reactivity/node_modules/@vue/shared": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.11.tgz",
+      "integrity": "sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA=="
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.2.tgz",
-      "integrity": "sha512-3m/jOs2xSipEFah9FgpEzvC9nERFonVGLN06+pf8iYPIy54Nlv7D2cyrk3Lhbjz4w3PbIrkxJnoTJYvJM7HDfA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.11.tgz",
+      "integrity": "sha512-87XPNwHfz9JkmOlayBeCCfMh9PT2NBnv795DSbi//C/RaAnc/bGZgECjmkD7oXJ526BZbgk9QZBPdFT8KMxkAg==",
       "dependencies": {
-        "@vue/reactivity": "3.0.2",
-        "@vue/shared": "3.0.2"
+        "@vue/reactivity": "3.0.11",
+        "@vue/shared": "3.0.11"
       }
     },
+    "node_modules/@vue/runtime-core/node_modules/@vue/shared": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.11.tgz",
+      "integrity": "sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA=="
+    },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.2.tgz",
-      "integrity": "sha512-vqC1KK1yWthTw1FKzajT0gYQaEqAq7bpeeXQC473nllGC5YHbJhNAJLSmrDun1tjXqGF0UNCWYljYm+++BJv6w==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.11.tgz",
+      "integrity": "sha512-jm3FVQESY3y2hKZ2wlkcmFDDyqaPyU3p1IdAX92zTNeCH7I8zZ37PtlE1b9NlCtzV53WjB4TZAYh9yDCMIEumA==",
       "dependencies": {
-        "@vue/runtime-core": "3.0.2",
-        "@vue/shared": "3.0.2",
+        "@vue/runtime-core": "3.0.11",
+        "@vue/shared": "3.0.11",
         "csstype": "^2.6.8"
       }
+    },
+    "node_modules/@vue/runtime-dom/node_modules/@vue/shared": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.11.tgz",
+      "integrity": "sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA=="
     },
     "node_modules/@vue/shared": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.2.tgz",
-      "integrity": "sha512-Zx869zlNoujFOclKIoYmkh8ES2RcS/+Jn546yOiPyZ+3+Ejivnr+fb8l+DdXUEFjo+iVDNR3KyLzg03aBFfZ4Q=="
+      "integrity": "sha512-Zx869zlNoujFOclKIoYmkh8ES2RcS/+Jn546yOiPyZ+3+Ejivnr+fb8l+DdXUEFjo+iVDNR3KyLzg03aBFfZ4Q==",
+      "dev": true
     },
     "node_modules/@vue/test-utils": {
       "version": "2.0.0-beta.10",
@@ -7978,9 +7997,9 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
-      "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
+      "version": "2.6.17",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
+      "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
     },
     "node_modules/cyclist": {
       "version": "1.0.1",
@@ -20718,13 +20737,13 @@
       "dev": true
     },
     "node_modules/vue": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.2.tgz",
-      "integrity": "sha512-ciKFjutKRs+2Vbvgrist1oDd5wZQqtOel/K//ku54zLbf8tcTV+XbyAfanTHcTkML9CUj09vnC+y+5uaOz2/9g==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.11.tgz",
+      "integrity": "sha512-3/eUi4InQz8MPzruHYSTQPxtM3LdZ1/S/BvaU021zBnZi0laRUyH6pfuE4wtUeLvI8wmUNwj5wrZFvbHUXL9dw==",
       "dependencies": {
-        "@vue/compiler-dom": "3.0.2",
-        "@vue/runtime-dom": "3.0.2",
-        "@vue/shared": "3.0.2"
+        "@vue/compiler-dom": "3.0.11",
+        "@vue/runtime-dom": "3.0.11",
+        "@vue/shared": "3.0.11"
       }
     },
     "node_modules/vue-eslint-parser": {
@@ -20906,6 +20925,40 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "node_modules/vue/node_modules/@vue/compiler-core": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.11.tgz",
+      "integrity": "sha512-6sFj6TBac1y2cWCvYCA8YzHJEbsVkX7zdRs/3yK/n1ilvRqcn983XvpBbnN3v4mZ1UiQycTvOiajJmOgN9EVgw==",
+      "dependencies": {
+        "@babel/parser": "^7.12.0",
+        "@babel/types": "^7.12.0",
+        "@vue/shared": "3.0.11",
+        "estree-walker": "^2.0.1",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/vue/node_modules/@vue/compiler-dom": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.11.tgz",
+      "integrity": "sha512-+3xB50uGeY5Fv9eMKVJs2WSRULfgwaTJsy23OIltKgMrynnIj8hTYY2UL97HCoz78aDw1VDXdrBQ4qepWjnQcw==",
+      "dependencies": {
+        "@vue/compiler-core": "3.0.11",
+        "@vue/shared": "3.0.11"
+      }
+    },
+    "node_modules/vue/node_modules/@vue/shared": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.11.tgz",
+      "integrity": "sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA=="
+    },
+    "node_modules/vue/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -26386,6 +26439,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.2.tgz",
       "integrity": "sha512-GOlEMTlC/OdzBkKaKOniYErbkjoKxkBOmulxGmMR10I2JJX6TvXd/peaO/kla2xhpliV/M6Z4TLJp0yjAvRIAw==",
+      "dev": true,
       "requires": {
         "@babel/parser": "^7.12.0",
         "@babel/types": "^7.12.0",
@@ -26397,7 +26451,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -26405,6 +26460,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.2.tgz",
       "integrity": "sha512-jvaL4QF2yXBJVD+JLbM2YA3e5fNfflJnfQ+GtfYk46ENGsEetqbkZqcX7fO+RHdG8tZBo7LCNBvgD0QLr+V4sg==",
+      "dev": true,
       "requires": {
         "@vue/compiler-core": "3.0.2",
         "@vue/shared": "3.0.2"
@@ -26524,36 +26580,58 @@
       "dev": true
     },
     "@vue/reactivity": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.2.tgz",
-      "integrity": "sha512-GdRloNcBar4yqWGXOcba1t//j/WizwfthfPUYkjcIPHjYnA/vTEQYp0C9+ZjPdinv1WRK1BSMeN/xj31kQES4A==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.11.tgz",
+      "integrity": "sha512-SKM3YKxtXHBPMf7yufXeBhCZ4XZDKP9/iXeQSC8bBO3ivBuzAi4aZi0bNoeE2IF2iGfP/AHEt1OU4ARj4ao/Xw==",
       "requires": {
-        "@vue/shared": "3.0.2"
+        "@vue/shared": "3.0.11"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.11.tgz",
+          "integrity": "sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA=="
+        }
       }
     },
     "@vue/runtime-core": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.2.tgz",
-      "integrity": "sha512-3m/jOs2xSipEFah9FgpEzvC9nERFonVGLN06+pf8iYPIy54Nlv7D2cyrk3Lhbjz4w3PbIrkxJnoTJYvJM7HDfA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.11.tgz",
+      "integrity": "sha512-87XPNwHfz9JkmOlayBeCCfMh9PT2NBnv795DSbi//C/RaAnc/bGZgECjmkD7oXJ526BZbgk9QZBPdFT8KMxkAg==",
       "requires": {
-        "@vue/reactivity": "3.0.2",
-        "@vue/shared": "3.0.2"
+        "@vue/reactivity": "3.0.11",
+        "@vue/shared": "3.0.11"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.11.tgz",
+          "integrity": "sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA=="
+        }
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.2.tgz",
-      "integrity": "sha512-vqC1KK1yWthTw1FKzajT0gYQaEqAq7bpeeXQC473nllGC5YHbJhNAJLSmrDun1tjXqGF0UNCWYljYm+++BJv6w==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.11.tgz",
+      "integrity": "sha512-jm3FVQESY3y2hKZ2wlkcmFDDyqaPyU3p1IdAX92zTNeCH7I8zZ37PtlE1b9NlCtzV53WjB4TZAYh9yDCMIEumA==",
       "requires": {
-        "@vue/runtime-core": "3.0.2",
-        "@vue/shared": "3.0.2",
+        "@vue/runtime-core": "3.0.11",
+        "@vue/shared": "3.0.11",
         "csstype": "^2.6.8"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.11.tgz",
+          "integrity": "sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA=="
+        }
       }
     },
     "@vue/shared": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.2.tgz",
-      "integrity": "sha512-Zx869zlNoujFOclKIoYmkh8ES2RcS/+Jn546yOiPyZ+3+Ejivnr+fb8l+DdXUEFjo+iVDNR3KyLzg03aBFfZ4Q=="
+      "integrity": "sha512-Zx869zlNoujFOclKIoYmkh8ES2RcS/+Jn546yOiPyZ+3+Ejivnr+fb8l+DdXUEFjo+iVDNR3KyLzg03aBFfZ4Q==",
+      "dev": true
     },
     "@vue/test-utils": {
       "version": "2.0.0-beta.10",
@@ -29368,9 +29446,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
-      "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
+      "version": "2.6.17",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
+      "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -39954,13 +40032,46 @@
       "dev": true
     },
     "vue": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.2.tgz",
-      "integrity": "sha512-ciKFjutKRs+2Vbvgrist1oDd5wZQqtOel/K//ku54zLbf8tcTV+XbyAfanTHcTkML9CUj09vnC+y+5uaOz2/9g==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.11.tgz",
+      "integrity": "sha512-3/eUi4InQz8MPzruHYSTQPxtM3LdZ1/S/BvaU021zBnZi0laRUyH6pfuE4wtUeLvI8wmUNwj5wrZFvbHUXL9dw==",
       "requires": {
-        "@vue/compiler-dom": "3.0.2",
-        "@vue/runtime-dom": "3.0.2",
-        "@vue/shared": "3.0.2"
+        "@vue/compiler-dom": "3.0.11",
+        "@vue/runtime-dom": "3.0.11",
+        "@vue/shared": "3.0.11"
+      },
+      "dependencies": {
+        "@vue/compiler-core": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.11.tgz",
+          "integrity": "sha512-6sFj6TBac1y2cWCvYCA8YzHJEbsVkX7zdRs/3yK/n1ilvRqcn983XvpBbnN3v4mZ1UiQycTvOiajJmOgN9EVgw==",
+          "requires": {
+            "@babel/parser": "^7.12.0",
+            "@babel/types": "^7.12.0",
+            "@vue/shared": "3.0.11",
+            "estree-walker": "^2.0.1",
+            "source-map": "^0.6.1"
+          }
+        },
+        "@vue/compiler-dom": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.11.tgz",
+          "integrity": "sha512-+3xB50uGeY5Fv9eMKVJs2WSRULfgwaTJsy23OIltKgMrynnIj8hTYY2UL97HCoz78aDw1VDXdrBQ4qepWjnQcw==",
+          "requires": {
+            "@vue/compiler-core": "3.0.11",
+            "@vue/shared": "3.0.11"
+          }
+        },
+        "@vue/shared": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.11.tgz",
+          "integrity": "sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "vue-eslint-parser": {

--- a/packages/vue/test-app/package.json
+++ b/packages/vue/test-app/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@ionic/vue": "5.6.3",
     "@ionic/vue-router": "5.6.3",
-    "vue": "^3.0.0-0",
+    "vue": "^3.0.11",
     "vue-router": "^4.0.0-rc.4"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- We deprecated "on" prefixed overlay events in Framework v5 but they were still usable
- Older versions of Vue 3 had a bug with how web component events were transformed that we had to support.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- "on" prefixed events have been removed in favor of non prefixed events
- Support for the old version of Vue 3 has been dropped.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
