### PR TITLE
fix(animation): typescript interface has correct return value for progress methods

### DIFF
--- a/core/src/utils/animation/animation-interface.ts
+++ b/core/src/utils/animation/animation-interface.ts
@@ -29,7 +29,7 @@ export interface Animation {
    */
   destroy(clearStyleSheets?: boolean): void;
 
-  progressStart(forceLinearEasing: boolean, step?: number): Animation;
+  progressStart(forceLinearEasing?: boolean, step?: number): Animation;
   progressStep(step: number): Animation;
   progressEnd(playTo: 0 | 1 | undefined, step: number, dur?: number): Animation;
 

--- a/core/src/utils/animation/animation-interface.ts
+++ b/core/src/utils/animation/animation-interface.ts
@@ -29,9 +29,9 @@ export interface Animation {
    */
   destroy(clearStyleSheets?: boolean): void;
 
-  progressStart(forceLinearEasing: boolean, step?: number): void;
-  progressStep(step: number): void;
-  progressEnd(playTo: 0 | 1 | undefined, step: number, dur?: number): void;
+  progressStart(forceLinearEasing: boolean, step?: number): Animation;
+  progressStep(step: number): Animation;
+  progressEnd(playTo: 0 | 1 | undefined, step: number, dur?: number): Animation;
 
   from(property: string, value: any): Animation;
   to(property: string, value: any): Animation;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

TypeScript interface says `progressStart`, `progressStep`, and `progressEnd` methods return `void`, but they actually return `Animation`: https://github.com/ionic-team/ionic-framework/blob/master/core/src/utils/animation/animation.ts#L661-L740

https://github.com/ionic-team/ionic-docs/issues/1930

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- TypeScript interface has correct return value now

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
