### PR TITLE
fix(angular): duplicate events no longer fire

### DIFF
--- a/angular/src/directives/angular-component-lib/utils.ts
+++ b/angular/src/directives/angular-component-lib/utils.ts
@@ -1,39 +1,37 @@
 /* eslint-disable */
 /* tslint:disable */
-import { fromEvent } from 'rxjs';
+import { EventEmitter } from '@angular/core';
 
 export const proxyInputs = (Cmp: any, inputs: string[]) => {
   const Prototype = Cmp.prototype;
-  inputs.forEach(item => {
+  inputs.forEach((item) => {
     Object.defineProperty(Prototype, item, {
       get() {
         return this.el[item];
       },
       set(val: any) {
         this.z.runOutsideAngular(() => (this.el[item] = val));
-      }
+      },
     });
   });
 };
 
 export const proxyMethods = (Cmp: any, methods: string[]) => {
   const Prototype = Cmp.prototype;
-  methods.forEach(methodName => {
+  methods.forEach((methodName) => {
     Prototype[methodName] = function () {
       const args = arguments;
-      return this.z.runOutsideAngular(() =>
-        this.el[methodName].apply(this.el, args)
-      );
+      return this.z.runOutsideAngular(() => this.el[methodName].apply(this.el, args));
     };
   });
 };
 
-export const proxyOutputs = (instance: any, el: any, events: string[]) => {
-  events.forEach(eventName => instance[eventName] = fromEvent(el, eventName));
-}
+export const proxyOutputs = (instance: any, events: string[]) => {
+  events.forEach((eventName) => (instance[eventName] = new EventEmitter()));
+};
 
 export function ProxyCmp(opts: { inputs?: any; methods?: any }) {
-  const decorator = function(cls: any) {
+  const decorator = function (cls: any) {
     if (opts.inputs) {
       proxyInputs(cls, opts.inputs);
     }

--- a/angular/src/directives/navigation/nav-delegate.ts
+++ b/angular/src/directives/navigation/nav-delegate.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @angular-eslint/no-outputs-metadata-property */
+/* eslint-disable @angular-eslint/no-inputs-metadata-property */
 import { ComponentFactoryResolver, ElementRef, Injector, ViewContainerRef, Directive } from '@angular/core';
 
 import { AngularDelegate } from '../../providers/angular-delegate';
@@ -23,6 +25,8 @@ import { ProxyCmp, proxyOutputs } from '../angular-component-lib/utils';
 })
 @Directive({
   selector: 'ion-nav',
+  inputs: ['animated', 'animation', 'root', 'rootParams', 'swipeGesture'],
+  outputs: ['ionNavDidChange', 'ionNavWillChange'],
 })
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export class NavDelegate {
@@ -36,6 +40,6 @@ export class NavDelegate {
   ) {
     this.el = ref.nativeElement;
     ref.nativeElement.delegate = angularDelegate.create(resolver, injector, location);
-    proxyOutputs(this, this.el, ['ionNavDidChange', 'ionNavWillChange']);
+    proxyOutputs(this, ['ionNavDidChange', 'ionNavWillChange']);
   }
 }

--- a/angular/src/directives/overlays/modal.ts
+++ b/angular/src/directives/overlays/modal.ts
@@ -60,6 +60,16 @@ export declare interface IonModal extends Components.IonModal {}
     'translucent',
     'trigger',
   ],
+  outputs: [
+    'ionModalDidPresent',
+    'ionModalWillPresent',
+    'ionModalWillDismiss',
+    'ionModalDidDismiss',
+    'didPresent',
+    'willPresent',
+    'willDismiss',
+    'didDismiss',
+  ],
 })
 export class IonModal {
   @ContentChild(TemplateRef, { static: false }) template: TemplateRef<any>;
@@ -87,8 +97,7 @@ export class IonModal {
       this.isCmpOpen = false;
       c.detectChanges();
     });
-
-    proxyOutputs(this, this.el, [
+    proxyOutputs(this, [
       'ionModalDidPresent',
       'ionModalWillPresent',
       'ionModalWillDismiss',

--- a/angular/src/directives/overlays/popover.ts
+++ b/angular/src/directives/overlays/popover.ts
@@ -60,6 +60,16 @@ export declare interface IonPopover extends Components.IonPopover {}
     'reference',
     'size',
   ],
+  outputs: [
+    'ionPopoverDidPresent',
+    'ionPopoverWillPresent',
+    'ionPopoverWillDismiss',
+    'ionPopoverDidDismiss',
+    'didPresent',
+    'willPresent',
+    'willDismiss',
+    'didDismiss',
+  ],
 })
 export class IonPopover {
   @ContentChild(TemplateRef, { static: false }) template: TemplateRef<any>;
@@ -87,8 +97,7 @@ export class IonPopover {
       this.isCmpOpen = false;
       c.detectChanges();
     });
-
-    proxyOutputs(this, this.el, [
+    proxyOutputs(this, [
       'ionPopoverDidPresent',
       'ionPopoverWillPresent',
       'ionPopoverWillDismiss',

--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -43,7 +43,7 @@ export class IonAccordionGroup {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionChange']);
+    proxyOutputs(this, ['ionChange']);
   }
 }
 
@@ -117,7 +117,7 @@ export class IonBackdrop {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionBackdropTap']);
+    proxyOutputs(this, ['ionBackdropTap']);
   }
 }
 
@@ -161,7 +161,7 @@ export class IonBreadcrumb {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionFocus', 'ionBlur']);
+    proxyOutputs(this, ['ionFocus', 'ionBlur']);
   }
 }
 
@@ -184,7 +184,7 @@ export class IonBreadcrumbs {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionCollapsedClick']);
+    proxyOutputs(this, ['ionCollapsedClick']);
   }
 }
 
@@ -209,7 +209,7 @@ export class IonButton {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionFocus', 'ionBlur']);
+    proxyOutputs(this, ['ionFocus', 'ionBlur']);
   }
 }
 
@@ -350,7 +350,7 @@ export class IonCheckbox {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionChange', 'ionFocus', 'ionBlur']);
+    proxyOutputs(this, ['ionChange', 'ionFocus', 'ionBlur']);
   }
 }
 
