### PR TITLE
fix(modal): border radius is correctly set on card style modal

### DIFF
--- a/core/src/components/modal/modal.ios.scss
+++ b/core/src/components/modal/modal.ios.scss
@@ -68,10 +68,3 @@
     box-shadow: var(--box-shadow);
   }
 }
-
-:host(.overlay-datetime) {
-  --width: 316px;
-  --height: 296px;
-  --background: transparent;
-  --border-radius: #{$modal-ios-border-radius};
-}

--- a/core/src/components/modal/modal.ios.vars.scss
+++ b/core/src/components/modal/modal.ios.vars.scss
@@ -8,5 +8,3 @@ $modal-ios-background-color:          $background-color !default;
 
 /// @prop - Border radius for the modal
 $modal-ios-border-radius:             10px !default;
-
-$modal-ios-card-border-radius:        10px !default;

--- a/core/src/css/core.scss
+++ b/core/src/css/core.scss
@@ -33,7 +33,7 @@ body.backdrop-no-scroll {
 // Modal - Card Style
 // --------------------------------------------------
 /**
- * Card style modal needs additional padding on the 
+ * Card style modal needs additional padding on the
  * top of the header. We accomplish this by targeting
  * the first toolbar in the header.
  * Footer also needs this. We do not adjust the bottom
@@ -45,7 +45,7 @@ html.ios ion-modal ion-footer ion-toolbar:first-of-type {
 }
 
 /**
-* Card style modal needs additional padding on the 
+* Card style modal needs additional padding on the
 * bottom of the header. We accomplish this by targeting
 * the last toolbar in the header.
 */
@@ -63,11 +63,15 @@ html.ios ion-modal ion-toolbar {
   padding-left: calc(var(--ion-safe-area-left) + 8px);
 }
 
-// .ion-page needs to explicitly inherit
-// the border radius in safari otherwise
-// modals will not show border radius properly
+/**
+ * .ion-page needs to explicitly set
+ * the border radius in WebKit otherwise
+ * modals will not show border radius properly.
+ * Do not use inherit as that will not
+ * work with shadow dom in this case.
+ */
 html.ios ion-modal .ion-page {
-  border-radius: inherit;
+  border-radius: 10px 10px 0 0;
 }
 
 /**


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

With the conversion to shadow dom, `inherit` no longer worked as a workaround for the border radius bug in WebKit w/ card style modals


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Explicitly set 10px for border radius instead

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
