### PR TITLE
fix(tabs): add transition animation to another tab if direction was explicitly defined

### DIFF
--- a/angular/src/directives/navigation/stack-controller.ts
+++ b/angular/src/directives/navigation/stack-controller.ts
@@ -53,10 +53,12 @@ export class StackController {
 
   setActive(enteringView: RouteView): Promise<StackEvent> {
     const consumeResult = this.navCtrl.consumeTransition();
-    let { direction, animation, animationBuilder } = consumeResult;
+    let { direction, animation, animationBuilder, isDirectionDefined } = consumeResult;
     const leavingView = this.activeView;
     const tabSwitch = isTabSwitch(enteringView, leavingView);
-    if (tabSwitch) {
+
+    // if direction was defined explicitly, then ignore tab switch and play transition animation
+    if (!isDirectionDefined && tabSwitch) {
       direction = 'back';
       animation = undefined;
     }

--- a/angular/src/providers/nav-controller.ts
+++ b/angular/src/providers/nav-controller.ts
@@ -169,6 +169,7 @@ export class NavController {
    * @internal
    */
   consumeTransition() {
+    let isDirectionDefined = this.direction === 'forward' || this.direction === 'back';
     let direction: RouterDirection = 'root';
     let animation: NavDirection | undefined;
     const animationBuilder = this.animationBuilder;
@@ -187,7 +188,8 @@ export class NavController {
     return {
       direction,
       animation,
-      animationBuilder
+      animationBuilder,
+      isDirectionDefined
     };
   }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
It's not possible to have an animation for the transition to another stack (tab).

Issue Number: [19419](https://github.com/ionic-team/ionic-framework/issues/19419)


## What is the new behavior?
- If navigation direction was explicitly defined (`'back'` or `'forward'`), then we play transition animation, even if the navigation is tab switching.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
