### PR TITLE
fix(overlays): declarative modals now work properly with the hardware back button

### DIFF
--- a/core/src/components/action-sheet/action-sheet.tsx
+++ b/core/src/components/action-sheet/action-sheet.tsx
@@ -252,6 +252,7 @@ export class ActionSheet implements ComponentInterface, OverlayInterface {
           [mode]: true,
 
           ...getClassMap(this.cssClass),
+          'overlay-hidden': true,
           'action-sheet-translucent': this.translucent
         }}
         onIonActionSheetWillDismiss={this.dispatchCancelHandler}

--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -575,6 +575,7 @@ export class Alert implements ComponentInterface, OverlayInterface {
         class={{
           ...getClassMap(this.cssClass),
           [mode]: true,
+          'overlay-hidden': true,
           'alert-translucent': this.translucent
         }}
         onIonAlertWillDismiss={this.dispatchCancelHandler}

--- a/core/src/components/loading/loading.tsx
+++ b/core/src/components/loading/loading.tsx
@@ -197,6 +197,7 @@ export class Loading implements ComponentInterface, OverlayInterface {
         class={{
           ...getClassMap(this.cssClass),
           [mode]: true,
+          'overlay-hidden': true,
           'loading-translucent': this.translucent
         }}
       >

--- a/core/src/components/modal/test/basic/index.html
+++ b/core/src/components/modal/test/basic/index.html
@@ -84,7 +84,7 @@
     async function presentModal() {
       const presentingEl = document.querySelectorAll('.ion-page')[1];
       const modal = createModal();
-      //await modal.present(presentingEl);
+      await modal.present(presentingEl);
     }
     async function presentCloseModal() {
       const modal = createModal();
@@ -92,15 +92,6 @@
       await modal.dismiss();
     }
 
-
-const backButton = () => {
-  const ev = new CustomEvent('backbutton');
-  document.dispatchEvent(ev);
-}
-
-window.Ionic.config = {
-  hardwareBackButton: true
-}
     async function presentCloseModal2() {
       const modal = createModal();
       modal.present();

--- a/core/src/components/modal/test/basic/index.html
+++ b/core/src/components/modal/test/basic/index.html
@@ -84,7 +84,7 @@
     async function presentModal() {
       const presentingEl = document.querySelectorAll('.ion-page')[1];
       const modal = createModal();
-      await modal.present(presentingEl);
+      //await modal.present(presentingEl);
     }
     async function presentCloseModal() {
       const modal = createModal();
@@ -92,6 +92,15 @@
       await modal.dismiss();
     }
 
+
+const backButton = () => {
+  const ev = new CustomEvent('backbutton');
+  document.dispatchEvent(ev);
+}
+
+window.Ionic.config = {
+  hardwareBackButton: true
+}
     async function presentCloseModal2() {
       const modal = createModal();
       modal.present();

--- a/core/src/components/picker/picker.tsx
+++ b/core/src/components/picker/picker.tsx
@@ -233,7 +233,7 @@ export class Picker implements ComponentInterface, OverlayInterface {
 
           // Used internally for styling
           [`picker-${mode}`]: true,
-
+          'overlay-hidden': true,
           ...getClassMap(this.cssClass)
         }}
         onIonBackdropTap={this.onBackdropTap}

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -289,6 +289,7 @@ export class Toast implements ComponentInterface, OverlayInterface {
         class={createColorClasses(this.color, {
           [mode]: true,
           ...getClassMap(this.cssClass),
+          'overlay-hidden': true,
           'toast-translucent': this.translucent
         })}
         onIonToastWillDismiss={this.dispatchCancelHandler}

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -256,7 +256,7 @@ export const connectListeners = (doc: Document) => {
 
     // handle back-button click
     doc.addEventListener('ionBackButton', ev => {
-      const lastOverlay = getOverlay(doc);
+      const lastOverlay = getTopOpenOverlay(doc);
       if (lastOverlay && lastOverlay.backdropDismiss) {
         (ev as BackButtonEvent).detail.register(OVERLAY_BACK_BUTTON_PRIORITY, () => {
           return lastOverlay.dismiss(undefined, BACKDROP);
@@ -267,7 +267,7 @@ export const connectListeners = (doc: Document) => {
     // handle ESC to close overlay
     doc.addEventListener('keyup', ev => {
       if (ev.key === 'Escape') {
-        const lastOverlay = getOverlay(doc);
+        const lastOverlay = getTopOpenOverlay(doc);
         if (lastOverlay && lastOverlay.backdropDismiss) {
           lastOverlay.dismiss(undefined, BACKDROP);
         }
@@ -291,6 +291,29 @@ export const getOverlays = (doc: Document, selector?: string): HTMLIonOverlayEle
   return (Array.from(doc.querySelectorAll(selector)) as HTMLIonOverlayElement[])
     .filter(c => c.overlayIndex > 0);
 };
+
+/**
+ * Gets the top-most/last opened
+ * overlay that is currently presented.
+ */
+const getTopOpenOverlay = (doc: Document): HTMLIonOverlayElement | undefined => {
+  const overlays = getOverlays(doc);
+  for (let i = overlays.length - 1; i >= 0; i--) {
+    const overlay = overlays[i];
+
+    /**
+     * Only consider overlays that
+     * are presented. Presented overlays
+     * will not have the .overlay-hidden
+     * class on the host.
+     */
+    if (!overlay.classList.contains('overlay-hidden')) {
+      return overlay;
+    }
+  }
+
+  return;
+}
 
 export const getOverlay = (doc: Document, overlayTag?: string, id?: string): HTMLIonOverlayElement | undefined => {
   const overlays = getOverlays(doc, overlayTag);

--- a/core/src/utils/test/overlays/index.html
+++ b/core/src/utils/test/overlays/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8">
+    <title>Overlays</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+    <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
+    <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+    <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+    <script type="module">
+      import { modalController, createAnimation } from '../../../../../dist/ionic/index.esm.js';
+      window.modalController = modalController;
+    </script>
+  </head>
+  <body>
+    <ion-app>
+      <ion-menu content-id="main-content">
+        <ion-content>
+          <ion-button onclick="openModal(event)">Open Modal</ion-button>
+        </ion-content>
+      </ion-menu>
+      <div class="ion-page" id="main-content">
+        <ion-header>
+          <ion-toolbar>
+            <ion-title>Modal - Inline</ion-title>
+          </ion-toolbar>
+        </ion-header>
+
+        <ion-content class="ion-padding">
+          <ion-button id="create" onclick="createModal()">Create a Modal</ion-button>
+          <ion-button id="present" onclick="presentHiddenModal()">Present a Hidden Modal</ion-button>
+          <ion-button id="create-and-present" onclick="createAndPresentModal()">Create and Present a Modal</ion-button>
+          <ion-button id="simulate" onclick="backButton()">Simulate Hardware Back Button</ion-button>
+        </ion-content>
+      </div>
+    </ion-app>
+
+    <script>
+      const createModal = async () => {
+        const div = document.createElement('div');
+        div.innerHTML = `
+          <ion-header>
+            <ion-toolbar>
+              <ion-title>Modal</ion-title>
+            </ion-toolbar>
+          </ion-header>
+          <ion-content class="ion-padding">
+            Modal Content
+
+            <ion-button id="modal-create">Create a Modal</ion-button>
+            <ion-button id="modal-simulate">Simulate Hardware Back Button</ion-button>
+
+          </ion-content>
+        `;
+
+        const createButton = div.querySelector('ion-button#modal-create');
+        createButton.onclick = () => {
+          createModal();
+        }
+
+        const simulateButton = div.querySelector('ion-button#modal-simulate');
+        simulateButton.onclick = () => {
+          backButton();
+        }
+
+        const modal = await modalController.create({
+          component: div
+        });
+
+        return modal;
+      }
+
+      const createAndPresentModal = async () => {
+        const modal = await createModal();
+        await modal.present();
+      }
+
+      const backButton = () => {
+        const ev = new CustomEvent('backbutton');
+        document.dispatchEvent(ev);
+      }
+
+      const presentHiddenModal = () => {
+        const modal = document.querySelector('ion-modal.overlay-hidden');
+        if (modal) {
+          modal.present();
+        }
+      }
+
+      window.Ionic = {
+        config: {
+          hardwareBackButton: true
+        }
+      }
+    </script>
+
+  </body>
+</html>

--- a/core/src/utils/test/overlays/overlays.e2e.ts
+++ b/core/src/utils/test/overlays/overlays.e2e.ts
@@ -1,0 +1,55 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+test('overlays: should dismss a presented overlay', async () => {
+  const page = await newE2EPage({ url: '/src/utils/test/overlays?ionic:_testing=true' });
+
+  const createAndPresentButton = await page.find('#create-and-present');
+
+  const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+  const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
+
+  await createAndPresentButton.click()
+  const modal = await page.find('ion-modal');
+  expect(modal).not.toBe(null);
+
+  await ionModalDidPresent.next();
+
+  const simulateButton = await modal.find('#modal-simulate');
+  expect(simulateButton).not.toBe(null);
+
+  await simulateButton.click();
+
+  expect(modal).toHaveClass('overlay-hidden');
+});
+
+test('overlays: should dismss the presented overlay, even though another hidden modal was added last', async () => {
+  const page = await newE2EPage({ url: '/src/utils/test/overlays?ionic:_testing=true' });
+
+  const createAndPresentButton = await page.find('#create-and-present');
+
+  const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+  const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
+
+  await createAndPresentButton.click();
+  const modal = await page.find('ion-modal');
+  expect(modal).not.toBe(null);
+
+  await ionModalDidPresent.next();
+
+  const createButton = await page.find('#modal-create');
+  await createButton.click();
+
+  const modals = await page.$$('ion-modal');
+  expect(modals.length).toEqual(2);
+
+  expect(await modals[0].evaluate(node => node.classList.contains('overlay-hidden'))).toEqual(false);
+  expect(await modals[1].evaluate(node => node.classList.contains('overlay-hidden'))).toEqual(true);
+
+  const simulateButton = await modal.find('#modal-simulate');
+  expect(simulateButton).not.toBe(null);
+
+  await simulateButton.click();
+
+  expect(await modals[0].evaluate(node => node.classList.contains('overlay-hidden'))).toEqual(true);
+  expect(await modals[1].evaluate(node => node.classList.contains('overlay-hidden'))).toEqual(true);
+});

--- a/core/src/utils/test/overlays/overlays.e2e.ts
+++ b/core/src/utils/test/overlays/overlays.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-test('overlays: should dismss a presented overlay', async () => {
+test('overlays: hardware back button: should dismss a presented overlay', async () => {
   const page = await newE2EPage({ url: '/src/utils/test/overlays?ionic:_testing=true' });
 
   const createAndPresentButton = await page.find('#create-and-present');
@@ -19,10 +19,12 @@ test('overlays: should dismss a presented overlay', async () => {
 
   await simulateButton.click();
 
-  expect(modal).toHaveClass('overlay-hidden');
+  await ionModalDidDismiss.next();
+
+  await page.waitForSelector('ion-modal', { hidden: true })
 });
 
-test('overlays: should dismss the presented overlay, even though another hidden modal was added last', async () => {
+test('overlays: hardware back button: should dismss the presented overlay, even though another hidden modal was added last', async () => {
   const page = await newE2EPage({ url: '/src/utils/test/overlays?ionic:_testing=true' });
 
   const createAndPresentButton = await page.find('#create-and-present');
@@ -52,4 +54,51 @@ test('overlays: should dismss the presented overlay, even though another hidden 
 
   expect(await modals[0].evaluate(node => node.classList.contains('overlay-hidden'))).toEqual(true);
   expect(await modals[1].evaluate(node => node.classList.contains('overlay-hidden'))).toEqual(true);
+});
+
+test('overlays: Esc: should dismss a presented overlay', async () => {
+  const page = await newE2EPage({ url: '/src/utils/test/overlays?ionic:_testing=true' });
+
+  const createAndPresentButton = await page.find('#create-and-present');
+
+  const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+  const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
+
+  await createAndPresentButton.click()
+  const modal = await page.find('ion-modal');
+  expect(modal).not.toBe(null);
+
+  await ionModalDidPresent.next();
+
+  await page.keyboard.press('Escape');
+
+  await ionModalDidDismiss.next();
+
+  await page.waitForSelector('ion-modal', { hidden: true })
+});
+
+
+test('overlays: Esc: should dismss the presented overlay, even though another hidden modal was added last', async () => {
+  const page = await newE2EPage({ url: '/src/utils/test/overlays?ionic:_testing=true' });
+
+  const createAndPresentButton = await page.find('#create-and-present');
+
+  const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+  const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
+
+  await createAndPresentButton.click();
+  const modal = await page.find('ion-modal');
+  expect(modal).not.toBe(null);
+
+  await ionModalDidPresent.next();
+
+  const createButton = await page.find('#modal-create');
+  await createButton.click();
+
+  const modals = await page.$$('ion-modal');
+  expect(modals.length).toEqual(2);
+
+  await page.keyboard.press('Escape');
+
+  await page.waitForSelector('ion-modal#ion-overlay-1', { hidden: true });
 });

--- a/core/src/utils/test/overlays/overlays.spec.ts
+++ b/core/src/utils/test/overlays/overlays.spec.ts
@@ -1,7 +1,7 @@
 import { newSpecPage } from '@stencil/core/testing';
-import { setRootAriaHidden } from '../overlays';
-import { RouterOutlet } from '../../components/router-outlet/route-outlet';
-import { Nav } from '../../components/nav/nav';
+import { setRootAriaHidden } from '../../overlays';
+import { RouterOutlet } from '../../../components/router-outlet/route-outlet';
+import { Nav } from '../../../components/nav/nav';
 
 describe('setRootAriaHidden()', () => {
   it('should correctly remove and re-add router outlet from accessibility tree', async () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

This is a partial fix for https://github.com/ionic-team/ionic-framework/issues/23728

The hardware back button (HBB) listener for overlays always dismissed the last-presented (I.e. top most) overlay. The problem was that it did this regardless of whether or not that overlay was actually presented. So if you created and presented modal A, then created but did NOT present modal B, pressing the HBB would try to dismiss modal B, leaving modal A open.

This has been the behavior in Ionic for years, but it was never a big issue until the declarative overlays were introduced in Ionic 6. With the declarative overlays, the overlays are always in the DOM and so users started running into this issue more often.

Note: I will fix the other issue with the core delegate in a separate PR.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Both the hardware back button and Esc listener only accounts for the top-most open overlay when trying to dismiss. To do this we exclude any overlay with the `.overlay-hidden` class. This class is added when an overlay is initially created, and is removed when the `present()` method is called. The class is then re-added when the `dismiss()` method is called.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
