### PR TITLE
(FEAT): support 'all' as a direction in GestureConfig and gesture recognizers.ts

### DIFF
--- a/core/src/utils/gesture/index.ts
+++ b/core/src/utils/gesture/index.ts
@@ -311,7 +311,7 @@ export interface GestureConfig {
   el: Node;
   disableScroll?: boolean;
 
-  direction?: 'x' | 'y';
+  direction?: 'x' | 'y' | 'all';
   gestureName: string;
   gesturePriority?: number;
   passive?: boolean;

--- a/core/src/utils/gesture/recognizers.ts
+++ b/core/src/utils/gesture/recognizers.ts
@@ -42,7 +42,7 @@ export const createPanRecognizer = (direction: string, thresh: number, maxAngle:
       const hypotenuse = Math.sqrt(distance);
       
       if(isDirUndefined) {
-        pan = distance > 0 ? 1 : 0; // Could do the calculation with the bigger Dx or Dy
+        isPan = distance > 0 ? 1 : 0; // Could do the calculation with the bigger Dx or Dy
         dirty = false;
         return true;
       }

--- a/core/src/utils/gesture/recognizers.ts
+++ b/core/src/utils/gesture/recognizers.ts
@@ -9,7 +9,7 @@ export interface PanRecognizer {
 export const createPanRecognizer = (direction: string, thresh: number, maxAngle: number): PanRecognizer => {
   const radians = maxAngle * (Math.PI / 180);
   const isDirX = direction === 'x';
-  const isDirUndefined = direction === undefined;
+  const isDirAll = direction === 'all';
   const maxCosine = Math.cos(radians);
   const threshold = thresh * thresh;
 
@@ -40,13 +40,13 @@ export const createPanRecognizer = (direction: string, thresh: number, maxAngle:
         return false;
       }
       const hypotenuse = Math.sqrt(distance);
-      
-      if(isDirUndefined) {
-        isPan = distance > 0 ? 1 : 0; // Could do the calculation with the bigger Dx or Dy
+
+      if (isDirAll) {
+        isPan = distance > 0 ? 1 : 0;
         dirty = false;
         return true;
       }
-      
+
       const cosine = (isDirX ? deltaX : deltaY) / hypotenuse;
 
       if (cosine > maxCosine) {

--- a/core/src/utils/gesture/recognizers.ts
+++ b/core/src/utils/gesture/recognizers.ts
@@ -9,6 +9,7 @@ export interface PanRecognizer {
 export const createPanRecognizer = (direction: string, thresh: number, maxAngle: number): PanRecognizer => {
   const radians = maxAngle * (Math.PI / 180);
   const isDirX = direction === 'x';
+  const isDirUndefined = direction === undefined;
   const maxCosine = Math.cos(radians);
   const threshold = thresh * thresh;
 
@@ -39,6 +40,20 @@ export const createPanRecognizer = (direction: string, thresh: number, maxAngle:
         return false;
       }
       const hypotenuse = Math.sqrt(distance);
+      
+      if(isDirUndefined) {
+        pan = distance > 0 ? 1 : 0; // Could do the calculation with the bigger Dx or Dy
+        /* 
+          (WARNING): Pan the way it's used does not make sense since it does not have an X or Y element and just represents the chosen direction.
+          This change has the potential to be breaking for users who actually un-ironically use undefined for 'y', or if the base of
+          Ionic made that mistake anywhere.
+          (DOCS): undefined is now actually an option just like in the docs.
+          (PERF): Instead of creating 2 `createGesture`'s you can use one. (for people who need an X&Y draggable item) 
+        */
+        dirty = false;
+        return true;
+      }
+      
       const cosine = (isDirX ? deltaX : deltaY) / hypotenuse;
 
       if (cosine > maxCosine) {

--- a/core/src/utils/gesture/recognizers.ts
+++ b/core/src/utils/gesture/recognizers.ts
@@ -43,13 +43,6 @@ export const createPanRecognizer = (direction: string, thresh: number, maxAngle:
       
       if(isDirUndefined) {
         pan = distance > 0 ? 1 : 0; // Could do the calculation with the bigger Dx or Dy
-        /* 
-          (WARNING): Pan the way it's used does not make sense since it does not have an X or Y element and just represents the chosen direction.
-          This change has the potential to be breaking for users who actually un-ironically use undefined for 'y', or if the base of
-          Ionic made that mistake anywhere.
-          (DOCS): undefined is now actually an option just like in the docs.
-          (PERF): Instead of creating 2 `createGesture`'s you can use one. (for people who need an X&Y draggable item) 
-        */
         dirty = false;
         return true;
       }


### PR DESCRIPTION
Add's `'all'` to GestureConfig.direction union type.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

Issue Number: #23523 as it also relates to #21704

## What is the new behavior?

-  The user may now enter a direction of `'all'` which makes the gesture detection fire if it starts in either the horizontal or vertical plane. Previous work around was to use 2 gestures and have one be vertical actions and one be for horizontal actions.

## Does this introduce a breaking change?

- [] Yes 
- [x] No (we allow a new union type of `'all'` for GestureConfig.direction instead of just `'x'` and `'y'`, undefined still continues to have `'y'` behavior)

No breaking change introduced.

## Other information

- bug #23523 remains in effect, but there is now a way to get the expected behavior instead of expecting undefined to give both `x&y` functionality.
- (WARNING): `Pan` the way it's used does not make sense since it does not have an X or Y element and just represents the chosen direction.

