### PR TITLE
fix(datetime): add ionBlur/ionFocus events to whole component

### DIFF
--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -124,12 +124,12 @@ export class Button implements ComponentInterface, AnchorInterface, ButtonInterf
   /**
    * Emitted when the button has focus.
    */
-  @Event({ composed: false }) ionFocus!: EventEmitter<void>;
+  @Event() ionFocus!: EventEmitter<void>;
 
   /**
    * Emitted when the button loses focus.
    */
-  @Event({ composed: false }) ionBlur!: EventEmitter<void>;
+  @Event() ionBlur!: EventEmitter<void>;
 
   componentWillLoad() {
     this.inToolbar = !!this.el.closest('ion-buttons');

--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -124,12 +124,12 @@ export class Button implements ComponentInterface, AnchorInterface, ButtonInterf
   /**
    * Emitted when the button has focus.
    */
-  @Event() ionFocus!: EventEmitter<void>;
+  @Event({ composed: false }) ionFocus!: EventEmitter<void>;
 
   /**
    * Emitted when the button loses focus.
    */
-  @Event() ionBlur!: EventEmitter<void>;
+  @Event({ composed: false }) ionBlur!: EventEmitter<void>;
 
   componentWillLoad() {
     this.inToolbar = !!this.el.closest('ion-buttons');

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1190,6 +1190,14 @@ export class Datetime implements ComponentInterface {
     });
   }
 
+  private onFocus = () => {
+    this.ionFocus.emit();
+  }
+
+  private onBlur = () => {
+    this.ionBlur.emit();
+  }
+
   private nextMonth = () => {
     const { calendarBodyRef } = this;
     if (!calendarBodyRef) { return; }
@@ -1596,6 +1604,8 @@ export class Datetime implements ComponentInterface {
     return (
       <Host
         aria-disabled={disabled ? 'true' : null}
+        onFocus={this.onFocus}
+        onBlur={this.onBlur}
         class={{
           ...createColorClasses(color, {
             [mode]: true,

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -10,7 +10,7 @@ import {
 import { getIonMode } from '../../global/ionic-global';
 import { Color, DatetimeChangeEventDetail, DatetimeParts, Mode, StyleEventDetail } from '../../interface';
 import { startFocusVisible } from '../../utils/focus-visible';
-import { raf, renderHiddenInput } from '../../utils/helpers';
+import { getElementRoot, raf, renderHiddenInput } from '../../utils/helpers';
 import { createColorClasses } from '../../utils/theme';
 
 import {
@@ -880,6 +880,19 @@ export class Datetime implements ComponentInterface {
     }
     hiddenIO = new IntersectionObserver(hiddenCallback, { threshold: 0 });
     hiddenIO.observe(this.el);
+
+    /**
+     * Datetime uses Ionic components that emit
+     * ionFocus and ionBlur. These events are
+     * composed meaning they will cross
+     * the shadow dom boundary. We need to
+     * stop propagation on these events otherwise
+     * developers will see 2 ionFocus or 2 ionBlur
+     * events at a time.
+     */
+    const root = getElementRoot(this.el);
+    root.addEventListener('ionFocus', (ev: Event) => ev.stopPropagation());
+    root.addEventListener('ionBlur', (ev: Event) => ev.stopPropagation());
   }
 
   /**

--- a/core/src/components/datetime/test/basic/index.html
+++ b/core/src/components/datetime/test/basic/index.html
@@ -327,7 +327,7 @@
           datetimes.forEach(datetime => {
             datetime.locale = (!!value) ? value : 'default';
           });
-        })
+        });
 
         const darkModeCheckbox = document.querySelector('ion-checkbox');
         darkModeCheckbox.addEventListener('ionChange', (ev) => {
@@ -342,18 +342,28 @@
           buttons.forEach(button => {
             button.color = ev.target.value;
           })
-        })
+        });
 
         titleToggle.addEventListener('ionChange', (ev) => {
           datetimes.forEach(datetime => {
             datetime.showDefaultTitle = ev.detail.checked;
           });
-        })
+        });
         buttonsToggle.addEventListener('ionChange', (ev) => {
           datetimes.forEach(datetime => {
             datetime.showDefaultButtons = ev.detail.checked;
           });
-        })
+        });
+
+        datetimes.forEach(datetime => {
+          datetime.addEventListener('ionFocus', () => {
+            console.log('Listen ionFocus: fired');
+          });
+
+          datetime.addEventListener('ionBlur', () => {
+            console.log('Listen ionBlur: fired');
+          });
+        });
 
         const defaultPopover = document.querySelector('ion-popover#default-popover');
         const customPopover = document.querySelector('ion-popover#custom-popover');


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Resolves https://github.com/ionic-team/ionic-framework/issues/23842

Events for `ionBlur` and `ionFocus` aren't firing when clicking in and out of `ion-datetime`.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `ion-datetime` fires `ionFocus` and `ionBlur` events when clicking in and out of the component host.
- `ionFocus` and `ionBlur` events fired from components inside `ion-datetime`'s shadow DOM are now prevented from bubbling up, to avoid duplicate events appearing at the top level.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Even with this fix, clicking the `ion-button`s in `ion-datetime` (prev/next month, and buttons in the footer) will cause the datetime to lose focus in Safari (only). This does not apply to tabbing to the buttons instead -- focus is correctly maintained. There are two Webkit bugs driving the click issue:
- [22261](https://bugs.webkit.org/show_bug.cgi?id=22261): Clicking a button doesn't emit a focus event. Closed as "won't fix."
- [229895](https://bugs.webkit.org/show_bug.cgi?id=229895): Clicking a button causes focus to drop entirely (which causes the `ion-datetime` to emit a blur event).