@@ -418,7 +418,7 @@ Look at the property: `scrollEvents` */
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionScrollStart', 'ionScroll', 'ionScrollEnd']);
+    proxyOutputs(this, ['ionScrollStart', 'ionScroll', 'ionScrollEnd']);
   }
 }
 
@@ -448,7 +448,7 @@ export class IonDatetime {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionCancel', 'ionChange', 'ionFocus', 'ionBlur']);
+    proxyOutputs(this, ['ionCancel', 'ionChange', 'ionFocus', 'ionBlur']);
   }
 }
 
@@ -493,7 +493,7 @@ export class IonFabButton {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionFocus', 'ionBlur']);
+    proxyOutputs(this, ['ionFocus', 'ionBlur']);
   }
 }
 
@@ -615,7 +615,7 @@ export class IonImg {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionImgWillLoad', 'ionImgDidLoad', 'ionError']);
+    proxyOutputs(this, ['ionImgWillLoad', 'ionImgDidLoad', 'ionError']);
   }
 }
 
@@ -642,7 +642,7 @@ your async operation has completed. */
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionInfinite']);
+    proxyOutputs(this, ['ionInfinite']);
   }
 }
 
@@ -691,7 +691,7 @@ export class IonInput {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionInput', 'ionChange', 'ionBlur', 'ionFocus']);
+    proxyOutputs(this, ['ionInput', 'ionChange', 'ionBlur', 'ionFocus'])
   }
 }
 
@@ -787,7 +787,7 @@ export class IonItemOptions {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionSwipe']);
+    proxyOutputs(this, ['ionSwipe']);
   }
 }
 
@@ -811,7 +811,7 @@ export class IonItemSliding {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionDrag']);
+    proxyOutputs(this, ['ionDrag']);
   }
 }
 
@@ -899,7 +899,7 @@ export class IonMenu {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionWillOpen', 'ionWillClose', 'ionDidOpen', 'ionDidClose']);
+    proxyOutputs(this, ['ionWillOpen', 'ionWillClose', 'ionDidOpen', 'ionDidClose']);
   }
 }
 
@@ -963,7 +963,7 @@ export class IonNav {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionNavWillChange', 'ionNavDidChange']);
+    proxyOutputs(this, ['ionNavWillChange', 'ionNavDidChange']);
   }
 }
 
@@ -1045,7 +1045,7 @@ export class IonRadio {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionFocus', 'ionBlur']);
+    proxyOutputs(this, ['ionFocus', 'ionBlur']);
   }
 }
 
@@ -1068,7 +1068,7 @@ export class IonRadioGroup {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionChange']);
+    proxyOutputs(this, ['ionChange']);
   }
 }
 
@@ -1095,7 +1095,7 @@ export class IonRange {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionChange', 'ionFocus', 'ionBlur']);
+    proxyOutputs(this, ['ionChange', 'ionFocus', 'ionBlur']);
   }
 }
 
@@ -1126,7 +1126,7 @@ called when the async operation has completed. */
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionRefresh', 'ionPull', 'ionStart']);
+    proxyOutputs(this, ['ionRefresh', 'ionPull', 'ionStart']);
   }
 }
 
