### PR TITLE
fix(angular): prevent duplicate event emissions

### DIFF
--- a/angular/src/directives/overlays/modal.ts
+++ b/angular/src/directives/overlays/modal.ts
@@ -12,7 +12,41 @@ import {
 } from '@angular/core';
 import { ProxyCmp, proxyOutputs } from '../angular-component-lib/utils';
 import { Components } from '@ionic/core';
-export declare interface IonModal extends Components.IonModal {}
+
+export declare interface IonModal extends Components.IonModal {
+  /**
+   * Emitted after the modal has presented.
+   **/
+  ionModalDidPresent: EventEmitter<CustomEvent>;
+  /**
+   * Emitted before the modal has presented.
+   */
+  ionModalWillPresent: EventEmitter<CustomEvent>;
+  /**
+   * Emitted before the modal has dismissed.
+   */
+  ionModalWillDismiss: EventEmitter<CustomEvent>;
+  /**
+   * Emitted after the modal has dismissed.
+   */
+  ionModalDidDismiss: EventEmitter<CustomEvent>;
+  /**
+   * Emitted after the modal has presented. Shorthand for ionModalWillDismiss.
+   */
+  didPresent: EventEmitter<CustomEvent>;
+  /**
+   * Emitted before the modal has presented. Shorthand for ionModalWillPresent.
+   */
+  willPresent: EventEmitter<CustomEvent>;
+  /**
+   * Emitted before the modal has dismissed. Shorthand for ionModalWillDismiss.
+   */
+  willDismiss: EventEmitter<CustomEvent>;
+  /**
+   * Emitted after the modal has dismissed. Shorthand for ionModalDidDismiss.
+   */
+  didDismiss: EventEmitter<CustomEvent>;
+}
 @ProxyCmp({
   inputs: [
     'animated',
@@ -64,17 +98,10 @@ export declare interface IonModal extends Components.IonModal {}
 export class IonModal {
   @ContentChild(TemplateRef, { static: false }) template: TemplateRef<any>;
 
-  ionModalDidPresent!: EventEmitter<CustomEvent>;
-  ionModalWillPresent!: EventEmitter<CustomEvent>;
-  ionModalWillDismiss!: EventEmitter<CustomEvent>;
-  ionModalDidDismiss!: EventEmitter<CustomEvent>;
-  didPresent!: EventEmitter<CustomEvent>;
-  willPresent!: EventEmitter<CustomEvent>;
-  willDismiss!: EventEmitter<CustomEvent>;
-  didDismiss!: EventEmitter<CustomEvent>;
   isCmpOpen: boolean = false;
 
   protected el: HTMLElement;
+
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;

--- a/angular/src/directives/overlays/popover.ts
+++ b/angular/src/directives/overlays/popover.ts
@@ -12,7 +12,40 @@ import {
 } from '@angular/core';
 import { ProxyCmp, proxyOutputs } from '../angular-component-lib/utils';
 import { Components } from '@ionic/core';
-export declare interface IonPopover extends Components.IonPopover {}
+export declare interface IonPopover extends Components.IonPopover {
+  /**
+   * Emitted after the popover has presented.
+   */
+  ionPopoverDidPresent: EventEmitter<CustomEvent>;
+  /**
+   * Emitted before the popover has presented.
+   */
+  ionPopoverWillPresent: EventEmitter<CustomEvent>;
+  /**
+   * Emitted after the popover has dismissed.
+   */
+  ionPopoverWillDismiss: EventEmitter<CustomEvent>;
+  /**
+   * Emitted after the popover has dismissed.
+   */
+  ionPopoverDidDismiss: EventEmitter<CustomEvent>;
+  /**
+   * Emitted after the popover has presented. Shorthand for ionPopoverWillDismiss.
+   */
+  didPresent: EventEmitter<CustomEvent>;
+  /**
+   * Emitted before the popover has presented. Shorthand for ionPopoverWillPresent.
+   */
+  willPresent: EventEmitter<CustomEvent>;
+  /**
+   * Emitted after the popover has presented. Shorthand for ionPopoverWillDismiss.
+   */
+  willDismiss: EventEmitter<CustomEvent>;
+  /**
+   * Emitted after the popover has dismissed. Shorthand for ionPopoverDidDismiss.
+   */
+  didDismiss: EventEmitter<CustomEvent>;
+}
 @ProxyCmp({
   inputs: [
     'alignment',
@@ -64,17 +97,10 @@ export declare interface IonPopover extends Components.IonPopover {}
 export class IonPopover {
   @ContentChild(TemplateRef, { static: false }) template: TemplateRef<any>;
 
-  ionPopoverDidPresent!: EventEmitter<CustomEvent>;
-  ionPopoverWillPresent!: EventEmitter<CustomEvent>;
-  ionPopoverWillDismiss!: EventEmitter<CustomEvent>;
-  ionPopoverDidDismiss!: EventEmitter<CustomEvent>;
-  didPresent!: EventEmitter<CustomEvent>;
-  willPresent!: EventEmitter<CustomEvent>;
-  willDismiss!: EventEmitter<CustomEvent>;
-  didDismiss!: EventEmitter<CustomEvent>;
   isCmpOpen: boolean = false;
 
   protected el: HTMLElement;
+
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -87,7 +113,6 @@ export class IonPopover {
       this.isCmpOpen = false;
       c.detectChanges();
     });
-
     proxyOutputs(this, this.el, [
       'ionPopoverDidPresent',
       'ionPopoverWillPresent',

--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -7,6 +7,7 @@ import { Components } from '@ionic/core';
 
 
 export declare interface IonAccordion extends Components.IonAccordion {}
+
 @ProxyCmp({
   inputs: ['disabled', 'mode', 'readonly', 'toggleIcon', 'toggleIconSlot', 'value']
 })
@@ -25,7 +26,14 @@ export class IonAccordion {
 }
 
 import { AccordionGroupChangeEventDetail as IAccordionGroupAccordionGroupChangeEventDetail } from '@ionic/core';
-export declare interface IonAccordionGroup extends Components.IonAccordionGroup {}
+export declare interface IonAccordionGroup extends Components.IonAccordionGroup {
+  /**
+   * Emitted when the value property has changed. 
+   */
+  ionChange: EventEmitter<CustomEvent<IAccordionGroupAccordionGroupChangeEventDetail>>;
+
+}
+
 @ProxyCmp({
   inputs: ['animated', 'disabled', 'expand', 'mode', 'multiple', 'readonly', 'value']
 })
@@ -33,12 +41,9 @@ export declare interface IonAccordionGroup extends Components.IonAccordionGroup 
   selector: 'ion-accordion-group',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['animated', 'disabled', 'expand', 'mode', 'multiple', 'readonly', 'value'],
-  outputs: ['ionChange']
+  inputs: ['animated', 'disabled', 'expand', 'mode', 'multiple', 'readonly', 'value']
 })
 export class IonAccordionGroup {
-  /** Emitted when the value property has changed. */
-  ionChange!: EventEmitter<CustomEvent<IAccordionGroupAccordionGroupChangeEventDetail>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -49,6 +54,7 @@ export class IonAccordionGroup {
 
 
 export declare interface IonApp extends Components.IonApp {}
+
 
 @Component({
   selector: 'ion-app',
@@ -66,6 +72,7 @@ export class IonApp {
 
 export declare interface IonAvatar extends Components.IonAvatar {}
 
+
 @Component({
   selector: 'ion-avatar',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -81,6 +88,7 @@ export class IonAvatar {
 
 
 export declare interface IonBackButton extends Components.IonBackButton {}
+
 @ProxyCmp({
   inputs: ['color', 'defaultHref', 'disabled', 'icon', 'mode', 'routerAnimation', 'text', 'type']
 })
@@ -99,7 +107,14 @@ export class IonBackButton {
 }
 
 
-export declare interface IonBackdrop extends Components.IonBackdrop {}
+export declare interface IonBackdrop extends Components.IonBackdrop {
+  /**
+   * Emitted when the backdrop is tapped. 
+   */
+  ionBackdropTap: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['stopPropagation', 'tappable', 'visible']
 })
@@ -107,12 +122,9 @@ export declare interface IonBackdrop extends Components.IonBackdrop {}
   selector: 'ion-backdrop',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['stopPropagation', 'tappable', 'visible'],
-  outputs: ['ionBackdropTap']
+  inputs: ['stopPropagation', 'tappable', 'visible']
 })
 export class IonBackdrop {
-  /** Emitted when the backdrop is tapped. */
-  ionBackdropTap!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -123,6 +135,7 @@ export class IonBackdrop {
 
 
 export declare interface IonBadge extends Components.IonBadge {}
+
 @ProxyCmp({
   inputs: ['color', 'mode']
 })
@@ -141,7 +154,18 @@ export class IonBadge {
 }
 
 
-export declare interface IonBreadcrumb extends Components.IonBreadcrumb {}
+export declare interface IonBreadcrumb extends Components.IonBreadcrumb {
+  /**
+   * Emitted when the breadcrumb has focus. 
+   */
+  ionFocus: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the breadcrumb loses focus. 
+   */
+  ionBlur: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['active', 'color', 'disabled', 'download', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'separator', 'target']
 })
@@ -149,14 +173,9 @@ export declare interface IonBreadcrumb extends Components.IonBreadcrumb {}
   selector: 'ion-breadcrumb',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['active', 'color', 'disabled', 'download', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'separator', 'target'],
-  outputs: ['ionFocus', 'ionBlur']
+  inputs: ['active', 'color', 'disabled', 'download', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'separator', 'target']
 })
 export class IonBreadcrumb {
-  /** Emitted when the breadcrumb has focus. */
-  ionFocus!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the breadcrumb loses focus. */
-  ionBlur!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -166,7 +185,14 @@ export class IonBreadcrumb {
 }
 
 import { BreadcrumbCollapsedClickEventDetail as IBreadcrumbsBreadcrumbCollapsedClickEventDetail } from '@ionic/core';
-export declare interface IonBreadcrumbs extends Components.IonBreadcrumbs {}
+export declare interface IonBreadcrumbs extends Components.IonBreadcrumbs {
+  /**
+   * Emitted when the collapsed indicator is clicked on. 
+   */
+  ionCollapsedClick: EventEmitter<CustomEvent<IBreadcrumbsBreadcrumbCollapsedClickEventDetail>>;
+
+}
+
 @ProxyCmp({
   inputs: ['color', 'itemsAfterCollapse', 'itemsBeforeCollapse', 'maxItems', 'mode']
 })
@@ -174,12 +200,9 @@ export declare interface IonBreadcrumbs extends Components.IonBreadcrumbs {}
   selector: 'ion-breadcrumbs',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['color', 'itemsAfterCollapse', 'itemsBeforeCollapse', 'maxItems', 'mode'],
-  outputs: ['ionCollapsedClick']
+  inputs: ['color', 'itemsAfterCollapse', 'itemsBeforeCollapse', 'maxItems', 'mode']
 })
 export class IonBreadcrumbs {
-  /** Emitted when the collapsed indicator is clicked on. */
-  ionCollapsedClick!: EventEmitter<CustomEvent<IBreadcrumbsBreadcrumbCollapsedClickEventDetail>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -189,7 +212,18 @@ export class IonBreadcrumbs {
 }
 
 
-export declare interface IonButton extends Components.IonButton {}
+export declare interface IonButton extends Components.IonButton {
+  /**
+   * Emitted when the button has focus. 
+   */
+  ionFocus: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the button loses focus. 
+   */
+  ionBlur: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['buttonType', 'color', 'disabled', 'download', 'expand', 'fill', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'shape', 'size', 'strong', 'target', 'type']
 })
@@ -197,14 +231,9 @@ export declare interface IonButton extends Components.IonButton {}
   selector: 'ion-button',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['buttonType', 'color', 'disabled', 'download', 'expand', 'fill', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'shape', 'size', 'strong', 'target', 'type'],
-  outputs: ['ionFocus', 'ionBlur']
+  inputs: ['buttonType', 'color', 'disabled', 'download', 'expand', 'fill', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'shape', 'size', 'strong', 'target', 'type']
 })
 export class IonButton {
-  /** Emitted when the button has focus. */
-  ionFocus!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the button loses focus. */
-  ionBlur!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -215,6 +244,7 @@ export class IonButton {
 
 
 export declare interface IonButtons extends Components.IonButtons {}
+
 @ProxyCmp({
   inputs: ['collapse']
 })
@@ -234,6 +264,7 @@ export class IonButtons {
 
 
 export declare interface IonCard extends Components.IonCard {}
+
 @ProxyCmp({
   inputs: ['button', 'color', 'disabled', 'download', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'target', 'type']
 })
@@ -253,6 +284,7 @@ export class IonCard {
 
 
 export declare interface IonCardContent extends Components.IonCardContent {}
+
 @ProxyCmp({
   inputs: ['mode']
 })
@@ -272,6 +304,7 @@ export class IonCardContent {
 
 
 export declare interface IonCardHeader extends Components.IonCardHeader {}
+
 @ProxyCmp({
   inputs: ['color', 'mode', 'translucent']
 })
@@ -291,6 +324,7 @@ export class IonCardHeader {
 
 
 export declare interface IonCardSubtitle extends Components.IonCardSubtitle {}
+
 @ProxyCmp({
   inputs: ['color', 'mode']
 })
@@ -310,6 +344,7 @@ export class IonCardSubtitle {
 
 
 export declare interface IonCardTitle extends Components.IonCardTitle {}
+
 @ProxyCmp({
   inputs: ['color', 'mode']
 })
@@ -328,7 +363,22 @@ export class IonCardTitle {
 }
 
 import { CheckboxChangeEventDetail as ICheckboxCheckboxChangeEventDetail } from '@ionic/core';
-export declare interface IonCheckbox extends Components.IonCheckbox {}
+export declare interface IonCheckbox extends Components.IonCheckbox {
+  /**
+   * Emitted when the checked property has changed. 
+   */
+  ionChange: EventEmitter<CustomEvent<ICheckboxCheckboxChangeEventDetail>>;
+  /**
+   * Emitted when the checkbox has focus. 
+   */
+  ionFocus: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the checkbox loses focus. 
+   */
+  ionBlur: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['checked', 'color', 'disabled', 'indeterminate', 'mode', 'name', 'value']
 })
@@ -336,16 +386,9 @@ export declare interface IonCheckbox extends Components.IonCheckbox {}
   selector: 'ion-checkbox',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['checked', 'color', 'disabled', 'indeterminate', 'mode', 'name', 'value'],
-  outputs: ['ionChange', 'ionFocus', 'ionBlur']
+  inputs: ['checked', 'color', 'disabled', 'indeterminate', 'mode', 'name', 'value']
 })
 export class IonCheckbox {
-  /** Emitted when the checked property has changed. */
-  ionChange!: EventEmitter<CustomEvent<ICheckboxCheckboxChangeEventDetail>>;
-  /** Emitted when the checkbox has focus. */
-  ionFocus!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the checkbox loses focus. */
-  ionBlur!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -356,6 +399,7 @@ export class IonCheckbox {
 
 
 export declare interface IonChip extends Components.IonChip {}
+
 @ProxyCmp({
   inputs: ['color', 'disabled', 'mode', 'outline']
 })
@@ -375,6 +419,7 @@ export class IonChip {
 
 
 export declare interface IonCol extends Components.IonCol {}
+
 @ProxyCmp({
   inputs: ['offset', 'offsetLg', 'offsetMd', 'offsetSm', 'offsetXl', 'offsetXs', 'pull', 'pullLg', 'pullMd', 'pullSm', 'pullXl', 'pullXs', 'push', 'pushLg', 'pushMd', 'pushSm', 'pushXl', 'pushXs', 'size', 'sizeLg', 'sizeMd', 'sizeSm', 'sizeXl', 'sizeXs']
 })
@@ -394,7 +439,23 @@ export class IonCol {
 
 import { ScrollBaseDetail as IContentScrollBaseDetail } from '@ionic/core';
 import { ScrollDetail as IContentScrollDetail } from '@ionic/core';
-export declare interface IonContent extends Components.IonContent {}
+export declare interface IonContent extends Components.IonContent {
+  /**
+   * Emitted when the scroll has started. 
+   */
+  ionScrollStart: EventEmitter<CustomEvent<IContentScrollBaseDetail>>;
+  /**
+   * Emitted while scrolling. This event is disabled by default.
+Look at the property: `scrollEvents` 
+   */
+  ionScroll: EventEmitter<CustomEvent<IContentScrollDetail>>;
+  /**
+   * Emitted when the scroll has ended. 
+   */
+  ionScrollEnd: EventEmitter<CustomEvent<IContentScrollBaseDetail>>;
+
+}
+
 @ProxyCmp({
   inputs: ['color', 'forceOverscroll', 'fullscreen', 'scrollEvents', 'scrollX', 'scrollY'],
   methods: ['getScrollElement', 'scrollToTop', 'scrollToBottom', 'scrollByPoint', 'scrollToPoint']
@@ -403,17 +464,9 @@ export declare interface IonContent extends Components.IonContent {}
   selector: 'ion-content',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['color', 'forceOverscroll', 'fullscreen', 'scrollEvents', 'scrollX', 'scrollY'],
-  outputs: ['ionScrollStart', 'ionScroll', 'ionScrollEnd']
+  inputs: ['color', 'forceOverscroll', 'fullscreen', 'scrollEvents', 'scrollX', 'scrollY']
 })
 export class IonContent {
-  /** Emitted when the scroll has started. */
-  ionScrollStart!: EventEmitter<CustomEvent<IContentScrollBaseDetail>>;
-  /** Emitted while scrolling. This event is disabled by default.
-Look at the property: `scrollEvents` */
-  ionScroll!: EventEmitter<CustomEvent<IContentScrollDetail>>;
-  /** Emitted when the scroll has ended. */
-  ionScrollEnd!: EventEmitter<CustomEvent<IContentScrollBaseDetail>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -423,7 +476,26 @@ Look at the property: `scrollEvents` */
 }
 
 import { DatetimeChangeEventDetail as IDatetimeDatetimeChangeEventDetail } from '@ionic/core';
-export declare interface IonDatetime extends Components.IonDatetime {}
+export declare interface IonDatetime extends Components.IonDatetime {
+  /**
+   * Emitted when the datetime selection was cancelled. 
+   */
+  ionCancel: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the value (selected date) has changed. 
+   */
+  ionChange: EventEmitter<CustomEvent<IDatetimeDatetimeChangeEventDetail>>;
+  /**
+   * Emitted when the datetime has focus. 
+   */
+  ionFocus: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the datetime loses focus. 
+   */
+  ionBlur: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['cancelText', 'clearText', 'color', 'dayValues', 'disabled', 'doneText', 'firstDayOfWeek', 'hourCycle', 'hourValues', 'locale', 'max', 'min', 'minuteValues', 'mode', 'monthValues', 'name', 'presentation', 'readonly', 'showClearButton', 'showDefaultButtons', 'showDefaultTimeLabel', 'showDefaultTitle', 'size', 'value', 'yearValues'],
   methods: ['confirm', 'reset', 'cancel']
@@ -432,18 +504,9 @@ export declare interface IonDatetime extends Components.IonDatetime {}
   selector: 'ion-datetime',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['cancelText', 'clearText', 'color', 'dayValues', 'disabled', 'doneText', 'firstDayOfWeek', 'hourCycle', 'hourValues', 'locale', 'max', 'min', 'minuteValues', 'mode', 'monthValues', 'name', 'presentation', 'readonly', 'showClearButton', 'showDefaultButtons', 'showDefaultTimeLabel', 'showDefaultTitle', 'size', 'value', 'yearValues'],
-  outputs: ['ionCancel', 'ionChange', 'ionFocus', 'ionBlur']
+  inputs: ['cancelText', 'clearText', 'color', 'dayValues', 'disabled', 'doneText', 'firstDayOfWeek', 'hourCycle', 'hourValues', 'locale', 'max', 'min', 'minuteValues', 'mode', 'monthValues', 'name', 'presentation', 'readonly', 'showClearButton', 'showDefaultButtons', 'showDefaultTimeLabel', 'showDefaultTitle', 'size', 'value', 'yearValues']
 })
 export class IonDatetime {
-  /** Emitted when the datetime selection was cancelled. */
-  ionCancel!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the value (selected date) has changed. */
-  ionChange!: EventEmitter<CustomEvent<IDatetimeDatetimeChangeEventDetail>>;
-  /** Emitted when the datetime has focus. */
-  ionFocus!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the datetime loses focus. */
-  ionBlur!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -454,6 +517,7 @@ export class IonDatetime {
 
 
 export declare interface IonFab extends Components.IonFab {}
+
 @ProxyCmp({
   inputs: ['activated', 'edge', 'horizontal', 'vertical'],
   methods: ['close']
@@ -473,7 +537,18 @@ export class IonFab {
 }
 
 
-export declare interface IonFabButton extends Components.IonFabButton {}
+export declare interface IonFabButton extends Components.IonFabButton {
+  /**
+   * Emitted when the button has focus. 
+   */
+  ionFocus: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the button loses focus. 
+   */
+  ionBlur: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['activated', 'closeIcon', 'color', 'disabled', 'download', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'show', 'size', 'target', 'translucent', 'type']
 })
@@ -481,14 +556,9 @@ export declare interface IonFabButton extends Components.IonFabButton {}
   selector: 'ion-fab-button',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['activated', 'closeIcon', 'color', 'disabled', 'download', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'show', 'size', 'target', 'translucent', 'type'],
-  outputs: ['ionFocus', 'ionBlur']
+  inputs: ['activated', 'closeIcon', 'color', 'disabled', 'download', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'show', 'size', 'target', 'translucent', 'type']
 })
 export class IonFabButton {
-  /** Emitted when the button has focus. */
-  ionFocus!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the button loses focus. */
-  ionBlur!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -499,6 +569,7 @@ export class IonFabButton {
 
 
 export declare interface IonFabList extends Components.IonFabList {}
+
 @ProxyCmp({
   inputs: ['activated', 'side']
 })
@@ -518,6 +589,7 @@ export class IonFabList {
 
 
 export declare interface IonFooter extends Components.IonFooter {}
+
 @ProxyCmp({
   inputs: ['collapse', 'mode', 'translucent']
 })
@@ -537,6 +609,7 @@ export class IonFooter {
 
 
 export declare interface IonGrid extends Components.IonGrid {}
+
 @ProxyCmp({
   inputs: ['fixed']
 })
@@ -556,6 +629,7 @@ export class IonGrid {
 
 
 export declare interface IonHeader extends Components.IonHeader {}
+
 @ProxyCmp({
   inputs: ['collapse', 'mode', 'translucent']
 })
@@ -575,6 +649,7 @@ export class IonHeader {
 
 
 export declare interface IonIcon extends Components.IonIcon {}
+
 @ProxyCmp({
   inputs: ['color', 'flipRtl', 'icon', 'ios', 'lazy', 'md', 'mode', 'name', 'sanitize', 'size', 'src']
 })
@@ -593,7 +668,22 @@ export class IonIcon {
 }
 
 
-export declare interface IonImg extends Components.IonImg {}
+export declare interface IonImg extends Components.IonImg {
+  /**
+   * Emitted when the img src has been set 
+   */
+  ionImgWillLoad: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the image has finished loading 
+   */
+  ionImgDidLoad: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the img fails to load 
+   */
+  ionError: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['alt', 'src']
 })
@@ -601,16 +691,9 @@ export declare interface IonImg extends Components.IonImg {}
   selector: 'ion-img',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['alt', 'src'],
-  outputs: ['ionImgWillLoad', 'ionImgDidLoad', 'ionError']
+  inputs: ['alt', 'src']
 })
 export class IonImg {
-  /** Emitted when the img src has been set */
-  ionImgWillLoad!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the image has finished loading */
-  ionImgDidLoad!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the img fails to load */
-  ionError!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -620,7 +703,17 @@ export class IonImg {
 }
 
 
-export declare interface IonInfiniteScroll extends Components.IonInfiniteScroll {}
+export declare interface IonInfiniteScroll extends Components.IonInfiniteScroll {
+  /**
+   * Emitted when the scroll reaches
+the threshold distance. From within your infinite handler,
+you must call the infinite scroll's `complete()` method when
+your async operation has completed. 
+   */
+  ionInfinite: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['disabled', 'position', 'threshold'],
   methods: ['complete']
@@ -629,15 +722,9 @@ export declare interface IonInfiniteScroll extends Components.IonInfiniteScroll 
   selector: 'ion-infinite-scroll',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['disabled', 'position', 'threshold'],
-  outputs: ['ionInfinite']
+  inputs: ['disabled', 'position', 'threshold']
 })
 export class IonInfiniteScroll {
-  /** Emitted when the scroll reaches
-the threshold distance. From within your infinite handler,
-you must call the infinite scroll's `complete()` method when
-your async operation has completed. */
-  ionInfinite!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -648,6 +735,7 @@ your async operation has completed. */
 
 
 export declare interface IonInfiniteScrollContent extends Components.IonInfiniteScrollContent {}
+
 @ProxyCmp({
   inputs: ['loadingSpinner', 'loadingText']
 })
@@ -666,7 +754,26 @@ export class IonInfiniteScrollContent {
 }
 
 import { InputChangeEventDetail as IInputInputChangeEventDetail } from '@ionic/core';
-export declare interface IonInput extends Components.IonInput {}
+export declare interface IonInput extends Components.IonInput {
+  /**
+   * Emitted when a keyboard input occurred. 
+   */
+  ionInput: EventEmitter<CustomEvent<InputEvent>>;
+  /**
+   * Emitted when the value has changed. 
+   */
+  ionChange: EventEmitter<CustomEvent<IInputInputChangeEventDetail>>;
+  /**
+   * Emitted when the input loses focus. 
+   */
+  ionBlur: EventEmitter<CustomEvent<FocusEvent>>;
+  /**
+   * Emitted when the input has focus. 
+   */
+  ionFocus: EventEmitter<CustomEvent<FocusEvent>>;
+
+}
+
 @ProxyCmp({
   inputs: ['accept', 'autocapitalize', 'autocomplete', 'autocorrect', 'autofocus', 'clearInput', 'clearOnEdit', 'color', 'debounce', 'disabled', 'enterkeyhint', 'inputmode', 'max', 'maxlength', 'min', 'minlength', 'mode', 'multiple', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'size', 'spellcheck', 'step', 'type', 'value'],
   methods: ['setFocus', 'getInputElement']
@@ -675,18 +782,9 @@ export declare interface IonInput extends Components.IonInput {}
   selector: 'ion-input',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['accept', 'autocapitalize', 'autocomplete', 'autocorrect', 'autofocus', 'clearInput', 'clearOnEdit', 'color', 'debounce', 'disabled', 'enterkeyhint', 'inputmode', 'max', 'maxlength', 'min', 'minlength', 'mode', 'multiple', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'size', 'spellcheck', 'step', 'type', 'value'],
-  outputs: ['ionInput', 'ionChange', 'ionBlur', 'ionFocus']
+  inputs: ['accept', 'autocapitalize', 'autocomplete', 'autocorrect', 'autofocus', 'clearInput', 'clearOnEdit', 'color', 'debounce', 'disabled', 'enterkeyhint', 'inputmode', 'max', 'maxlength', 'min', 'minlength', 'mode', 'multiple', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'size', 'spellcheck', 'step', 'type', 'value']
 })
 export class IonInput {
-  /** Emitted when a keyboard input occurred. */
-  ionInput!: EventEmitter<CustomEvent<InputEvent>>;
-  /** Emitted when the value has changed. */
-  ionChange!: EventEmitter<CustomEvent<IInputInputChangeEventDetail>>;
-  /** Emitted when the input loses focus. */
-  ionBlur!: EventEmitter<CustomEvent<FocusEvent>>;
-  /** Emitted when the input has focus. */
-  ionFocus!: EventEmitter<CustomEvent<FocusEvent>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -697,6 +795,7 @@ export class IonInput {
 
 
 export declare interface IonItem extends Components.IonItem {}
+
 @ProxyCmp({
   inputs: ['button', 'color', 'counter', 'detail', 'detailIcon', 'disabled', 'download', 'fill', 'href', 'lines', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'shape', 'target', 'type']
 })
@@ -716,6 +815,7 @@ export class IonItem {
 
 
 export declare interface IonItemDivider extends Components.IonItemDivider {}
+
 @ProxyCmp({
   inputs: ['color', 'mode', 'sticky']
 })
@@ -736,6 +836,7 @@ export class IonItemDivider {
 
 export declare interface IonItemGroup extends Components.IonItemGroup {}
 
+
 @Component({
   selector: 'ion-item-group',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -751,6 +852,7 @@ export class IonItemGroup {
 
 
 export declare interface IonItemOption extends Components.IonItemOption {}
+
 @ProxyCmp({
   inputs: ['color', 'disabled', 'download', 'expandable', 'href', 'mode', 'rel', 'target', 'type']
 })
@@ -769,7 +871,14 @@ export class IonItemOption {
 }
 
 
-export declare interface IonItemOptions extends Components.IonItemOptions {}
+export declare interface IonItemOptions extends Components.IonItemOptions {
+  /**
+   * Emitted when the item has been fully swiped. 
+   */
+  ionSwipe: EventEmitter<CustomEvent<any>>;
+
+}
+
 @ProxyCmp({
   inputs: ['side']
 })
@@ -777,12 +886,9 @@ export declare interface IonItemOptions extends Components.IonItemOptions {}
   selector: 'ion-item-options',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['side'],
-  outputs: ['ionSwipe']
+  inputs: ['side']
 })
 export class IonItemOptions {
-  /** Emitted when the item has been fully swiped. */
-  ionSwipe!: EventEmitter<CustomEvent<any>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -792,7 +898,14 @@ export class IonItemOptions {
 }
 
 
-export declare interface IonItemSliding extends Components.IonItemSliding {}
+export declare interface IonItemSliding extends Components.IonItemSliding {
+  /**
+   * Emitted when the sliding position changes. 
+   */
+  ionDrag: EventEmitter<CustomEvent<any>>;
+
+}
+
 @ProxyCmp({
   inputs: ['disabled'],
   methods: ['getOpenAmount', 'getSlidingRatio', 'open', 'close', 'closeOpened']
@@ -801,12 +914,9 @@ export declare interface IonItemSliding extends Components.IonItemSliding {}
   selector: 'ion-item-sliding',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['disabled'],
-  outputs: ['ionDrag']
+  inputs: ['disabled']
 })
 export class IonItemSliding {
-  /** Emitted when the sliding position changes. */
-  ionDrag!: EventEmitter<CustomEvent<any>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -817,6 +927,7 @@ export class IonItemSliding {
 
 
 export declare interface IonLabel extends Components.IonLabel {}
+
 @ProxyCmp({
   inputs: ['color', 'mode', 'position']
 })
@@ -836,6 +947,7 @@ export class IonLabel {
 
 
 export declare interface IonList extends Components.IonList {}
+
 @ProxyCmp({
   inputs: ['inset', 'lines', 'mode'],
   methods: ['closeSlidingItems']
@@ -856,6 +968,7 @@ export class IonList {
 
 
 export declare interface IonListHeader extends Components.IonListHeader {}
+
 @ProxyCmp({
   inputs: ['color', 'lines', 'mode']
 })
@@ -874,7 +987,26 @@ export class IonListHeader {
 }
 
 
-export declare interface IonMenu extends Components.IonMenu {}
+export declare interface IonMenu extends Components.IonMenu {
+  /**
+   * Emitted when the menu is about to be opened. 
+   */
+  ionWillOpen: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the menu is about to be closed. 
+   */
+  ionWillClose: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the menu is open. 
+   */
+  ionDidOpen: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the menu is closed. 
+   */
+  ionDidClose: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['contentId', 'disabled', 'maxEdgeStart', 'menuId', 'side', 'swipeGesture', 'type'],
   methods: ['isOpen', 'isActive', 'open', 'close', 'toggle', 'setOpen']
@@ -883,18 +1015,9 @@ export declare interface IonMenu extends Components.IonMenu {}
   selector: 'ion-menu',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['contentId', 'disabled', 'maxEdgeStart', 'menuId', 'side', 'swipeGesture', 'type'],
-  outputs: ['ionWillOpen', 'ionWillClose', 'ionDidOpen', 'ionDidClose']
+  inputs: ['contentId', 'disabled', 'maxEdgeStart', 'menuId', 'side', 'swipeGesture', 'type']
 })
 export class IonMenu {
-  /** Emitted when the menu is about to be opened. */
-  ionWillOpen!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the menu is about to be closed. */
-  ionWillClose!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the menu is open. */
-  ionDidOpen!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the menu is closed. */
-  ionDidClose!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -905,6 +1028,7 @@ export class IonMenu {
 
 
 export declare interface IonMenuButton extends Components.IonMenuButton {}
+
 @ProxyCmp({
   inputs: ['autoHide', 'color', 'disabled', 'menu', 'mode', 'type']
 })
@@ -924,6 +1048,7 @@ export class IonMenuButton {
 
 
 export declare interface IonMenuToggle extends Components.IonMenuToggle {}
+
 @ProxyCmp({
   inputs: ['autoHide', 'menu']
 })
@@ -942,7 +1067,18 @@ export class IonMenuToggle {
 }
 
 
-export declare interface IonNav extends Components.IonNav {}
+export declare interface IonNav extends Components.IonNav {
+  /**
+   * Event fired when the nav will change components 
+   */
+  ionNavWillChange: EventEmitter<CustomEvent<void>>;
+  /**
+   * Event fired when the nav has changed components 
+   */
+  ionNavDidChange: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['animated', 'animation', 'root', 'rootParams', 'swipeGesture'],
   methods: ['push', 'insert', 'insertPages', 'pop', 'popTo', 'popToRoot', 'removeIndex', 'setRoot', 'setPages', 'getActive', 'getByIndex', 'canGoBack', 'getPrevious']
@@ -951,14 +1087,9 @@ export declare interface IonNav extends Components.IonNav {}
   selector: 'ion-nav',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['animated', 'animation', 'root', 'rootParams', 'swipeGesture'],
-  outputs: ['ionNavWillChange', 'ionNavDidChange']
+  inputs: ['animated', 'animation', 'root', 'rootParams', 'swipeGesture']
 })
 export class IonNav {
-  /** Event fired when the nav will change components */
-  ionNavWillChange!: EventEmitter<CustomEvent<void>>;
-  /** Event fired when the nav has changed components */
-  ionNavDidChange!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -969,6 +1100,7 @@ export class IonNav {
 
 
 export declare interface IonNavLink extends Components.IonNavLink {}
+
 @ProxyCmp({
   inputs: ['component', 'componentProps', 'routerAnimation', 'routerDirection']
 })
@@ -988,6 +1120,7 @@ export class IonNavLink {
 
 
 export declare interface IonNote extends Components.IonNote {}
+
 @ProxyCmp({
   inputs: ['color', 'mode']
 })
@@ -1007,6 +1140,7 @@ export class IonNote {
 
 
 export declare interface IonProgressBar extends Components.IonProgressBar {}
+
 @ProxyCmp({
   inputs: ['buffer', 'color', 'mode', 'reversed', 'type', 'value']
 })
@@ -1025,7 +1159,18 @@ export class IonProgressBar {
 }
 
 
-export declare interface IonRadio extends Components.IonRadio {}
+export declare interface IonRadio extends Components.IonRadio {
+  /**
+   * Emitted when the radio button has focus. 
+   */
+  ionFocus: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the radio button loses focus. 
+   */
+  ionBlur: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['color', 'disabled', 'mode', 'name', 'value']
 })
@@ -1033,14 +1178,9 @@ export declare interface IonRadio extends Components.IonRadio {}
   selector: 'ion-radio',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['color', 'disabled', 'mode', 'name', 'value'],
-  outputs: ['ionFocus', 'ionBlur']
+  inputs: ['color', 'disabled', 'mode', 'name', 'value']
 })
 export class IonRadio {
-  /** Emitted when the radio button has focus. */
-  ionFocus!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the radio button loses focus. */
-  ionBlur!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -1050,7 +1190,14 @@ export class IonRadio {
 }
 
 import { RadioGroupChangeEventDetail as IRadioGroupRadioGroupChangeEventDetail } from '@ionic/core';
-export declare interface IonRadioGroup extends Components.IonRadioGroup {}
+export declare interface IonRadioGroup extends Components.IonRadioGroup {
+  /**
+   * Emitted when the value has changed. 
+   */
+  ionChange: EventEmitter<CustomEvent<IRadioGroupRadioGroupChangeEventDetail>>;
+
+}
+
 @ProxyCmp({
   inputs: ['allowEmptySelection', 'name', 'value']
 })
@@ -1058,12 +1205,9 @@ export declare interface IonRadioGroup extends Components.IonRadioGroup {}
   selector: 'ion-radio-group',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['allowEmptySelection', 'name', 'value'],
-  outputs: ['ionChange']
+  inputs: ['allowEmptySelection', 'name', 'value']
 })
 export class IonRadioGroup {
-  /** Emitted when the value has changed. */
-  ionChange!: EventEmitter<CustomEvent<IRadioGroupRadioGroupChangeEventDetail>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -1073,7 +1217,22 @@ export class IonRadioGroup {
 }
 
 import { RangeChangeEventDetail as IRangeRangeChangeEventDetail } from '@ionic/core';
-export declare interface IonRange extends Components.IonRange {}
+export declare interface IonRange extends Components.IonRange {
+  /**
+   * Emitted when the value property has changed. 
+   */
+  ionChange: EventEmitter<CustomEvent<IRangeRangeChangeEventDetail>>;
+  /**
+   * Emitted when the range has focus. 
+   */
+  ionFocus: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the range loses focus. 
+   */
+  ionBlur: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['color', 'debounce', 'disabled', 'dualKnobs', 'max', 'min', 'mode', 'name', 'pin', 'pinFormatter', 'snaps', 'step', 'ticks', 'value']
 })
@@ -1081,16 +1240,9 @@ export declare interface IonRange extends Components.IonRange {}
   selector: 'ion-range',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['color', 'debounce', 'disabled', 'dualKnobs', 'max', 'min', 'mode', 'name', 'pin', 'pinFormatter', 'snaps', 'step', 'ticks', 'value'],
-  outputs: ['ionChange', 'ionFocus', 'ionBlur']
+  inputs: ['color', 'debounce', 'disabled', 'dualKnobs', 'max', 'min', 'mode', 'name', 'pin', 'pinFormatter', 'snaps', 'step', 'ticks', 'value']
 })
 export class IonRange {
-  /** Emitted when the value property has changed. */
-  ionChange!: EventEmitter<CustomEvent<IRangeRangeChangeEventDetail>>;
-  /** Emitted when the range has focus. */
-  ionFocus!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the range loses focus. */
-  ionBlur!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -1100,7 +1252,25 @@ export class IonRange {
 }
 
 import { RefresherEventDetail as IRefresherRefresherEventDetail } from '@ionic/core';
-export declare interface IonRefresher extends Components.IonRefresher {}
+export declare interface IonRefresher extends Components.IonRefresher {
+  /**
+   * Emitted when the user lets go of the content and has pulled down
+further than the `pullMin` or pulls the content down and exceeds the pullMax.
+Updates the refresher state to `refreshing`. The `complete()` method should be
+called when the async operation has completed. 
+   */
+  ionRefresh: EventEmitter<CustomEvent<IRefresherRefresherEventDetail>>;
+  /**
+   * Emitted while the user is pulling down the content and exposing the refresher. 
+   */
+  ionPull: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the user begins to start pulling down. 
+   */
+  ionStart: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['closeDuration', 'disabled', 'pullFactor', 'pullMax', 'pullMin', 'snapbackDuration'],
   methods: ['complete', 'cancel', 'getProgress']
@@ -1109,19 +1279,9 @@ export declare interface IonRefresher extends Components.IonRefresher {}
   selector: 'ion-refresher',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['closeDuration', 'disabled', 'pullFactor', 'pullMax', 'pullMin', 'snapbackDuration'],
-  outputs: ['ionRefresh', 'ionPull', 'ionStart']
+  inputs: ['closeDuration', 'disabled', 'pullFactor', 'pullMax', 'pullMin', 'snapbackDuration']
 })
 export class IonRefresher {
-  /** Emitted when the user lets go of the content and has pulled down
-further than the `pullMin` or pulls the content down and exceeds the pullMax.
-Updates the refresher state to `refreshing`. The `complete()` method should be
-called when the async operation has completed. */
-  ionRefresh!: EventEmitter<CustomEvent<IRefresherRefresherEventDetail>>;
-  /** Emitted while the user is pulling down the content and exposing the refresher. */
-  ionPull!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the user begins to start pulling down. */
-  ionStart!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -1132,6 +1292,7 @@ called when the async operation has completed. */
 
 
 export declare interface IonRefresherContent extends Components.IonRefresherContent {}
+
 @ProxyCmp({
   inputs: ['pullingIcon', 'pullingText', 'refreshingSpinner', 'refreshingText']
 })
@@ -1152,6 +1313,7 @@ export class IonRefresherContent {
 
 export declare interface IonReorder extends Components.IonReorder {}
 
+
 @Component({
   selector: 'ion-reorder',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -1166,7 +1328,16 @@ export class IonReorder {
 }
 
 import { ItemReorderEventDetail as IReorderGroupItemReorderEventDetail } from '@ionic/core';
-export declare interface IonReorderGroup extends Components.IonReorderGroup {}
+export declare interface IonReorderGroup extends Components.IonReorderGroup {
+  /**
+   * Event that needs to be listened to in order to complete the reorder action.
+Once the event has been emitted, the `complete()` method then needs
+to be called in order to finalize the reorder action. 
+   */
+  ionItemReorder: EventEmitter<CustomEvent<IReorderGroupItemReorderEventDetail>>;
+
+}
+
 @ProxyCmp({
   inputs: ['disabled'],
   methods: ['complete']
@@ -1175,14 +1346,9 @@ export declare interface IonReorderGroup extends Components.IonReorderGroup {}
   selector: 'ion-reorder-group',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['disabled'],
-  outputs: ['ionItemReorder']
+  inputs: ['disabled']
 })
 export class IonReorderGroup {
-  /** Event that needs to be listened to in order to complete the reorder action.
-Once the event has been emitted, the `complete()` method then needs
-to be called in order to finalize the reorder action. */
-  ionItemReorder!: EventEmitter<CustomEvent<IReorderGroupItemReorderEventDetail>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -1193,6 +1359,7 @@ to be called in order to finalize the reorder action. */
 
 
 export declare interface IonRippleEffect extends Components.IonRippleEffect {}
+
 @ProxyCmp({
   inputs: ['type'],
   methods: ['addRipple']
@@ -1214,6 +1381,7 @@ export class IonRippleEffect {
 
 export declare interface IonRow extends Components.IonRow {}
 
+
 @Component({
   selector: 'ion-row',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -1228,7 +1396,34 @@ export class IonRow {
 }
 
 import { SearchbarChangeEventDetail as ISearchbarSearchbarChangeEventDetail } from '@ionic/core';
-export declare interface IonSearchbar extends Components.IonSearchbar {}
+export declare interface IonSearchbar extends Components.IonSearchbar {
+  /**
+   * Emitted when a keyboard input occurred. 
+   */
+  ionInput: EventEmitter<CustomEvent<KeyboardEvent>>;
+  /**
+   * Emitted when the value has changed. 
+   */
+  ionChange: EventEmitter<CustomEvent<ISearchbarSearchbarChangeEventDetail>>;
+  /**
+   * Emitted when the cancel button is clicked. 
+   */
+  ionCancel: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the clear input button is clicked. 
+   */
+  ionClear: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the input loses focus. 
+   */
+  ionBlur: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the input has focus. 
+   */
+  ionFocus: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['animated', 'autocomplete', 'autocorrect', 'cancelButtonIcon', 'cancelButtonText', 'clearIcon', 'color', 'debounce', 'disabled', 'enterkeyhint', 'inputmode', 'mode', 'placeholder', 'searchIcon', 'showCancelButton', 'showClearButton', 'spellcheck', 'type', 'value'],
   methods: ['setFocus', 'getInputElement']
@@ -1237,22 +1432,9 @@ export declare interface IonSearchbar extends Components.IonSearchbar {}
   selector: 'ion-searchbar',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['animated', 'autocomplete', 'autocorrect', 'cancelButtonIcon', 'cancelButtonText', 'clearIcon', 'color', 'debounce', 'disabled', 'enterkeyhint', 'inputmode', 'mode', 'placeholder', 'searchIcon', 'showCancelButton', 'showClearButton', 'spellcheck', 'type', 'value'],
-  outputs: ['ionInput', 'ionChange', 'ionCancel', 'ionClear', 'ionBlur', 'ionFocus']
+  inputs: ['animated', 'autocomplete', 'autocorrect', 'cancelButtonIcon', 'cancelButtonText', 'clearIcon', 'color', 'debounce', 'disabled', 'enterkeyhint', 'inputmode', 'mode', 'placeholder', 'searchIcon', 'showCancelButton', 'showClearButton', 'spellcheck', 'type', 'value']
 })
 export class IonSearchbar {
-  /** Emitted when a keyboard input occurred. */
-  ionInput!: EventEmitter<CustomEvent<KeyboardEvent>>;
-  /** Emitted when the value has changed. */
-  ionChange!: EventEmitter<CustomEvent<ISearchbarSearchbarChangeEventDetail>>;
-  /** Emitted when the cancel button is clicked. */
-  ionCancel!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the clear input button is clicked. */
-  ionClear!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the input loses focus. */
-  ionBlur!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the input has focus. */
-  ionFocus!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -1262,7 +1444,15 @@ export class IonSearchbar {
 }
 
 import { SegmentChangeEventDetail as ISegmentSegmentChangeEventDetail } from '@ionic/core';
-export declare interface IonSegment extends Components.IonSegment {}
+export declare interface IonSegment extends Components.IonSegment {
+  /**
+   * Emitted when the value property has changed and any
+dragging pointer has been released from `ion-segment`. 
+   */
+  ionChange: EventEmitter<CustomEvent<ISegmentSegmentChangeEventDetail>>;
+
+}
+
 @ProxyCmp({
   inputs: ['color', 'disabled', 'mode', 'scrollable', 'selectOnFocus', 'swipeGesture', 'value']
 })
@@ -1270,13 +1460,9 @@ export declare interface IonSegment extends Components.IonSegment {}
   selector: 'ion-segment',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['color', 'disabled', 'mode', 'scrollable', 'selectOnFocus', 'swipeGesture', 'value'],
-  outputs: ['ionChange']
+  inputs: ['color', 'disabled', 'mode', 'scrollable', 'selectOnFocus', 'swipeGesture', 'value']
 })
 export class IonSegment {
-  /** Emitted when the value property has changed and any
-dragging pointer has been released from `ion-segment`. */
-  ionChange!: EventEmitter<CustomEvent<ISegmentSegmentChangeEventDetail>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -1287,6 +1473,7 @@ dragging pointer has been released from `ion-segment`. */
 
 
 export declare interface IonSegmentButton extends Components.IonSegmentButton {}
+
 @ProxyCmp({
   inputs: ['disabled', 'layout', 'mode', 'type', 'value']
 })
@@ -1305,7 +1492,26 @@ export class IonSegmentButton {
 }
 
 import { SelectChangeEventDetail as ISelectSelectChangeEventDetail } from '@ionic/core';
-export declare interface IonSelect extends Components.IonSelect {}
+export declare interface IonSelect extends Components.IonSelect {
+  /**
+   * Emitted when the value has changed. 
+   */
+  ionChange: EventEmitter<CustomEvent<ISelectSelectChangeEventDetail>>;
+  /**
+   * Emitted when the selection is cancelled. 
+   */
+  ionCancel: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the select has focus. 
+   */
+  ionFocus: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the select loses focus. 
+   */
+  ionBlur: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['cancelText', 'compareWith', 'disabled', 'interface', 'interfaceOptions', 'mode', 'multiple', 'name', 'okText', 'placeholder', 'selectedText', 'value'],
   methods: ['open']
@@ -1314,18 +1520,9 @@ export declare interface IonSelect extends Components.IonSelect {}
   selector: 'ion-select',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['cancelText', 'compareWith', 'disabled', 'interface', 'interfaceOptions', 'mode', 'multiple', 'name', 'okText', 'placeholder', 'selectedText', 'value'],
-  outputs: ['ionChange', 'ionCancel', 'ionFocus', 'ionBlur']
+  inputs: ['cancelText', 'compareWith', 'disabled', 'interface', 'interfaceOptions', 'mode', 'multiple', 'name', 'okText', 'placeholder', 'selectedText', 'value']
 })
 export class IonSelect {
-  /** Emitted when the value has changed. */
-  ionChange!: EventEmitter<CustomEvent<ISelectSelectChangeEventDetail>>;
-  /** Emitted when the selection is cancelled. */
-  ionCancel!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the select has focus. */
-  ionFocus!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the select loses focus. */
-  ionBlur!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -1336,6 +1533,7 @@ export class IonSelect {
 
 
 export declare interface IonSelectOption extends Components.IonSelectOption {}
+
 @ProxyCmp({
   inputs: ['disabled', 'value']
 })
@@ -1355,6 +1553,7 @@ export class IonSelectOption {
 
 
 export declare interface IonSkeletonText extends Components.IonSkeletonText {}
+
 @ProxyCmp({
   inputs: ['animated']
 })
@@ -1375,6 +1574,7 @@ export class IonSkeletonText {
 
 export declare interface IonSlide extends Components.IonSlide {}
 
+
 @Component({
   selector: 'ion-slide',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -1389,7 +1589,74 @@ export class IonSlide {
 }
 
 
-export declare interface IonSlides extends Components.IonSlides {}
+export declare interface IonSlides extends Components.IonSlides {
+  /**
+   * Emitted after Swiper initialization 
+   */
+  ionSlidesDidLoad: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the user taps/clicks on the slide's container. 
+   */
+  ionSlideTap: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the user double taps on the slide's container. 
+   */
+  ionSlideDoubleTap: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted before the active slide has changed. 
+   */
+  ionSlideWillChange: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted after the active slide has changed. 
+   */
+  ionSlideDidChange: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the next slide has started. 
+   */
+  ionSlideNextStart: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the previous slide has started. 
+   */
+  ionSlidePrevStart: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the next slide has ended. 
+   */
+  ionSlideNextEnd: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the previous slide has ended. 
+   */
+  ionSlidePrevEnd: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the slide transition has started. 
+   */
+  ionSlideTransitionStart: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the slide transition has ended. 
+   */
+  ionSlideTransitionEnd: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the slider is actively being moved. 
+   */
+  ionSlideDrag: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the slider is at its initial position. 
+   */
+  ionSlideReachStart: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the slider is at the last slide. 
+   */
+  ionSlideReachEnd: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the user first touches the slider. 
+   */
+  ionSlideTouchStart: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the user releases the touch. 
+   */
+  ionSlideTouchEnd: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['mode', 'options', 'pager', 'scrollbar'],
   methods: ['update', 'updateAutoHeight', 'slideTo', 'slideNext', 'slidePrev', 'getActiveIndex', 'getPreviousIndex', 'length', 'isEnd', 'isBeginning', 'startAutoplay', 'stopAutoplay', 'lockSwipeToNext', 'lockSwipeToPrev', 'lockSwipes', 'getSwiper']
@@ -1398,42 +1665,9 @@ export declare interface IonSlides extends Components.IonSlides {}
   selector: 'ion-slides',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['mode', 'options', 'pager', 'scrollbar'],
-  outputs: ['ionSlidesDidLoad', 'ionSlideTap', 'ionSlideDoubleTap', 'ionSlideWillChange', 'ionSlideDidChange', 'ionSlideNextStart', 'ionSlidePrevStart', 'ionSlideNextEnd', 'ionSlidePrevEnd', 'ionSlideTransitionStart', 'ionSlideTransitionEnd', 'ionSlideDrag', 'ionSlideReachStart', 'ionSlideReachEnd', 'ionSlideTouchStart', 'ionSlideTouchEnd']
+  inputs: ['mode', 'options', 'pager', 'scrollbar']
 })
 export class IonSlides {
-  /** Emitted after Swiper initialization */
-  ionSlidesDidLoad!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the user taps/clicks on the slide's container. */
-  ionSlideTap!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the user double taps on the slide's container. */
-  ionSlideDoubleTap!: EventEmitter<CustomEvent<void>>;
-  /** Emitted before the active slide has changed. */
-  ionSlideWillChange!: EventEmitter<CustomEvent<void>>;
-  /** Emitted after the active slide has changed. */
-  ionSlideDidChange!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the next slide has started. */
-  ionSlideNextStart!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the previous slide has started. */
-  ionSlidePrevStart!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the next slide has ended. */
-  ionSlideNextEnd!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the previous slide has ended. */
-  ionSlidePrevEnd!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the slide transition has started. */
-  ionSlideTransitionStart!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the slide transition has ended. */
-  ionSlideTransitionEnd!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the slider is actively being moved. */
-  ionSlideDrag!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the slider is at its initial position. */
-  ionSlideReachStart!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the slider is at the last slide. */
-  ionSlideReachEnd!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the user first touches the slider. */
-  ionSlideTouchStart!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the user releases the touch. */
-  ionSlideTouchEnd!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -1444,6 +1678,7 @@ export class IonSlides {
 
 
 export declare interface IonSpinner extends Components.IonSpinner {}
+
 @ProxyCmp({
   inputs: ['color', 'duration', 'name', 'paused']
 })
@@ -1462,7 +1697,14 @@ export class IonSpinner {
 }
 
 
-export declare interface IonSplitPane extends Components.IonSplitPane {}
+export declare interface IonSplitPane extends Components.IonSplitPane {
+  /**
+   * Expression to be called when the split-pane visibility has changed 
+   */
+  ionSplitPaneVisible: EventEmitter<CustomEvent<{visible: boolean}>>;
+
+}
+
 @ProxyCmp({
   inputs: ['contentId', 'disabled', 'when']
 })
@@ -1470,12 +1712,9 @@ export declare interface IonSplitPane extends Components.IonSplitPane {}
   selector: 'ion-split-pane',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['contentId', 'disabled', 'when'],
-  outputs: ['ionSplitPaneVisible']
+  inputs: ['contentId', 'disabled', 'when']
 })
 export class IonSplitPane {
-  /** Expression to be called when the split-pane visibility has changed */
-  ionSplitPaneVisible!: EventEmitter<CustomEvent<{visible: boolean}>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -1486,6 +1725,7 @@ export class IonSplitPane {
 
 
 export declare interface IonTabBar extends Components.IonTabBar {}
+
 @ProxyCmp({
   inputs: ['color', 'mode', 'selectedTab', 'translucent']
 })
@@ -1505,6 +1745,7 @@ export class IonTabBar {
 
 
 export declare interface IonTabButton extends Components.IonTabButton {}
+
 @ProxyCmp({
   inputs: ['disabled', 'download', 'href', 'layout', 'mode', 'rel', 'selected', 'tab', 'target']
 })
@@ -1524,6 +1765,7 @@ export class IonTabButton {
 
 
 export declare interface IonText extends Components.IonText {}
+
 @ProxyCmp({
   inputs: ['color', 'mode']
 })
@@ -1542,7 +1784,26 @@ export class IonText {
 }
 
 import { TextareaChangeEventDetail as ITextareaTextareaChangeEventDetail } from '@ionic/core';
-export declare interface IonTextarea extends Components.IonTextarea {}
+export declare interface IonTextarea extends Components.IonTextarea {
+  /**
+   * Emitted when the input value has changed. 
+   */
+  ionChange: EventEmitter<CustomEvent<ITextareaTextareaChangeEventDetail>>;
+  /**
+   * Emitted when a keyboard input occurred. 
+   */
+  ionInput: EventEmitter<CustomEvent<InputEvent>>;
+  /**
+   * Emitted when the input loses focus. 
+   */
+  ionBlur: EventEmitter<CustomEvent<FocusEvent>>;
+  /**
+   * Emitted when the input has focus. 
+   */
+  ionFocus: EventEmitter<CustomEvent<FocusEvent>>;
+
+}
+
 @ProxyCmp({
   inputs: ['autoGrow', 'autocapitalize', 'autofocus', 'clearOnEdit', 'color', 'cols', 'debounce', 'disabled', 'enterkeyhint', 'inputmode', 'maxlength', 'minlength', 'mode', 'name', 'placeholder', 'readonly', 'required', 'rows', 'spellcheck', 'value', 'wrap'],
   methods: ['setFocus', 'getInputElement']
@@ -1551,18 +1812,9 @@ export declare interface IonTextarea extends Components.IonTextarea {}
   selector: 'ion-textarea',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['autoGrow', 'autocapitalize', 'autofocus', 'clearOnEdit', 'color', 'cols', 'debounce', 'disabled', 'enterkeyhint', 'inputmode', 'maxlength', 'minlength', 'mode', 'name', 'placeholder', 'readonly', 'required', 'rows', 'spellcheck', 'value', 'wrap'],
-  outputs: ['ionChange', 'ionInput', 'ionBlur', 'ionFocus']
+  inputs: ['autoGrow', 'autocapitalize', 'autofocus', 'clearOnEdit', 'color', 'cols', 'debounce', 'disabled', 'enterkeyhint', 'inputmode', 'maxlength', 'minlength', 'mode', 'name', 'placeholder', 'readonly', 'required', 'rows', 'spellcheck', 'value', 'wrap']
 })
 export class IonTextarea {
-  /** Emitted when the input value has changed. */
-  ionChange!: EventEmitter<CustomEvent<ITextareaTextareaChangeEventDetail>>;
-  /** Emitted when a keyboard input occurred. */
-  ionInput!: EventEmitter<CustomEvent<InputEvent>>;
-  /** Emitted when the input loses focus. */
-  ionBlur!: EventEmitter<CustomEvent<FocusEvent>>;
-  /** Emitted when the input has focus. */
-  ionFocus!: EventEmitter<CustomEvent<FocusEvent>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -1573,6 +1825,7 @@ export class IonTextarea {
 
 
 export declare interface IonThumbnail extends Components.IonThumbnail {}
+
 
 @Component({
   selector: 'ion-thumbnail',
@@ -1589,6 +1842,7 @@ export class IonThumbnail {
 
 
 export declare interface IonTitle extends Components.IonTitle {}
+
 @ProxyCmp({
   inputs: ['color', 'size']
 })
@@ -1607,7 +1861,22 @@ export class IonTitle {
 }
 
 import { ToggleChangeEventDetail as IToggleToggleChangeEventDetail } from '@ionic/core';
-export declare interface IonToggle extends Components.IonToggle {}
+export declare interface IonToggle extends Components.IonToggle {
+  /**
+   * Emitted when the value property has changed. 
+   */
+  ionChange: EventEmitter<CustomEvent<IToggleToggleChangeEventDetail>>;
+  /**
+   * Emitted when the toggle has focus. 
+   */
+  ionFocus: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the toggle loses focus. 
+   */
+  ionBlur: EventEmitter<CustomEvent<void>>;
+
+}
+
 @ProxyCmp({
   inputs: ['checked', 'color', 'disabled', 'mode', 'name', 'value']
 })
@@ -1615,16 +1884,9 @@ export declare interface IonToggle extends Components.IonToggle {}
   selector: 'ion-toggle',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['checked', 'color', 'disabled', 'mode', 'name', 'value'],
-  outputs: ['ionChange', 'ionFocus', 'ionBlur']
+  inputs: ['checked', 'color', 'disabled', 'mode', 'name', 'value']
 })
 export class IonToggle {
-  /** Emitted when the value property has changed. */
-  ionChange!: EventEmitter<CustomEvent<IToggleToggleChangeEventDetail>>;
-  /** Emitted when the toggle has focus. */
-  ionFocus!: EventEmitter<CustomEvent<void>>;
-  /** Emitted when the toggle loses focus. */
-  ionBlur!: EventEmitter<CustomEvent<void>>;
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -1635,6 +1897,7 @@ export class IonToggle {
 
 
 export declare interface IonToolbar extends Components.IonToolbar {}
+
 @ProxyCmp({
   inputs: ['color', 'mode']
 })

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -18,7 +18,7 @@
         "@jest/core": "^26.6.3",
         "@rollup/plugin-node-resolve": "^8.4.0",
         "@rollup/plugin-virtual": "^2.0.3",
-        "@stencil/angular-output-target": "^0.2.0",
+        "@stencil/angular-output-target": "^0.2.1-0",
         "@stencil/react-output-target": "^0.1.0",
         "@stencil/sass": "1.3.2",
         "@stencil/vue-output-target": "^0.5.1",
@@ -1358,9 +1358,9 @@
       }
     },
     "node_modules/@stencil/angular-output-target": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.2.0.tgz",
-      "integrity": "sha512-Ptr5vigf8v+EnF9Y9LXTKimcVPfB9arC5FnSuKt5ZdNQ8IATWGLx4fhoD2/LThhkPwG9QtjDj9A4GPidu0Fomg==",
+      "version": "0.2.1-0",
+      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.2.1-0.tgz",
+      "integrity": "sha512-A1dkYiGc11bxy83/7SvEek90EzDzfJVgoVML8bUWIpET9by+FDLi+2bq3xkTdYE3TDQesV2Ome2pY/XVsoqs6w==",
       "dev": true
     },
     "node_modules/@stencil/core": {
@@ -15037,9 +15037,9 @@
       }
     },
     "@stencil/angular-output-target": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.2.0.tgz",
-      "integrity": "sha512-Ptr5vigf8v+EnF9Y9LXTKimcVPfB9arC5FnSuKt5ZdNQ8IATWGLx4fhoD2/LThhkPwG9QtjDj9A4GPidu0Fomg==",
+      "version": "0.2.1-0",
+      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.2.1-0.tgz",
+      "integrity": "sha512-A1dkYiGc11bxy83/7SvEek90EzDzfJVgoVML8bUWIpET9by+FDLi+2bq3xkTdYE3TDQesV2Ome2pY/XVsoqs6w==",
       "dev": true
     },
     "@stencil/core": {
@@ -15051,7 +15051,8 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.1.0.tgz",
       "integrity": "sha512-NWeN2S43dwWDIousfojzGXIMkJJhfcdS1JxpwgE7IOqy4tZ+nqlDLPhM6tXvZ3eq4rJm8bkF+3/WbPJNR9xR7Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@stencil/sass": {
       "version": "1.3.2",
@@ -15063,7 +15064,8 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.5.1.tgz",
       "integrity": "sha512-E9HeuUf4DjHO8VFd+faR6T+/JwLtU/2kIA000YTTv0ARPUXuxr/3+U3YMBRPCVFPC5n2jsFxU3E9rTmVH1MGyg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@stylelint/postcss-css-in-js": {
       "version": "0.37.2",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -18,7 +18,7 @@
         "@jest/core": "^26.6.3",
         "@rollup/plugin-node-resolve": "^8.4.0",
         "@rollup/plugin-virtual": "^2.0.3",
-        "@stencil/angular-output-target": "^0.2.1-0",
+        "@stencil/angular-output-target": "^0.2.1",
         "@stencil/react-output-target": "^0.1.0",
         "@stencil/sass": "1.3.2",
         "@stencil/vue-output-target": "^0.5.1",
@@ -1358,9 +1358,9 @@
       }
     },
     "node_modules/@stencil/angular-output-target": {
-      "version": "0.2.1-0",
-      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.2.1-0.tgz",
-      "integrity": "sha512-A1dkYiGc11bxy83/7SvEek90EzDzfJVgoVML8bUWIpET9by+FDLi+2bq3xkTdYE3TDQesV2Ome2pY/XVsoqs6w==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.2.1.tgz",
+      "integrity": "sha512-OoLabH/PtvrYDX6VZWzcyBCXyCozWr6I+YELyz3ThuinIQx9HcbPrNjzobedluoyLxRMDc7AbQPjDi5fObNcqg==",
       "dev": true
     },
     "node_modules/@stencil/core": {
@@ -15037,9 +15037,9 @@
       }
     },
     "@stencil/angular-output-target": {
-      "version": "0.2.1-0",
-      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.2.1-0.tgz",
-      "integrity": "sha512-A1dkYiGc11bxy83/7SvEek90EzDzfJVgoVML8bUWIpET9by+FDLi+2bq3xkTdYE3TDQesV2Ome2pY/XVsoqs6w==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.2.1.tgz",
+      "integrity": "sha512-OoLabH/PtvrYDX6VZWzcyBCXyCozWr6I+YELyz3ThuinIQx9HcbPrNjzobedluoyLxRMDc7AbQPjDi5fObNcqg==",
       "dev": true
     },
     "@stencil/core": {

--- a/core/package.json
+++ b/core/package.json
@@ -40,7 +40,7 @@
     "@jest/core": "^26.6.3",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@rollup/plugin-virtual": "^2.0.3",
-    "@stencil/angular-output-target": "^0.2.1-0",
+    "@stencil/angular-output-target": "^0.2.1",
     "@stencil/react-output-target": "^0.1.0",
     "@stencil/sass": "1.3.2",
     "@stencil/vue-output-target": "^0.5.1",

--- a/core/package.json
+++ b/core/package.json
@@ -40,7 +40,7 @@
     "@jest/core": "^26.6.3",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@rollup/plugin-virtual": "^2.0.3",
-    "@stencil/angular-output-target": "^0.2.0",
+    "@stencil/angular-output-target": "^0.2.1-0",
     "@stencil/react-output-target": "^0.1.0",
     "@stencil/sass": "1.3.2",
     "@stencil/vue-output-target": "^0.5.1",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Changes in `stencil-ds-output-targets` to support strict mode in Angular, caused multiple observers to bind to the same events. This resulted in duplicate events emitting for each change (only in Angular).

Issue Number: #24057


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Event types generated through `angular-output-targets` are written to the global type, instead of defined as a class member. This maintains strict type support and solves `proxyOutputs` conflicting with the class members.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Closing #24186 in preference to this PR.
