### PR TITLE
fix(content): ensure scrollEl is always available in scroll methods

### DIFF
--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -185,8 +185,10 @@ export class Content implements ComponentInterface {
    */
   @Method()
   async getScrollElement(): Promise<HTMLElement> {
-    // if this gets called in certain early lifecycle hooks (ex: Vue onMounted),
-    // scrollEl won't be defined yet, so wait for it to load in
+    /**
+     * If this gets called in certain early lifecycle hooks (ex: Vue onMounted),
+     * scrollEl won't be defined yet with the custom elements build, so wait for it to load in.
+     */
     if (!this.scrollEl) {
       await new Promise(resolve => componentOnReady(this.el, resolve));
     }

--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -2,9 +2,9 @@ import { Component, ComponentInterface, Element, Event, EventEmitter, Host, List
 
 import { getIonMode } from '../../global/ionic-global';
 import { Color, ScrollBaseDetail, ScrollDetail } from '../../interface';
+import { raf } from '../../utils/helpers';
 import { isPlatform } from '../../utils/platform';
 import { createColorClasses, hostContext } from '../../utils/theme';
-import { raf } from '../../utils/helpers';
 
 /**
  * @slot - Content is placed in the scrollable area if provided without a slot.
@@ -26,7 +26,7 @@ export class Content implements ComponentInterface {
   private queued = false;
   private cTop = -1;
   private cBottom = -1;
-  private scrollEl!: HTMLElement;
+  private scrollEl?: HTMLElement;
   private isMainContent = true;
 
   // Detail is used in a hot loop in the scroll event, by allocating it here
@@ -169,7 +169,7 @@ export class Content implements ComponentInterface {
       readTask(ts => {
         this.queued = false;
         this.detail.event = ev;
-        updateScrollDetail(this.detail, this.scrollEl, ts, shouldStart);
+        updateScrollDetail(this.detail, this.scrollEl!, ts, shouldStart);
         this.ionScroll.emit(this.detail);
       });
     }
@@ -179,7 +179,7 @@ export class Content implements ComponentInterface {
   // (ex: Vue onMounted)
   // this ensures scrollEl is present, only waiting as long as is necessary
   private awaitScrollEl() {
-    if(this.scrollEl) {
+    if (this.scrollEl) {
       return Promise.resolve(this.scrollEl);
     } else {
       return new Promise(resolve => raf(resolve(this.scrollEl)));
@@ -196,7 +196,7 @@ export class Content implements ComponentInterface {
    */
   @Method()
   getScrollElement(): Promise<HTMLElement> {
-    return Promise.resolve(this.scrollEl);
+    return Promise.resolve(this.scrollEl!);
   }
 
   /**
@@ -217,7 +217,7 @@ export class Content implements ComponentInterface {
   @Method()
   async scrollToBottom(duration = 0): Promise<void> {
     await this.awaitScrollEl();
-    const y = this.scrollEl.scrollHeight - this.scrollEl.clientHeight;
+    const y = this.scrollEl!.scrollHeight - this.scrollEl!.clientHeight;
     return this.scrollToPoint(undefined, y, duration);
   }
 
@@ -231,7 +231,7 @@ export class Content implements ComponentInterface {
   @Method()
   async scrollByPoint(x: number, y: number, duration: number): Promise<void> {
     await this.awaitScrollEl();
-    return this.scrollToPoint(x + this.scrollEl.scrollLeft, y + this.scrollEl.scrollTop, duration);
+    return this.scrollToPoint(x + this.scrollEl!.scrollLeft, y + this.scrollEl!.scrollTop, duration);
   }
 
   /**
@@ -244,7 +244,7 @@ export class Content implements ComponentInterface {
   @Method()
   async scrollToPoint(x: number | undefined | null, y: number | undefined | null, duration = 0): Promise<void> {
     await this.awaitScrollEl();
-    const el = this.scrollEl;
+    const el = this.scrollEl!;
     if (duration < 32) {
       if (y != null) {
         el.scrollTop = y;

--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -2,7 +2,7 @@ import { Component, ComponentInterface, Element, Event, EventEmitter, Host, List
 
 import { getIonMode } from '../../global/ionic-global';
 import { Color, ScrollBaseDetail, ScrollDetail } from '../../interface';
-import { raf } from '../../utils/helpers';
+import { componentOnReady } from '../../utils/helpers';
 import { isPlatform } from '../../utils/platform';
 import { createColorClasses, hostContext } from '../../utils/theme';
 
@@ -175,15 +175,15 @@ export class Content implements ComponentInterface {
     }
   }
 
-  // some scroll methods can be called in lifecycle hooks where scrollEl isn't ready
+  // scroll methods can be called in lifecycle hooks where scrollEl isn't ready
   // (ex: Vue onMounted)
-  // this ensures scrollEl is present, only waiting as long as is necessary
-  private awaitScrollEl() {
-    if (this.scrollEl) {
-      return Promise.resolve(this.scrollEl);
-    } else {
-      return new Promise(resolve => raf(() => resolve(this.scrollEl)));
+  // ensure scrollEl is present
+  private async awaitScrollEl() {
+    if (!this.scrollEl) {
+      await new Promise(resolve => componentOnReady(this.el, resolve));
     }
+
+    return Promise.resolve(this.scrollEl);
   }
 
   /**

--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -182,7 +182,7 @@ export class Content implements ComponentInterface {
     if (this.scrollEl) {
       return Promise.resolve(this.scrollEl);
     } else {
-      return new Promise(resolve => raf(resolve(this.scrollEl)));
+      return new Promise(resolve => raf(() => resolve(this.scrollEl)));
     }
   }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Resolves https://github.com/ionic-team/ionic-framework/issues/24168


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `ion-content` methods for manual scrolling will wait for component ready if `scrollEl` isn't ready yet. This ensures that if those methods are called in certain lifecycle hooks (such as Vue's `onMounted`), `scrollEl` is defined and the method works properly.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
