### PR TITLE
fix(popover): size property now works when providing only event

### DIFF
--- a/core/src/components/popover/animations/ios.enter.ts
+++ b/core/src/components/popover/animations/ios.enter.ts
@@ -19,7 +19,7 @@ export const iosEnterAnimation = (baseEl: HTMLElement, opts?: any): Animation =>
   const contentEl = root.querySelector('.popover-content') as HTMLElement;
   const arrowEl = root.querySelector('.popover-arrow') as HTMLElement | null;
 
-  const referenceSizeEl = trigger || ev?.target;
+  const referenceSizeEl = trigger || ev?.detail?.ionShadowTarget || ev?.target;
   const { contentWidth, contentHeight } = getPopoverDimensions(size, contentEl, referenceSizeEl);
   const { arrowWidth, arrowHeight } = getArrowDimensions(arrowEl);
 

--- a/core/src/components/popover/animations/ios.enter.ts
+++ b/core/src/components/popover/animations/ios.enter.ts
@@ -19,7 +19,8 @@ export const iosEnterAnimation = (baseEl: HTMLElement, opts?: any): Animation =>
   const contentEl = root.querySelector('.popover-content') as HTMLElement;
   const arrowEl = root.querySelector('.popover-arrow') as HTMLElement | null;
 
-  const { contentWidth, contentHeight } = getPopoverDimensions(size, contentEl, trigger);
+  const referenceSizeEl = trigger || ev?.target;
+  const { contentWidth, contentHeight } = getPopoverDimensions(size, contentEl, referenceSizeEl);
   const { arrowWidth, arrowHeight } = getArrowDimensions(arrowEl);
 
   const defaultPosition = {

--- a/core/src/components/popover/animations/md.enter.ts
+++ b/core/src/components/popover/animations/md.enter.ts
@@ -18,7 +18,9 @@ export const mdEnterAnimation = (baseEl: HTMLElement, opts?: any): Animation => 
 
   const root = getElementRoot(baseEl);
   const contentEl = root.querySelector('.popover-content') as HTMLElement;
-  const { contentWidth, contentHeight } = getPopoverDimensions(size, contentEl, trigger);
+
+  const referenceSizeEl = trigger || ev?.target;
+  const { contentWidth, contentHeight } = getPopoverDimensions(size, contentEl, referenceSizeEl);
 
   const defaultPosition = {
     top: bodyHeight / 2 - contentHeight / 2,

--- a/core/src/components/popover/animations/md.enter.ts
+++ b/core/src/components/popover/animations/md.enter.ts
@@ -19,7 +19,7 @@ export const mdEnterAnimation = (baseEl: HTMLElement, opts?: any): Animation => 
   const root = getElementRoot(baseEl);
   const contentEl = root.querySelector('.popover-content') as HTMLElement;
 
-  const referenceSizeEl = trigger || ev?.target;
+  const referenceSizeEl = trigger || ev?.detail?.ionShadowTarget || ev?.target;
   const { contentWidth, contentHeight } = getPopoverDimensions(size, contentEl, referenceSizeEl);
 
   const defaultPosition = {

--- a/core/src/components/popover/test/size/e2e.ts
+++ b/core/src/components/popover/test/size/e2e.ts
@@ -49,3 +49,54 @@ test('should calculate popover width based on trigger width', async () => {
     expect(screenshotCompare).toMatchScreenshot();
   }
 });
+
+test('should calculate popover width based on event width', async () => {
+  const page = await newE2EPage({ url: '/src/components/popover/test/size?ionic:_testing=true' });
+
+  const screenshotCompares = [];
+
+  const trigger = await page.find('#event-trigger');
+  trigger.click();
+
+  await page.waitForSelector('.event-popover');
+  const popover = await page.find('.event-popover');
+  await popover.waitForVisible();
+
+  const triggerHandler = await page.$('#event-trigger');
+  const popoverContentHandle = await page.evaluateHandle(`document.querySelector('.event-popover').shadowRoot.querySelector('.popover-content')`);
+  const triggerBbox = await triggerHandler.boundingBox();
+  const popoverBbox = await popoverContentHandle.boundingBox();
+  expect(popoverBbox.width).toEqual(triggerBbox.width);
+
+  screenshotCompares.push(await page.compareScreenshot());
+
+  for (const screenshotCompare of screenshotCompares) {
+    expect(screenshotCompare).toMatchScreenshot();
+  }
+});
+
+
+test('should not calculate popover width with no trigger or event', async () => {
+  const page = await newE2EPage({ url: '/src/components/popover/test/size?ionic:_testing=true' });
+
+  const screenshotCompares = [];
+
+  const trigger = await page.find('#no-event-trigger');
+  trigger.click();
+
+  await page.waitForSelector('.no-event-popover');
+  const popover = await page.find('.no-event-popover');
+  await popover.waitForVisible();
+
+  const triggerHandler = await page.$('#no-event-trigger');
+  const popoverContentHandle = await page.evaluateHandle(`document.querySelector('.no-event-popover').shadowRoot.querySelector('.popover-content')`);
+  const triggerBbox = await triggerHandler.boundingBox();
+  const popoverBbox = await popoverContentHandle.boundingBox();
+  expect(popoverBbox.width).not.toEqual(triggerBbox.width);
+
+  screenshotCompares.push(await page.compareScreenshot());
+
+  for (const screenshotCompare of screenshotCompares) {
+    expect(screenshotCompare).toMatchScreenshot();
+  }
+});

--- a/core/src/components/popover/test/size/index.html
+++ b/core/src/components/popover/test/size/index.html
@@ -8,10 +8,14 @@
     <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
     <script src="../../../../../scripts/testing/scripts.js"></script>
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+    <script type="module">
+      import { popoverController } from '../../../../dist/ionic/index.esm.js';
+      window.popoverController = popoverController;
+    </script>
     <style>
       .grid {
         display: grid;
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(4, 1fr);
         grid-row-gap: 20px;
         grid-column-gap: 20px;
 
@@ -66,8 +70,45 @@
               </ion-content>
             </ion-popover>
           </div>
+          <div class="grid-item">
+            <h2>With Event</h2>
+            <ion-button id="event-trigger" onclick="openPopover('event-popover', event)">Trigger</ion-button>
+          </div>
+
+          <div class="grid-item">
+            <h2>No Event</h2>
+            <ion-button id="no-event-trigger" onclick="openPopover('no-event-popover')">Trigger</ion-button>
+          </div>
         </div>
       </ion-content>
     </ion-app>
+
+    <script>
+      class PopoverComponent extends HTMLElement {
+        constructor() {
+          super();
+        }
+
+        connectedCallback() {
+          this.innerHTML = `
+            <ion-content class="ion-padding">
+              My really really really really long content
+            </ion-content>
+          `;
+        }
+      }
+
+      customElements.define('popover-component', PopoverComponent);
+
+      const openPopover = async (cssClass, ev) => {
+        const popover = await popoverController.create({
+          component: 'popover-component',
+          cssClass,
+          size: 'cover',
+          event: ev
+        });
+        await popover.present();
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/23528


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- the animations (incorrectly) assume that only the `trigger` prop would be used to determine popover dimensions when `size="cover"`. However, the trigger could also be found via `event.target` if `event` is provided.
- I updated the animation code to pass in either the trigger element or the event target if no trigger was found and an event was provided.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
