### PR TITLE
refactor(datetime): e2e does not support components option

### DIFF
--- a/core/src/components/datetime/test/basic/e2e.ts
+++ b/core/src/components/datetime/test/basic/e2e.ts
@@ -1,10 +1,8 @@
 import { newE2EPage } from '@stencil/core/testing';
-import { Datetime } from '../../datetime';
 
 describe('Footer', () => {
   test('should render default buttons', async () => {
     const page = await newE2EPage({
-      components: [Datetime],
       html: '<ion-datetime show-default-buttons="true"></ion-datetime>'
     });
 
@@ -19,7 +17,6 @@ describe('Footer', () => {
 
   test('should render clear button', async () => {
     const page = await newE2EPage({
-      components: [Datetime],
       html: '<ion-datetime show-clear-button="true"></ion-datetime>'
     });
 
@@ -31,7 +28,6 @@ describe('Footer', () => {
 
   test('should render clear and default buttons', async () => {
     const page = await newE2EPage({
-      components: [Datetime],
       html: '<ion-datetime show-default-buttons="true" show-clear-button="true"></ion-datetime>'
     });
 
@@ -49,7 +45,6 @@ describe('Footer', () => {
 
   test('should render custom buttons', async () => {
     const page = await newE2EPage({
-      components: [Datetime],
       html: `
         <ion-datetime show-default-buttons="true" show-clear-button="true">
           <ion-buttons slot="buttons">
@@ -67,7 +62,6 @@ describe('Footer', () => {
 
   test('should render custom buttons', async () => {
     const page = await newE2EPage({
-      components: [Datetime],
       html: `
         <ion-datetime show-default-buttons="true" show-clear-button="true">
           <ion-buttons slot="buttons">


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Removes unsupported `components` option from e2e test for datetime. `components` is a supported property for `newSpecPage` for registering custom elements.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
