### PR TITLE
feat(textarea): revised approach to auto grow

### DIFF
--- a/core/src/components/item/item.md.scss
+++ b/core/src/components/item/item.md.scss
@@ -463,7 +463,7 @@
 :host(.item-fill-outline.item-label-floating.item-has-focus) .item-native ::slotted(ion-textarea:not(:first-child)),
 :host(.item-fill-outline.item-label-floating.item-has-value) .item-native ::slotted(ion-input:not(:first-child)),
 :host(.item-fill-outline.item-label-floating.item-has-value) .item-native ::slotted(ion-textarea:not(:first-child)) {
-  transform: translateY(-25%);
+  transform: translateY(-14px);
 }
 
 @media (any-hover: hover) {

--- a/core/src/components/textarea/textarea.scss
+++ b/core/src/components/textarea/textarea.scss
@@ -71,22 +71,39 @@
   --padding-start: 0;
 }
 
-
 // Native Textarea
 // --------------------------------------------------
 
 .textarea-wrapper {
+  display: grid;
+
   min-width: inherit;
   max-width: inherit;
   min-height: inherit;
   max-height: inherit;
+
+  &::after {
+    content: attr(data-replicated-value) " ";
+    white-space: pre-wrap;
+    visibility: hidden;
+  }
+}
+
+.textarea-wrapper::after,
+.native-textarea {
+  @include padding(
+    var(--padding-top),
+    var(--padding-end),
+    var(--padding-bottom),
+    var(--padding-start)
+  );
+  @include text-inherit();
+  grid-area: 1 / 1 / 2 / 2;
 }
 
 .native-textarea {
   @include border-radius(var(--border-radius));
   @include margin(0);
-  @include padding(var(--padding-top), var(--padding-end), var(--padding-bottom), var(--padding-start));
-  @include text-inherit();
 
   display: block;
 
@@ -101,6 +118,7 @@
   background: transparent;
   box-sizing: border-box;
   resize: none;
+  overflow: hidden;
   appearance: none;
 
   &::placeholder {
@@ -135,7 +153,6 @@
 
   pointer-events: none;
 }
-
 
 // Item Floating: Placeholder
 // ----------------------------------------------------------------

--- a/core/src/components/textarea/textarea.scss
+++ b/core/src/components/textarea/textarea.scss
@@ -83,8 +83,10 @@
   max-height: inherit;
 
   &::after {
-    content: attr(data-replicated-value) " ";
     white-space: pre-wrap;
+
+    content: attr(data-replicated-value) " ";
+
     visibility: hidden;
   }
 }
@@ -118,8 +120,9 @@
   background: transparent;
   box-sizing: border-box;
   resize: none;
-  overflow: hidden;
   appearance: none;
+  
+  overflow: hidden;
 
   &::placeholder {
     @include padding(0);

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -226,7 +226,7 @@ export class Textarea implements ComponentInterface {
     if (nativeInput && this.autoGrow) {
       writeTask(() => {
         if (this.textareaWrapper) {
-          this.textareaWrapper.dataset.replicatedValue = this.value ?? "";
+          this.textareaWrapper.dataset.replicatedValue = this.value ?? '';
         }
       });
     }

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -1,8 +1,8 @@
-import { Build, Component, ComponentInterface, Element, Event, EventEmitter, Host, Method, Prop, State, Watch, h, readTask } from '@stencil/core';
+import { Build, Component, ComponentInterface, Element, Event, EventEmitter, Host, Method, Prop, State, Watch, h, writeTask } from '@stencil/core';
 
 import { getIonMode } from '../../global/ionic-global';
 import { Color, StyleEventDetail, TextareaChangeEventDetail } from '../../interface';
-import { debounceEvent, findItemLabel, inheritAttributes, raf } from '../../utils/helpers';
+import { debounceEvent, findItemLabel, inheritAttributes } from '../../utils/helpers';
 import { createColorClasses } from '../../utils/theme';
 
 /**
@@ -218,17 +218,15 @@ export class Textarea implements ComponentInterface {
   }
 
   componentDidLoad() {
-    raf(() => this.runAutoGrow());
+    this.runAutoGrow();
   }
 
   private runAutoGrow() {
     const nativeInput = this.nativeInput;
     if (nativeInput && this.autoGrow) {
-      readTask(() => {
-        nativeInput.style.height = 'auto';
-        nativeInput.style.height = nativeInput.scrollHeight + 'px';
+      writeTask(() => {
         if (this.textareaWrapper) {
-          this.textareaWrapper.style.height = nativeInput.scrollHeight + 'px';
+          this.textareaWrapper.dataset.replicatedValue = this.value ?? "";
         }
       });
     }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resize behavior currently is using the scroll height of the control, to resize the outer container. 

Additionally, floating labels are being translated by 25% of the container height, which does not apply consistently when dealing with auto growing textareas.

Issue Number: #24187


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- All controls slotted through a `fill="outline"` `ion-item` and using a float label, will translate the slotted control by a consistent 14px (equivalent to 25% of the original height). This allows auto-growing textareas to follow Material's spec for floating labels.
- Resize behavior with textarea experimentally reflects the value of the textarea to the container (inspired from: https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
