### PR TITLE
fix(vue): ionic lifecycle hooks now run when using vue 3.2 setup syntax

### DIFF
--- a/packages/vue/src/hooks.ts
+++ b/packages/vue/src/hooks.ts
@@ -80,8 +80,9 @@ const injectHook = (lifecycleType: LifecycleHooks, hook: Function, component: Co
     // Add to public instance so it is accessible to IonRouterOutlet
     const target = component as any;
     const hooks = target.proxy[lifecycleType] || (target.proxy[lifecycleType] = []);
-    // Directly define property on an instance just make a private property when use script-setup
-    // So make a reference to exposed source when used script-setup
+    /**
+     * Define property on public instances using `setup` syntax in Vue 3.x
+     */
     if (target.exposed) {
       target.exposed[lifecycleType] = hooks;
     }

--- a/packages/vue/src/hooks.ts
+++ b/packages/vue/src/hooks.ts
@@ -80,9 +80,11 @@ const injectHook = (lifecycleType: LifecycleHooks, hook: Function, component: Co
     // Add to public instance so it is accessible to IonRouterOutlet
     const target = component as any;
     const hooks = target.proxy[lifecycleType] || (target.proxy[lifecycleType] = []);
-    // Directly define property on an instance just make a private property, need use defineExpose to declase which is public but not work outside setup script
-    // So make a reference at exposed source to hook array to make them public
-    target.exposed[lifecycleType] = hooks;
+    // Directly define property on an instance just make a private property when use script-setup
+    // So make a reference to exposed source when used script-setup
+    if (target.exposed) {
+      target.exposed[lifecycleType] = hooks;
+    }
     const wrappedHook = (...args: unknown[]) => {
       if (target.isUnmounted) {
         return;

--- a/packages/vue/src/hooks.ts
+++ b/packages/vue/src/hooks.ts
@@ -80,8 +80,8 @@ const injectHook = (lifecycleType: LifecycleHooks, hook: Function, component: Co
     // Add to public instance so it is accessible to IonRouterOutlet
     const target = component as any;
     const hooks = target.proxy[lifecycleType] || (target.proxy[lifecycleType] = []);
-    // Directly expose hook function - outside setup script defineExpose not so you cant directly access defined methods
-    // So give the expose property source the hooks then make the hook property can be access by others
+    // Directly define property on an instance just make a private property, need use defineExpose to declase which is public but not work outside setup script
+    // So make a reference at exposed source to hook array to make them public
     target.exposed[lifecycleType] = hooks;
     const wrappedHook = (...args: unknown[]) => {
       if (target.isUnmounted) {

--- a/packages/vue/src/hooks.ts
+++ b/packages/vue/src/hooks.ts
@@ -80,6 +80,9 @@ const injectHook = (lifecycleType: LifecycleHooks, hook: Function, component: Co
     // Add to public instance so it is accessible to IonRouterOutlet
     const target = component as any;
     const hooks = target.proxy[lifecycleType] || (target.proxy[lifecycleType] = []);
+    // Directly expose hook function - outside setup script defineExpose not so you cant directly access defined methods
+    // So give the expose property source the hooks then make the hook property can be access by others
+    target.exposed[lifecycleType] = hooks;
     const wrappedHook = (...args: unknown[]) => {
       if (target.isUnmounted) {
         return;

--- a/packages/vue/test-app/src/router/index.ts
+++ b/packages/vue/test-app/src/router/index.ts
@@ -18,6 +18,10 @@ const routes: Array<RouteRecordRaw> = [
     component: () => import('@/views/Lifecycle.vue')
   },
   {
+    path: '/lifecycle-setup',
+    component: () => import('@/views/LifecycleSetup.vue')
+  },
+  {
     path: '/overlays',
     name: 'Overlays',
     component: () => import('@/views/Overlays.vue')

--- a/packages/vue/test-app/src/views/Home.vue
+++ b/packages/vue/test-app/src/views/Home.vue
@@ -47,6 +47,9 @@
         <ion-item button router-link="/lifecycle" id="lifecycle">
           <ion-label>Lifecycle</ion-label>
         </ion-item>
+        <ion-item button router-link="/lifecycle-setup" id="lifecycle-setup">
+          <ion-label>Lifecycle (Setup)</ion-label>
+        </ion-item>
         <ion-item button router-link="/delayed-redirect" id="delayed-redirect">
           <ion-label>Delayed Redirect</ion-label>
         </ion-item>

--- a/packages/vue/test-app/src/views/LifecycleSetup.vue
+++ b/packages/vue/test-app/src/views/LifecycleSetup.vue
@@ -1,0 +1,56 @@
+<template>
+  <ion-page data-pageid="lifecycle-setup">
+    <ion-header :translucent="true">
+      <ion-toolbar>
+        <ion-buttons>
+          <ion-back-button></ion-back-button>
+        </ion-buttons>
+        <ion-title>Lifecycle (Setup)</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content :fullscreen="true">
+      <ion-header collapse="condense">
+        <ion-toolbar>
+          <ion-title size="large">Lifecycle (Setup)</ion-title>
+        </ion-toolbar>
+      </ion-header>
+
+      <div class="ion-padding">
+        onIonViewWillEnter: <div id="onWillEnter">{{ onWillEnter }}</div><br />
+        onIonViewDidEnter: <div id="onDidEnter">{{ onDidEnter }}</div><br />
+        onIonViewWillLeave: <div id="onWillLeave">{{ onWillLeave }}</div><br />
+        onIonViewDidLeave: <div id="onDidLeave">{{ onDidLeave }}</div><br />
+
+        <ion-button router-link="/navigation" id="lifecycle-navigation">Go to another page</ion-button>
+      </div>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script lang="ts" setup>
+import {
+  IonButton,
+  IonBackButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonPage,
+  IonTitle,
+  IonToolbar,
+  onIonViewWillEnter,
+  onIonViewDidEnter,
+  onIonViewWillLeave,
+  onIonViewDidLeave
+} from '@ionic/vue';
+import { ref } from 'vue';
+const onWillEnter = ref(0);
+const onDidEnter = ref(0);
+const onWillLeave = ref(0);
+const onDidLeave = ref(0);
+
+onIonViewWillEnter(() => onWillEnter.value += 1);
+onIonViewDidEnter(() => onDidEnter.value += 1);
+onIonViewWillLeave(() => onWillLeave.value += 1);
+onIonViewDidLeave(() => onDidLeave.value += 1);
+</script>

--- a/packages/vue/test-app/tests/e2e/specs/lifecycle.js
+++ b/packages/vue/test-app/tests/e2e/specs/lifecycle.js
@@ -55,14 +55,62 @@ describe('Lifecycle', () => {
       onIonViewDidLeave: 0
     });
   });
+
+  it('should fire lifecycle events when navigating to and from a page - setup', () => {
+    cy.visit('http://localhost:8080');
+    cy.get('#lifecycle-setup').click();
+
+    testLifecycle('lifecycle-setup', {
+      onIonViewWillEnter: 1,
+      onIonViewDidEnter: 1,
+      onIonViewWillLeave: 0,
+      onIonViewDidLeave: 0
+    });
+
+    cy.get('#lifecycle-navigation').click();
+
+    testLifecycle('lifecycle-setup', {
+      onIonViewWillEnter: 1,
+      onIonViewDidEnter: 1,
+      onIonViewWillLeave: 1,
+      onIonViewDidLeave: 1
+    });
+
+    cy.ionBackClick('navigation');
+
+    testLifecycle('lifecycle-setup', {
+      onIonViewWillEnter: 2,
+      onIonViewDidEnter: 2,
+      onIonViewWillLeave: 1,
+      onIonViewDidLeave: 1
+    });
+  });
+
+  it('should fire lifecycle events when landed on directly - setup', () => {
+    cy.visit('http://localhost:8080/lifecycle-setup');
+
+    testLifecycle('lifecycle-setup', {
+      onIonViewWillEnter: 1,
+      onIonViewDidEnter: 1,
+      onIonViewWillLeave: 0,
+      onIonViewDidLeave: 0
+    });
+  });
 })
 
 const testLifecycle = (selector, expected = {}) => {
-  cy.get(`[data-pageid=${selector}] #willEnter`).should('have.text', expected.ionViewWillEnter);
-  cy.get(`[data-pageid=${selector}] #didEnter`).should('have.text', expected.ionViewDidEnter);
-  cy.get(`[data-pageid=${selector}] #willLeave`).should('have.text', expected.ionViewWillLeave);
-  cy.get(`[data-pageid=${selector}] #didLeave`).should('have.text', expected.ionViewDidLeave);
-
+  if (expected.ionViewWillEnter) {
+    cy.get(`[data-pageid=${selector}] #willEnter`).should('have.text', expected.ionViewWillEnter);
+  }
+  if (expected.ionViewDidEnter) {
+    cy.get(`[data-pageid=${selector}] #didEnter`).should('have.text', expected.ionViewDidEnter);
+  }
+  if (expected.ionViewWillLeave) {
+    cy.get(`[data-pageid=${selector}] #willLeave`).should('have.text', expected.ionViewWillLeave);
+  }
+  if (expected.ionViewDidLeave) {
+    cy.get(`[data-pageid=${selector}] #didLeave`).should('have.text', expected.ionViewDidLeave);
+  }
   cy.get(`[data-pageid=${selector}] #onWillEnter`).should('have.text', expected.onIonViewWillEnter);
   cy.get(`[data-pageid=${selector}] #onDidEnter`).should('have.text', expected.onIonViewDidEnter);
   cy.get(`[data-pageid=${selector}] #onWillLeave`).should('have.text', expected.onIonViewWillLeave);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #23824


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Define a property on vue instance exposed source object make the hooks be public then they can be access and fire;
-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
