### PR TITLE
fix(label): label now only takes up as much space as needed when slotted

### DIFF
--- a/core/src/components/item/item.scss
+++ b/core/src/components/item/item.scss
@@ -308,10 +308,6 @@ button, a {
   z-index: 1;
 }
 
-::slotted(ion-label) {
-  flex: 1;
-}
-
 
 // Item Input
 // --------------------------------------------------

--- a/core/src/components/item/item.scss
+++ b/core/src/components/item/item.scss
@@ -308,6 +308,10 @@ button, a {
   z-index: 1;
 }
 
+::slotted(ion-label:not([slot="end"])) {
+  flex: 1;
+}
+
 
 // Item Input
 // --------------------------------------------------

--- a/core/src/components/item/test/alignment/index.html
+++ b/core/src/components/item/test/alignment/index.html
@@ -59,6 +59,22 @@
             <ion-select-option>Atlanta, GA</ion-select-option>
           </ion-select>
         </ion-item>
+
+        <ion-item>
+          <ion-label slot="end">Time</ion-label>
+          <ion-datetime display-format="DDDD MMMM D YYYY hh:mm:ss a" value="2019-10-01T15:43:40.394Z"></ion-datetime>
+        </ion-item>
+        <ion-item>
+          <ion-label slot="end">From</ion-label>
+          <ion-input placeholder="Choose Starting Point"></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-label slot="end">Destination</ion-label>
+          <ion-select placeholder="Choose Really Really Long Destination Here">
+            <ion-select-option>Madison, WI</ion-select-option>
+            <ion-select-option>Atlanta, GA</ion-select-option>
+          </ion-select>
+        </ion-item>
       </ion-list>
 
       <ion-list>

--- a/core/src/components/item/test/alignment/index.html
+++ b/core/src/components/item/test/alignment/index.html
@@ -59,22 +59,6 @@
             <ion-select-option>Atlanta, GA</ion-select-option>
           </ion-select>
         </ion-item>
-
-        <ion-item>
-          <ion-label slot="end">Time</ion-label>
-          <ion-datetime display-format="DDDD MMMM D YYYY hh:mm:ss a" value="2019-10-01T15:43:40.394Z"></ion-datetime>
-        </ion-item>
-        <ion-item>
-          <ion-label slot="end">From</ion-label>
-          <ion-input placeholder="Choose Starting Point"></ion-input>
-        </ion-item>
-        <ion-item>
-          <ion-label slot="end">Destination</ion-label>
-          <ion-select placeholder="Choose Really Really Long Destination Here">
-            <ion-select-option>Madison, WI</ion-select-option>
-            <ion-select-option>Atlanta, GA</ion-select-option>
-          </ion-select>
-        </ion-item>
       </ion-list>
 
       <ion-list>
@@ -127,6 +111,25 @@
         </ion-item>
         <ion-item>
           <ion-label position="stacked">Destination</ion-label>
+          <ion-select placeholder="Choose Really Really Long Destination Here">
+            <ion-select-option>Madison, WI</ion-select-option>
+            <ion-select-option>Atlanta, GA</ion-select-option>
+          </ion-select>
+        </ion-item>
+      </ion-list>
+
+      <ion-list>
+        <ion-list-header>End Labels</ion-list-header>
+        <ion-item>
+          <ion-label slot="end">Time</ion-label>
+          <ion-datetime display-format="DDDD MMMM D YYYY hh:mm:ss a" value="2019-10-01T15:43:40.394Z"></ion-datetime>
+        </ion-item>
+        <ion-item>
+          <ion-label slot="end">From</ion-label>
+          <ion-input placeholder="Choose Starting Point"></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-label slot="end">Destination</ion-label>
           <ion-select placeholder="Choose Really Really Long Destination Here">
             <ion-select-option>Madison, WI</ion-select-option>
             <ion-select-option>Atlanta, GA</ion-select-option>

--- a/core/src/components/label/test/basic/index.html
+++ b/core/src/components/label/test/basic/index.html
@@ -75,6 +75,10 @@
           <ion-label position="stacked" color="danger">Stacked: Danger</ion-label>
           <ion-input></ion-input>
         </ion-item>
+        <ion-item>
+          <ion-input placeholder="Enter a name"></ion-input>
+          <ion-label slot="end">End Label</ion-label>
+        </ion-item>
       </ion-list>
 
       <ion-list>

--- a/core/src/components/label/test/basic/index.html
+++ b/core/src/components/label/test/basic/index.html
@@ -75,10 +75,6 @@
           <ion-label position="stacked" color="danger">Stacked: Danger</ion-label>
           <ion-input></ion-input>
         </ion-item>
-        <ion-item>
-          <ion-input placeholder="Enter a name"></ion-input>
-          <ion-label slot="end">End Label</ion-label>
-        </ion-item>
       </ion-list>
 
       <ion-list>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`ion-label` components slotted in `ion-item` always had `flex: 1`. This was fine for labels at the start, but labels slotted in the end slot ended up taking up ~50% of the item width which did not look correct.

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/23806

| `main` | `branch` |
| ------- | --------- |
| ![localhost_3333_src_components_item_test_alignment(Moto G4) (1)](https://user-images.githubusercontent.com/2721089/130632351-4f392d64-a8c1-4544-9d9d-eb11f46319e6.png) | ![localhost_3333_src_components_item_test_alignment(Moto G4)](https://user-images.githubusercontent.com/2721089/130632373-07035d35-1d71-4f1b-9d9e-b6a9ae26ca7a.png) |




## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Labels in the end slot no longer get `flex: 1`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
