### PR TITLE
fix(react): overlays shown with useIonModal and useIonPopover no longer render outside of main react tree

### DIFF
--- a/packages/react/src/components/IonApp.tsx
+++ b/packages/react/src/components/IonApp.tsx
@@ -1,0 +1,62 @@
+import { JSX as LocalJSX } from '@ionic/core/components';
+import React from 'react';
+
+import { IonicReactProps } from './IonicReactProps';
+import { IonAppInner } from './inner-proxies';
+import { IonOverlayManager } from './IonOverlayManager';
+import { IonContext, IonContextInterface } from '../contexts/IonContext';
+import { ReactComponentOrElement } from '../models';
+
+type Props = LocalJSX.IonApp &
+  IonicReactProps & {
+    ref?: React.Ref<HTMLIonAppElement>;
+  };
+
+export class IonApp extends React.Component<Props> {
+  addOverlayCallback?: (id: string, overlay: any, containerElement: HTMLDivElement) => void;
+  removeOverlayCallback?: (id: string) => void;
+
+  constructor(props: Props) {
+    super(props);
+  }
+
+  /*
+    Wire up methods to call into IonOverlayManager
+  */
+  ionContext: IonContextInterface = {
+    addOverlay: (
+      id: string,
+      overlay: ReactComponentOrElement,
+      containerElement: HTMLDivElement
+    ) => {
+      if (this.addOverlayCallback) {
+        this.addOverlayCallback(id, overlay, containerElement);
+      }
+    },
+    removeOverlay: (id: string) => {
+      if (this.removeOverlayCallback) {
+        this.removeOverlayCallback(id);
+      }
+    },
+  };
+
+  render() {
+    return (
+      <IonContext.Provider value={this.ionContext}>
+        <IonAppInner {...this.props}>{this.props.children}</IonAppInner>
+        <IonOverlayManager
+          onAddOverlay={(callback) => {
+            this.addOverlayCallback = callback;
+          }}
+          onRemoveOverlay={(callback) => {
+            this.removeOverlayCallback = callback;
+          }}
+        />
+      </IonContext.Provider>
+    );
+  }
+
+  static get displayName() {
+    return 'IonApp';
+  }
+}

--- a/packages/react/src/components/IonOverlayManager.tsx
+++ b/packages/react/src/components/IonOverlayManager.tsx
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from 'react';
+import ReactDOM from 'react-dom';
+import { ReactComponentOrElement } from '../models';
+
+interface IonOverlayManagerProps {
+  onAddOverlay: (
+    callback: (
+      id: string,
+      component: ReactComponentOrElement,
+      containerElement: HTMLDivElement
+    ) => void
+  ) => void;
+  onRemoveOverlay: (callback: (id: string) => void) => void;
+}
+
+/**
+ * Manages overlays that are added via the useOverlay hook.
+ * This is a standalone component so changes to its children don't cause other descendant
+ * components to re-render when overlays are added. However, we need to communicate with the IonContext
+ * that is set up in <IonApp />, so we register callbacks so when overlays are added to IonContext,
+ * they ultimately added here.
+ * @param param0
+ */
+export const IonOverlayManager: React.FC<IonOverlayManagerProps> = ({
+  onAddOverlay,
+  onRemoveOverlay,
+}) => {
+  const [overlays, setOverlays] = useState<{
+    [key: string]: {
+      component: any;
+      containerElement: HTMLDivElement;
+    };
+  }>({});
+
+  useEffect(() => {
+    /* Setup the callbacks that get called from <IonApp /> */
+    onAddOverlay(addOverlay);
+    onRemoveOverlay(removeOverlay);
+  }, []);
+
+  const addOverlay = (
+    id: string,
+    component: ReactComponentOrElement,
+    containerElement: HTMLDivElement
+  ) => {
+    const newOverlays = { ...overlays };
+    newOverlays[id] = { component, containerElement };
+    setOverlays(newOverlays);
+  };
+
+  const removeOverlay = (id: string) => {
+    const newOverlays = { ...overlays };
+    delete newOverlays[id];
+    setOverlays(newOverlays);
+  };
+
+  const overlayKeys = Object.keys(overlays);
+
+  return (
+    <>
+      {overlayKeys.map((key) => {
+        const overlay = overlays[key];
+        return ReactDOM.createPortal(overlay.component, overlay.containerElement, `overlay-${key}`);
+      })}
+    </>
+  );
+};

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -142,6 +142,7 @@ export { IonModal } from './IonModal';
 export { IonPopover } from './IonPopover';
 
 // Custom Components
