### PR TITLE
fix(item): allow click targets inside of label

### DIFF
--- a/core/src/components/item/item.scss
+++ b/core/src/components/item/item.scss
@@ -309,12 +309,6 @@ button, a {
   z-index: 1;
 }
 
-// Setting pointer-events to none allows the label
-// to be clicked to open the select interface
-::slotted(ion-label) {
-  pointer-events: none;
-}
-
 ::slotted(ion-label:not([slot="end"])) {
   flex: 1;
 }

--- a/core/src/components/label/label.md.scss
+++ b/core/src/components/label/label.md.scss
@@ -69,6 +69,7 @@
   background-color: $item-md-background;
 
   overflow: visible;
+  // Places the label on top of the item outline
   z-index: 3;
 
   &::before,

--- a/core/src/components/label/label.md.scss
+++ b/core/src/components/label/label.md.scss
@@ -23,7 +23,6 @@
    /* stylelint-disable property-disallowed-list */
    transform-origin: top left;
    /* stylelint-enable property-disallowed-list */
-   z-index: 3;
  }
 
  :host(.label-stacked.label-rtl),


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Click targets inside of an `ion-label` are ignored.

Issue Number: #24215


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Pointer events are no longer disabled on the `ion-label` when slotted in an `ion-item`. This allows clicking the label to open a select as well as clicking a slotted button inside of an `ion-label`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Maintains clickable labels used with select:
<video src="https://user-images.githubusercontent.com/13732623/142052631-dd74efca-a878-48f0-ba75-093084cf2d4d.mp4"></video>




