### PR TITLE
fix(vue): IonTabs can now accept IonRouterOutlet

### DIFF
--- a/packages/vue/src/components/IonTabs.ts
+++ b/packages/vue/src/components/IonTabs.ts
@@ -7,9 +7,22 @@ const DID_CHANGE = 'ionTabsDidChange';
 export const IonTabs = defineComponent({
   name: 'IonTabs',
   emits: [WILL_CHANGE, DID_CHANGE],
+  data() {
+    return { didWarn: false }
+  },
   render() {
-    const { $slots: slots, $emit } = this;
+    const { $slots: slots, $emit, $data } = this;
     const slottedContent = slots.default && slots.default();
+    let userProvidedRouterOutlet;
+
+    if (slottedContent && slottedContent.length > 0) {
+      /**
+       * If developer passed in their own ion-router-outlet
+       * instance, then we should not init a default one
+       */
+      userProvidedRouterOutlet = slottedContent.find((child: VNode) => child.type && (child.type as any).name === 'IonRouterOutlet');
+    }
+
     let childrenToRender = [
       h('div', {
         class: 'tabs-inner',
@@ -18,10 +31,34 @@ export const IonTabs = defineComponent({
             'flex': '1',
             'contain': 'layout size style'
         }
-      }, [
-        h(IonRouterOutlet, { tabs: true })
-      ])
+      }, (userProvidedRouterOutlet) ? userProvidedRouterOutlet : [h(IonRouterOutlet, { tabs: true })])
     ];
+
+    if (userProvidedRouterOutlet && !$data.didWarn) {
+      console.warn(`[@ionic/vue Deprecation] Starting Ionic Vue v6.0, developers must pass add an 'ion-router-outlet' instance inside of 'ion-tabs'.
+
+      Before:
+
+      <ion-tabs>
+        <ion-tab-bar slot="bottom">
+          ...
+        </ion-tab-bar>
+      </ion-tabs>
+
+      After:
+
+      <ion-tabs>
+        <ion-router-outlet></ion-router-outlet>
+        <ion-tab-bar slot="bottom">
+          ...
+        </ion-tab-bar>
+      </ion-tabs>
+
+      Be sure to also import 'IonRouterOutlet' from '@ionic/vue' and provide that import to your Vue component. See https://ionicframework.com/docs/vue/navigation#working-with-tabs for more information.
+      `);
+
+      $data.didWarn = true;
+    }
 
     /**
      * If ion-tab-bar has slot="top" it needs to be
@@ -29,7 +66,17 @@ export const IonTabs = defineComponent({
      * not show above the tab content.
      */
     if (slottedContent && slottedContent.length > 0) {
-      const slottedTabBar = slottedContent.find((child: VNode) => child.type && (child.type as any).name === 'IonTabBar');
+
+      /**
+       * Render all content except for router outlet
+       * since that needs to be inside of `.tabs-inner`.
+       */
+      const filteredContent = slottedContent.filter((child: VNode) => (
+        !child.type ||
+        (child.type && (child.type as any).name !== 'IonRouterOutlet')
+      ));
+
+      const slottedTabBar = filteredContent.find((child: VNode) => child.type && (child.type as any).name === 'IonTabBar');
       const hasTopSlotTabBar = slottedTabBar && slottedTabBar.props?.slot === 'top';
 
       if (slottedTabBar) {
@@ -49,13 +96,13 @@ export const IonTabs = defineComponent({
 
       if (hasTopSlotTabBar) {
         childrenToRender = [
-          ...slottedContent,
+          ...filteredContent,
           ...childrenToRender
         ];
       } else {
         childrenToRender = [
           ...childrenToRender,
-          ...slottedContent
+          ...filteredContent
         ]
       }
     }

--- a/packages/vue/src/components/IonTabs.ts
+++ b/packages/vue/src/components/IonTabs.ts
@@ -35,7 +35,7 @@ export const IonTabs = defineComponent({
     ];
 
     if (userProvidedRouterOutlet && !$data.didWarn) {
-      console.warn(`[@ionic/vue Deprecation] Starting Ionic Vue v6.0, developers must pass add an 'ion-router-outlet' instance inside of 'ion-tabs'.
+      console.warn(`[@ionic/vue Deprecation] Starting in Ionic Vue v6.0, developers must add an 'ion-router-outlet' instance inside of 'ion-tabs'.
 
       Before:
 
@@ -54,7 +54,7 @@ export const IonTabs = defineComponent({
         </ion-tab-bar>
       </ion-tabs>
 
-      Be sure to also import 'IonRouterOutlet' from '@ionic/vue' and provide that import to your Vue component. See https://ionicframework.com/docs/vue/navigation#working-with-tabs for more information.
+      Be sure to import 'IonRouterOutlet' from '@ionic/vue' and provide that import to your Vue component. See https://ionicframework.com/docs/vue/navigation#working-with-tabs for more information.
       `);
 
       $data.didWarn = true;

--- a/packages/vue/test-app/src/router/index.ts
+++ b/packages/vue/test-app/src/router/index.ts
@@ -118,7 +118,7 @@ const routes: Array<RouteRecordRaw> = [
   },
   {
     path: '/tabs-new/',
-    component: () => import('@/views/Tabs.vue'),
+    component: () => import('@/views/TabsNew.vue'),
     children: [
       {
         path: '',

--- a/packages/vue/test-app/src/views/TabsNew.vue
+++ b/packages/vue/test-app/src/views/TabsNew.vue
@@ -7,7 +7,7 @@
           <ion-tab-button
             v-for="tab in tabs"
             :tab="'tab' + tab.id"
-            :href="'/tabs/tab' + tab.id"
+            :href="'/tabs-new/tab' + tab.id"
             :key="tab.id"
           >
             <ion-icon :icon="tab.icon" />

--- a/packages/vue/test-app/src/views/TabsNew.vue
+++ b/packages/vue/test-app/src/views/TabsNew.vue
@@ -1,0 +1,54 @@
+<template>
+  <ion-page data-pageid="tabs">
+    <ion-content>
+      <ion-tabs id="tabs">
+        <ion-router-outlet></ion-router-outlet>
+        <ion-tab-bar slot="bottom">
+          <ion-tab-button
+            v-for="tab in tabs"
+            :tab="'tab' + tab.id"
+            :href="'/tabs/tab' + tab.id"
+            :key="tab.id"
+          >
+            <ion-icon :icon="tab.icon" />
+            <ion-label>Tab {{ tab.id }}</ion-label>
+          </ion-tab-button>
+
+          <ion-button id="add-tab" @click="addTab()">Add Tab</ion-button>
+        </ion-tab-bar>
+      </ion-tabs>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script lang="ts">
+import { IonButton, IonTabBar, IonTabButton, IonTabs, IonContent, IonLabel, IonIcon, IonPage, IonRouterOutlet } from '@ionic/vue';
+import { ellipse, square, triangle, shield } from 'ionicons/icons';
+import { useRouter } from 'vue-router';
+import { ref, defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'Tabs',
+  components: { IonButton, IonContent, IonLabel, IonTabs, IonTabBar, IonTabButton, IonIcon, IonPage, IonRouterOutlet },
+  setup() {
+    const tabs = ref([
+      { id: 1, icon: triangle },
+      { id: 2, icon: ellipse },
+      { id: 3, icon: square }
+    ])
+    const router = useRouter();
+    const addTab = () => {
+      router.addRoute({ path: '/tabs/tab4', component: () => import('@/views/Tab4.vue') });
+      tabs.value = [
+        ...tabs.value,
+        {
+          id: 4,
+          icon: shield
+        }
+      ]
+    }
+
+    return { tabs, addTab }
+  }
+});
+</script>


### PR DESCRIPTION
v6 Docs: https://github.com/ionic-team/ionic-docs/pull/1972
v5 Docs: https://github.com/ionic-team/ionic-docs/pull/1973
Vue Tabs Starter: https://github.com/ionic-team/starters/pull/1685

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/23321


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- IonTabs can now accept an IonRouterOutlet so developers can access the IonRouterOutlet props within a tabs context.
- Existing developers can continue to use the default IonRouterOutlet provided in IonTabs, though this behavior will not be supported in Framework v6.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
