### PR TITLE
fix(modal): swipe to close modal is no longer swipeable on footer

### DIFF
--- a/core/src/components/modal/gestures/swipe-to-close.ts
+++ b/core/src/components/modal/gestures/swipe-to-close.ts
@@ -24,11 +24,11 @@ export const createSwipeToCloseGesture = (
       return true;
     }
 
-    const content = target.closest('ion-content');
-    if (content === null) {
+    const contentOrFooter = target.closest('ion-content, ion-footer');
+    if (contentOrFooter === null) {
       return true;
     }
-    // Target is in the content so we don't start the gesture.
+    // Target is in the content or the footer so we don't start the gesture.
     // We could be more nuanced here and allow it for content that
     // does not need to scroll.
     return false;

--- a/core/src/components/modal/gestures/swipe-to-close.ts
+++ b/core/src/components/modal/gestures/swipe-to-close.ts
@@ -28,7 +28,7 @@ export const createSwipeToCloseGesture = (
     if (contentOrFooter === null) {
       return true;
     }
-    // Target is in the content or the footer so we don't start the gesture.
+    // Target is in the content or the footer so do not start the gesture.
     // We could be more nuanced here and allow it for content that
     // does not need to scroll.
     return false;


### PR DESCRIPTION
closes #23398

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

An iOS Card Style Modal is currently able to swipe down on the Footer.

Issue Number: #23398 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- According to @liamdebeasi 's comments in my issue i edited the code to make the gesture not be start-able on the footer as well

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
