### PR TITLE
fix(react): modal now mounts child component independently of other modals

### DIFF
--- a/packages/react/src/components/createOverlayComponent.tsx
+++ b/packages/react/src/components/createOverlayComponent.tsx
@@ -35,8 +35,6 @@ export const createOverlayComponent = <
       forwardedRef?: React.ForwardedRef<OverlayType>;
     };
 
-  let isDismissing = false;
-
   class Overlay extends React.Component<Props> {
     overlay?: OverlayType;
     el!: HTMLDivElement;
@@ -47,6 +45,7 @@ export const createOverlayComponent = <
         this.el = document.createElement('div');
       }
       this.handleDismiss = this.handleDismiss.bind(this);
+      this.isDismissing = false;
     }
 
     static get displayName() {
@@ -75,7 +74,7 @@ export const createOverlayComponent = <
     shouldComponentUpdate(nextProps: Props) {
       // Check if the overlay component is about to dismiss
       if (this.overlay && nextProps.isOpen !== this.props.isOpen && nextProps.isOpen === false) {
-        isDismissing = true;
+        this.isDismissing = true;
       }
 
       return true;
@@ -91,7 +90,7 @@ export const createOverlayComponent = <
       }
       if (this.overlay && prevProps.isOpen !== this.props.isOpen && this.props.isOpen === false) {
         await this.overlay.dismiss();
-        isDismissing = false;
+        this.isDismissing = false;
 
         /**
          * Now that the overlay is dismissed
@@ -142,7 +141,7 @@ export const createOverlayComponent = <
        * overlay is dismissing otherwise component
        * will be hidden before animation is done.
        */
-      return ReactDOM.createPortal(this.props.isOpen || isDismissing ? this.props.children : null, this.el);
+      return ReactDOM.createPortal(this.props.isOpen || this.isDismissing ? this.props.children : null, this.el);
     }
   }
 

--- a/packages/react/src/components/createOverlayComponent.tsx
+++ b/packages/react/src/components/createOverlayComponent.tsx
@@ -38,8 +38,7 @@ export const createOverlayComponent = <
   class Overlay extends React.Component<Props> {
     overlay?: OverlayType;
     el!: HTMLDivElement;
-    isDismissing: boolean = false;
-    
+    isDismissing = false;
     constructor(props: Props) {
       super(props);
       if (typeof document !== 'undefined') {

--- a/packages/react/src/components/createOverlayComponent.tsx
+++ b/packages/react/src/components/createOverlayComponent.tsx
@@ -38,14 +38,14 @@ export const createOverlayComponent = <
   class Overlay extends React.Component<Props> {
     overlay?: OverlayType;
     el!: HTMLDivElement;
-
+    isDismissing: boolean = false;
+    
     constructor(props: Props) {
       super(props);
       if (typeof document !== 'undefined') {
         this.el = document.createElement('div');
       }
       this.handleDismiss = this.handleDismiss.bind(this);
-      this.isDismissing = false;
     }
 
     static get displayName() {


### PR DESCRIPTION
Currently, when Ion components such as `IonModal` are created using the `createOverlayComponent` HOC, the isDismissing flag is scoped to the definition of the class. So in this case, when IonModal gets exported, the isDismissing flag is scoped to the IonModal class definition and not an instance of the IonModal. 

Consider when you have multiple IonModals controlling different dialogs or whatever. So I believe this `isDismissing` flag should be scoped to the instance of the Overlay class, as if I chose to render 10 IonModals, each should be controlled independently.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/23904


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
