### PR TITLE
feat: autodefine dependent components in CE builds

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -15038,8 +15038,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.1.0.tgz",
       "integrity": "sha512-NWeN2S43dwWDIousfojzGXIMkJJhfcdS1JxpwgE7IOqy4tZ+nqlDLPhM6tXvZ3eq4rJm8bkF+3/WbPJNR9xR7Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@stencil/sass": {
       "version": "1.3.2",
@@ -15051,8 +15050,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.5.1.tgz",
       "integrity": "sha512-E9HeuUf4DjHO8VFd+faR6T+/JwLtU/2kIA000YTTv0ARPUXuxr/3+U3YMBRPCVFPC5n2jsFxU3E9rTmVH1MGyg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@stylelint/postcss-css-in-js": {
       "version": "0.37.2",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.0.0-rc.0",
       "license": "MIT",
       "dependencies": {
-        "@stencil/core": "^2.6.0",
+        "@stencil/core": "^2.9.0",
         "ionicons": "^5.5.1",
         "tslib": "^2.1.0"
       },
@@ -1364,9 +1364,10 @@
       "dev": true
     },
     "node_modules/@stencil/core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.6.0.tgz",
-      "integrity": "sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-kY3xYolZoJO1MKslL0NQccHy72R3TIl1prHgfmIrEoGcnMgc6uiskdWaGMuI5/sCGz9T+QuTVz76B1H2ySyBZg==",
+      "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -15029,15 +15030,16 @@
       "dev": true
     },
     "@stencil/core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.6.0.tgz",
-      "integrity": "sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-kY3xYolZoJO1MKslL0NQccHy72R3TIl1prHgfmIrEoGcnMgc6uiskdWaGMuI5/sCGz9T+QuTVz76B1H2ySyBZg=="
     },
     "@stencil/react-output-target": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.1.0.tgz",
       "integrity": "sha512-NWeN2S43dwWDIousfojzGXIMkJJhfcdS1JxpwgE7IOqy4tZ+nqlDLPhM6tXvZ3eq4rJm8bkF+3/WbPJNR9xR7Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@stencil/sass": {
       "version": "1.3.2",
@@ -15049,7 +15051,8 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.5.1.tgz",
       "integrity": "sha512-E9HeuUf4DjHO8VFd+faR6T+/JwLtU/2kIA000YTTv0ARPUXuxr/3+U3YMBRPCVFPC5n2jsFxU3E9rTmVH1MGyg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@stylelint/postcss-css-in-js": {
       "version": "0.37.2",

--- a/core/package.json
+++ b/core/package.json
@@ -31,7 +31,7 @@
     "loader/"
   ],
   "dependencies": {
-    "@stencil/core": "^2.6.0",
+    "@stencil/core": "^2.9.0",
     "ionicons": "^5.5.1",
     "tslib": "^2.1.0"
   },

--- a/core/src/components/action-sheet/readme.md
+++ b/core/src/components/action-sheet/readme.md
@@ -661,6 +661,10 @@ Type: `Promise<void>`
 
 ## Dependencies
 
+### Used by
+
+ - [ion-app](../app)
+
 ### Depends on
 
 - [ion-backdrop](../backdrop)
@@ -673,6 +677,7 @@ graph TD;
   ion-action-sheet --> ion-backdrop
   ion-action-sheet --> ion-icon
   ion-action-sheet --> ion-ripple-effect
+  ion-app --> ion-action-sheet
   style ion-action-sheet fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/core/src/components/alert/readme.md
+++ b/core/src/components/alert/readme.md
@@ -1863,6 +1863,10 @@ Type: `Promise<void>`
 
 ## Dependencies
 
+### Used by
+
+ - [ion-app](../app)
+
 ### Depends on
 
 - [ion-ripple-effect](../ripple-effect)
@@ -1873,6 +1877,7 @@ Type: `Promise<void>`
 graph TD;
   ion-alert --> ion-ripple-effect
   ion-alert --> ion-backdrop
+  ion-app --> ion-alert
   style ion-alert fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/core/src/components/app/app.tsx
+++ b/core/src/components/app/app.tsx
@@ -38,6 +38,24 @@ export class App implements ComponentInterface {
         import('../../utils/focus-visible').then(module => this.focusVisible = module.startFocusVisible());
       });
     }
