### PR TITLE
fix(status-bar): tapping status bar now correctly scrolls content to top

### DIFF
--- a/core/src/utils/status-tap.ts
+++ b/core/src/utils/status-tap.ts
@@ -15,7 +15,21 @@ export const startStatusTap = () => {
       const contentEl = el.closest('ion-content');
       if (contentEl) {
         new Promise(resolve => componentOnReady(contentEl, resolve)).then(() => {
-          writeTask(() => contentEl.scrollToTop(300));
+          writeTask(async () => {
+
+            /**
+             * If scrolling and user taps status bar,
+             * only calling scrollToTop is not enough
+             * as engines like WebKit will jump the
+             * scroll position back down and complete
+             * any in-progress momentum scrolling.
+             */
+            contentEl.style.setProperty('--overflow', 'hidden');
+
+            await contentEl.scrollToTop(300);
+
+            contentEl.style.removeProperty('--overflow');
+          });
         });
       }
     });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves #20423


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Tapping status bar now interrupts momentum scrolling and scrolls the page to the top.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
