### PR TITLE
fix(ion-item-sliding): open buttons immediately on first swipe  close…

### DIFF
--- a/core/src/components/item-sliding/item-sliding.tsx
+++ b/core/src/components/item-sliding/item-sliding.tsx
@@ -247,7 +247,6 @@ export class ItemSliding implements ComponentInterface {
     const selected = openSlidingItem;
     if (selected && selected !== this.el) {
       this.closeOpened();
-      return false;
     }
 
     return !!(this.rightOptions || this.leftOptions);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
When swipe on the first element to open the buttons, the buttons open immediately, if  swipe on another element, the buttons will not open, they will open only if  swipe a second time

Issue Number: resolves #21579


## What is the new behavior?
Buttons open immediately after swiping on items

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
