### PR TITLE
fix(icon): update to ionicons 6 to resolve typescript 4.4 errors

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -15,6 +15,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
 - [Components](#components)
   * [Datetime](#datetime)
   * [Header](#header)
+  * [Icons](#icons)
   * [Input](#input)
   * [Modal](#modal)
   * [Popover](#popover)
@@ -90,6 +91,10 @@ ion-header.header-collapse-condense ion-toolbar:last-of-type {
   --border-width: 0 0 0.55px;
 }
 ```
+
+#### Icons
+
+Ionic 6 now ships with Ionicons 6. Please be sure to review the [Ionicons 6.0.0 Changelog](https://github.com/ionic-team/ionicons/releases/tag/v6.0.0) and make any necessary changes.
 
 #### Input
 

--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -576,13 +576,13 @@ export class IonHeader {
 
 export declare interface IonIcon extends Components.IonIcon {}
 @ProxyCmp({
-  inputs: ['ariaHidden', 'ariaLabel', 'color', 'flipRtl', 'icon', 'ios', 'lazy', 'md', 'mode', 'name', 'sanitize', 'size', 'src']
+  inputs: ['color', 'flipRtl', 'icon', 'ios', 'lazy', 'md', 'mode', 'name', 'sanitize', 'size', 'src']
 })
 @Component({
   selector: 'ion-icon',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaHidden', 'ariaLabel', 'color', 'flipRtl', 'icon', 'ios', 'lazy', 'md', 'mode', 'name', 'sanitize', 'size', 'src']
+  inputs: ['color', 'flipRtl', 'icon', 'ios', 'lazy', 'md', 'mode', 'name', 'sanitize', 'size', 'src']
 })
 export class IonIcon {
   protected el: HTMLElement;

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "~2.10.0",
-        "ionicons": "^5.5.4",
+        "ionicons": "^6.0.0",
         "tslib": "^2.1.0"
       },
       "devDependencies": {
@@ -5549,9 +5549,9 @@
       }
     },
     "node_modules/ionicons": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-5.5.4.tgz",
-      "integrity": "sha512-3ph8X9my3inhabWEZ7N0XRA0MnnNQ1v9a602mLNgWsIXnxE9G5BybIZ/pws/OZZ/hoNlvSjk801N03yL9/FNgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.0.tgz",
+      "integrity": "sha512-p83W1T8jZUlllHAjuIWaDQbI36OYqdrwcf8MhYbKW7+9rjGlCMP9+5OaR0W7tl0QfM004uAiy/zkc7HTpDNKgA==",
       "dependencies": {
         "@stencil/core": "~2.10.0"
       }
@@ -18407,9 +18407,9 @@
       }
     },
     "ionicons": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-5.5.4.tgz",
-      "integrity": "sha512-3ph8X9my3inhabWEZ7N0XRA0MnnNQ1v9a602mLNgWsIXnxE9G5BybIZ/pws/OZZ/hoNlvSjk801N03yL9/FNgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.0.tgz",
+      "integrity": "sha512-p83W1T8jZUlllHAjuIWaDQbI36OYqdrwcf8MhYbKW7+9rjGlCMP9+5OaR0W7tl0QfM004uAiy/zkc7HTpDNKgA==",
       "requires": {
         "@stencil/core": "~2.10.0"
       }

--- a/core/package.json
+++ b/core/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "@stencil/core": "~2.10.0",
-    "ionicons": "^5.5.4",
+    "ionicons": "^6.0.0",
     "tslib": "^2.1.0"
   },
   "devDependencies": {

--- a/core/src/components/accordion/accordion.tsx
+++ b/core/src/components/accordion/accordion.tsx
@@ -187,7 +187,7 @@ export class Accordion implements ComponentInterface {
     iconEl.lazy = false;
     iconEl.classList.add('ion-accordion-toggle-icon');
     iconEl.icon = toggleIcon;
-    iconEl.ariaHidden = 'true';
+    iconEl.setAttribute('aria-hidden', 'true');
 
     ionItem.appendChild(iconEl);
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,7 @@
   ],
   "dependencies": {
     "@ionic/core": "6.0.0-rc.2",
-    "ionicons": "^5.5.4",
+    "ionicons": "^6.0.0",
     "tslib": "*"
   },
   "peerDependencies": {

--- a/packages/react/src/components/IonIcon.tsx
+++ b/packages/react/src/components/IonIcon.tsx
@@ -7,7 +7,6 @@ import { IonIconInner } from './inner-proxies';
 import { createForwardRef, isPlatform } from './utils';
 
 interface IonIconProps {
-  ariaLabel?: string;
   color?: string;
   flipRtl?: boolean;
   icon?: string;

--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -9,8 +9,8 @@
       "version": "6.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
-        "@ionic/core": "6.0.0-rc.1",
-        "ionicons": "^5.5.4"
+        "@ionic/core": "6.0.0-rc.2",
+        "ionicons": "^6.0.0"
       },
       "devDependencies": {
         "@stencil/core": "^1.17.0",
@@ -53,25 +53,33 @@
       }
     },
     "node_modules/@ionic/core": {
-      "version": "6.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.0.0-rc.1.tgz",
-      "integrity": "sha512-O7kqodTo61gJKaeokYcdM5KwnfZ1Li5UiBbQH5oZXeU0jzJWfp5dU02Chk3dCMlMI1dUYmQRnu2KCwETV/X5Kg==",
+      "version": "6.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.0.0-rc.2.tgz",
+      "integrity": "sha512-evf3J01B91zs386bBYz55zjG0I7BXSs/+pySkj+fDHVT/teXYntpUzebm5rqA0/IoUn6QXEdz1x3Nrz8040/Jg==",
       "dependencies": {
-        "@stencil/core": "^2.6.0",
-        "ionicons": "^5.5.1",
+        "@stencil/core": "~2.10.0",
+        "ionicons": "^5.5.4",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@ionic/core/node_modules/@stencil/core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.6.0.tgz",
-      "integrity": "sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-15rWMTPQ/sp0lSV82HVCXkIya3QLN+uBl7pqK4JnTrp4HiLrzLmNbWjbvgCs55gw0lULbCIGbRIEsFz+Pe/Q+A==",
       "bin": {
         "stencil": "bin/stencil"
       },
       "engines": {
         "node": ">=12.10.0",
         "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@ionic/core/node_modules/ionicons": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-5.5.4.tgz",
+      "integrity": "sha512-3ph8X9my3inhabWEZ7N0XRA0MnnNQ1v9a602mLNgWsIXnxE9G5BybIZ/pws/OZZ/hoNlvSjk801N03yL9/FNgQ==",
+      "dependencies": {
+        "@stencil/core": "~2.10.0"
       }
     },
     "node_modules/@ionic/core/node_modules/tslib": {
@@ -356,9 +364,9 @@
       "dev": true
     },
     "node_modules/ionicons": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-5.5.4.tgz",
-      "integrity": "sha512-3ph8X9my3inhabWEZ7N0XRA0MnnNQ1v9a602mLNgWsIXnxE9G5BybIZ/pws/OZZ/hoNlvSjk801N03yL9/FNgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.0.tgz",
+      "integrity": "sha512-p83W1T8jZUlllHAjuIWaDQbI36OYqdrwcf8MhYbKW7+9rjGlCMP9+5OaR0W7tl0QfM004uAiy/zkc7HTpDNKgA==",
       "dependencies": {
         "@stencil/core": "~2.10.0"
       }
@@ -633,19 +641,27 @@
       }
     },
     "@ionic/core": {
-      "version": "6.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.0.0-rc.1.tgz",
-      "integrity": "sha512-O7kqodTo61gJKaeokYcdM5KwnfZ1Li5UiBbQH5oZXeU0jzJWfp5dU02Chk3dCMlMI1dUYmQRnu2KCwETV/X5Kg==",
+      "version": "6.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.0.0-rc.2.tgz",
+      "integrity": "sha512-evf3J01B91zs386bBYz55zjG0I7BXSs/+pySkj+fDHVT/teXYntpUzebm5rqA0/IoUn6QXEdz1x3Nrz8040/Jg==",
       "requires": {
-        "@stencil/core": "^2.6.0",
-        "ionicons": "^5.5.1",
+        "@stencil/core": "~2.10.0",
+        "ionicons": "^5.5.4",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "@stencil/core": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.6.0.tgz",
-          "integrity": "sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ=="
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.10.0.tgz",
+          "integrity": "sha512-15rWMTPQ/sp0lSV82HVCXkIya3QLN+uBl7pqK4JnTrp4HiLrzLmNbWjbvgCs55gw0lULbCIGbRIEsFz+Pe/Q+A=="
+        },
+        "ionicons": {
+          "version": "5.5.4",
+          "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-5.5.4.tgz",
+          "integrity": "sha512-3ph8X9my3inhabWEZ7N0XRA0MnnNQ1v9a602mLNgWsIXnxE9G5BybIZ/pws/OZZ/hoNlvSjk801N03yL9/FNgQ==",
+          "requires": {
+            "@stencil/core": "~2.10.0"
+          }
         },
         "tslib": {
           "version": "2.2.0",
@@ -904,9 +920,9 @@
       "dev": true
     },
     "ionicons": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-5.5.4.tgz",
-      "integrity": "sha512-3ph8X9my3inhabWEZ7N0XRA0MnnNQ1v9a602mLNgWsIXnxE9G5BybIZ/pws/OZZ/hoNlvSjk801N03yL9/FNgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.0.tgz",
+      "integrity": "sha512-p83W1T8jZUlllHAjuIWaDQbI36OYqdrwcf8MhYbKW7+9rjGlCMP9+5OaR0W7tl0QfM004uAiy/zkc7HTpDNKgA==",
       "requires": {
         "@stencil/core": "~2.10.0"
       },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@ionic/core": "6.0.0-rc.2",
-    "ionicons": "^5.5.4"
+    "ionicons": "^6.0.0"
   },
   "vetur": {
     "tags": "dist/vetur/tags.json",

--- a/packages/vue/src/components/IonIcon.ts
+++ b/packages/vue/src/components/IonIcon.ts
@@ -6,7 +6,6 @@ import { IonIcon as IonIconCmp } from 'ionicons/components/ion-icon.js';
 export const IonIcon = /*@__PURE__*/ defineComponent({
   name: 'IonIcon',
   props: {
-    ariaLabel: String,
     color: String,
     flipRtl: Boolean,
     icon: String,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionicons/issues/1011 Most commonly found when updating to Angular 13 + TypeScript 4.4


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Ionic now uses Ionicons 6

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

Note: Not a breaking change in Ionic 6, but a breaking change in Ionicons.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
