### PR TITLE
fix(img): correctly determine when to load image when scrolling quickly on slower devices

### DIFF
--- a/core/src/components/img/img.tsx
+++ b/core/src/components/img/img.tsx
@@ -61,7 +61,7 @@ export class Img implements ComponentInterface {
       this.removeIO();
       this.io = new IntersectionObserver(data => {
         /**
-         * On slower devices, it is possible for an intersection observer entry to contain multiple 
+         * On slower devices, it is possible for an intersection observer entry to contain multiple
          * objects in the array. This happens when quickly scrolling an image into view and then out of
          * view. In this case, the last object represents the current state of the component.
          */

--- a/core/src/components/img/img.tsx
+++ b/core/src/components/img/img.tsx
@@ -60,7 +60,7 @@ export class Img implements ComponentInterface {
       'isIntersecting' in window.IntersectionObserverEntry.prototype) {
       this.removeIO();
       this.io = new IntersectionObserver(data => {
-        if (data[data.length-1].isIntersecting) {
+        if (data[data.length - 1].isIntersecting) {
           this.load();
           this.removeIO();
         }

--- a/core/src/components/img/img.tsx
+++ b/core/src/components/img/img.tsx
@@ -60,10 +60,7 @@ export class Img implements ComponentInterface {
       'isIntersecting' in window.IntersectionObserverEntry.prototype) {
       this.removeIO();
       this.io = new IntersectionObserver(data => {
-        // because there will only ever be one instance
-        // of the element we are observing
-        // we can just use data[0]
-        if (data[0].isIntersecting) {
+        if (data[data.length-1].isIntersecting) {
           this.load();
           this.removeIO();
         }

--- a/core/src/components/img/img.tsx
+++ b/core/src/components/img/img.tsx
@@ -60,6 +60,11 @@ export class Img implements ComponentInterface {
       'isIntersecting' in window.IntersectionObserverEntry.prototype) {
       this.removeIO();
       this.io = new IntersectionObserver(data => {
+        /**
+         * On slower devices, it is possible for an intersection observer entry to contain multiple 
+         * objects in the array. This happens when quickly scrolling an image into view and then out of
+         * view. In this case, the last object represents the current state of the component.
+         */
         if (data[data.length - 1].isIntersecting) {
           this.load();
           this.removeIO();


### PR DESCRIPTION
Fix for this issue: https://github.com/ionic-team/ionic-framework/issues/23703

There is a rare race condition you may experience on devices with slower CPU where the Intersection Observer API supplies multiple items to the callback, instead of only a single element which the previous code assumed it would get.  This changes takes the last item (which will be the most current information).

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [23703](https://github.com/ionic-team/ionic-framework/issues/23703)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Instead of keying off of the first item in the callback to the ion-img Intersection Observer API callback, take the last, most recent one to determine whether the img is on screen and should load

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
