### PR TITLE
fix(ion-textarea) autoGrow does not fire when style display changes c…

### DIFF
--- a/core/src/components/textarea/test/a11y/textarea.spec.ts
+++ b/core/src/components/textarea/test/a11y/textarea.spec.ts
@@ -3,6 +3,12 @@ import { Textarea } from '../../textarea';
 import { Item } from '../../../item/item';
 import { Label } from '../../../label/label';
 
+global.MutationObserver = class {
+  constructor() {}
+  disconnect() {}
+  observe() {}
+};
+
 describe('Textarea a11y', () => {
   it('does not set a default aria-labelledby when there is not a neighboring ion-label', async () => {
     const page = await newSpecPage({

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -203,6 +203,7 @@ export class Textarea implements ComponentInterface {
         detail: this.el
       }));
     }
+    this.watchDisplay();
   }
 
   disconnectedCallback() {
@@ -219,6 +220,16 @@ export class Textarea implements ComponentInterface {
 
   componentDidLoad() {
     raf(() => this.runAutoGrow());
+  }
+
+  protected watchDisplay(): void {
+    const observer = new MutationObserver(() => {
+      const child: any = this.el.children[0];
+      if (this.el.style.display != 'none' && child.style.height === '0px') {
+        this.runAutoGrow();
+      }
+    });
+    observer.observe(this.el, {attributes: true, childList: true});
   }
 
   private runAutoGrow() {

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -225,11 +225,11 @@ export class Textarea implements ComponentInterface {
   protected watchDisplay(): void {
     const observer = new MutationObserver(() => {
       const child: any = this.el.children[0];
-      if (this.el.style.display != 'none' && child.style.height === '0px') {
+      if (this.el.style.display !== 'none' && child.style.height === '0px') {
         this.runAutoGrow();
       }
     });
-    observer.observe(this.el, {attributes: true, childList: true});
+    observer.observe(this.el, { attributes: true, childList: true });
   }
 
   private runAutoGrow() {


### PR DESCRIPTION
Hello ionic team, I described this problem here
https://github.com/ionic-team/ionic-framework/issues/21242#issuecomment-889204822

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The runAutoGrow function does not fire and the height for the element is not set


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

If the element is initialized on the page with display: none and then after a while becomes display: block the runAutoGrow function will be called

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Sample code with a bug
https://github.com/Sitronik/ionic-vue-bug-textarea