### PR TITLE
fix(item): display helper/error slots correctly without fill property

### DIFF
--- a/core/src/components/item/item.md.scss
+++ b/core/src/components/item/item.md.scss
@@ -56,6 +56,10 @@
   --show-inset-highlight: 0;
 }
 
+:host(.item-interactive:not(.item-fill-outline):not(.item-fill-solid)) .item-highlight {
+  transform: translateY(#{$item-md-border-bottom-width});
+}
+
 // Full lines - apply the border to the item
 // Inset lines - apply the border to the item inner
 :host(.item-lines-full) {

--- a/core/src/components/item/item.md.scss
+++ b/core/src/components/item/item.md.scss
@@ -57,7 +57,7 @@
 }
 
 :host(.item-interactive:not(.item-fill-outline):not(.item-fill-solid)) .item-highlight {
-  transform: translateY(#{$item-md-border-bottom-width});
+  --translateHightlightY: #{$item-md-border-bottom-width};
 }
 
 // Full lines - apply the border to the item
@@ -94,6 +94,7 @@
  */
 :host(.item-fill-outline) .item-highlight {
   --position-offset: calc(-1 * var(--border-width));
+  --scaleHightlightX: 1;
 
   @include position(var(--position-offset), null, null, var(--position-offset));
 

--- a/core/src/components/item/item.scss
+++ b/core/src/components/item/item.scss
@@ -221,7 +221,7 @@
 
   background: var(--background);
 
-  overflow: inherit;
+  overflow: visible;
   box-sizing: border-box;
 
   z-index: 1;
@@ -377,6 +377,8 @@ button, a {
   border-style: var(--border-style);
   border-color: var(--highlight-background);
 }
+
+//TODO: change transform to animation
 
 :host(.item-has-focus) .item-highlight {
   border-width: var(--full-highlight-height);

--- a/core/src/components/item/item.scss
+++ b/core/src/components/item/item.scss
@@ -362,7 +362,7 @@ button, a {
   
   transform: scaleX(0);
 
-  transition: transform 200ms, border-bottom-width 200ms;
+  transition: border-bottom-width 200ms;
 
   z-index: 2;
 
@@ -372,13 +372,25 @@ button, a {
 
 :host(.item-has-focus) .item-highlight,
 :host(.item-has-focus) .item-inner-highlight {
-  transform: scaleX(1);
+  --translateHightlightY: 0px;
+  --scaleHightlightX: 0;
+  animation-name: scaleHighlight;
+  animation-duration: 200ms;
+  animation-fill-mode: forwards;
 
   border-style: var(--border-style);
   border-color: var(--highlight-background);
 }
 
-//TODO: change transform to animation
+@keyframes scaleHighlight {
+  from {
+    transform: translateY(var(--translateHightlightY)) scaleX(var(--scaleHightlightX));
+  }
+
+  to {
+    transform: translateY(var(--translateHightlightY)) scaleX(1);
+  }
+}
 
 :host(.item-has-focus) .item-highlight {
   border-width: var(--full-highlight-height);

--- a/core/src/components/item/item.tsx
+++ b/core/src/components/item/item.tsx
@@ -13,6 +13,8 @@ import { InputChangeEventDetail } from '../input/input-interface';
  * @slot - Content is placed between the named slots if provided without a slot.
  * @slot start - Content is placed to the left of the item text in LTR, and to the right in RTL.
  * @slot end - Content is placed to the right of the item text in LTR, and to the left in RTL.
+ * @slot helper - Content is placed under the item and displayed when no error is detected.
+ * @slot error - Content is placed under the item and displayed when an error is detected.
  *
  * @part native - The native HTML button, anchor or div element that wraps all child elements.
  * @part detail-icon - The chevron icon for the item. Only applies when `detail="true"`.
@@ -303,7 +305,6 @@ export class Item implements ComponentInterface, AnchorInterface, ButtonInterfac
     const mode = getIonMode(this);
     const clickable = this.isClickable();
     const canActivate = this.canActivate();
-    const hasFill = fill === 'outline' || fill === 'solid';
     const TagType = clickable ? (href === undefined ? 'button' : 'a') : 'div' as any;
     const attrs = (TagType === 'button')
       ? { type: this.type }
@@ -361,9 +362,8 @@ export class Item implements ComponentInterface, AnchorInterface, ButtonInterfac
             <div class="item-inner-highlight"></div>
           </div>
           {canActivate && mode === 'md' && <ion-ripple-effect></ion-ripple-effect>}
-          {hasFill && <div class="item-highlight"></div>}
+          <div class="item-highlight"></div>
         </TagType>
-        {!hasFill && <div class="item-highlight"></div>}
         <div class="item-bottom">
           <slot name="error"></slot>
           <slot name="helper"></slot>

--- a/core/src/components/item/readme.md
+++ b/core/src/components/item/readme.md
@@ -1952,11 +1952,13 @@ export default defineComponent({
 
 ## Slots
 
-| Slot      | Description                                                                     |
-| --------- | ------------------------------------------------------------------------------- |
-|           | Content is placed between the named slots if provided without a slot.           |
-| `"end"`   | Content is placed to the right of the item text in LTR, and to the left in RTL. |
-| `"start"` | Content is placed to the left of the item text in LTR, and to the right in RTL. |
+| Slot       | Description                                                                     |
+| ---------- | ------------------------------------------------------------------------------- |
+|            | Content is placed between the named slots if provided without a slot.           |
+| `"end"`    | Content is placed to the right of the item text in LTR, and to the left in RTL. |
+| `"error"`  | Content is placed under the item and displayed when an error is detected.       |
+| `"helper"` | Content is placed under the item and displayed when no error is detected.       |
+| `"start"`  | Content is placed to the left of the item text in LTR, and to the right in RTL. |
 
 
 ## Shadow Parts

--- a/core/src/components/item/test/inputs/index.html
+++ b/core/src/components/item/test/inputs/index.html
@@ -57,6 +57,8 @@
           <ion-item>
             <ion-label>Input (text)</ion-label>
             <ion-input name="input" id="text"></ion-input>
+            <ion-note slot="helper">Helper Text</ion-note>
+            <ion-note slot="error">Error Text</ion-note>
           </ion-item>
 
           <ion-item>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves #23510 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The `helper` and `error` slots in `ion-item` no longer rely on the `fill` property being set.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
