### PR TITLE
fix(menu-button): custom aria-label can now be set

### DIFF
--- a/core/src/components/menu-button/menu-button.tsx
+++ b/core/src/components/menu-button/menu-button.tsx
@@ -4,6 +4,7 @@ import { config } from '../../global/config';
 import { getIonMode } from '../../global/ionic-global';
 import { Color } from '../../interface';
 import { ButtonInterface } from '../../utils/element-interface';
+import { inheritAttributes } from '../../utils/helpers';
 import { menuController } from '../../utils/menu-controller';
 import { createColorClasses, hostContext } from '../../utils/theme';
 import { updateVisibility } from '../menu-toggle/menu-toggle-util';
@@ -23,6 +24,8 @@ import { updateVisibility } from '../menu-toggle/menu-toggle-util';
   shadow: true
 })
 export class MenuButton implements ComponentInterface, ButtonInterface {
+  private inheritedAttributes: { [k: string]: any } = {};
+
   @Element() el!: HTMLIonSegmentElement;
 
   @State() visible = false;
@@ -54,6 +57,10 @@ export class MenuButton implements ComponentInterface, ButtonInterface {
    */
   @Prop() type: 'submit' | 'reset' | 'button' = 'button';
 
+  componentWillLoad() {
+    this.inheritedAttributes = inheritAttributes(this.el, ['aria-label']);
+  }
+
   componentDidLoad() {
     this.visibilityChanged();
   }
@@ -69,7 +76,7 @@ export class MenuButton implements ComponentInterface, ButtonInterface {
   }
 
   render() {
-    const { color, disabled } = this;
+    const { color, disabled, inheritedAttributes } = this;
     const mode = getIonMode(this);
     const menuIcon = config.get('menuIcon', mode === 'ios' ? 'menu-outline' : 'menu-sharp');
     const hidden = this.autoHide && !this.visible;
@@ -77,6 +84,8 @@ export class MenuButton implements ComponentInterface, ButtonInterface {
     const attrs = {
       type: this.type
     };
+
+    const ariaLabel = inheritedAttributes['aria-label'] || 'menu';
 
     return (
       <Host
@@ -99,7 +108,7 @@ export class MenuButton implements ComponentInterface, ButtonInterface {
           disabled={disabled}
           class="button-native"
           part="native"
-          aria-label="menu"
+          aria-label={ariaLabel}
         >
           <span class="button-inner">
             <slot>

--- a/core/src/components/menu-button/test/a11y/e2e.ts
+++ b/core/src/components/menu-button/test/a11y/e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+import { AxePuppeteer } from '@axe-core/puppeteer';
+
+test('menu-button: axe', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/menu-button/test/a11y?ionic:_testing=true'
+  });
+
+  const results = await new AxePuppeteer(page).analyze();
+  expect(results.violations.length).toEqual(0);
+});

--- a/core/src/components/menu-button/test/a11y/index.html
+++ b/core/src/components/menu-button/test/a11y/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8">
+    <title>Menu Button - a11y</title>
+    <meta name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+    <link href="../../../../../css/core.css" rel="stylesheet">
+    <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+    <script src="../../../../../scripts/testing/scripts.js"></script>
+    <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+  </head>
+
+  <body>
+    <main>
+      <h1>Menu Button</h1>
+      <ion-menu-button auto-hide="false"></ion-menu-button>
+      <ion-menu-button auto-hide="false" aria-label="Custom Label"></ion-menu-button>
+    </main>
+  </body>
+</html>

--- a/core/src/components/menu-button/test/basic/index.html
+++ b/core/src/components/menu-button/test/basic/index.html
@@ -29,6 +29,7 @@
       <ion-menu-button auto-hide="false" color="secondary" class="custom ion-focused"></ion-menu-button>
       <ion-menu-button auto-hide="false" class="custom-large"></ion-menu-button>
       <ion-menu-button auto-hide="false" class="custom-large ion-focused"></ion-menu-button>
+      <ion-menu-button auto-hide="false" aria-label="My Custom Menu Button Label"></ion-menu-button>
 
       <h1>Colors</h1>
       <ion-menu-button auto-hide="false" color="primary"></ion-menu-button>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/23604


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- aria-label is now inherited to inner button inside of shadow dom
- defaults "menu" if not specified

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
