### PR TITLE
fix(angular): config.get not a function in karma (#22853)

### DIFF
--- a/angular/src/app-initialize.ts
+++ b/angular/src/app-initialize.ts
@@ -11,10 +11,14 @@ export const appInitialize = (config: Config, doc: Document, zone: NgZone) => {
     if (win && typeof (window as any) !== 'undefined') {
       const Ionic = win.Ionic = win.Ionic || {};
 
-      Ionic.config = {
-        ...config,
-        _zoneGate: (h: any) => zone.run(h)
-      };
+      // Only set the config key/value if one does not already exist
+      // Subsequent initilizations (eg in karma) should not overwrite the config if exists already in the window
+      if (!Ionic.config) {
+        Ionic.config = {
+          ...config,
+          _zoneGate: (h: any) => zone.run(h)
+        };
+      }
 
       const aelFn = '__zone_symbol__addEventListener' in (doc.body as any)
         ? '__zone_symbol__addEventListener'


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
When angular bootstraps it sets `Ionic.config` regardless of whether it is set or not. This is fine in normal applications such as serving in the browser where angular is only initialised once. 

However in karma test suites angular is initialised on every test case but the window object persists between all test cases which causes ionic/angular to overwrite the config with something that is not compatible with the core components. This has been reported in #22853 as config.get throwing warnings when using ion-segment but I guess the issue could be for any components that use the config object.

Issue Number: 22853


## What is the new behavior?
Now during startup ionic/angular checks to see if `Ionic.config` is set. If it is it does not do anything with that variable. This seems to solve the problem described in #22853 and I've not noticed any adverse effects when stepping through the event listeners in [helpers](https://github.com/ionic-team/ionic-framework/blob/25eb8cdf98fe455433ca6185e89d9e1223a6d3ae/core/src/utils/helpers.ts#L71) that were previously failing because the config had been overwritten with another object

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
When inspecting Ionic.config on a second test case

Before | After
--- | ---
<img width="298" alt="Screenshot 2021-10-01 at 15 30 04" src="https://user-images.githubusercontent.com/846587/135652618-2df04304-2bcd-42f0-b2cb-76ff9e61e7f3.png"> | <img width="300" alt="Screenshot 2021-10-01 at 15 28 48" src="https://user-images.githubusercontent.com/846587/135652614-914c6128-ed02-42f8-99c0-490dd7f8465b.png">

PS: I wasn't able to find any tests for this part and running npm test gave me `angular no tests yet`. If theres some tests I need to write let me know and also how I should run the test suite.
