### PR TITLE
fix(picker-internal): ionChange now emitted when value is set

### DIFF
--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -64,7 +64,13 @@ export class PickerColumnInternal implements ComponentInterface {
 
   @Watch('value')
   valueChange() {
+    const { items, value } = this;
     this.scrollActiveItemIntoView();
+
+    const findItem = items.find(item => item.value === value);
+    if (findItem) {
+      this.ionChange.emit(findItem);
+    }
   }
 
   /**
@@ -206,7 +212,6 @@ export class PickerColumnInternal implements ComponentInterface {
 
           if (selectedItem.value !== this.value) {
             this.value = selectedItem.value;
-            this.ionChange.emit(selectedItem);
             hapticSelectionEnd();
             this.hapticsStarted = false;
           }

--- a/core/src/components/picker-internal/test/basic/index.html
+++ b/core/src/components/picker-internal/test/basic/index.html
@@ -107,7 +107,7 @@
     </ion-app>
 
     <script>
-      const column = document.querySelector('ion-picker-column-internal');
+      const column = document.querySelector('ion-picker-column-internal#numeric-first');
       column.addEventListener('ionChange', (ev) => {
         console.log('Column change', ev.detail);
       });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Typing to search for a time in ion-datetime was not updating the value because ionChange was only getting fired when the column was scrolled, not when the value prop was changed.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- ionChange is now fired when the value prop changes

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
