### PR TITLE
fix(vue): use correct history mode when doing ssr to avoid errors

### DIFF
--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -40,6 +40,7 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
      * but we can check to see if the latest routing action
      * was a replace action by looking at the history state.
      */
+    const history = opts.history;
     const replaceAction = history.state.replaced ? 'replace' : undefined;
     handleHistoryChange(to, action || replaceAction, direction);
 

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -39,9 +39,10 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
      * about the replace action in opts.history.listen
      * but we can check to see if the latest routing action
      * was a replace action by looking at the history state.
+     * We need to use opts.history rather than window.history
+     * because window.history will be undefined when using SSR.
      */
-    const history = opts.history;
-    const replaceAction = history.state.replaced ? 'replace' : undefined;
+    const replaceAction = opts.history.state.replaced ? 'replace' : undefined;
     handleHistoryChange(to, action || replaceAction, direction);
 
     currentNavigationInfo = { direction: undefined, action: undefined };


### PR DESCRIPTION
if this runs in SSR mode, we are getting history is undefined! so I just initialized the history variable from opts.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #23254 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- No error
- SSR works great

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I have just added a line to initialize history variable before using it, so on the server it doesn't break
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
