### PR TITLE
fix(angular): return to correct tab outside tab context

### DIFF
--- a/angular/src/directives/navigation/stack-controller.ts
+++ b/angular/src/directives/navigation/stack-controller.ts
@@ -164,10 +164,13 @@ export class StackController {
       if (views.length <= deep) {
         return Promise.resolve(false);
       }
-      const view = views[views.length - deep - 1];
+      let view = views[views.length - deep - 1];
+      let viewSavedData = view.savedData;
+      while (viewSavedData.get('primary')) {
+        view = viewSavedData.get('primary').outlet.stackCtrl.activeView;
+        viewSavedData = view.savedData;
+      }
       let url = view.url;
-
-      const viewSavedData = view.savedData;
       if (viewSavedData) {
         const primaryOutlet = viewSavedData.get('primary');
         if (


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features) 
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, after leaving ion-tabs context (for example pushing route that is defined outside the tabs routing paths) the view hierarchy is preserved. However, after moving back using ion-back-button or swiping back, after transition completed - we are routed back to the default tab.

Issue Number: #19801

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

For now, we are returning to the previous tab (or whether route was activated inside).

To achieve that, I'm searching the view that is the leaf of the routing hierarchy, branched from the view on the stack (in this case - tabs), and using its url (or context) to resolve the correct destination (consistent with the visible underlying view).
In other words, I'm looking for the deepest view I can find inside the view we are backing to.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Tested on reproduction present in #23218 and in my project. Any suggestions are welcome.

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
