### PR TITLE
fix(datetime): years displayed now more consistent with v5 datetime, max and min are now accounted for in MD mode

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1181,12 +1181,11 @@ export class Datetime implements ComponentInterface {
   }
 
   private renderMDYearView() {
-    return getCalendarYears(this.activeParts, true, undefined, undefined, this.parsedYearValues).map(year => {
+    return getCalendarYears(this.activeParts, this.minParts, this.maxParts, this.parsedYearValues).map(year => {
 
-      const { isCurrentYear, isActiveYear, disabled, ariaSelected } = getCalendarYearState(year, this.workingParts, this.todayParts, this.minParts, this.maxParts);
+      const { isCurrentYear, isActiveYear, ariaSelected } = getCalendarYearState(year, this.workingParts, this.todayParts);
       return (
         <button
-          disabled={disabled}
           aria-selected={ariaSelected}
           class={{
             'datetime-year-item': true,
@@ -1238,7 +1237,7 @@ export class Datetime implements ComponentInterface {
         <div class="picker-col-item picker-col-item-empty">&nbsp;</div>
         <div class="picker-col-item picker-col-item-empty">&nbsp;</div>
         <div class="picker-col-item picker-col-item-empty">&nbsp;</div>
-        {getCalendarYears(this.workingParts, false, this.minParts, this.maxParts, this.parsedYearValues).map(year => {
+        {getCalendarYears(this.workingParts, this.minParts, this.maxParts, this.parsedYearValues).map(year => {
           return (
             <div
               class="picker-col-item"

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1180,8 +1180,8 @@ export class Datetime implements ComponentInterface {
     this.showMonthAndYear = !this.showMonthAndYear;
   }
 
-  private renderMDYearView() {
-    return getCalendarYears(this.todayParts, this.minParts, this.maxParts, this.parsedYearValues).map(year => {
+  private renderMDYearView(calendarYears: number[] = []) {
+    return calendarYears.map(year => {
 
       const { isCurrentYear, isActiveYear, ariaSelected } = getCalendarYearState(year, this.workingParts, this.todayParts);
       return (
@@ -1208,7 +1208,7 @@ export class Datetime implements ComponentInterface {
     })
   }
 
-  private renderiOSYearView() {
+  private renderiOSYearView(calendarYears: number[] = []) {
     return [
       <div class="datetime-picker-before"></div>,
       <div class="datetime-picker-after"></div>,
@@ -1237,7 +1237,7 @@ export class Datetime implements ComponentInterface {
         <div class="picker-col-item picker-col-item-empty">&nbsp;</div>
         <div class="picker-col-item picker-col-item-empty">&nbsp;</div>
         <div class="picker-col-item picker-col-item-empty">&nbsp;</div>
-        {getCalendarYears(this.todayParts, this.minParts, this.maxParts, this.parsedYearValues).map(year => {
+        {calendarYears.map(year => {
           return (
             <div
               class="picker-col-item"
@@ -1257,10 +1257,11 @@ export class Datetime implements ComponentInterface {
   }
 
   private renderYearView(mode: Mode) {
+    const calendarYears = getCalendarYears(this.todayParts, this.minParts, this.maxParts, this.parsedYearValues);
     return (
       <div class="datetime-year">
         <div class="datetime-year-body">
-          {mode === 'ios' ? this.renderiOSYearView() : this.renderMDYearView()}
+          {mode === 'ios' ? this.renderiOSYearView(calendarYears) : this.renderMDYearView(calendarYears)}
         </div>
       </div>
     );

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1181,7 +1181,7 @@ export class Datetime implements ComponentInterface {
   }
 
   private renderMDYearView() {
-    return getCalendarYears(this.activeParts, this.minParts, this.maxParts, this.parsedYearValues).map(year => {
+    return getCalendarYears(this.todayParts, this.minParts, this.maxParts, this.parsedYearValues).map(year => {
 
       const { isCurrentYear, isActiveYear, ariaSelected } = getCalendarYearState(year, this.workingParts, this.todayParts);
       return (
@@ -1237,7 +1237,7 @@ export class Datetime implements ComponentInterface {
         <div class="picker-col-item picker-col-item-empty">&nbsp;</div>
         <div class="picker-col-item picker-col-item-empty">&nbsp;</div>
         <div class="picker-col-item picker-col-item-empty">&nbsp;</div>
-        {getCalendarYears(this.workingParts, this.minParts, this.maxParts, this.parsedYearValues).map(year => {
+        {getCalendarYears(this.todayParts, this.minParts, this.maxParts, this.parsedYearValues).map(year => {
           return (
             <div
               class="picker-col-item"

--- a/core/src/components/datetime/readme.md
+++ b/core/src/components/datetime/readme.md
@@ -44,7 +44,9 @@ always in the 24-hour format, so `00` is `12am` on a 12-hour clock, `13` means
 
 ## Min and Max Datetimes
 
-By default, there is no maximum or minimum date a user can select. To customize the minimum and maximum datetime values, the `min` and `max` component properties can be provided which may make more sense for the app's use-case. Following the same IS0 8601 format listed in the table above, each component can restrict which dates can be selected by the user. By passing `2016` to the `min` property and `2020-10-31` to the `max` property, the datetime will restrict the date selection between the beginning of `2016`, and `October 31st of 2020`.
+Dates are infinite in either direction, so for a user's selection there should be at least some form of restricting the dates that can be selected. By default, the maximum date is to the end of the current year, and the minimum date is from the beginning of the year that was 100 years ago.
+
+To customize the minimum and maximum datetime values, the `min` and `max` component properties can be provided which may make more sense for the app's use-case. Following the same IS0 8601 format listed in the table above, each component can restrict which dates can be selected by the user. By passing `2016` to the `min` property and `2020-10-31` to the `max` property, the datetime will restrict the date selection between the beginning of `2016`, and `October 31st of 2020`.
 
 ## Selecting Specific Values
 

--- a/core/src/components/datetime/test/minmax/e2e.ts
+++ b/core/src/components/datetime/test/minmax/e2e.ts
@@ -9,6 +9,13 @@ test('minmax', async () => {
 
   screenshotCompares.push(await page.compareScreenshot());
 
+  const monthYearItem = await page.find('ion-datetime#inside >>> .calendar-month-year');
+
+  await monthYearItem.click();
+  await page.waitForChanges();
+
+  screenshotCompares.push(await page.compareScreenshot());
+
   for (const screenshotCompare of screenshotCompares) {
     expect(screenshotCompare).toMatchScreenshot();
   }

--- a/core/src/components/datetime/test/minmax/index.html
+++ b/core/src/components/datetime/test/minmax/index.html
@@ -43,7 +43,7 @@
           <div class="grid-item">
             <h2>Value inside Bounds</h2>
             <ion-datetime
-              id="outside"
+              id="inside"
               min="2021-06-05"
               max="2021-06-29"
               value="2021-06-20"
@@ -52,7 +52,7 @@
           <div class="grid-item">
             <h2>Value Outside Bounds</h2>
             <ion-datetime
-              id="inside"
+              id="outside"
               min="2021-06-05"
               max="2021-06-19"
               value="2021-06-20"

--- a/core/src/components/datetime/utils/data.ts
+++ b/core/src/components/datetime/utils/data.ts
@@ -276,8 +276,8 @@ export const getCalendarYears = (
     return processedYears;
   } else {
     const { year } = refParts;
-    const maxYear = (maxParts?.year || year + 20);
-    const minYear = (minParts?.year || year - 20);
+    const maxYear = (maxParts?.year || year);
+    const minYear = (minParts?.year || year - 100);
 
     const years = [];
     for (let i = maxYear; i >= minYear; i--) {

--- a/core/src/components/datetime/utils/data.ts
+++ b/core/src/components/datetime/utils/data.ts
@@ -261,7 +261,6 @@ export const getPickerMonths = (
 
 export const getCalendarYears = (
   refParts: DatetimeParts,
-  showOutOfBoundsYears = false,
   minParts?: DatetimeParts,
   maxParts?: DatetimeParts,
   yearValues?: number[]
@@ -277,8 +276,8 @@ export const getCalendarYears = (
     return processedYears;
   } else {
     const { year } = refParts;
-    const maxYear = (showOutOfBoundsYears) ? year + 20 : (maxParts?.year || year + 20)
-    const minYear = (showOutOfBoundsYears) ? year - 20 : (minParts?.year || year - 20);
+    const maxYear = (maxParts?.year || year + 20);
+    const minYear = (minParts?.year || year - 20);
 
     const years = [];
     for (let i = maxYear; i >= minYear; i--) {

--- a/core/src/components/datetime/utils/state.ts
+++ b/core/src/components/datetime/utils/state.ts
@@ -77,13 +77,11 @@ export const isDayDisabled = (
   return false;
 }
 
-export const getCalendarYearState = (refYear: number, activeParts: DatetimeParts, todayParts: DatetimeParts, minParts?: DatetimeParts, maxParts?: DatetimeParts) => {
+export const getCalendarYearState = (refYear: number, activeParts: DatetimeParts, todayParts: DatetimeParts) => {
   const isActiveYear = refYear === activeParts.year;
   const isCurrentYear = refYear === todayParts.year;
-  const disabled = isYearDisabled(refYear, minParts, maxParts);
 
   return {
-    disabled,
     isActiveYear,
     isCurrentYear,
     ariaSelected: isActiveYear ? 'true' : null


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/23615


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Max/Min are now accounted for when generating years in MD mode
- Out of bounds years are no longer shown in MD mode, making behavior more consistent with iOS mode
- Datetime renders max year as current year and min year as current year - 100 by default for better consistency with old datetime behavior.
- I also changed the internals so that the years array is passed into the ios and MD functions so something like this doesn't happen again

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
