### PR TITLE
chore(): warn if developer forgot to use ionpage component in view

### DIFF
--- a/packages/vue/src/components/IonRouterOutlet.ts
+++ b/packages/vue/src/components/IonRouterOutlet.ts
@@ -327,10 +327,10 @@ export const IonRouterOutlet = defineComponent({
         /**
          * All views that can be transitioned to must have
          * an `<ion-page>` element for transitions and lifecycle
-         * hooks to work properly.
+         * methods to work properly.
          */
         if (enteringViewItem.vueComponent?.components?.IonPage === undefined) {
-          console.warn(`[@ionic/vue Warning]: The view you are trying to render for path ${currentRoute.pathname} does not have the required <ion-page> component. Transitions and lifecycle hooks may not work as expected.
+          console.warn(`[@ionic/vue Warning]: The view you are trying to render for path ${currentRoute.pathname} does not have the required <ion-page> component. Transitions and lifecycle methods may not work as expected.
 
 See https://ionicframework.com/docs/vue/navigation#ionpage for more information.`);
         }

--- a/packages/vue/src/components/IonRouterOutlet.ts
+++ b/packages/vue/src/components/IonRouterOutlet.ts
@@ -323,6 +323,17 @@ export const IonRouterOutlet = defineComponent({
       if (!enteringViewItem) {
         enteringViewItem = viewStacks.createViewItem(id, matchedRouteRef.value.components.default, matchedRouteRef.value, currentRoute);
         viewStacks.add(enteringViewItem);
+
+        /**
+         * All views that can be transitioned to must have
+         * an `<ion-page>` element for transitions and lifecycle
+         * hooks to work properly.
+         */
+        if (enteringViewItem.vueComponent?.components?.IonPage === undefined) {
+          console.warn(`[@ionic/vue Warning]: The view you are trying to render for path ${currentRoute.pathname} does not have the required <ion-page> component. Transitions and lifecycle hooks may not work as expected.
+
+See https://ionicframework.com/docs/vue/navigation#ionpage for more information.`);
+        }
       }
 
       if (!enteringViewItem.mount) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


A common issue people run into is not adding `<ion-page>` to their views. This results in ambiguous errors such as https://github.com/ionic-team/ionic-framework/issues/23620 and https://github.com/ionic-team/ionic-framework/issues/22967.

This PR will detect and warn developers if they forgot the `<ion-page>` component in the hopes that it will help developers catch these errors before they happen.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
