### PR TITLE
fix(reorder-group): dragging reorder item to bottom no longer gives out of bounds index

### DIFF
--- a/core/src/components/reorder-group/reorder-group.tsx
+++ b/core/src/components/reorder-group/reorder-group.tsx
@@ -245,17 +245,16 @@ export class ReorderGroup implements ComponentInterface {
 
   private itemIndexForTop(deltaY: number): number {
     const heights = this.cachedHeights;
-    let i = 0;
 
     // TODO: since heights is a sorted array of integers, we can do
     // speed up the search using binary search. Remember that linear-search is still
     // faster than binary-search for small arrays (<64) due CPU branch misprediction.
-    for (i = 0; i < heights.length; i++) {
+    for (let i = 0; i < heights.length; i++) {
       if (heights[i] > deltaY) {
-        break;
+        return i;
       }
     }
-    return i;
+    return heights.length - 1;
   }
 
   /********* DOM WRITE ********* */


### PR DESCRIPTION
Previously the 'to' detail on item reorder events could be one too high if the item was dragged far enough

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves #23796

The `to` field on the `ItemReorderEventDetail` event is off-by-one (too high) when an item is dragged past the end the list.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The `to` field will never be more that the number of items - 1.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I haven't modified any tests because I could only find e2e tests, not unit tests. This fix isn't for something which is visible on the screen and therefore cannot be protected against in a e2e test.
I haven't run the linter because it doesn't appear to run at all on my machine - I assume it to be an environment issue for myself but I am confident that this PR sticks to your style guide and should pass the linting.