### PR TITLE
docs(popover): resolve variable naming conflict

### DIFF
--- a/core/src/components/popover/readme.md
+++ b/core/src/components/popover/readme.md
@@ -346,8 +346,8 @@ export default defineComponent({
   setup() {
     const isOpenRef = ref(false);
     const event = ref();
-    const setOpen = (state: boolean, event?: Event) => {
-      event.value = event; 
+    const setOpen = (state: boolean, ev?: Event) => {
+      event.value = ev; 
       isOpenRef.value = state;
     }
     return { isOpenRef, setOpen, event }

--- a/core/src/components/popover/usage/vue.md
+++ b/core/src/components/popover/usage/vue.md
@@ -76,8 +76,8 @@ export default defineComponent({
   setup() {
     const isOpenRef = ref(false);
     const event = ref();
-    const setOpen = (state: boolean, event?: Event) => {
-      event.value = event; 
+    const setOpen = (state: boolean, ev?: Event) => {
+      event.value = ev; 
       isOpenRef.value = state;
     }
     return { isOpenRef, setOpen, event }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is an `event` variable and a `event` parameter inside the `open` function for Vue which is causing issues. See https://forum.ionicframework.com/t/popover-positioned-in-the-center-of-screen-not-near-the-button-activated/210246/6


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Changed "event" to "ev" in the function
- 
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
