### PR TITLE
fix(vue): props are now passed to ion-router-outlet

### DIFF
--- a/packages/vue/src/components/IonRouterOutlet.ts
+++ b/packages/vue/src/components/IonRouterOutlet.ts
@@ -18,9 +18,9 @@ let viewDepthKey: InjectionKey<0> = Symbol(0);
 export const IonRouterOutlet = defineComponent({
   name: 'IonRouterOutlet',
   props: {
-    animation: Object,
-    animated: Boolean,
-    mode: String
+    animation: { type: Function, default: undefined },
+    animated: { type: Boolean, default: true },
+    mode: { type: String, default: undefined }
   },
   setup(props, { attrs }) {
     const injectedRoute = inject(routeLocationKey)!;

--- a/packages/vue/src/components/IonRouterOutlet.ts
+++ b/packages/vue/src/components/IonRouterOutlet.ts
@@ -17,6 +17,11 @@ import { fireLifecycle, generateId, getConfig } from '../utils';
 let viewDepthKey: InjectionKey<0> = Symbol(0);
 export const IonRouterOutlet = defineComponent({
   name: 'IonRouterOutlet',
+  props: {
+    animation: Object,
+    animated: Boolean,
+    mode: String
+  },
   setup(_, { attrs }) {
     const injectedRoute = inject(routeLocationKey)!;
     const route = useRoute();
@@ -381,15 +386,16 @@ export const IonRouterOutlet = defineComponent({
       components,
       injectedRoute,
       ionRouterOutlet,
-      registerIonPage
+      registerIonPage,
+      props
     }
   },
   render() {
-    const { components, registerIonPage, injectedRoute } = this;
+    const { components, registerIonPage, injectedRoute, props } = this;
 
     return h(
       'ion-router-outlet',
-      { ref: 'ionRouterOutlet' },
+      { ref: 'ionRouterOutlet', ...props },
       // TODO types
       components && components.map((c: any) => {
         let props = {

--- a/packages/vue/src/components/IonRouterOutlet.ts
+++ b/packages/vue/src/components/IonRouterOutlet.ts
@@ -22,7 +22,7 @@ export const IonRouterOutlet = defineComponent({
     animated: Boolean,
     mode: String
   },
-  setup(_, { attrs }) {
+  setup(props, { attrs }) {
     const injectedRoute = inject(routeLocationKey)!;
     const route = useRoute();
     const depth = inject(viewDepthKey, 0);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Props were not being passed to underlying web component, so ion-router-outlet props did not work


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Props are now passed to underlying Web Component ion-router-outlet

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
