### PR TITLE
fix(datetime): text color on ios mode now accounts for color contrast

### DIFF
--- a/core/src/components/datetime/datetime.ios.scss
+++ b/core/src/components/datetime/datetime.ios.scss
@@ -116,78 +116,11 @@
 }
 
 /**
- * Day that is not today but
- * is selected should have ion-color for
- * text color and be bolder.
- */
-:host .calendar-day.calendar-day-active .calendar-day-content {
-  background: current-color(contrast);
-}
-
-/**
  * Day that is selected and is today
  * should have white color.
  */
 :host .calendar-day.calendar-day-today.calendar-day-active {
-  color: var(--ion-text-color, #ffffff);
-}
-
-:host .calendar-day.calendar-day-today.calendar-day-active:after {
-  background: current-color(base);
-
-  opacity: 1;
-}
-
-:host .calendar-day {
-  font-size: 20px;
-}
-
-:host .calendar-day:after {
-  opacity: 0.2;
-}
-
-:host .calendar-day:focus:after {
-  background: current-color(base);
-}
-
-/**
- * Day that today but not selected
- * should have ion-color for text color.
- */
-:host .calendar-day.calendar-day-today {
-  color: current-color(base);
-}
-
-/**
- * Day that is not today but
- * is selected should have ion-color for
- * text color and be bolder.
- */
-:host .calendar-day.calendar-day-active {
-  color: current-color(base);
-
-  font-weight: 600;
-}
-
-:host .calendar-day.calendar-day-active:after {
-  background: current-color(base);
-}
-
-/**
- * Day that is not today but
- * is selected should have ion-color for
- * text color and be bolder.
- */
-:host .calendar-day.calendar-day-active .calendar-day-content {
-  background: current-color(contrast);
-}
-
-/**
- * Day that is selected and is today
- * should have white color.
- */
-:host .calendar-day.calendar-day-today.calendar-day-active {
-  color: var(--ion-text-color, #ffffff);
+  color: current-color(contrast);
 }
 
 :host .calendar-day.calendar-day-today.calendar-day-active:after {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/23723


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Today date text color now uses color contrast instead of text color (this is what MD does too)
There was also duplicated CSS so I removed that too

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