+export { IonApp } from './IonApp';
 export { IonPage } from './IonPage';
 export { IonTabsContext, IonTabsContextState } from './navigation/IonTabsContext';
 export { IonTabs } from './navigation/IonTabs';

--- a/packages/react/src/components/inner-proxies.ts
+++ b/packages/react/src/components/inner-proxies.ts
@@ -5,6 +5,7 @@ import { IonTabBar as IonTabBarCmp } from '@ionic/core/components/ion-tab-bar.js
 import { IonTabButton as IonTabButtonCmp } from '@ionic/core/components/ion-tab-button.js';
 import { JSX as IoniconsJSX } from 'ionicons';
 import { IonIcon as IonIconCmp } from 'ionicons/components/ion-icon.js';
+import { IonApp as IonAppCmp } from '@ionic/core/components/ion-app.js';
 
 import { /*@__PURE__*/ createReactComponent } from './react-component-lib';
 
@@ -27,6 +28,13 @@ export const IonRouterOutletInner = /*@__PURE__*/ createReactComponent<
   },
   HTMLIonRouterOutletElement
 >('ion-router-outlet', undefined, undefined, IonRouterOutletCmp);
+
+export const IonAppInner = /*@__PURE__*/ createReactComponent<JSX.IonApp, HTMLIonAppElement>(
+  'ion-app',
+  undefined,
+  undefined,
+  IonAppCmp
+);
 
 // ionicons
 export const IonIconInner = /*@__PURE__*/ createReactComponent<

--- a/packages/react/src/components/proxies.ts
+++ b/packages/react/src/components/proxies.ts
@@ -7,7 +7,6 @@ import type { JSX } from '@ionic/core/components';
 
 import { IonAccordion as IonAccordionCmp } from '@ionic/core/components/ion-accordion.js';
 import { IonAccordionGroup as IonAccordionGroupCmp } from '@ionic/core/components/ion-accordion-group.js';
-import { IonApp as IonAppCmp } from '@ionic/core/components/ion-app.js';
 import { IonAvatar as IonAvatarCmp } from '@ionic/core/components/ion-avatar.js';
 import { IonBackdrop as IonBackdropCmp } from '@ionic/core/components/ion-backdrop.js';
 import { IonBadge as IonBadgeCmp } from '@ionic/core/components/ion-badge.js';
@@ -76,7 +75,6 @@ import { IonVirtualScroll as IonVirtualScrollCmp } from '@ionic/core/components/
 
 export const IonAccordion = /*@__PURE__*/createReactComponent<JSX.IonAccordion, HTMLIonAccordionElement>('ion-accordion', undefined, undefined, IonAccordionCmp);
 export const IonAccordionGroup = /*@__PURE__*/createReactComponent<JSX.IonAccordionGroup, HTMLIonAccordionGroupElement>('ion-accordion-group', undefined, undefined, IonAccordionGroupCmp);
-export const IonApp = /*@__PURE__*/createReactComponent<JSX.IonApp, HTMLIonAppElement>('ion-app', undefined, undefined, IonAppCmp);
 export const IonAvatar = /*@__PURE__*/createReactComponent<JSX.IonAvatar, HTMLIonAvatarElement>('ion-avatar', undefined, undefined, IonAvatarCmp);
 export const IonBackdrop = /*@__PURE__*/createReactComponent<JSX.IonBackdrop, HTMLIonBackdropElement>('ion-backdrop', undefined, undefined, IonBackdropCmp);
 export const IonBadge = /*@__PURE__*/createReactComponent<JSX.IonBadge, HTMLIonBadgeElement>('ion-badge', undefined, undefined, IonBadgeCmp);

