### PR TITLE
fix(nav): custom animation is no longer overridden

### DIFF
--- a/core/src/components/nav/nav.tsx
+++ b/core/src/components/nav/nav.tsx
@@ -872,14 +872,15 @@ export class Nav implements NavOutlet {
       mode,
       showGoBack: this.canGoBackSync(enteringView),
       baseEl: this.el,
-      animationBuilder: this.animation || opts.animationBuilder || config.get('navAnimation'),
       progressCallback,
       animated: this.animated && config.getBoolean('animated', true),
 
       enteringEl,
       leavingEl,
 
-      ...opts
+      ...opts,
+      
+      animationBuilder: opts.animationBuilder || this.animation || config.get('navAnimation')
     };
     const { hasCompleted } = await transition(animationOpts);
     return this.transitionFinish(hasCompleted, enteringView, leavingView, opts);

--- a/core/src/components/nav/nav.tsx
+++ b/core/src/components/nav/nav.tsx
@@ -879,7 +879,7 @@ export class Nav implements NavOutlet {
       leavingEl,
 
       ...opts,
-      
+
       animationBuilder: opts.animationBuilder || this.animation || config.get('navAnimation')
     };
     const { hasCompleted } = await transition(animationOpts);

--- a/core/src/components/router-outlet/route-outlet.tsx
+++ b/core/src/components/router-outlet/route-outlet.tsx
@@ -188,7 +188,7 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
 
     const { el, mode } = this;
     const animated = this.animated && config.getBoolean('animated', true);
-    const animationBuilder = this.animation || opts.animationBuilder || config.get('navAnimation');
+    const animationBuilder = opts.animationBuilder || this.animation || config.get('navAnimation');
 
     await transition({
       mode,


### PR DESCRIPTION
opts will always have animationBuilder prop when used with ion-router and this fix will make sure, that animationBuilder will be set with appropriate value

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #23777

## What is the new behavior?
Use custom transition if set on ion-nav and page change triggered by ion-router.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
