### PR TITLE
fix(vue): prevent error from being thrown when testing on certain jest runners

### DIFF
--- a/core/src/utils/config.ts
+++ b/core/src/utils/config.ts
@@ -201,7 +201,6 @@ export const setupConfig = (config: IonicConfig) => {
   const win = window as any;
   const Ionic = win.Ionic;
   if (Ionic && Ionic.config && Ionic.config.constructor.name !== 'Object') {
-    console.error('ionic config was already initialized');
     return;
   }
   win.Ionic = win.Ionic || {};


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/23397


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed the `console.error`. We had a similar issue with Angular: https://github.com/ionic-team/ionic-framework/commit/9cb6c80b3db4273e9c003a62a3065427995cb353

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
