### PR TITLE
fix(datetime): resolve month and year jumping issue on ios

### DIFF
--- a/core/src/components/datetime/datetime.scss
+++ b/core/src/components/datetime/datetime.scss
@@ -90,7 +90,12 @@
 
   position: absolute;
 
-  opacity: 0;
+  /**
+   * Use visibility instead of
+   * opacity to ensure element
+   * cannot receive focus
+   */
+  visibility: hidden;
   pointer-events: none;
 }
 

--- a/core/src/components/datetime/datetime.scss
+++ b/core/src/components/datetime/datetime.scss
@@ -73,11 +73,25 @@
   display: flex;
 }
 
+/**
+ * Safari 14 has an issue where Intersection
+ * Observer is incorrectly fired when
+ * unhiding the calendar content.
+ * To workaround this, we set the opacity
+ * of the content to 0 and hide it offscreen.
+ * TODO: This is fixed in Safari 15+, so remove
+ * when Safari 14 support is dropped.
+ */
 :host(.show-month-and-year) .calendar-next-prev,
 :host(.show-month-and-year) .calendar-days-of-week,
 :host(.show-month-and-year) .calendar-body,
 :host(.show-month-and-year) .datetime-time {
-  display: none;
+  @include position(null, null, null, -99999px);
+
+  position: absolute;
+
+  opacity: 0;
+  pointer-events: none;
 }
 
 :host(.datetime-readonly),


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/23910


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Instead of using `display: none` we hide the main content offscreen and set `visibility: hidden` to avoid the additional Intersection Observer callback. I did a brief paint test and there should be no significant changes to painting in terms of performance.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