@@ -1187,7 +1187,7 @@ to be called in order to finalize the reorder action. */
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionItemReorder']);
+    proxyOutputs(this, ['ionItemReorder']);
   }
 }
 
@@ -1257,7 +1257,7 @@ export class IonSearchbar {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionInput', 'ionChange', 'ionCancel', 'ionClear', 'ionBlur', 'ionFocus']);
+    proxyOutputs(this, ['ionInput', 'ionChange', 'ionCancel', 'ionClear', 'ionBlur', 'ionFocus']);
   }
 }
 
@@ -1281,7 +1281,7 @@ dragging pointer has been released from `ion-segment`. */
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionChange']);
+    proxyOutputs(this, ['ionChange']);
   }
 }
 
@@ -1330,7 +1330,7 @@ export class IonSelect {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionChange', 'ionCancel', 'ionFocus', 'ionBlur']);
+    proxyOutputs(this, ['ionChange', 'ionCancel', 'ionFocus', 'ionBlur']);
   }
 }
 
@@ -1438,7 +1438,7 @@ export class IonSlides {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionSlidesDidLoad', 'ionSlideTap', 'ionSlideDoubleTap', 'ionSlideWillChange', 'ionSlideDidChange', 'ionSlideNextStart', 'ionSlidePrevStart', 'ionSlideNextEnd', 'ionSlidePrevEnd', 'ionSlideTransitionStart', 'ionSlideTransitionEnd', 'ionSlideDrag', 'ionSlideReachStart', 'ionSlideReachEnd', 'ionSlideTouchStart', 'ionSlideTouchEnd']);
+    proxyOutputs(this, ['ionSlidesDidLoad', 'ionSlideTap', 'ionSlideDoubleTap', 'ionSlideWillChange', 'ionSlideDidChange', 'ionSlideNextStart', 'ionSlidePrevStart', 'ionSlideNextEnd', 'ionSlidePrevEnd', 'ionSlideTransitionStart', 'ionSlideTransitionEnd', 'ionSlideDrag', 'ionSlideReachStart', 'ionSlideReachEnd', 'ionSlideTouchStart', 'ionSlideTouchEnd']);
   }
 }
 
@@ -1480,7 +1480,7 @@ export class IonSplitPane {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionSplitPaneVisible']);
+    proxyOutputs(this, ['ionSplitPaneVisible']);
   }
 }
 
@@ -1567,7 +1567,7 @@ export class IonTextarea {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionChange', 'ionInput', 'ionBlur', 'ionFocus']);
+    proxyOutputs(this, ['ionChange', 'ionInput', 'ionBlur', 'ionFocus']);
   }
 }
 
@@ -1629,7 +1629,7 @@ export class IonToggle {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionChange', 'ionFocus', 'ionBlur']);
+    proxyOutputs(this, ['ionChange', 'ionFocus', 'ionBlur']);
   }
 }
 

--- a/angular/src/providers/gesture-controller.ts
+++ b/angular/src/providers/gesture-controller.ts
@@ -10,15 +10,16 @@ export class GestureController {
    * Create a new gesture
    */
   create(opts: GestureConfig, runInsideAngularZone = false): Gesture {
+    const config: any = opts;
     if (runInsideAngularZone) {
       Object.getOwnPropertyNames(opts).forEach((key) => {
-        if (typeof opts[key] === 'function') {
-          const fn = opts[key];
-          opts[key] = (...props: any[]) => this.zone.run(() => fn(...props));
+        if (typeof config[key] === 'function') {
+          const fn = config[key];
+          config[key] = (...props: any[]) => this.zone.run(() => fn(...props));
         }
       });
     }
 
-    return createGesture(opts);
+    return createGesture(config);
   }
 }


### PR DESCRIPTION
Fix Angular proxies to prevent duplicate event emission when wrapping DOM event.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The combination of the `fromEvent` syntax for proxying outputs and the `outputs` usage in the `@Component` decorator, is defining two hot observables mapped to the same event name. 

Issue Number: #24057

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Proxy outputs no longer need to use `fromEvent` from `rxjs` and instead can use `EventEmitter` directly. This resolves duplicate events firing for each individual event type.

I have additionally updated the usages of modal, popover and nav-delegate to match the modified usage of output targets. 

Lastly, the gesture controller types are causing local build issues after recent dependency changes. Internally treating the type as `any`, since `GestureConfig` doesn't directly have function types on it's definition.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I need to update the Stencil output targets to reflect this modified signature (`el` is no longer required). Will follow-up with a PR in that repository shortly.

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

