### PR TITLE
fix(input, textarea): add correct padding when used outside ion-item in ios mode

### DIFF
--- a/core/src/components/input/input.ios.vars.scss
+++ b/core/src/components/input/input.ios.vars.scss
@@ -17,7 +17,7 @@ $input-ios-padding-end:                    ($item-ios-padding-end / 2) !default;
 $input-ios-padding-bottom:                 $item-ios-padding-bottom !default;
 
 /// @prop - Margin start of the input
-$input-ios-padding-start:                  0 !default;
+$input-ios-padding-start:                  ($item-ios-padding-start / 2) !default;
 
 /// @prop - Margin start of the input when it is after a label
 $input-ios-by-label-margin-start:         $item-ios-padding-start !default;

--- a/core/src/components/input/test/standalone/index.html
+++ b/core/src/components/input/test/standalone/index.html
@@ -9,7 +9,8 @@
   <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
   <script src="../../../../../scripts/testing/scripts.js"></script>
   <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
-  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script></head>
+  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+</head>
 
 <body>
   <h1>Default</h1>
@@ -17,6 +18,7 @@
   <ion-input value="value"></ion-input>
   <ion-input type="number" placeholder="Enter a Number"></ion-input>
   <ion-input type="number" value="44"></ion-input>
+  <ion-input class="custom-border" placeholder="Enter some text"></ion-input>
 
   <h1>Colors</h1>
   <ion-grid>
@@ -91,6 +93,10 @@
   <style>
     .custom {
       --color: green;
+    }
+
+    .custom-border {
+      border: 1px solid green;
     }
   </style>
 </body>

--- a/core/src/components/textarea/test/standalone/index.html
+++ b/core/src/components/textarea/test/standalone/index.html
@@ -20,8 +20,12 @@
   <ion-textarea placeholder="Custom" class="custom"></ion-textarea>
   <ion-textarea id="nowrap" rows="15"></ion-textarea>
   <ion-textarea placeholder="Auto Grow!" auto-grow="true"></ion-textarea>
+  <ion-textarea class="custom-border" placeholder="Enter some text"></ion-textarea>
 
   <style>
+    .custom-border {
+      border: 1px solid green;
+    }
     .custom {
       --background: papayawhip;
       --color: blue;

--- a/core/src/components/textarea/textarea.ios.vars.scss
+++ b/core/src/components/textarea/textarea.ios.vars.scss
@@ -20,7 +20,7 @@ $textarea-ios-padding-end:                    ($item-ios-padding-end / 2) !defau
 $textarea-ios-padding-bottom:                 $item-ios-padding-bottom !default;
 
 /// @prop - Margin start of the textarea
-$textarea-ios-padding-start:                  0 !default;
+$textarea-ios-padding-start:                  ($item-ios-padding-start / 2) !default;
 
 /// @prop - Placeholder text color of the textarea
 $textarea-ios-placeholder-color:            $placeholder-text-color !default;


### PR DESCRIPTION
…n the starting edge

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/23881


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added padding start value to ion-input on iOS mode when used outside of ion-item. This makes the input look nicer when devs add a border.

| `main` | `FW-74` |
| ------- | --------- |
| ![image](https://user-images.githubusercontent.com/2721089/132362183-e2e15382-c0e7-454c-b936-337143e2caa6.png) | ![image](https://user-images.githubusercontent.com/2721089/132361179-6f0fbd34-b78e-46c0-8d89-6d9f3a703997.png) |
| ![image](https://user-images.githubusercontent.com/2721089/132362261-e64c2fdc-26d0-460c-839e-1bd74644c1ee.png) | ![image](https://user-images.githubusercontent.com/2721089/132363034-2e32da1b-ba67-4e48-8966-d11e1035a31c.png) |

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
