### PR TITLE
feat(react): add setupIonicReact function

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -29,14 +29,15 @@ This is a comprehensive list of the breaking changes introduced in the major ver
 - [Config](#config)
   * [Transition Shadow](#transition-shadow)
 - [Angular](#angular)
-  * [Config Provider](#config-provider)
+  * [Config](#config-1)
 - [Vue](#vue)
+  * [Config](#config-2)
   * [Tabs Config](#tabs-config)
   * [Tabs Router Outlet](#tabs-router-outlet)
   * [Overlay Events](#overlay-events)
   * [Utility Function Types](#utility-function-types)
 - [React](#react)
-  * [App Initialization](#app-initialization)
+  * [Config](#config-3)
 - [Browser and Platform Support](#browser-and-platform-support)
 
 
@@ -166,13 +167,15 @@ The `experimentalTransitionShadow` config option has been removed. The transitio
 
 ### Angular
 
-#### Config Provider
+#### Config
 
 The `Config.set()` method has been removed. See https://ionicframework.com/docs/angular/config for examples on how to set config globally, per-component, and per-platform.
 
+Additionally, the `setupConfig` function is no longer exported from `@ionic/angular`. Developers should use `IonicModule.forRoot` to set the config instead. See https://ionicframework.com/docs/angular/config for more information.
+
 ### React
 
-#### App Initialization
+#### Config
 
 All Ionic React applications must now import `setupIonicReact` from `@ionic/react` and call it. If you are setting a custom config with `setupConfig`, pass your config directly to `setupIonicReact` instead:
 
@@ -196,7 +199,13 @@ setupIonicReact({
 
 Note that all Ionic React applications must call `setupIonicReact` even if they are not setting custom configuration.
 
+Additionally, the `setupConfig` function is no longer exported from `@ionic/react`.
+
 ### Vue
+
+#### Config
+
+The `setupConfig` function is no longer exported from `@ionic/vue`. Developers should pass their config into the `IonicVue` plugin. See https://ionicframework.com/docs/vue/config for more information.
 
 #### Tabs Config
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -35,6 +35,8 @@ This is a comprehensive list of the breaking changes introduced in the major ver
   * [Tabs Router Outlet](#tabs-router-outlet)
   * [Overlay Events](#overlay-events)
   * [Utility Function Types](#utility-function-types)
+- [React](#react)
+  * [App Initialization](#app-initialization)
 - [Browser and Platform Support](#browser-and-platform-support)
 
 
@@ -168,6 +170,31 @@ The `experimentalTransitionShadow` config option has been removed. The transitio
 
 The `Config.set()` method has been removed. See https://ionicframework.com/docs/angular/config for examples on how to set config globally, per-component, and per-platform.
 
+### React
+
+#### App Initialization
+
+All Ionic React applications must now import `setupIonicReact` from `@ionic/react` and call it. If you are setting a custom config with `setupConfig`, pass your config directly to `setupIonicReact` instead:
+
+**Old**
+```javascript
+import { setupConfig } from '@ionic/react';
+
+setupConfig({
+  mode: 'md'
+})
+```
+
+**New**
+```javascript
+import { setupIonicReact } from '@ionic/react';
+
+setupIonicReact({
+  mode: 'md'
+})
+```
+
+Note that all Ionic React applications must call `setupIonicReact` even if they are not setting custom configuration.
 
 ### Vue
 

--- a/angular/src/index.ts
+++ b/angular/src/index.ts
@@ -50,7 +50,6 @@ export {
   createGesture,
   iosTransitionAnimation,
   mdTransitionAnimation,
-  setupConfig,
   IonicSwiper,
   IonicSlides,
   getPlatforms,

--- a/packages/react-router/test-app/src/App.tsx
+++ b/packages/react-router/test-app/src/App.tsx
@@ -1,4 +1,4 @@
-import { IonApp } from '@ionic/react';
+import { IonApp, setupIonicReact } from '@ionic/react';
 import React from 'react';
 import { Route } from 'react-router-dom';
 
@@ -36,6 +36,9 @@ import Refs from './pages/refs/Refs';
 import DynamicIonpageClassnames from './pages/dynamic-ionpage-classnames/DynamicIonpageClassnames';
 import Tabs from './pages/tabs/Tabs';
 import TabsSecondary from './pages/tabs/TabsSecondary';
+
+setupIonicReact();
+
 const App: React.FC = () => {
   return (
     <IonApp>

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,4 +1,4 @@
-import { initialize } from '@ionic/core/components';
+import { initialize, IonicConfig } from '@ionic/core/components';
 import { addIcons } from 'ionicons';
 import {
   arrowBackSharp,
@@ -23,7 +23,6 @@ export {
   createGesture,
   iosTransitionAnimation,
   mdTransitionAnimation,
-  setupConfig,
   IonicSwiper,
   IonicSlides,
   getTimeGivenProgression,
@@ -190,13 +189,17 @@ addIcons({
   'search-sharp': searchSharp,
 });
 
-/**
- * By default Ionic Framework hides elements that
- * are not hydrated, but in the CE build there is no
- * hydration.
- * TODO: Remove when all integrations have been
- * migrated to CE build.
- */
-document.documentElement.classList.add('ion-ce');
+export const setupIonicReact = (config: IonicConfig = {}) => {
+  /**
+   * By default Ionic Framework hides elements that
+   * are not hydrated, but in the CE build there is no
+   * hydration.
+   * TODO: Remove when all integrations have been
+   * migrated to CE build.
+   */
+  document.documentElement.classList.add('ion-ce');
 
-initialize();
+  initialize({
+    ...config
+  });
+}

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,4 +1,4 @@
-import { initialize, IonicConfig } from '@ionic/core/components';
+import { IonicConfig, initialize } from '@ionic/core/components';
 import { addIcons } from 'ionicons';
 import {
   arrowBackSharp,

--- a/packages/react/test-app/src/App.tsx
+++ b/packages/react/test-app/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { IonApp } from '@ionic/react';
+import { IonApp, setupIonicReact } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
 
 /* Core CSS required for Ionic components to work properly */
@@ -24,6 +24,8 @@ import './theme/variables.css';
 import Main from './pages/Main';
 import OverlayHooks from './pages/overlay-hooks/OverlayHooks';
 import OverlayComponents from './pages/overlay-components/OverlayComponents';
+
+setupIonicReact();
 
 const App: React.FC = () => (
   <IonApp>

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -40,7 +40,6 @@ export {
   createGesture,
   iosTransitionAnimation,
   mdTransitionAnimation,
-  setupConfig,
   IonicSwiper,
   IonicSlides,
   getPlatforms,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/24139

With the Custom Elements build, we now need to call `initialize()`: https://github.com/ionic-team/ionic-framework/blob/next/packages/react/src/components/index.ts#L202. The problem is that this call also sets up the Ionic config. Given that Ionic config is not designed to be reactive, subsequent calls to `setupConfig` had no effect.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- After discussing with the team, we feel the best path forward is a (small) breaking change. Developers will be required to add `setupIonicReact` to their `App.tsx`/`App.jsx` file. This function will call `initialize` and allow developers to pass in a config, so it can be used instead of `setupConfig`.
- We explored non-breaking change options, but we think this change is the best option long term.
- I also noticed that setupConfig was being exported from Angular/React/Vue packages when it should not be. Developers should be going through the main entry points and not calling `setupConfig` on their own. If they need to eject from the normal process, they should call `initialize` instead.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


Migration:

1. Import `setupIonicReact` from '@ionic/react';
2. In `App.tsx`, call `setupIonicReact();`. Config should be passed here instead of `setupConfig`.
3. Remove any calls to `setupConfig`.