### PR TITLE
Allow ion-tab to work with router-view

### DIFF
--- a/packages/vue/src/components/IonTabs.ts
+++ b/packages/vue/src/components/IonTabs.ts
@@ -16,7 +16,7 @@ export const IonTabs = /*@__PURE__*/ defineComponent({
      * inside of ion-tabs.
      */
     if (slottedContent && slottedContent.length > 0) {
-      routerOutlet = slottedContent.find((child: VNode) => child.type && ((child.type as any).name === 'IonRouterOutlet' || child.type as any).name === 'RouterView');
+      routerOutlet = slottedContent.find((child: VNode) => child.type && ((child.type as any).name === 'IonRouterOutlet' || (child.type as any).name === 'RouterView'));
     }
 
     if (!routerOutlet) {

--- a/packages/vue/src/components/IonTabs.ts
+++ b/packages/vue/src/components/IonTabs.ts
@@ -12,15 +12,18 @@ export const IonTabs = /*@__PURE__*/ defineComponent({
     let routerOutlet;
 
     /**
-     * Developers must pass an ion-router-outlet
+     * Developers must pass an ion-router-outlet or router-view
      * inside of ion-tabs.
      */
     if (slottedContent && slottedContent.length > 0) {
       routerOutlet = slottedContent.find((child: VNode) => child.type && (child.type as any).name === 'IonRouterOutlet');
+      if (!routerOutlet) {
+        routerOutlet = slottedContent.find((child: VNode) => child.type && (child.type as any).name === 'RouterView');
+      }
     }
 
     if (!routerOutlet) {
-      throw new Error('IonTabs must contain an IonRouterOutlet. See https://ionicframework.com/docs/vue/navigation#working-with-tabs for more information.');
+      throw new Error('IonTabs must contain an IonRouterOutlet or RouterView. See https://ionicframework.com/docs/vue/navigation#working-with-tabs for more information.');
     }
 
     let childrenToRender = [

--- a/packages/vue/src/components/IonTabs.ts
+++ b/packages/vue/src/components/IonTabs.ts
@@ -16,10 +16,7 @@ export const IonTabs = /*@__PURE__*/ defineComponent({
      * inside of ion-tabs.
      */
     if (slottedContent && slottedContent.length > 0) {
-      routerOutlet = slottedContent.find((child: VNode) => child.type && (child.type as any).name === 'IonRouterOutlet');
-      if (!routerOutlet) {
-        routerOutlet = slottedContent.find((child: VNode) => child.type && (child.type as any).name === 'RouterView');
-      }
+      routerOutlet = slottedContent.find((child: VNode) => child.type && ((child.type as any).name === 'IonRouterOutlet' || child.type as any).name === 'RouterView'));
     }
 
     if (!routerOutlet) {

--- a/packages/vue/src/components/IonTabs.ts
+++ b/packages/vue/src/components/IonTabs.ts
@@ -16,7 +16,7 @@ export const IonTabs = /*@__PURE__*/ defineComponent({
      * inside of ion-tabs.
      */
     if (slottedContent && slottedContent.length > 0) {
-      routerOutlet = slottedContent.find((child: VNode) => child.type && ((child.type as any).name === 'IonRouterOutlet' || child.type as any).name === 'RouterView'));
+      routerOutlet = slottedContent.find((child: VNode) => child.type && ((child.type as any).name === 'IonRouterOutlet' || child.type as any).name === 'RouterView');
     }
 
     if (!routerOutlet) {


### PR DESCRIPTION

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
i don't use ion-vue-router in my project, but i cannot use ion-tab without it, instead of hacking routing i make possible to use it without. 
The only change is there are no animation anymore.

Issue Number: [N/A](https://github.com/ionic-team/ionic-framework/issues/24192)


## What is the new behavior?

- Allow use of ion-tab with basic routing component
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


## Other information

