### PR TITLE
fix(modal): border radius is now correctly applied to card modals

### DIFF
--- a/core/src/components/modal/modal.ios.scss
+++ b/core/src/components/modal/modal.ios.scss
@@ -8,6 +8,11 @@
   --backdrop-opacity: var(--ion-backdrop-opacity, 0.4);
 }
 
+:host(.modal-card),
+:host(.modal-sheet) {
+  --border-radius: #{$modal-ios-border-radius};
+}
+
 @media only screen and (min-width: $modal-inset-min-width) and (min-height: $modal-inset-min-height-small) {
   :host {
     --border-radius: #{$modal-ios-border-radius};
@@ -36,7 +41,7 @@
   }
 
   :host(.modal-card) .modal-wrapper {
-    @include border-radius($modal-ios-border-radius, $modal-ios-border-radius, 0, 0);
+    @include border-radius(var(--border-radius), var(--border-radius), 0, 0);
   }
 
   :host(.modal-card) {
@@ -76,5 +81,5 @@
 // --------------------------------------------------
 
 :host(.modal-sheet) .modal-wrapper {
-  @include border-radius($modal-ios-border-radius, $modal-ios-border-radius, 0, 0);
+  @include border-radius(var(--border-radius), var(--border-radius), 0, 0);
 }

--- a/core/src/components/modal/test/card/e2e.ts
+++ b/core/src/components/modal/test/card/e2e.ts
@@ -1,0 +1,10 @@
+import { testModal } from '../test.utils';
+
+const DIRECTORY = 'card';
+
+test('modal: card', async () => {
+  await testModal(DIRECTORY, '#card', true);
+});
+test('modal: card - custom', async () => {
+  await testModal(DIRECTORY, '#card-custom', true);
+});

--- a/core/src/components/modal/test/card/index.html
+++ b/core/src/components/modal/test/card/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Modal - Card</title>
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="viewport" content="viewport-fit=cover, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
+  <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+  <script src="../../../../../scripts/testing/scripts.js"></script>
+  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+  <script type="module">
+    import { modalController } from '../../../../dist/ionic/index.esm.js';
+    window.modalController = modalController;
+  </script>
+  <style>
+  ion-modal#custom {
+    --border-radius: 50px !important;
+  }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+
+    <div class="ion-page">
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Card</ion-title>
+        </ion-toolbar>
+      </ion-header>
+
+      <ion-content class="ion-padding">
+       <ion-button expand="block" id="card" onclick="presentModal(document.querySelectorAll('.ion-page')[1])">Card Modal</ion-button>
+       <ion-button expand="block" id="card-custom" onclick="presentModal(document.querySelectorAll('.ion-page')[1], { id: 'custom' })">Card Modal Custom Radius</ion-button>
+      </ion-content>
+    </div>
+  </ion-app>
+
+  <script>
+    async function createModal(presentingEl, opts) {
+
+      // create component to open
+      const element = document.createElement('div');
+      element.innerHTML = `
+      <ion-header id="modal-header">
+        <ion-toolbar>
+          <ion-title>Contacts</ion-title>
+          <ion-buttons slot="end">
+            <ion-button class="add">
+              <ion-icon name="add" slot="icon-only"></ion-icon>
+            </ion-button>
+          </ion-buttons>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        Hello World!
+        <ion-button class="dismiss">Dismiss Modal</ion-button>
+      </ion-content>
+      `;
+
+      // listen for close event
+      const button = element.querySelector('ion-button.dismiss');
+      button.addEventListener('click', () => {
+        modalController.dismiss();
+      });
+
+      const create = element.querySelector('ion-button.add');
+      create.addEventListener('click', async () => {
+        const topModal = await modalController.getTop();
+
+        presentModal(topModal, opts);
+      });
+
+      // present the modal
+      const modalElement = await modalController.create({
+        presentingElement: presentingEl,
+        component: element,
+        swipeToClose: true,
+        ...opts
+      });
+      return modalElement;
+    }
+
+    async function presentModal(presentingEl, opts) {
+      const modal = await createModal(presentingEl, opts);
+      await modal.present();
+    }
+  </script>
+</body>
+
+</html>

--- a/core/src/components/modal/test/spec/index.html
+++ b/core/src/components/modal/test/spec/index.html
@@ -18,6 +18,9 @@
     window.createAnimation = createAnimation;
   </script>
   <style>
+  ion-modal {
+    --border-radius: 20px !important;
+  }
   #modal-header {
     padding-top: 5px !important;
     height: 55px;

--- a/core/src/components/modal/test/spec/index.html
+++ b/core/src/components/modal/test/spec/index.html
@@ -18,9 +18,6 @@
     window.createAnimation = createAnimation;
   </script>
   <style>
-  ion-modal {
-    --border-radius: 20px !important;
-  }
   #modal-header {
     padding-top: 5px !important;
     height: 55px;

--- a/core/src/css/core.scss
+++ b/core/src/css/core.scss
@@ -66,15 +66,6 @@ html.ios ion-modal ion-toolbar {
 }
 
 /**
- * .ion-page needs to explicitly set
- * the border radius in WebKit otherwise
- * modals will not show border radius properly.
- * Do not use inherit as that will not
- * work with shadow dom in this case.
- */
-
-
-/**
  * Card style modal on iPadOS
  * should only have backdrop on first instance.
  */

--- a/core/src/css/core.scss
+++ b/core/src/css/core.scss
@@ -72,9 +72,7 @@ html.ios ion-modal ion-toolbar {
  * Do not use inherit as that will not
  * work with shadow dom in this case.
  */
-html.ios ion-modal .ion-page {
-  border-radius: 10px 10px 0 0;
-}
+
 
 /**
  * Card style modal on iPadOS


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Two issues here:

1. Border radius cannot be overridden with card or sheet modals. This was due to our usage of hard coding the border radius on the modal wrapper inside of the Shadow DOM.
2. Incorrect global styles was applying border radius to every single modal.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Border radius can now be overridden using the CSS Variable.
- Global border radius style is removed. It was previously there as an `inherit` to workaround some WebKit issues, but with the conversion to shadow DOM + dropping of support for iOS 12 this isn't needed anymore.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
