### PR TITLE
fix(button): buttons are now disabled during page transitions

### DIFF
--- a/core/src/components/button/button.scss
+++ b/core/src/components/button/button.scss
@@ -62,7 +62,6 @@
   user-select: none;
   vertical-align: top; // the better option for most scenarios
   vertical-align: -webkit-baseline-middle; // the best for those that support it
-  pointer-events: auto;
 
   font-kerning: none;
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/23588


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- During the v4 beta, `pointer-events: auto` was set on `ion-button` to resolve https://github.com/ionic-team/ionic-framework/issues/15623. However, the underlying issue was related to a different issue which was fixed in https://github.com/ionic-team/ionic-framework/commit/e189cc6ec2d5b176914e239927ee40d7fe89a318. The original `pointer-events` fix was never removed. As a result, when we set `pointer-events: none` on `.ion-page` during the page transition, all `ion-button` elements still receive pointer events because they have `pointer-events: auto` set. By removing `pointer-events: auto` on `ion-button`, buttons still receive pointer events by default, but they will not receive pointer events during transitions.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
