### PR TITLE
fix(input): safari 15 webkit text alignment issue with input type date

### DIFF
--- a/core/src/css/core.scss
+++ b/core/src/css/core.scss
@@ -310,3 +310,10 @@ ion-accordion-group.accordion-group-expand-inset.md ion-accordion.accordion-expa
 ion-accordion-group.accordion-group-expand-inset.md ion-accordion.accordion-expanded:first-of-type {
   margin-top: 0;
 }
+
+// Safari/iOS 15 changes the appearance of input[type="date"].
+// For backwards compatibility from Ionic 5/Safari 14 designs,
+// we override the appearance only when using within an ion-input.
+ion-input input::-webkit-date-and-time-value {
+  text-align: start;
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Date inputs on Safari 15 are center aligning text contents. This is due to a change in the appearance of `input[type="date"]` in Safari, that isn't aligned with the previous design considerations of `ion-input`. 

<img width="477" alt="Screen Shot 2021-11-11 at 9 51 55 PM" src="https://user-images.githubusercontent.com/13732623/141400877-b7f6c810-b7a3-4ac7-b6ad-5c2beee9e175.png">
Issue Number: #24197


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Text alignment of `input[type="date"]` pseudo element aligns left on LTR and right on RTL; only when used inside of `ion-input`.

<img width="477" alt="Screen Shot 2021-11-11 at 9 49 22 PM" src="https://user-images.githubusercontent.com/13732623/141400602-feed5468-dae0-42df-892c-a90a169b30d8.png">


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Repo used to replicate/isolate the bug: https://github.com/sean-perkins/24197-date-input-center

Likely this same issue should be resolved in Ionic 5.*.