### PR TITLE
fix(angular): select method now has correct types

### DIFF
--- a/angular/src/directives/navigation/ion-tabs.ts
+++ b/angular/src/directives/navigation/ion-tabs.ts
@@ -87,8 +87,9 @@ export class IonTabs {
    *      to the default tabRootUrl
    */
   @HostListener('ionTabButtonClick', ['$event'])
-  select(ev: CustomEvent) {
-    const tab = ev.detail.tab;
+  select(tabOrEvent: string | CustomEvent) {
+    const isTabString = typeof tabOrEvent === 'string';
+    const tab = (isTabString) ? tabOrEvent : (tabOrEvent as CustomEvent).detail.tab;
     const alreadySelected = this.outlet.getActiveStackId() === tab;
     const tabRootUrl = `${this.outlet.tabsPrefix}/${tab}`;
 
@@ -98,7 +99,9 @@ export class IonTabs {
      * will respond to this event too, causing
      * the app to get directed to the wrong place.
      */
-    ev.stopPropagation();
+    if (!isTabString) {
+      (tabOrEvent as CustomEvent).stopPropagation();
+    }
 
     if (alreadySelected) {
       const activeStackId = this.outlet.getActiveStackId();


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves #23952
https://github.com/ionic-team/ionic-framework/commit/1ed9f07060736d0c951910427fb12b250d7dd9af regressed the `select` method where uses could pass in a tab string to select a tab.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Update `select` method to account for both string name and custom event.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