+
+    /**
+     *  Workaround for manual dependedancy declaration in the custom elements build.
+     *  Stencil will automatically define dependedent custom elements
+     *  based on calls to functions like `document.createElement`.
+     *  This does not currently work with Framework's overlay controllers,
+     *  so we can trick Stencil with the following.
+     */
+    if (false) {
+      //@ts-ignore
+      document.createElement('ion-alert');
+      document.createElement('ion-action-sheet');
+      document.createElement('ion-loading');
+      document.createElement('ion-modal');
+      document.createElement('ion-picker');
+      document.createElement('ion-popover');
+      document.createElement('ion-toast');
+    }
   }
 
   /**

--- a/core/src/components/app/readme.md
+++ b/core/src/components/app/readme.md
@@ -5,6 +5,44 @@ App is a container element for an Ionic application. There should only be one `<
 <!-- Auto Generated Below -->
 
 
+## Dependencies
+
+### Depends on
+
+- [ion-alert](../alert)
+- [ion-action-sheet](../action-sheet)
+- [ion-loading](../loading)
+- [ion-modal](../modal)
+- [ion-picker](../picker)
+- [ion-popover](../popover)
+- [ion-toast](../toast)
+
+### Graph
+```mermaid
+graph TD;
+  ion-app --> ion-alert
+  ion-app --> ion-action-sheet
+  ion-app --> ion-loading
+  ion-app --> ion-modal
+  ion-app --> ion-picker
+  ion-app --> ion-popover
+  ion-app --> ion-toast
+  ion-alert --> ion-ripple-effect
+  ion-alert --> ion-backdrop
+  ion-action-sheet --> ion-backdrop
+  ion-action-sheet --> ion-icon
+  ion-action-sheet --> ion-ripple-effect
+  ion-loading --> ion-backdrop
+  ion-loading --> ion-spinner
+  ion-modal --> ion-backdrop
+  ion-picker --> ion-backdrop
+  ion-picker --> ion-picker-column
+  ion-popover --> ion-backdrop
+  ion-toast --> ion-icon
+  ion-toast --> ion-ripple-effect
+  style ion-app fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/loading/readme.md
+++ b/core/src/components/loading/readme.md
@@ -462,6 +462,10 @@ Type: `Promise<void>`
 
 ## Dependencies
 
+### Used by
+
+ - [ion-app](../app)
+
 ### Depends on
 
 - [ion-backdrop](../backdrop)
@@ -472,6 +476,7 @@ Type: `Promise<void>`
 graph TD;
   ion-loading --> ion-backdrop
   ion-loading --> ion-spinner
+  ion-app --> ion-loading
   style ion-loading fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/core/src/components/modal/readme.md
+++ b/core/src/components/modal/readme.md
@@ -1227,6 +1227,10 @@ Type: `Promise<void>`
 
 ## Dependencies
 
+### Used by
+
+ - [ion-app](../app)
+
 ### Depends on
 
 - [ion-backdrop](../backdrop)
@@ -1235,6 +1239,7 @@ Type: `Promise<void>`
 ```mermaid
 graph TD;
   ion-modal --> ion-backdrop
+  ion-app --> ion-modal
   style ion-modal fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/core/src/components/picker/readme.md
+++ b/core/src/components/picker/readme.md
@@ -326,6 +326,10 @@ Type: `Promise<void>`
 
 ## Dependencies
 
+### Used by
+
+ - [ion-app](../app)
+
 ### Depends on
 
 - [ion-backdrop](../backdrop)
@@ -336,6 +340,7 @@ Type: `Promise<void>`
 graph TD;
   ion-picker --> ion-backdrop
   ion-picker --> ion-picker-column
+  ion-app --> ion-picker
   style ion-picker fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/core/src/components/popover/readme.md
+++ b/core/src/components/popover/readme.md
@@ -635,6 +635,7 @@ Type: `Promise<void>`
 
 ### Used by
 
+ - [ion-app](../app)
  - [ion-datetime](../datetime)
 
 ### Depends on
@@ -645,6 +646,7 @@ Type: `Promise<void>`
 ```mermaid
 graph TD;
   ion-popover --> ion-backdrop
+  ion-app --> ion-popover
   ion-datetime --> ion-popover
   style ion-popover fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/core/src/components/select/readme.md
+++ b/core/src/components/select/readme.md
@@ -1428,6 +1428,29 @@ Type: `Promise<any>`
 | `--placeholder-opacity` | Opacity of the select placeholder text                                                                    |
 
 
+## Dependencies
+
+### Depends on
+
+- ion-select-popover
+
+### Graph
+```mermaid
+graph TD;
+  ion-select --> ion-select-popover
+  ion-select-popover --> ion-item
+  ion-select-popover --> ion-checkbox
+  ion-select-popover --> ion-label
+  ion-select-popover --> ion-radio-group
+  ion-select-popover --> ion-radio
+  ion-select-popover --> ion-list
+  ion-select-popover --> ion-list-header
+  ion-item --> ion-icon
+  ion-item --> ion-ripple-effect
+  ion-item --> ion-note
+  style ion-select fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -147,6 +147,18 @@ export class Select implements ComponentInterface {
     this.mutationO = watchForOptions<HTMLIonSelectOptionElement>(this.el, 'ion-select-option', async () => {
       this.updateOverlayOptions();
     });
+
+    /**
+     *  Workaround for manual dependedancy declaration in the custom elements build.
+     *  Stencil will automatically define dependedent custom elements
+     *  based on calls to functions like `document.createElement`.
+     *  This does not currently work with Framework's overlay controllers,
+     *  so we can trick Stencil with the following.
+     */
+    if (false) {
+      //@ts-ignore
+      document.createElement('ion-select-popover');
+    }
   }
 
   disconnectedCallback() {

--- a/core/src/components/toast/readme.md
+++ b/core/src/components/toast/readme.md
@@ -522,6 +522,10 @@ Type: `Promise<void>`
 
 ## Dependencies
 
+### Used by
+
+ - [ion-app](../app)
+
 ### Depends on
 
 - ion-icon
@@ -532,6 +536,7 @@ Type: `Promise<void>`
 graph TD;
   ion-toast --> ion-icon
   ion-toast --> ion-ripple-effect
+  ion-app --> ion-toast
   style ion-toast fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/core/stencil.config.ts
+++ b/core/stencil.config.ts
@@ -161,7 +161,8 @@ export const config: Config = {
         dest: 'components',
         warn: true
       }],
