### PR TITLE
fix(modal): modal displays in middle of screen on desktop

### DIFF
--- a/core/src/components/modal/modal.scss
+++ b/core/src/components/modal/modal.scss
@@ -65,9 +65,6 @@
 .modal-shadow {
   @include border-radius(var(--border-radius));
 
-  position: absolute;
-  bottom: 0;
-
   width: var(--width);
   min-width: var(--min-width);
   max-width: var(--max-width);
@@ -141,4 +138,10 @@
  */
 :host(.modal-sheet) {
   --height: calc(100% - (var(--ion-safe-area-top) + 10px));
+}
+
+:host(.modal-sheet) .modal-wrapper,
+:host(.modal-sheet) .modal-shadow {
+  position: absolute;
+  bottom: 0;
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

https://github.com/ionic-team/ionic-framework/commit/12216d378df091e16fd77d271b107e819278481c regressed modal positioning on desktop. Sheet modal needs to be fixed at the bottom, but desktop modal should be centered in middle of screen.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Desktop modal is now centered in middle of screen

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
