### PR TITLE
fix(overlays): screen readers no longer read content behind overlays

### DIFF
--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -252,6 +252,11 @@ export const getOverlay = (doc: Document, overlayTag?: string, id?: string): HTM
  * that devs are not using a router,
  * they will need to add the "ion-view-container-root"
  * id to the element that contains all of their views.
+ *
+ * TODO: If Framework supports having multiple top
+ * level router outlets we would need to update this.
+ * Example: One outlet for side menu and one outlet
+ * for main content.
  */
 export const setRootAriaHidden = (hidden = false) => {
   const root = getAppRoot(document);

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -236,6 +236,28 @@ export const getOverlay = (doc: Document, overlayTag?: string, id?: string): HTM
     : overlays.find(o => o.id === id);
 };
 
+/**
+ * When an overlay is presented, the main
+ * focus is the overlay not the page content.
+ * We need to remove the page content from the
+ * accessibility tree otherwise when
+ * users use "read screen from top" gestures with
+ * TalkBack and VoiceOver, the screen reader will begin
+ * to read the content underneath the overlay.
+ */
+const setRootAriaHidden = (overlayEl: HTMLElement, hidden = false) => {
+  const root = getAppRoot(document);
+  const routerOutlet = root.querySelector('ion-router-outlet');
+
+  if (!routerOutlet) { return; }
+
+  if (hidden) {
+    routerOutlet.setAttribute('aria-hidden', 'true');
+  } else {
+    routerOutlet.removeAttribute('aria-hidden');
+  }
+}
+
 export const present = async (
   overlay: OverlayInterface,
   name: keyof IonicConfig,

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -244,17 +244,25 @@ export const getOverlay = (doc: Document, overlayTag?: string, id?: string): HTM
  * users use "read screen from top" gestures with
  * TalkBack and VoiceOver, the screen reader will begin
  * to read the content underneath the overlay.
+ *
+ * We need a container where all page components
+ * exist that is separate from where the overlays
+ * are added in the DOM. For most apps, this element
+ * is the top most ion-router-outlet. In the event
+ * that devs are not using a router,
+ * they will need to add the "ion-view-container-root"
+ * id to the element that contains all of their views.
  */
-const setRootAriaHidden = (overlayEl: HTMLElement, hidden = false) => {
+export const setRootAriaHidden = (hidden = false) => {
   const root = getAppRoot(document);
-  const routerOutlet = root.querySelector('ion-router-outlet');
+  const viewContainer = root.querySelector('ion-router-outlet, #ion-view-container-root');
 
-  if (!routerOutlet) { return; }
+  if (!viewContainer) { return; }
 
   if (hidden) {
-    routerOutlet.setAttribute('aria-hidden', 'true');
+    viewContainer.setAttribute('aria-hidden', 'true');
   } else {
-    routerOutlet.removeAttribute('aria-hidden');
+    viewContainer.removeAttribute('aria-hidden');
   }
 }
 
@@ -268,6 +276,9 @@ export const present = async (
   if (overlay.presented) {
     return;
   }
+
+  setRootAriaHidden(true);
+
   overlay.presented = true;
   overlay.willPresent.emit();
 
@@ -335,6 +346,9 @@ export const dismiss = async (
   if (!overlay.presented) {
     return false;
   }
+
+  setRootAriaHidden(false);
+
   overlay.presented = false;
 
   try {

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -260,7 +260,7 @@ export const getOverlay = (doc: Document, overlayTag?: string, id?: string): HTM
  */
 export const setRootAriaHidden = (hidden = false) => {
   const root = getAppRoot(document);
-  const viewContainer = root.querySelector('ion-router-outlet, #ion-view-container-root');
+  const viewContainer = root.querySelector('ion-router-outlet, ion-nav, #ion-view-container-root');
 
   if (!viewContainer) { return; }
 

--- a/core/src/utils/test/overlays.spec.ts
+++ b/core/src/utils/test/overlays.spec.ts
@@ -1,0 +1,59 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { setRootAriaHidden } from '../overlays';
+import { RouterOutlet } from '../../components/router-outlet/route-outlet';
+
+describe('setRootAriaHidden()', () => {
+  it('should correctly remove and re-add router outlet from accessibility tree', async () => {
+    const page = await newSpecPage({
+      components: [RouterOutlet],
+      html: `
+        <ion-router-outlet></ion-router-outlet>
+      `
+    });
+
+    const routerOutlet = page.body.querySelector('ion-router-outlet');
+
+    expect(routerOutlet.hasAttribute('aria-hidden')).toEqual(false);
+
+    setRootAriaHidden(true);
+    expect(routerOutlet.hasAttribute('aria-hidden')).toEqual(true);
+
+    setRootAriaHidden(false);
+    expect(routerOutlet.hasAttribute('aria-hidden')).toEqual(false);
+  });
+
+  it('should correctly remove and re-add custom container from accessibility tree', async () => {
+    const page = await newSpecPage({
+      components: [],
+      html: `
+        <div id="ion-view-container-root"></div>
+        <div id="not-container-root"></div>
+      `
+    });
+
+    const containerRoot = page.body.querySelector('#ion-view-container-root');
+    const notContainerRoot = page.body.querySelector('#not-container-root');
+
+    expect(containerRoot.hasAttribute('aria-hidden')).toEqual(false);
+    expect(notContainerRoot.hasAttribute('aria-hidden')).toEqual(false);
+
+    setRootAriaHidden(true);
+    expect(containerRoot.hasAttribute('aria-hidden')).toEqual(true);
+    expect(notContainerRoot.hasAttribute('aria-hidden')).toEqual(false);
+
+    setRootAriaHidden(false);
+    expect(containerRoot.hasAttribute('aria-hidden')).toEqual(false);
+    expect(notContainerRoot.hasAttribute('aria-hidden')).toEqual(false);
+  });
+
+  it('should not error if router outlet was not found', async () => {
+    const page = await newSpecPage({
+      components: [],
+      html: `
+        <div></div>
+      `
+    });
+
+    setRootAriaHidden(true);
+  });
+});

--- a/core/src/utils/test/overlays.spec.ts
+++ b/core/src/utils/test/overlays.spec.ts
@@ -1,6 +1,7 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { setRootAriaHidden } from '../overlays';
 import { RouterOutlet } from '../../components/router-outlet/route-outlet';
+import { Nav } from '../../components/nav/nav';
 
 describe('setRootAriaHidden()', () => {
   it('should correctly remove and re-add router outlet from accessibility tree', async () => {
@@ -20,6 +21,25 @@ describe('setRootAriaHidden()', () => {
 
     setRootAriaHidden(false);
     expect(routerOutlet.hasAttribute('aria-hidden')).toEqual(false);
+  });
+
+  it('should correctly remove and re-add nav from accessibility tree', async () => {
+    const page = await newSpecPage({
+      components: [Nav],
+      html: `
+        <ion-nav></ion-nav>
+      `
+    });
+
+    const nav = page.body.querySelector('ion-nav');
+
+    expect(nav.hasAttribute('aria-hidden')).toEqual(false);
+
+    setRootAriaHidden(true);
+    expect(nav.hasAttribute('aria-hidden')).toEqual(true);
+
+    setRootAriaHidden(false);
+    expect(nav.hasAttribute('aria-hidden')).toEqual(false);
   });
 
   it('should correctly remove and re-add custom container from accessibility tree', async () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/22714


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Apps will need to have one of the following in order for this to work: 

1. A top-level ion-router-outlet and ion-nav
2. A wrapper div with the "ion-view-container-root" ID 

Overlay util will look for this to set `aria-hidden="true"` on so that the main view is not read while the overlay is presented.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
