### PR TITLE
fix(vue): popover positioning is now correct with custom elements build

### DIFF
--- a/core/src/utils/transition/index.ts
+++ b/core/src/utils/transition/index.ts
@@ -205,13 +205,19 @@ export const deepReady = async (el: any | undefined): Promise<void> => {
       if (stencilEl != null) {
         return;
       }
-    } else {
+
+    /**
+     * Custom elements in Stencil will have __registerHost.
+     */
+    } else if (element.__registerHost != null) {
       /**
        * Non-lazy loaded custom elements need to wait
        * one frame for component to be loaded.
        */
       const waitForCustomElement = new Promise(resolve => raf(resolve));
       await waitForCustomElement;
+
+      return;
     }
     await Promise.all(Array.from(element.children).map(deepReady));
   }

--- a/core/src/utils/transition/index.ts
+++ b/core/src/utils/transition/index.ts
@@ -2,7 +2,7 @@ import { Build, writeTask } from '@stencil/core';
 
 import { LIFECYCLE_DID_ENTER, LIFECYCLE_DID_LEAVE, LIFECYCLE_WILL_ENTER, LIFECYCLE_WILL_LEAVE } from '../../components/nav/constants';
 import { Animation, AnimationBuilder, NavDirection, NavOptions } from '../../interface';
-import { componentOnReady } from '../helpers';
+import { componentOnReady, raf } from '../helpers';
 
 const iosTransitionAnimation = () => import('./ios.transition');
 const mdTransitionAnimation = () => import('./md.transition');
@@ -205,6 +205,13 @@ export const deepReady = async (el: any | undefined): Promise<void> => {
       if (stencilEl != null) {
         return;
       }
+    } else {
+      /**
+       * Non-lazy loaded custom elements need to wait
+       * one frame for component to be loaded.
+       */
+      const waitForCustomElement = new Promise(resolve => raf(resolve));
+      await waitForCustomElement;
     }
     await Promise.all(Array.from(element.children).map(deepReady));
   }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In v6 we use a `deepReady` function to wait for all stencil components to have been initialized. In the lazy loaded version, we wait for the `componentOnReady` function to fire. In the non-lazy loaded version we return immediately. Since `customElements.define` is not synchronous, we were resolving one frame too early.

This resulted in `ion-popover` not computing the height of the content correctly because the inner `ion-content` had not been initialized yet.

https://forum.ionicframework.com/t/ionic-6-popover-tab-problem/212754


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Wait 1 frame for the custom element to be registered

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
