### PR TITLE
build(commitizen): do not run on main, next, or release branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "release.dev": "node .scripts/release-dev.js",
     "release.prepare": "node .scripts/prepare.js",
     "release": "node .scripts/release.js",
-    "changelog": "conventional-changelog -p angular -i ./CHANGELOG.md -k core -s"
+    "changelog": "conventional-changelog -p angular -i ./CHANGELOG.md -k core -s",
+    "commitizenBranches": "git-branch-is -q --not -r \"^(main|next|release-)\""
   },
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",
@@ -18,6 +19,7 @@
     "cz-conventional-changelog": "^3.3.0",
     "execa": "^0.10.0",
     "fs-extra": "^7.0.0",
+    "git-branch-is": "^4.0.0",
     "husky": "^4.3.8",
     "inquirer": "^6.0.0",
     "listr": "^0.14.0",
@@ -34,8 +36,8 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "prepare-commit-msg": "exec < /dev/tty && git cz --hook || true"
+      "commit-msg": "npm run commitizenBranches --silent && commitlint -E HUSKY_GIT_PARAMS || true",
+      "prepare-commit-msg": "npm run commitizenBranches --silent && exec < /dev/tty && git cz --hook || true"
     }
   }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The interactive Commitizen CLI will no longer run on the `main`, `next`, and `release-` branches. This change is for better compatibility with our release process. All direct commits to feature branches will still utilize the CLI. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
