### PR TITLE
fix(react): support history@5 in preparation for react router 6

### DIFF
--- a/packages/react-router/src/ReactRouter/IonReactHashRouter.tsx
+++ b/packages/react-router/src/ReactRouter/IonReactHashRouter.tsx
@@ -25,9 +25,19 @@ export class IonReactHashRouter extends React.Component<IonReactHashRouterProps>
     this.registerHistoryListener = this.registerHistoryListener.bind(this);
   }
 
+  /**
+   * history@4.x passes separate location and action
+   * params. history@5.x passes location and action
+   * together as a single object.
+   * TODO: If support for React Router <=5 is dropped
+   * this logic is no longer needed. We can just assume
+   * a single object with both location and action.
+   */
   handleHistoryChange(location: HistoryLocation, action: HistoryAction) {
+    const locationValue = (location as any).location || location;
+    const actionValue = (location as any).action || action;
     if (this.historyListenHandler) {
-      this.historyListenHandler(location, action);
+      this.historyListenHandler(locationValue, actionValue);
     }
   }
 

--- a/packages/react-router/src/ReactRouter/IonReactMemoryRouter.tsx
+++ b/packages/react-router/src/ReactRouter/IonReactMemoryRouter.tsx
@@ -19,9 +19,19 @@ export class IonReactMemoryRouter extends React.Component<IonReactMemoryRouterPr
     this.registerHistoryListener = this.registerHistoryListener.bind(this);
   }
 
+  /**
+   * history@4.x passes separate location and action
+   * params. history@5.x passes location and action
+   * together as a single object.
+   * TODO: If support for React Router <=5 is dropped
+   * this logic is no longer needed. We can just assume
+   * a single object with both location and action.
+   */
   handleHistoryChange(location: HistoryLocation, action: HistoryAction) {
+    const locationValue = (location as any).location || location;
+    const actionValue = (location as any).action || action;
     if (this.historyListenHandler) {
-      this.historyListenHandler(location, action);
+      this.historyListenHandler(locationValue, actionValue);
     }
   }
 

--- a/packages/react-router/src/ReactRouter/IonReactRouter.tsx
+++ b/packages/react-router/src/ReactRouter/IonReactRouter.tsx
@@ -33,7 +33,7 @@ export class IonReactRouter extends React.Component<IonReactRouterProps> {
   * this logic is no longer needed. We can just assume
   * a single object with both location and action.
   */
- handleHistoryChange(location: HistoryLocation, action: HistoryAction) {
+  handleHistoryChange(location: HistoryLocation, action: HistoryAction) {
    const locationValue = (location as any).location || location;
    const actionValue = (location as any).action || action;
    if (this.historyListenHandler) {

--- a/packages/react-router/src/ReactRouter/IonReactRouter.tsx
+++ b/packages/react-router/src/ReactRouter/IonReactRouter.tsx
@@ -25,11 +25,21 @@ export class IonReactRouter extends React.Component<IonReactRouterProps> {
     this.registerHistoryListener = this.registerHistoryListener.bind(this);
   }
 
-  handleHistoryChange(location: HistoryLocation, action: HistoryAction) {
-    if (this.historyListenHandler) {
-      this.historyListenHandler(location, action);
-    }
-  }
+ /**
+  * history@4.x passes separate location and action
+  * params. history@5.x passes location and action
+  * together as a single object.
+  * TODO: If support for React Router <=5 is dropped
+  * this logic is no longer needed. We can just assume
+  * a single object with both location and action.
+  */
+ handleHistoryChange(location: HistoryLocation, action: HistoryAction) {
+   const locationValue = (location as any).location || location;
+   const actionValue = (location as any).action || action;
+   if (this.historyListenHandler) {
+     this.historyListenHandler(locationValue, actionValue);
+   }
+ }
 
   registerHistoryListener(cb: (location: HistoryLocation, action: HistoryAction) => void) {
     this.historyListenHandler = cb;

--- a/packages/react-router/src/ReactRouter/IonRouter.tsx
+++ b/packages/react-router/src/ReactRouter/IonRouter.tsx
@@ -203,8 +203,16 @@ class IonRouterInner extends React.PureComponent<IonRouteProps, IonRouteState> {
     this.incomingRouteParams = undefined;
   }
 
+  /**
+   * history@4.x uses goBack(), history@5.x uses back()
+   * TODO: If support for React Router <=5 is dropped
+   * this logic is no longer needed. We can just
+   * assume back() is available.
+   */
   handleNativeBack() {
-    this.props.history.goBack();
+    const history = this.props.history as any;
+    const goBack = history.goBack || history.back;
+    goBack();
   }
 
   handleNavigate(
@@ -256,7 +264,15 @@ class IonRouterInner extends React.PureComponent<IonRouteProps, IonRouteState> {
             routeInfo.tab === '' && prevInfo.tab === ''
           )
         ) {
-          this.props.history.goBack();
+          /**
+           * history@4.x uses goBack(), history@5.x uses back()
+           * TODO: If support for React Router <=5 is dropped
+           * this logic is no longer needed. We can just
+           * assume back() is available.
+           */
+          const history = this.props.history as any;
+          const goBack = history.goBack || history.back;
+          goBack();
         } else {
           this.handleNavigate(prevInfo.pathname + (prevInfo.search || ''), 'pop', 'back');
         }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/23294


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Ionic React now supports history@5x
- Most developers will not notice a difference, and it is not currently recommended to use `history@5` as react router expected `history@4.x` but react router 6 will support `history@5` so we will need to add support anyways.
- I opted to support both so we do not need to make any breaking changes right away (I.e. dropping support for react router 5)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
