### PR TITLE
build(): publish to prod but not dev builds

### DIFF
--- a/.scripts/common.js
+++ b/.scripts/common.js
@@ -318,7 +318,7 @@ function copyPackageToDist(tasks, packages) {
   });
 }
 
-function publishPackages(tasks, packages, version, npmTag = 'latest') {
+function verifyPackages(tasks, packages, version, npmTag = 'latest') {
   // verify version
   packages.forEach(package => {
     if (package === 'core') {
@@ -333,6 +333,26 @@ function publishPackages(tasks, packages, version, npmTag = 'latest') {
         if (version !== pkg.version) {
           throw new Error(`${pkg.name} version ${pkg.version} must match ${version}`);
         }
+      }
+    });
+  });
+}
+
+function publishPackages(tasks, packages, version, npmTag = 'latest') {
+  verifyPackages(tasks, packages, version, npmTag);
+
+  // Publish
+  packages.forEach(package => {
+    let projectRoot = projectPath(package);
+
+    if (package === 'packages/angular-server' || package === 'angular') {
+      projectRoot = path.join(projectRoot, 'dist')
+    }
+
+    tasks.push({
+      title: `${package}: publish to ${npmTag} tag`,
+      task: async () => {
+        await execa('npm', ['publish', '--tag', npmTag], { cwd: projectRoot });
       }
     });
   });
@@ -379,6 +399,7 @@ module.exports = {
   preparePackage,
   projectPath,
   publishPackages,
+  verifyPackages,
   readPkg,
   rootDir,
   updateDependency,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I disabled the publishing to npm for the dev build scripts so that GitHub actions could do it (Access token is stored in GitHub secrets, so the npm publish command needed to be done by GHA). However, I didn't realize this function is also used for production publishes, so everything will build but nothing will get pushed out to npm.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Prod build scripts now verify packages + publish npm
- Dev build scripts only verify packages

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
