### PR TITLE
fix(popover): handle scrolling in content so header can be sticky

### DIFF
--- a/core/src/components/content/content.ios.scss
+++ b/core/src/components/content/content.ios.scss
@@ -6,3 +6,6 @@
 :host(.content-sizing) {
   -webkit-overflow-scrolling: touch;
 }
+:host(.content-sizing) .inner-scroll {
+  overflow: hidden;
+}

--- a/core/src/components/content/content.ios.scss
+++ b/core/src/components/content/content.ios.scss
@@ -1,8 +1,0 @@
-@import "./content";
-
-// iOS Content
-// --------------------------------------------------
-
-:host(.content-sizing) .inner-scroll {
-  overflow: hidden;
-}

--- a/core/src/components/content/content.ios.scss
+++ b/core/src/components/content/content.ios.scss
@@ -1,0 +1,8 @@
+@import "./content";
+
+// iOS Content
+// --------------------------------------------------
+
+:host(.content-sizing) {
+  -webkit-overflow-scrolling: touch;
+}

--- a/core/src/components/content/content.ios.scss
+++ b/core/src/components/content/content.ios.scss
@@ -3,9 +3,6 @@
 // iOS Content
 // --------------------------------------------------
 
-:host(.content-sizing) {
-  -webkit-overflow-scrolling: touch;
-}
 :host(.content-sizing) .inner-scroll {
   overflow: hidden;
 }

--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -145,7 +145,13 @@
   flex-direction: column;
   
   contain: none;
-  overflow: hidden;
+
+  /**
+   * This resolves a sizing issue in popovers where extra long content
+   * would overflow the popover's height, preventing scrolling. It's a
+   * quirk of flexbox that forces the content to shrink to fit.
+   */
+  min-height: 0;
 }
 :host(.content-sizing) .inner-scroll {
   position: relative;

--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -150,6 +150,9 @@
    * This resolves a sizing issue in popovers where extra long content
    * would overflow the popover's height, preventing scrolling. It's a
    * quirk of flexbox that forces the content to shrink to fit.
+   *
+   * overflow: hidden can't be used here because it prevents the visual
+   * effect from showing on translucent headers.
    */
   min-height: 0;
 }

--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -163,11 +163,14 @@
    * Because the outer content has display: flex here (to help enable
    * scrolling in a popover), offsetting via `top` (such as when using
    * a translucent header) creates white space under the content. Use
-   * a negative margin instead to keep the bottom in place.
+   * a negative margin instead to keep the bottom in place. (A similar
+   * thing happens with `bottom` and footers.)
    */
   top: 0;
+  bottom: 0;
   
   margin-top: calc(var(--offset-top) * -1);
+  margin-bottom: calc(var(--offset-bottom) * -1);
 }
 
 .transition-effect {

--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -145,8 +145,6 @@
 }
 :host(.content-sizing) .inner-scroll {
   overscroll-behavior-y: auto;
-  touch-action: auto;
-
   position: relative;
 }
 

--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -140,9 +140,11 @@
 }
 
 :host(.content-sizing) {
-  contain: none;
   display: flex;
+
   flex-direction: column;
+  
+  contain: none;
   overflow: hidden;
 }
 :host(.content-sizing) .inner-scroll {

--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -156,6 +156,7 @@
    */
   overscroll-behavior-y: auto;
 
+  overflow: hidden;
   position: relative;
 }
 

--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -141,10 +141,21 @@
 
 :host(.content-sizing) {
   contain: none;
+
+  /**
+   * Using position: relative on .inner-scroll below breaks
+   * its scrolling, but is needed to ensure content in a 
+   * popover has appropriate height. When in a popover, make
+   * the outer wrapper scrollable instead to get around this.
+   */
   overflow: auto;
 }
 :host(.content-sizing) .inner-scroll {
+  /**
+   * Needed to allow scrolling with mouse wheel on Windows.
+   */
   overscroll-behavior-y: auto;
+
   position: relative;
 }
 

--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -143,8 +143,6 @@
   display: flex;
 
   flex-direction: column;
-  
-  contain: none;
 
   /**
    * This resolves a sizing issue in popovers where extra long content
@@ -155,6 +153,8 @@
    * effect from showing on translucent headers.
    */
   min-height: 0;