-      includeGlobalScripts: false
+      includeGlobalScripts: false,
+      autoDefineCustomElements: true
     },
     {
       type: 'docs-readme',

--- a/packages/react-router/test-app/package-lock.json
+++ b/packages/react-router/test-app/package-lock.json
@@ -14,7 +14,7 @@
         "@capacitor/ios": "^2.2.0",
         "@ionic/react": "5.6.3",
         "@ionic/react-router": "^5.6.3",
-        "@stencil/core": "^2.8.0",
+        "@stencil/core": "^2.9.0",
         "@svgr/webpack": "4.3.3",
         "@testing-library/jest-dom": "^4.2.4",
         "@testing-library/react": "^9.4.0",
@@ -2028,9 +2028,9 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@stencil/core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.8.0.tgz",
-      "integrity": "sha512-WazFGUMnbumg8ePNvej8cIOEcxvuZ0ugKQkkE1xFbDYcl7DgJd62MiG+bIqCcQlIdLEfhjAdoixxlFdJgrgjyA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-kY3xYolZoJO1MKslL0NQccHy72R3TIl1prHgfmIrEoGcnMgc6uiskdWaGMuI5/sCGz9T+QuTVz76B1H2ySyBZg==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -22991,9 +22991,9 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@stencil/core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.8.0.tgz",
-      "integrity": "sha512-WazFGUMnbumg8ePNvej8cIOEcxvuZ0ugKQkkE1xFbDYcl7DgJd62MiG+bIqCcQlIdLEfhjAdoixxlFdJgrgjyA=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-kY3xYolZoJO1MKslL0NQccHy72R3TIl1prHgfmIrEoGcnMgc6uiskdWaGMuI5/sCGz9T+QuTVz76B1H2ySyBZg=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",

--- a/packages/react-router/test-app/package.json
+++ b/packages/react-router/test-app/package.json
@@ -9,7 +9,7 @@
     "@capacitor/ios": "^2.2.0",
     "@ionic/react": "5.6.3",
     "@ionic/react-router": "^5.6.3",
-    "@stencil/core": "^2.8.0",
+    "@stencil/core": "^2.9.0",
     "@svgr/webpack": "4.3.3",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.4.0",

--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -9,11 +9,11 @@
       "version": "6.0.0-rc.0",
       "license": "MIT",
       "dependencies": {
-        "@ionic/core": "6.0.0-beta.7",
+        "@ionic/core": "6.0.0-rc.0",
         "ionicons": "^5.1.2"
       },
       "devDependencies": {
-        "@stencil/core": "^1.17.0",
+        "@stencil/core": "^2.9.0",
         "change-case": "^4.1.1",
         "fs-extra": "^9.1.0",
         "rimraf": "^3.0.2",
@@ -53,25 +53,13 @@
       }
     },
     "node_modules/@ionic/core": {
-      "version": "6.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.0.0-beta.7.tgz",
-      "integrity": "sha512-zy+he/i6AuecjH0rIFWINwvBhCBUA9ijdgeW3WJw14XDmiSu+LBo57pzY5U84L9WQPd+f5I/DqJpBA8yYHaGPQ==",
+      "version": "6.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.0.0-rc.0.tgz",
+      "integrity": "sha512-FNdkfqHfN7p1o/p4/WWwGxTVdgEKdGz8vX0LPI57IhrV2zZ0cpVUATYZZx+HysgeFxezs34xU0qDODqJR2j3NA==",
       "dependencies": {
         "@stencil/core": "^2.6.0",
         "ionicons": "^5.5.1",
         "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@ionic/core/node_modules/@stencil/core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.6.0.tgz",
-      "integrity": "sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ==",
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
       }
     },
     "node_modules/@ionic/core/node_modules/tslib": {
@@ -80,32 +68,15 @@
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "node_modules/@stencil/core": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.17.3.tgz",
-      "integrity": "sha512-q5joOYUPHTNa/5hEThMT/QEJ/suN8bpcYbV/LrSNsgsgHN+RJ05jCpU8VAShdUPT6WzoyF2iGgYc/EI2xeqFzw==",
-      "dev": true,
-      "dependencies": {
-        "typescript": "3.9.7"
-      },
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-kY3xYolZoJO1MKslL0NQccHy72R3TIl1prHgfmIrEoGcnMgc6uiskdWaGMuI5/sCGz9T+QuTVz76B1H2ySyBZg==",
       "bin": {
         "stencil": "bin/stencil"
       },
       "engines": {
-        "node": ">=10.13.0",
+        "node": ">=12.10.0",
         "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/@stencil/core/node_modules/typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/@vue/compiler-core": {
@@ -361,18 +332,6 @@
       "integrity": "sha512-L71djrMi8pAad66tpwdnO1vwcyluCFvehzxU1PpH1k/HpYBZhZ5IaYhqXipmqUvu5aEbd4cbRguYyI5Fd4bxTw==",
       "dependencies": {
         "@stencil/core": "^2.5.0"
-      }
-    },
-    "node_modules/ionicons/node_modules/@stencil/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-gpoYJEYzu5LV2hr7uPZklug3zXhEbYGKyNodPfmOOYZtO9q42l7RQ3cAnC8MzEoF4jFrfemgtevGik8sqn9ClQ==",
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
       }
     },
     "node_modules/jsonfile": {
@@ -633,20 +592,15 @@
       }
     },
     "@ionic/core": {
-      "version": "6.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.0.0-beta.7.tgz",
-      "integrity": "sha512-zy+he/i6AuecjH0rIFWINwvBhCBUA9ijdgeW3WJw14XDmiSu+LBo57pzY5U84L9WQPd+f5I/DqJpBA8yYHaGPQ==",
+      "version": "6.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.0.0-rc.0.tgz",
+      "integrity": "sha512-FNdkfqHfN7p1o/p4/WWwGxTVdgEKdGz8vX0LPI57IhrV2zZ0cpVUATYZZx+HysgeFxezs34xU0qDODqJR2j3NA==",
       "requires": {
         "@stencil/core": "^2.6.0",
         "ionicons": "^5.5.1",
         "tslib": "^2.1.0"
       },
       "dependencies": {
-        "@stencil/core": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.6.0.tgz",
-          "integrity": "sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ=="
-        },
         "tslib": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
@@ -655,21 +609,9 @@
       }
     },
     "@stencil/core": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.17.3.tgz",
