### PR TITLE
fix(alert): allow 5.5 items to show in alert-mode select popup in md

### DIFF
--- a/core/src/components/alert/alert.md.vars.scss
+++ b/core/src/components/alert/alert.md.vars.scss
@@ -80,7 +80,7 @@ $alert-md-message-empty-padding-bottom:       $alert-md-message-empty-padding-to
 $alert-md-message-empty-padding-start:        $alert-md-message-empty-padding-end !default;
 
 /// @prop - Maximum height of the alert content
-$alert-md-content-max-height:                 264px !default;
+$alert-md-content-max-height:                 266px !default;
 
 /// @prop - Border width of the alert input
 $alert-md-input-border-width:                 1px !default;

--- a/core/src/components/alert/alert.md.vars.scss
+++ b/core/src/components/alert/alert.md.vars.scss
@@ -80,7 +80,7 @@ $alert-md-message-empty-padding-bottom:       $alert-md-message-empty-padding-to
 $alert-md-message-empty-padding-start:        $alert-md-message-empty-padding-end !default;
 
 /// @prop - Maximum height of the alert content
-$alert-md-content-max-height:                 240px !default;
+$alert-md-content-max-height:                 264px !default;
 
 /// @prop - Border width of the alert input
 $alert-md-input-border-width:                 1px !default;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Resolves https://github.com/ionic-team/ionic-framework/issues/23760

In `md` mode, alert-style `ion-select`s with more than 5 items don't look scrollable, due to the alert content having the height for exactly 5 items.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Alert content height increased to allow for 5.5 items (going off the MD spec item height of 48px). The cut-off item makes it clear that the list can be scrolled to reveal more items.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