+
+  contain: none;
 }
 :host(.content-sizing) .inner-scroll {
   position: relative;
@@ -166,6 +166,7 @@
    * a negative margin instead to keep the bottom in place.
    */
   top: 0;
+  
   margin-top: calc(var(--offset-top) * -1);
 }
 

--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -158,6 +158,15 @@
 }
 :host(.content-sizing) .inner-scroll {
   position: relative;
+
+  /**
+   * Because the outer content has display: flex here (to help enable
+   * scrolling in a popover), offsetting via `top` (such as when using
+   * a translucent header) creates white space under the content. Use
+   * a negative margin instead to keep the bottom in place.
+   */
+  top: 0;
+  margin-top: calc(var(--offset-top) * -1);
 }
 
 .transition-effect {

--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -141,8 +141,12 @@
 
 :host(.content-sizing) {
   contain: none;
+  overflow: auto;
 }
 :host(.content-sizing) .inner-scroll {
+  overscroll-behavior-y: auto;
+  touch-action: auto;
+
   position: relative;
 }
 

--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -141,22 +141,11 @@
 
 :host(.content-sizing) {
   contain: none;
-
-  /**
-   * Using position: relative on .inner-scroll below breaks
-   * its scrolling, but is needed to ensure content in a 
-   * popover has appropriate height. When in a popover, make
-   * the outer wrapper scrollable instead to get around this.
-   */
-  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 :host(.content-sizing) .inner-scroll {
-  /**
-   * Needed to allow scrolling with mouse wheel on Windows.
-   */
-  overscroll-behavior-y: auto;
-
-  overflow: hidden;
   position: relative;
 }
 

--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -374,10 +374,17 @@ const getPageElement = (el: HTMLElement) => {
   if (tabs) {
     return tabs;
   }
-  const page = el.closest('ion-app,ion-page,.ion-page,page-inner');
+
+  /**
+   * If we're in a popover, we need to use its wrapper so we can account for space
+   * between the popover and the edges of the screen. But if the popover contains
+   * its own page element, we should use that instead.
+   */
+  const page = el.closest('ion-app, ion-page, .ion-page, page-inner, .popover-content');
   if (page) {
     return page;
   }
+
   return getParentElement(el);
 };
 

--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -15,10 +15,7 @@ import { createColorClasses, hostContext } from '../../utils/theme';
  */
 @Component({
   tag: 'ion-content',
-  styleUrls: {
-    ios: 'content.ios.scss',
-    md: 'content.scss'
-  },
+  styleUrl: 'content.scss',
   shadow: true
 })
 export class Content implements ComponentInterface {

--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -15,7 +15,10 @@ import { createColorClasses, hostContext } from '../../utils/theme';
  */
 @Component({
   tag: 'ion-content',
-  styleUrl: 'content.scss',
+  styleUrls: {
+    ios: 'content.ios.scss',
+    md: 'content.scss'
+  },
   shadow: true
 })
 export class Content implements ComponentInterface {

--- a/core/src/components/popover/popover.scss
+++ b/core/src/components/popover/popover.scss
@@ -76,6 +76,8 @@
   --ion-safe-area-bottom: 0px;
   --ion-safe-area-left: 0px;
   display: flex;
+
   flex-direction: column;
+
   overflow: hidden;
 }

--- a/core/src/components/popover/popover.scss
+++ b/core/src/components/popover/popover.scss
@@ -75,5 +75,7 @@
   --ion-safe-area-right: 0px;
   --ion-safe-area-bottom: 0px;
   --ion-safe-area-left: 0px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
-

--- a/core/src/components/popover/test/basic/e2e.ts
+++ b/core/src/components/popover/test/basic/e2e.ts
@@ -57,6 +57,14 @@ test('popover: custom class', async () => {
   await testPopover(DIRECTORY, '#custom-class-popover');
 });
 
+test('popover: header', async () => {
+  await testPopover(DIRECTORY, '#header-popover');
+});
+
+test('popover: translucent header', async () => {
+  await testPopover(DIRECTORY, '#translucent-header-popover');
+});
+
 /**
  * RTL Tests
  */
@@ -79,6 +87,14 @@ test('popover:rtl: no event', async () => {
 
 test('popover:rtl: custom class', async () => {
   await testPopover(DIRECTORY, '#custom-class-popover', true);
+});
+
+test('popover:rtl: header', async () => {
+  await testPopover(DIRECTORY, '#header-popover', true);
+});
+
+test('popover:rtl: translucent header', async () => {
+  await testPopover(DIRECTORY, '#translucent-header-popover', true);
 });
 
 test('popover: htmlAttributes', async () => {

--- a/core/src/components/popover/test/basic/index.html
+++ b/core/src/components/popover/test/basic/index.html
@@ -34,6 +34,7 @@
       <ion-button id="long-list-popover" expand="block" color="secondary" onclick="presentPopover({ component: 'list-page', event: event })">Show Long List Popover</ion-button>
       <ion-button id="no-event-popover" expand="block" color="danger" onclick="presentPopover({ component: 'profile-page' })">No Event Popover</ion-button>
       <ion-button id="custom-class-popover" expand="block" color="tertiary" onclick="presentPopover({ component: 'translucent-page', event: event, cssClass: 'my-custom-class' })">Custom Class Popover</ion-button>
+      <ion-button id="header-popover" expand="block" onclick="presentPopover({ component: 'header-page' })">Popover With Header</ion-button>
     </ion-content>
 
     <ion-footer>
@@ -126,6 +127,40 @@
     }
 
     customElements.define('translucent-page', TranslucentPage);
+
+    class HeaderPage extends HTMLElement {
+      constructor() {
+        super();
+      }
+
+      connectedCallback() {
+        this.innerHTML = `
+          <ion-header class="ion-no-border">
+            <ion-toolbar>
+              <ion-title id="title" class="ion-text-center">Header</ion-title>
+              <a class="pointer" slot="end">
+                <ion-icon color="primary" class="ct-text-color ct-font-size-24px ct-margin-right-8px" slot="icon-only"
+                  name="close-circle-outline"></ion-icon>
+              </a>
+            </ion-toolbar>
+          </ion-header>
+
+          <ion-content class="ct-text-color">
+            <ion-list>
+              <ion-item lines="none">
+                <div class="ion-padding">
+                  <div>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.In rutrum tortor lacus, ac interdum ipsum bibendum vel.Aenean non nibh gravida, ullamcorper mi at, tempor nulla.Proin malesuada tellus ut ullamcorper accumsan.Donec semper justo vulputate neque tempus ultricies.Proin non aliquet ipsum.Praesent mauris sem, facilisis eu justo nec, euismod imperdiet tellus.Duis eget justo congue, lacinia orci sed, fermentum urna.Quisque sed massa faucibus, interdum dolor rhoncus, molestie erat.Proin suscipit ante non mauris volutpat egestas.Donec a ultrices ligula.Mauris in felis vel dui consectetur viverra.Nam vitae quam in arcu aliquam aliquam.Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.Cras non velit nisl.Donec viverra, magna quis vestibulum volutpat, metus ante tincidunt augue, non porta nisi mi sit amet neque.Proin dapibus eros vitae nibh tincidunt, blandit rhoncus est porttitor.
+                  </div>
+                </div>
+              </ion-item>
+            </ion-list>
+          </ion-content>
+        `;
+      }
+    }
+
+    customElements.define('header-page', HeaderPage);
   </script>
 </body>
 

--- a/core/src/components/popover/test/basic/index.html
+++ b/core/src/components/popover/test/basic/index.html
@@ -191,6 +191,12 @@
               </ion-item>
             </ion-list>
           </ion-content>
+
+          <ion-footer translucent>
+            <ion-toolbar>
+              <ion-title>Footer</ion-title>
+            </ion-toolbar>
+          </ion-footer>
         `;
       }
     }

--- a/core/src/components/popover/test/basic/index.html
+++ b/core/src/components/popover/test/basic/index.html
@@ -35,6 +35,7 @@
       <ion-button id="no-event-popover" expand="block" color="danger" onclick="presentPopover({ component: 'profile-page' })">No Event Popover</ion-button>
       <ion-button id="custom-class-popover" expand="block" color="tertiary" onclick="presentPopover({ component: 'translucent-page', event: event, cssClass: 'my-custom-class' })">Custom Class Popover</ion-button>
       <ion-button id="header-popover" expand="block" onclick="presentPopover({ component: 'header-page' })">Popover With Header</ion-button>
+      <ion-button id="translucent-header-popover" expand="block" onclick="presentPopover({ component: 'translucent-header-page' })">Popover With Translucent Header</ion-button>
     </ion-content>
 
     <ion-footer>
@@ -161,6 +162,40 @@
     }
 
     customElements.define('header-page', HeaderPage);
+
+    class TranslucentHeaderPage extends HTMLElement {
+      constructor() {
+        super();
+      }
+
+      connectedCallback() {
+        this.innerHTML = `
+          <ion-header class="ion-no-border" translucent>
+            <ion-toolbar>
+              <ion-title id="title" class="ion-text-center">Header</ion-title>
+              <a class="pointer" slot="end">
+                <ion-icon color="primary" class="ct-text-color ct-font-size-24px ct-margin-right-8px" slot="icon-only"
+                  name="close-circle-outline"></ion-icon>
+              </a>
+            </ion-toolbar>
+          </ion-header>
+
+          <ion-content class="ct-text-color" fullscreen color="primary">
+            <ion-list>
+              <ion-item lines="none" style="--background: var(--ion-color-base)">
+                <div class="ion-padding">
+                  <div>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.In rutrum tortor lacus, ac interdum ipsum bibendum vel.Aenean non nibh gravida, ullamcorper mi at, tempor nulla.Proin malesuada tellus ut ullamcorper accumsan.Donec semper justo vulputate neque tempus ultricies.Proin non aliquet ipsum.Praesent mauris sem, facilisis eu justo nec, euismod imperdiet tellus.Duis eget justo congue, lacinia orci sed, fermentum urna.Quisque sed massa faucibus, interdum dolor rhoncus, molestie erat.Proin suscipit ante non mauris volutpat egestas.Donec a ultrices ligula.Mauris in felis vel dui consectetur viverra.Nam vitae quam in arcu aliquam aliquam.Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.Cras non velit nisl.Donec viverra, magna quis vestibulum volutpat, metus ante tincidunt augue, non porta nisi mi sit amet neque.Proin dapibus eros vitae nibh tincidunt, blandit rhoncus est porttitor.
+                  </div>
+                </div>
+              </ion-item>
+            </ion-list>
+          </ion-content>
+        `;
+      }
+    }
+
+    customElements.define('translucent-header-page', TranslucentHeaderPage);
   </script>
 </body>
 

--- a/core/src/components/popover/test/basic/index.html
+++ b/core/src/components/popover/test/basic/index.html
@@ -136,26 +136,14 @@
 
       connectedCallback() {
         this.innerHTML = `
-          <ion-header class="ion-no-border">
+          <ion-header>
             <ion-toolbar>
-              <ion-title id="title" class="ion-text-center">Header</ion-title>
-              <a class="pointer" slot="end">
-                <ion-icon color="primary" class="ct-text-color ct-font-size-24px ct-margin-right-8px" slot="icon-only"
-                  name="close-circle-outline"></ion-icon>
-              </a>
+              <ion-title>Header</ion-title>
             </ion-toolbar>
           </ion-header>
 
-          <ion-content class="ct-text-color">
-            <ion-list>
-              <ion-item lines="none">
-                <div class="ion-padding">
-                  <div>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.In rutrum tortor lacus, ac interdum ipsum bibendum vel.Aenean non nibh gravida, ullamcorper mi at, tempor nulla.Proin malesuada tellus ut ullamcorper accumsan.Donec semper justo vulputate neque tempus ultricies.Proin non aliquet ipsum.Praesent mauris sem, facilisis eu justo nec, euismod imperdiet tellus.Duis eget justo congue, lacinia orci sed, fermentum urna.Quisque sed massa faucibus, interdum dolor rhoncus, molestie erat.Proin suscipit ante non mauris volutpat egestas.Donec a ultrices ligula.Mauris in felis vel dui consectetur viverra.Nam vitae quam in arcu aliquam aliquam.Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.Cras non velit nisl.Donec viverra, magna quis vestibulum volutpat, metus ante tincidunt augue, non porta nisi mi sit amet neque.Proin dapibus eros vitae nibh tincidunt, blandit rhoncus est porttitor.
-                  </div>
-                </div>
-              </ion-item>
-            </ion-list>
+          <ion-content class="ion-padding" color="primary">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.In rutrum tortor lacus, ac interdum ipsum bibendum vel.Aenean non nibh gravida, ullamcorper mi at, tempor nulla.Proin malesuada tellus ut ullamcorper accumsan.Donec semper justo vulputate neque tempus ultricies.Proin non aliquet ipsum.Praesent mauris sem, facilisis eu justo nec, euismod imperdiet tellus.Duis eget justo congue, lacinia orci sed, fermentum urna.Quisque sed massa faucibus, interdum dolor rhoncus, molestie erat.Proin suscipit ante non mauris volutpat egestas.Donec a ultrices ligula.Mauris in felis vel dui consectetur viverra.Nam vitae quam in arcu aliquam aliquam.Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.Cras non velit nisl.Donec viverra, magna quis vestibulum volutpat, metus ante tincidunt augue, non porta nisi mi sit amet neque.Proin dapibus eros vitae nibh tincidunt, blandit rhoncus est porttitor.
           </ion-content>
         `;
       }
@@ -170,26 +158,14 @@
 
       connectedCallback() {
         this.innerHTML = `
-          <ion-header class="ion-no-border" translucent>
+          <ion-header translucent>
             <ion-toolbar>
-              <ion-title id="title" class="ion-text-center">Header</ion-title>
-              <a class="pointer" slot="end">
-                <ion-icon color="primary" class="ct-text-color ct-font-size-24px ct-margin-right-8px" slot="icon-only"
-                  name="close-circle-outline"></ion-icon>
-              </a>
+              <ion-title>Header</ion-title>
             </ion-toolbar>
           </ion-header>
 
-          <ion-content class="ct-text-color" fullscreen color="primary">
-            <ion-list>
-              <ion-item lines="none" style="--background: var(--ion-color-base)">
-                <div class="ion-padding">
-                  <div>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.In rutrum tortor lacus, ac interdum ipsum bibendum vel.Aenean non nibh gravida, ullamcorper mi at, tempor nulla.Proin malesuada tellus ut ullamcorper accumsan.Donec semper justo vulputate neque tempus ultricies.Proin non aliquet ipsum.Praesent mauris sem, facilisis eu justo nec, euismod imperdiet tellus.Duis eget justo congue, lacinia orci sed, fermentum urna.Quisque sed massa faucibus, interdum dolor rhoncus, molestie erat.Proin suscipit ante non mauris volutpat egestas.Donec a ultrices ligula.Mauris in felis vel dui consectetur viverra.Nam vitae quam in arcu aliquam aliquam.Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.Cras non velit nisl.Donec viverra, magna quis vestibulum volutpat, metus ante tincidunt augue, non porta nisi mi sit amet neque.Proin dapibus eros vitae nibh tincidunt, blandit rhoncus est porttitor.
-                  </div>
-                </div>
-              </ion-item>
-            </ion-list>
+          <ion-content class="ion-padding" fullscreen color="primary">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.In rutrum tortor lacus, ac interdum ipsum bibendum vel.Aenean non nibh gravida, ullamcorper mi at, tempor nulla.Proin malesuada tellus ut ullamcorper accumsan.Donec semper justo vulputate neque tempus ultricies.Proin non aliquet ipsum.Praesent mauris sem, facilisis eu justo nec, euismod imperdiet tellus.Duis eget justo congue, lacinia orci sed, fermentum urna.Quisque sed massa faucibus, interdum dolor rhoncus, molestie erat.Proin suscipit ante non mauris volutpat egestas.Donec a ultrices ligula.Mauris in felis vel dui consectetur viverra.Nam vitae quam in arcu aliquam aliquam.Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.Cras non velit nisl.Donec viverra, magna quis vestibulum volutpat, metus ante tincidunt augue, non porta nisi mi sit amet neque.Proin dapibus eros vitae nibh tincidunt, blandit rhoncus est porttitor.
           </ion-content>
 
           <ion-footer translucent>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-v3/issues/102


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Scrolling is now handled by the `content` inside the popover, rather than the outer popover viewport.
- Prevents the `.inner-scroll` in the popover's `content` component from overflowing said content's height, through `display: flex` in a couple places. This ensures the content scrolls properly.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