-      "integrity": "sha512-q5joOYUPHTNa/5hEThMT/QEJ/suN8bpcYbV/LrSNsgsgHN+RJ05jCpU8VAShdUPT6WzoyF2iGgYc/EI2xeqFzw==",
-      "dev": true,
-      "requires": {
-        "typescript": "3.9.7"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "3.9.7",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-          "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
-          "dev": true
-        }
-      }
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-kY3xYolZoJO1MKslL0NQccHy72R3TIl1prHgfmIrEoGcnMgc6uiskdWaGMuI5/sCGz9T+QuTVz76B1H2ySyBZg=="
     },
     "@vue/compiler-core": {
       "version": "3.0.0",
@@ -909,13 +851,6 @@
       "integrity": "sha512-L71djrMi8pAad66tpwdnO1vwcyluCFvehzxU1PpH1k/HpYBZhZ5IaYhqXipmqUvu5aEbd4cbRguYyI5Fd4bxTw==",
       "requires": {
         "@stencil/core": "^2.5.0"
-      },
-      "dependencies": {
-        "@stencil/core": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.5.0.tgz",
-          "integrity": "sha512-gpoYJEYzu5LV2hr7uPZklug3zXhEbYGKyNodPfmOOYZtO9q42l7RQ3cAnC8MzEoF4jFrfemgtevGik8sqn9ClQ=="
-        }
       }
     },
     "jsonfile": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/ionic-team/ionic#readme",
   "devDependencies": {
-    "@stencil/core": "^1.17.0",
+    "@stencil/core": "^2.9.0",
     "change-case": "^4.1.1",
     "fs-extra": "^9.1.0",
     "rimraf": "^3.0.2",

--- a/packages/vue/test-app/package-lock.json
+++ b/packages/vue/test-app/package-lock.json
@@ -13,7 +13,7 @@
         "vue-router": "^4.0.0-rc.4"
       },
       "devDependencies": {
-        "@stencil/core": "2.6.0",
+        "@stencil/core": "^2.9.0",
         "@types/jest": "^24.0.19",
         "@typescript-eslint/eslint-plugin": "^2.33.0",
         "@typescript-eslint/parser": "^2.33.0",
@@ -1703,9 +1703,9 @@
       "dev": true
     },
     "node_modules/@stencil/core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.6.0.tgz",