--- a/packages/react/src/contexts/IonContext.tsx
+++ b/packages/react/src/contexts/IonContext.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { ReactComponentOrElement } from '../models';
+
+export interface IonContextInterface {
+  addOverlay: (
+    id: string,
+    overlay: ReactComponentOrElement,
+    containerElement: HTMLDivElement
+  ) => void;
+  removeOverlay: (id: string) => void;
+}
+
+export const IonContext = React.createContext<IonContextInterface>({
+  addOverlay: () => {
+    return;
+  },
+  removeOverlay: () => {
+    return;
+  },
+});

--- a/packages/react/src/hooks/useIonModal.ts
+++ b/packages/react/src/hooks/useIonModal.ts
@@ -1,7 +1,8 @@
 import { ModalOptions, modalController } from '@ionic/core/components';
 
 import { HookOverlayOptions } from './HookOverlayOptions';
-import { ReactComponentOrElement, useOverlay } from './useOverlay';
+import { useOverlay } from './useOverlay';
+import { ReactComponentOrElement } from "../models/ReactComponentOrElement";
 
 /**
  * A hook for presenting/dismissing an IonModal component

--- a/packages/react/src/hooks/useIonPopover.ts
+++ b/packages/react/src/hooks/useIonPopover.ts
@@ -1,7 +1,8 @@
 import { PopoverOptions, popoverController } from '@ionic/core/components';
 
 import { HookOverlayOptions } from './HookOverlayOptions';
-import { ReactComponentOrElement, useOverlay } from './useOverlay';
+import { useOverlay } from './useOverlay';
+import { ReactComponentOrElement } from "../models/ReactComponentOrElement";
 
 /**
  * A hook for presenting/dismissing an IonPicker component

--- a/packages/react/src/hooks/useOverlay.ts
+++ b/packages/react/src/hooks/useOverlay.ts
@@ -1,53 +1,40 @@
 import { OverlayEventDetail } from '@ionic/core/components';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import ReactDOM from 'react-dom';
-
+import React, { useMemo, useRef, useState, useContext, useEffect } from 'react';
 import { attachProps } from '../components/react-component-lib/utils';
 
 import { HookOverlayOptions } from './HookOverlayOptions';
-
-export type ReactComponentOrElement = React.ComponentClass<any, any> | React.FC<any> | JSX.Element;
+import { IonContext } from '../contexts/IonContext';
+import { generateId } from '../utils/generateId';
+import { ReactComponentOrElement } from '../models/ReactComponentOrElement';
 
 interface OverlayBase extends HTMLElement {
   present: () => Promise<void>;
   dismiss: (data?: any, role?: string | undefined) => Promise<boolean>;
 }
 
-export function useOverlay<
-  OptionsType,
-  OverlayType extends OverlayBase
->(
+export function useOverlay<OptionsType, OverlayType extends OverlayBase>(
   displayName: string,
-  controller: { create: (options: OptionsType) => Promise<OverlayType>; },
+  controller: { create: (options: OptionsType) => Promise<OverlayType> },
   component: ReactComponentOrElement,
   componentProps?: any
 ) {
   const overlayRef = useRef<OverlayType>();
   const containerElRef = useRef<HTMLDivElement>();
-  const didDismissEventName = useMemo(
-    () => `on${displayName}DidDismiss`,
-    [displayName]
-  );
-  const didPresentEventName = useMemo(
-    () => `on${displayName}DidPresent`,
-    [displayName]
-  );
-  const willDismissEventName = useMemo(
-    () => `on${displayName}WillDismiss`,
-    [displayName]
-  );
-  const willPresentEventName = useMemo(
-    () => `on${displayName}WillPresent`,
-    [displayName]
-  );
+  const didDismissEventName = useMemo(() => `on${displayName}DidDismiss`, [displayName]);
+  const didPresentEventName = useMemo(() => `on${displayName}DidPresent`, [displayName]);
+  const willDismissEventName = useMemo(() => `on${displayName}WillDismiss`, [displayName]);
+  const willPresentEventName = useMemo(() => `on${displayName}WillPresent`, [displayName]);
   const [isOpen, setIsOpen] = useState(false);
+  const ionContext = useContext(IonContext);
+  const [overlayId] = useState(generateId('overlay'));
 
   useEffect(() => {
     if (isOpen && component && containerElRef.current) {
       if (React.isValidElement(component)) {
-        ReactDOM.render(component, containerElRef.current);
+        ionContext.addOverlay(overlayId, component, containerElRef.current!);
       } else {
-        ReactDOM.render(React.createElement(component as React.ComponentClass, componentProps), containerElRef.current);
+        const element = React.createElement(component as React.ComponentClass, componentProps);
+        ionContext.addOverlay(overlayId, element, containerElRef.current!);
       }
     }
   }, [component, containerElRef.current, isOpen, componentProps]);
@@ -57,13 +44,7 @@ export function useOverlay<
       return;
     }
 
-    const {
-      onDidDismiss,
-      onWillDismiss,
-      onDidPresent,
-      onWillPresent,
-      ...rest
-    } = options;
+    const { onDidDismiss, onWillDismiss, onDidPresent, onWillPresent, ...rest } = options;
 
     if (typeof document !== 'undefined') {
       containerElRef.current = document.createElement('div');
@@ -71,17 +52,14 @@ export function useOverlay<
 
     overlayRef.current = await controller.create({
       ...(rest as any),
-      component: containerElRef.current
+      component: containerElRef.current,
     });
 
     attachProps(overlayRef.current, {
       [didDismissEventName]: handleDismiss,
-      [didPresentEventName]: (e: CustomEvent) =>
-        onDidPresent && onDidPresent(e),
-      [willDismissEventName]: (e: CustomEvent) =>
-        onWillDismiss && onWillDismiss(e),
-      [willPresentEventName]: (e: CustomEvent) =>
-        onWillPresent && onWillPresent(e),
+      [didPresentEventName]: (e: CustomEvent) => onDidPresent && onDidPresent(e),
+      [willDismissEventName]: (e: CustomEvent) => onWillDismiss && onWillDismiss(e),
+      [willPresentEventName]: (e: CustomEvent) => onWillPresent && onWillPresent(e),
     });
 
     overlayRef.current.present();
@@ -95,11 +73,12 @@ export function useOverlay<
       overlayRef.current = undefined;
       containerElRef.current = undefined;
       setIsOpen(false);
+      ionContext.removeOverlay(overlayId);
     }
   };
 
   const dismiss = async () => {
-    overlayRef.current && await overlayRef.current.dismiss();
+    overlayRef.current && (await overlayRef.current.dismiss());
     overlayRef.current = undefined;
     containerElRef.current = undefined;
   };

--- a/packages/react/src/models/ReactComponentOrElement.ts
+++ b/packages/react/src/models/ReactComponentOrElement.ts
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export type ReactComponentOrElement = React.ComponentClass<any, any> | React.FC<any> | JSX.Element;

--- a/packages/react/src/models/index.ts
+++ b/packages/react/src/models/index.ts
@@ -2,3 +2,4 @@ export * from './RouteAction';
 export * from './RouteInfo';
 export * from './RouterDirection';
 export * from './RouterOptions';
+export * from './ReactComponentOrElement';


### PR DESCRIPTION

BREAKING CHANGE: useIonModal and useIonPopover are now required to be descendants of IonApp

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

useOverlay currently adds the children of the Modals with `ReactDOM.render`. This created a new React application, and therefore the children of the overlays were not able to access context created in the ancestry. Also, the components were not cleaned up properly when the overlays were dismissed.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

In order to properly add the overlay's children to the React tree, a new context was added that useOverlay can communicate with to add the components. The new `IonContext` has methods to add and remove overlays that should be rendered. The new `IonOverlayManager` stores the list of the components and renders them in an isolated hierarchy so when new overlays are added/removed, they don't cause the entire tree to re-render.

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

A new context is required for this communication between `useOverlay` and `IonOverlayManager`. The logical place to put it was at the top of most Ionic applications inside of `<IonApp>`. Therefore, any app using either `useIonModal` or `useIonPopover` needs `<IonApp>` to be in its parent tree. Apps that don't use `<IonApp>` will have to migrate to the `<IonModal>` or `<IonPopover>` components instead of the hooks.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
