### PR TITLE
docs(loading): show how to use dismiss method returns from useIonLoading for react

### DIFF
--- a/core/src/components/loading/readme.md
+++ b/core/src/components/loading/readme.md
@@ -139,17 +139,18 @@ import { IonButton, IonContent, IonPage, useIonLoading } from '@ionic/react';
 interface LoadingProps {}
 
 const LoadingExample: React.FC<LoadingProps> = () => {
-  const [present] = useIonLoading();
+  const [present, dismiss] = useIonLoading();
   return (
     <IonPage>
       <IonContent>
         <IonButton
           expand="block"
-          onClick={() =>
+          onClick={() => {
             present({
-              duration: 3000,
+              message: 'Loading...',
             })
-          }
+            setTimeout(dismiss, 3000)
+          }}
         >
           Show Loading
         </IonButton>

--- a/core/src/components/loading/readme.md
+++ b/core/src/components/loading/readme.md
@@ -133,17 +133,12 @@ async function presentLoadingWithOptions() {
 ```tsx
 /* Using with useIonLoading Hook */
 
-import React from "react";
-import { IonButton, IonContent, IonPage, useIonLoading } from "@ionic/react";
+import React from 'react';
+import { IonButton, IonContent, IonPage, useIonLoading } from '@ionic/react';
 
 interface LoadingProps {}
 
 const LoadingExample: React.FC<LoadingProps> = () => {
-  /**
-   * The recommended way of dismissing is to use the `dismiss` property
-   * on `IonLoading`, but the `dismiss` method returned from `useIonLoading`
-   * can be used for more complex scenarios.
-   */
   const [present, dismiss] = useIonLoading();
   return (
     <IonPage>
@@ -152,16 +147,16 @@ const LoadingExample: React.FC<LoadingProps> = () => {
           expand="block"
           onClick={() => {
             present({
-              message: "Loading...",
-              duration: 3000,
-            });
+              message: 'Loading...',
+            })
+            setTimeout(dismiss, 3000)
           }}
         >
           Show Loading
         </IonButton>
         <IonButton
           expand="block"
-          onClick={() => present("Loading", 2000, "dots")}
+          onClick={() => present('Loading', 2000, 'dots')}
         >
           Show Loading using params
         </IonButton>
@@ -174,8 +169,8 @@ const LoadingExample: React.FC<LoadingProps> = () => {
 ```tsx
 /* Using with IonLoading Component */
 
-import React, { useState } from "react";
-import { IonLoading, IonButton, IonContent } from "@ionic/react";
+import React, { useState } from 'react';
+import { IonLoading, IonButton, IonContent } from '@ionic/react';
 
 export const LoadingExample: React.FC = () => {
   const [showLoading, setShowLoading] = useState(true);
@@ -188,10 +183,10 @@ export const LoadingExample: React.FC = () => {
     <IonContent>
       <IonButton onClick={() => setShowLoading(true)}>Show Loading</IonButton>
       <IonLoading
-        cssClass="my-custom-class"
+        cssClass='my-custom-class'
         isOpen={showLoading}
         onDidDismiss={() => setShowLoading(false)}
-        message={"Please wait..."}
+        message={'Please wait...'}
         duration={5000}
       />
     </IonContent>

--- a/core/src/components/loading/readme.md
+++ b/core/src/components/loading/readme.md
@@ -140,6 +140,11 @@ interface LoadingProps {}
 
 const LoadingExample: React.FC<LoadingProps> = () => {
   const [present, dismiss] = useIonLoading();
+  /**
+   * The recommended way of dismissing is to use the `dismiss` property
+   * on `IonLoading`, but the `dismiss` method returned from `useIonLoading`
+   * can be used for more complex scenarios.
+   */
   return (
     <IonPage>
       <IonContent>
@@ -148,8 +153,8 @@ const LoadingExample: React.FC<LoadingProps> = () => {
           onClick={() => {
             present({
               message: 'Loading...',
+              duration: 3000
             })
-            setTimeout(dismiss, 3000)
           }}
         >
           Show Loading

--- a/core/src/components/loading/readme.md
+++ b/core/src/components/loading/readme.md
@@ -133,12 +133,17 @@ async function presentLoadingWithOptions() {
 ```tsx
 /* Using with useIonLoading Hook */
 
-import React from 'react';
-import { IonButton, IonContent, IonPage, useIonLoading } from '@ionic/react';
+import React from "react";
+import { IonButton, IonContent, IonPage, useIonLoading } from "@ionic/react";
 
 interface LoadingProps {}
 
 const LoadingExample: React.FC<LoadingProps> = () => {
+  /**
+   * The recommended way of dismissing is to use the `dismiss` property
+   * on `IonLoading`, but the `dismiss` method returned from `useIonLoading`
+   * can be used for more complex scenarios.
+   */
   const [present, dismiss] = useIonLoading();
   return (
     <IonPage>
@@ -147,16 +152,16 @@ const LoadingExample: React.FC<LoadingProps> = () => {
           expand="block"
           onClick={() => {
             present({
-              message: 'Loading...',
-            })
-            setTimeout(dismiss, 3000)
+              message: "Loading...",
+              duration: 3000,
+            });
           }}
         >
           Show Loading
         </IonButton>
         <IonButton
           expand="block"
-          onClick={() => present('Loading', 2000, 'dots')}
+          onClick={() => present("Loading", 2000, "dots")}
         >
           Show Loading using params
         </IonButton>
@@ -169,8 +174,8 @@ const LoadingExample: React.FC<LoadingProps> = () => {
 ```tsx
 /* Using with IonLoading Component */
 
-import React, { useState } from 'react';
-import { IonLoading, IonButton, IonContent } from '@ionic/react';
+import React, { useState } from "react";
+import { IonLoading, IonButton, IonContent } from "@ionic/react";
 
 export const LoadingExample: React.FC = () => {
   const [showLoading, setShowLoading] = useState(true);
@@ -183,10 +188,10 @@ export const LoadingExample: React.FC = () => {
     <IonContent>
       <IonButton onClick={() => setShowLoading(true)}>Show Loading</IonButton>
       <IonLoading
-        cssClass='my-custom-class'
+        cssClass="my-custom-class"
         isOpen={showLoading}
         onDidDismiss={() => setShowLoading(false)}
-        message={'Please wait...'}
+        message={"Please wait..."}
         duration={5000}
       />
     </IonContent>

--- a/core/src/components/loading/usage/react.md
+++ b/core/src/components/loading/usage/react.md
@@ -7,17 +7,18 @@ import { IonButton, IonContent, IonPage, useIonLoading } from '@ionic/react';
 interface LoadingProps {}
 
 const LoadingExample: React.FC<LoadingProps> = () => {
-  const [present] = useIonLoading();
+  const [present, dismiss] = useIonLoading();
   return (
     <IonPage>
       <IonContent>
         <IonButton
           expand="block"
-          onClick={() =>
+          onClick={() => {
             present({
-              duration: 3000,
+              message: 'Loading...',
             })
-          }
+            setTimeout(dismiss, 3000)
+          }}
         >
           Show Loading
         </IonButton>

--- a/core/src/components/loading/usage/react.md
+++ b/core/src/components/loading/usage/react.md
@@ -1,17 +1,12 @@
 ```tsx
 /* Using with useIonLoading Hook */
 
-import React from "react";
-import { IonButton, IonContent, IonPage, useIonLoading } from "@ionic/react";
+import React from 'react';
+import { IonButton, IonContent, IonPage, useIonLoading } from '@ionic/react';
 
 interface LoadingProps {}
 
 const LoadingExample: React.FC<LoadingProps> = () => {
-  /**
-   * The recommended way of dismissing is to use the `dismiss` property
-   * on `IonLoading`, but the `dismiss` method returned from `useIonLoading`
-   * can be used for more complex scenarios.
-   */
   const [present, dismiss] = useIonLoading();
   return (
     <IonPage>
@@ -20,16 +15,16 @@ const LoadingExample: React.FC<LoadingProps> = () => {
           expand="block"
           onClick={() => {
             present({
-              message: "Loading...",
-              duration: 3000,
-            });
+              message: 'Loading...',
+            })
+            setTimeout(dismiss, 3000)
           }}
         >
           Show Loading
         </IonButton>
         <IonButton
           expand="block"
-          onClick={() => present("Loading", 2000, "dots")}
+          onClick={() => present('Loading', 2000, 'dots')}
         >
           Show Loading using params
         </IonButton>
@@ -42,8 +37,8 @@ const LoadingExample: React.FC<LoadingProps> = () => {
 ```tsx
 /* Using with IonLoading Component */
 
-import React, { useState } from "react";
-import { IonLoading, IonButton, IonContent } from "@ionic/react";
+import React, { useState } from 'react';
+import { IonLoading, IonButton, IonContent } from '@ionic/react';
 
 export const LoadingExample: React.FC = () => {
   const [showLoading, setShowLoading] = useState(true);
@@ -56,10 +51,10 @@ export const LoadingExample: React.FC = () => {
     <IonContent>
       <IonButton onClick={() => setShowLoading(true)}>Show Loading</IonButton>
       <IonLoading
-        cssClass="my-custom-class"
+        cssClass='my-custom-class'
         isOpen={showLoading}
         onDidDismiss={() => setShowLoading(false)}
-        message={"Please wait..."}
+        message={'Please wait...'}
         duration={5000}
       />
     </IonContent>

--- a/core/src/components/loading/usage/react.md
+++ b/core/src/components/loading/usage/react.md
@@ -8,6 +8,11 @@ interface LoadingProps {}
 
 const LoadingExample: React.FC<LoadingProps> = () => {
   const [present, dismiss] = useIonLoading();
+  /**
+   * The recommended way of dismissing is to use the `dismiss` property
+   * on `IonLoading`, but the `dismiss` method returned from `useIonLoading`
+   * can be used for more complex scenarios.
+   */
   return (
     <IonPage>
       <IonContent>
@@ -16,8 +21,8 @@ const LoadingExample: React.FC<LoadingProps> = () => {
           onClick={() => {
             present({
               message: 'Loading...',
+              duration: 3000
             })
-            setTimeout(dismiss, 3000)
           }}
         >
           Show Loading

--- a/core/src/components/loading/usage/react.md
+++ b/core/src/components/loading/usage/react.md
@@ -1,12 +1,17 @@
 ```tsx
 /* Using with useIonLoading Hook */
 
-import React from 'react';
-import { IonButton, IonContent, IonPage, useIonLoading } from '@ionic/react';
+import React from "react";
+import { IonButton, IonContent, IonPage, useIonLoading } from "@ionic/react";
 
 interface LoadingProps {}
 
 const LoadingExample: React.FC<LoadingProps> = () => {
+  /**
+   * The recommended way of dismissing is to use the `dismiss` property
+   * on `IonLoading`, but the `dismiss` method returned from `useIonLoading`
+   * can be used for more complex scenarios.
+   */
   const [present, dismiss] = useIonLoading();
   return (
     <IonPage>
@@ -15,16 +20,16 @@ const LoadingExample: React.FC<LoadingProps> = () => {
           expand="block"
           onClick={() => {
             present({
-              message: 'Loading...',
-            })
-            setTimeout(dismiss, 3000)
+              message: "Loading...",
+              duration: 3000,
+            });
           }}
         >
           Show Loading
         </IonButton>
         <IonButton
           expand="block"
-          onClick={() => present('Loading', 2000, 'dots')}
+          onClick={() => present("Loading", 2000, "dots")}
         >
           Show Loading using params
         </IonButton>
@@ -37,8 +42,8 @@ const LoadingExample: React.FC<LoadingProps> = () => {
 ```tsx
 /* Using with IonLoading Component */
 
-import React, { useState } from 'react';
-import { IonLoading, IonButton, IonContent } from '@ionic/react';
+import React, { useState } from "react";
+import { IonLoading, IonButton, IonContent } from "@ionic/react";
 
 export const LoadingExample: React.FC = () => {
   const [showLoading, setShowLoading] = useState(true);
@@ -51,10 +56,10 @@ export const LoadingExample: React.FC = () => {
     <IonContent>
       <IonButton onClick={() => setShowLoading(true)}>Show Loading</IonButton>
       <IonLoading
-        cssClass='my-custom-class'
+        cssClass="my-custom-class"
         isOpen={showLoading}
         onDidDismiss={() => setShowLoading(false)}
-        message={'Please wait...'}
+        message={"Please wait..."}
         duration={5000}
       />
     </IonContent>


### PR DESCRIPTION
The docs don't say how to use dismiss(), this shows that the `useIonLoading` hook returns the present and dismiss functions.

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The docs mention quickly using dismiss() to close the IonLoading, but it doesn't say how to access this function.

Issue Number: N/A


## What is the new behavior?
- Just adds the dismiss as a second return in the react example.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