-      "integrity": "sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-kY3xYolZoJO1MKslL0NQccHy72R3TIl1prHgfmIrEoGcnMgc6uiskdWaGMuI5/sCGz9T+QuTVz76B1H2ySyBZg==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -24112,9 +24112,9 @@
       "dev": true
     },
     "@stencil/core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.6.0.tgz",
-      "integrity": "sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-kY3xYolZoJO1MKslL0NQccHy72R3TIl1prHgfmIrEoGcnMgc6uiskdWaGMuI5/sCGz9T+QuTVz76B1H2ySyBZg=="
     },
     "@types/anymatch": {
       "version": "1.3.1",

--- a/packages/vue/test-app/package.json
+++ b/packages/vue/test-app/package.json
@@ -18,7 +18,7 @@
     "vue-router": "^4.0.0-rc.4"
   },
   "devDependencies": {
-    "@stencil/core": "2.6.0",
+    "@stencil/core": "^2.9.0",
     "@types/jest": "^24.0.19",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
     "@typescript-eslint/parser": "^2.33.0",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 
- 
-

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

Overlay controllers now expect to be used alongside `ion-app`. This is already best practice, and brings the usage in line with Ionic React, which requires `useIonModal` and `useIonPopover` to be descendants on `IonApp`: https://github.com/ionic-team/ionic-framework/pull/24008

## Other information

Blockers:
https://github.com/ionic-team/stencil/issues/3101#issuecomment-952336416
