### PR TITLE
fix(accordion): improve functionality with nested accordions

### DIFF
--- a/core/src/components/accordion-group/accordion-group.tsx
+++ b/core/src/components/accordion-group/accordion-group.tsx
@@ -199,7 +199,7 @@ export class AccordionGroup implements ComponentInterface {
    */
   @Method()
   async getAccordions() {
-    return Array.from(this.el.querySelectorAll('ion-accordion'));
+    return Array.from(this.el.querySelectorAll(':scope > ion-accordion')) as HTMLIonAccordionElement[];
   }
 
   render() {

--- a/core/src/components/accordion/accordion.scss
+++ b/core/src/components/accordion/accordion.scss
@@ -58,7 +58,9 @@
 }
 
 :host(.accordion-disabled) #header,
-:host(.accordion-readonly) #header {
+:host(.accordion-readonly) #header,
+:host(.accordion-disabled) #content,
+:host(.accordion-readonly) #content {
   pointer-events: none;
 }
 

--- a/core/src/components/accordion/test/accordion.e2e.ts
+++ b/core/src/components/accordion/test/accordion.e2e.ts
@@ -1,0 +1,55 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+test('should properly set readonly on child accordions', async () => {
+  const page = await newE2EPage({
+    html: `
+      <ion-accordion-group animated="false">
+        <ion-accordion>
+          <ion-item slot="header">Label</ion-item>
+          <div slot="content">Content</div>
+        </ion-accordion>
+      </ion-accordion-group>
+    `
+  });
+
+  const accordion = await page.find('ion-accordion');
+  const value = await accordion.getProperty('readonly');
+
+  expect(value).toBe(false);
+
+  await page.$eval('ion-accordion-group', (el: HTMLIonAccordionGroupElement) => {
+    el.readonly = true;
+  });
+
+  await page.waitForChanges();
+
+  const valueAgain = await accordion.getProperty('readonly');
+  expect(valueAgain).toBe(true);
+});
+
+test('should properly set disabled on child accordions', async () => {
+  const page = await newE2EPage({
+    html: `
+      <ion-accordion-group animated="false">
+        <ion-accordion>
+          <ion-item slot="header">Label</ion-item>
+          <div slot="content">Content</div>
+        </ion-accordion>
+      </ion-accordion-group>
+    `
+  });
+
+  const accordion = await page.find('ion-accordion');
+  const value = await accordion.getProperty('disabled');
+
+  expect(value).toBe(false);
+
+  await page.$eval('ion-accordion-group', (el: HTMLIonAccordionGroupElement) => {
+    el.disabled = true;
+  });
+
+  await page.waitForChanges();
+
+  const valueAgain = await accordion.getProperty('disabled');
+  expect(valueAgain).toBe(true);
+});

--- a/core/src/components/accordion/test/accordion.spec.ts
+++ b/core/src/components/accordion/test/accordion.spec.ts
@@ -3,64 +3,6 @@ import { AccordionGroup } from '../../accordion-group/accordion-group.tsx';
 import { Accordion } from '../accordion.tsx';
 import { Item } from '../../item/item.tsx';
 
-it('should properly set readonly on child accordions', async () => {
-  const page = await newSpecPage({
-    components: [Item, Accordion, AccordionGroup],
-    html: `
-      <ion-accordion-group animated="false">
-        <ion-accordion>
-          <ion-item slot="header">Label</ion-item>
-          <div slot="content">Content</div>
-        </ion-accordion>
-      </ion-accordion-group>
-    `
-  });
-
-  const accordionGroup = page.body.querySelector('ion-accordion-group');
-  const accordions = accordionGroup.querySelectorAll('ion-accordion');
-
-  expect(accordions.length).toEqual(1);
-  accordions.forEach(accordion => {
-    expect(accordion.readonly).toEqual(false);
-  });
-
-  accordionGroup.readonly = true;
-  await page.waitForChanges();
-
-  accordions.forEach(accordion => {
-    expect(accordion.readonly).toEqual(true);
-  });
-});
-
-it('should properly set disabled on child accordions', async () => {
-  const page = await newSpecPage({
-    components: [Item, Accordion, AccordionGroup],
-    html: `
-      <ion-accordion-group animated="false">
-        <ion-accordion>
-          <ion-item slot="header">Label</ion-item>
-          <div slot="content">Content</div>
-        </ion-accordion>
-      </ion-accordion-group>
-    `
-  });
-
-  const accordionGroup = page.body.querySelector('ion-accordion-group');
-  const accordions = accordionGroup.querySelectorAll('ion-accordion');
-
-  expect(accordions.length).toEqual(1);
-  accordions.forEach(accordion => {
-    expect(accordion.disabled).toEqual(false);
-  });
-
-  accordionGroup.disabled = true;
-  await page.waitForChanges();
-
-  accordions.forEach(accordion => {
-    expect(accordion.disabled).toEqual(true);
-  });
-});
-
 it('should open correct accordions', async () => {
   const page = await newSpecPage({
     components: [Item, Accordion, AccordionGroup],

--- a/core/src/components/accordion/test/nested/e2e.ts
+++ b/core/src/components/accordion/test/nested/e2e.ts
@@ -1,0 +1,10 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+test('nested: basic', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/accordion/test/nested?ionic:_testing=true'
+  });
+
+  const compare = await page.compareScreenshot();
+  expect(compare).toMatchScreenshot();
+});

--- a/core/src/components/accordion/test/nested/index.html
+++ b/core/src/components/accordion/test/nested/index.html
@@ -74,6 +74,70 @@
               </ion-accordion>
             </ion-accordion-group>
           </div>
+          <div class="grid-item">
+            <h2>Nested Disabled</h2>
+            <ion-accordion-group expand="inset" value="attractions">
+              <ion-accordion value="attractions">
+                <ion-item color="primary" slot="header" button detail="false">
+                  <ion-icon slot="start" ios="film-outline" md="film"></ion-icon>
+                  <ion-label> Attractions</ion-label>
+                </ion-item>
+
+                <ion-accordion-group slot="content" value="second" disabled="true">
+                  <ion-accordion value="first">
+                    <ion-item color="primary" slot="header" button detail="false">
+                      <ion-label>First Item</ion-label>
+                    </ion-item>
+                    <div slot="content">First item content!</div>
+                  </ion-accordion>
+                  <ion-accordion value="second">
+                    <ion-item color="warning" slot="header" button detail="false">
+                      <ion-label>Second Item</ion-label>
+                    </ion-item>
+                    <div slot="content">Second item content!</div>
+                  </ion-accordion>
+                  <ion-accordion value="third">
+                    <ion-item color="tertiary" slot="header" button detail="false">
+                      <ion-label>Third Item</ion-label>
+                    </ion-item>
+                    <div slot="content">Third item content!</div>
+                  </ion-accordion>
+                </ion-accordion-group>
+              </ion-accordion>
+            </ion-accordion-group>
+          </div>
+          <div class="grid-item">
+            <h2>Nested Parent Disabled</h2>
+            <ion-accordion-group expand="inset" value="attractions" disabled="true">
+              <ion-accordion value="attractions">
+                <ion-item color="primary" slot="header" button detail="false">
+                  <ion-icon slot="start" ios="film-outline" md="film"></ion-icon>
+                  <ion-label> Attractions</ion-label>
+                </ion-item>
+
+                <ion-accordion-group slot="content" value="second">
+                  <ion-accordion value="first">
+                    <ion-item color="primary" slot="header" button detail="false">
+                      <ion-label>First Item</ion-label>
+                    </ion-item>
+                    <div slot="content">First item content!</div>
+                  </ion-accordion>
+                  <ion-accordion value="second">
+                    <ion-item color="warning" slot="header" button detail="false">
+                      <ion-label>Second Item</ion-label>
+                    </ion-item>
+                    <div slot="content">Second item content!</div>
+                  </ion-accordion>
+                  <ion-accordion value="third">
+                    <ion-item color="tertiary" slot="header" button detail="false">
+                      <ion-label>Third Item</ion-label>
+                    </ion-item>
+                    <div slot="content">Third item content!</div>
+                  </ion-accordion>
+                </ion-accordion-group>
+              </ion-accordion>
+            </ion-accordion-group>
+          </div>
         </div>
       </ion-content>
     </ion-app>

--- a/core/src/components/accordion/test/nested/index.html
+++ b/core/src/components/accordion/test/nested/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8">
+    <title>Accordion - Nested</title>
+    <meta name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+    <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
+    <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+    <script src="../../../../../scripts/testing/scripts.js"></script>
+    <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+    <style>
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+        grid-row-gap: 20px;
+        grid-column-gap: 20px;
+      }
+      h2 {
+        font-size: 12px;
+        font-weight: normal;
+
+        color: #6f7378;
+
+        margin-top: 10px;
+        margin-left: 5px;
+      }
+    </style>
+  </head>
+  <body>
+    <ion-app>
+      <ion-header translucent="true">
+        <ion-toolbar>
+          <ion-title>Accordion - Nested</ion-title>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content fullscreen="true" color="light">
+        <ion-header collapse="condense">
+          <ion-toolbar color="light">
+            <ion-title size="large">Accordion - Basic</ion-title>
+          </ion-toolbar>
+        </ion-header>
+
+        <div class="grid ion-padding">
+          <div class="grid-item">
+            <h2>Nested</h2>
+            <ion-accordion-group expand="inset" value="attractions">
+              <ion-accordion value="attractions">
+                <ion-item color="primary" slot="header" button detail="false">
+                  <ion-icon slot="start" ios="film-outline" md="film"></ion-icon>
+                  <ion-label> Attractions</ion-label>
+                </ion-item>
+
+                <ion-accordion-group slot="content" value="second">
+                  <ion-accordion value="first">
+                    <ion-item color="primary" slot="header" button detail="false">
+                      <ion-label>First Item</ion-label>
+                    </ion-item>
+                    <div slot="content">First item content!</div>
+                  </ion-accordion>
+                  <ion-accordion value="second">
+                    <ion-item color="warning" slot="header" button detail="false">
+                      <ion-label>Second Item</ion-label>
+                    </ion-item>
+                    <div slot="content">Second item content!</div>
+                  </ion-accordion>
+                  <ion-accordion value="third">
+                    <ion-item color="tertiary" slot="header" button detail="false">
+                      <ion-label>Third Item</ion-label>
+                    </ion-item>
+                    <div slot="content">Third item content!</div>
+                  </ion-accordion>
+                </ion-accordion-group>
+              </ion-accordion>
+            </ion-accordion-group>
+          </div>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/core/src/css/core.scss
+++ b/core/src/css/core.scss
@@ -286,7 +286,7 @@ ion-accordion-group > ion-accordion:last-of-type ion-item {
   --border-width: 0px;
 }
 
-ion-accordion.accordion-animated > [slot="header"] > .ion-accordion-toggle-icon {
+ion-accordion.accordion-animated > [slot="header"] .ion-accordion-toggle-icon {
   transition: 300ms transform cubic-bezier(0.25, 0.8, 0.5, 1);
 }
 
@@ -302,8 +302,8 @@ ion-accordion.accordion-animated > [slot="header"] > .ion-accordion-toggle-icon 
  * of one accordion should not affect any accordions inside
  * of a nested accordion group.
  */
-ion-accordion.accordion-expanding > [slot="header"] > .ion-accordion-toggle-icon,
-ion-accordion.accordion-expanded > [slot="header"] > .ion-accordion-toggle-icon {
+ion-accordion.accordion-expanding > [slot="header"] .ion-accordion-toggle-icon,
+ion-accordion.accordion-expanded > [slot="header"] .ion-accordion-toggle-icon {
   transform: rotate(180deg);
 }
 

--- a/core/src/css/core.scss
+++ b/core/src/css/core.scss
@@ -297,7 +297,7 @@ ion-accordion.accordion-animated > [slot="header"] .ion-accordion-toggle-icon {
   }
 }
 /**
- * The > [slot="header"] > selector ensures that we do
+ * The > [slot="header"] selector ensures that we do
  * not modify toggle icons for any nested accordions. The state
  * of one accordion should not affect any accordions inside
  * of a nested accordion group.

--- a/core/src/css/core.scss
+++ b/core/src/css/core.scss
@@ -274,19 +274,19 @@ ion-card-header.ion-color .ion-inherit-color {
 }
 
 // Accordion Styles
-ion-accordion-group.accordion-group-expand-inset ion-accordion:first-of-type {
+ion-accordion-group.accordion-group-expand-inset > ion-accordion:first-of-type {
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
 }
-ion-accordion-group.accordion-group-expand-inset ion-accordion:last-of-type {
+ion-accordion-group.accordion-group-expand-inset > ion-accordion:last-of-type {
   border-bottom-left-radius: 8px;
   border-bottom-right-radius: 8px;
 }
-ion-accordion-group ion-accordion:last-of-type ion-item {
+ion-accordion-group > ion-accordion:last-of-type ion-item {
   --border-width: 0px;
 }
 
-ion-accordion.accordion-animated .ion-accordion-toggle-icon {
+ion-accordion.accordion-animated > [slot="header"] > .ion-accordion-toggle-icon {
   transition: 300ms transform cubic-bezier(0.25, 0.8, 0.5, 1);
 }
 
@@ -296,18 +296,24 @@ ion-accordion.accordion-animated .ion-accordion-toggle-icon {
     transition: none !important;
   }
 }
-
-ion-accordion.accordion-expanding .ion-accordion-toggle-icon,
-ion-accordion.accordion-expanded .ion-accordion-toggle-icon {
+/**
+ * The > [slot="header"] > selector ensures that we do
+ * not modify toggle icons for any nested accordions. The state
+ * of one accordion should not affect any accordions inside
+ * of a nested accordion group.
+ */
+ion-accordion.accordion-expanding > [slot="header"] > .ion-accordion-toggle-icon,
+ion-accordion.accordion-expanded > [slot="header"] > .ion-accordion-toggle-icon {
   transform: rotate(180deg);
 }
-ion-accordion-group.accordion-group-expand-inset.md ion-accordion.accordion-previous ion-item[slot="header"] {
+
+ion-accordion-group.accordion-group-expand-inset.md > ion-accordion.accordion-previous ion-item[slot="header"] {
   --border-width: 0px;
   --inner-border-width: 0px;
 }
 
-ion-accordion-group.accordion-group-expand-inset.md ion-accordion.accordion-expanding:first-of-type,
-ion-accordion-group.accordion-group-expand-inset.md ion-accordion.accordion-expanded:first-of-type {
+ion-accordion-group.accordion-group-expand-inset.md > ion-accordion.accordion-expanding:first-of-type,
+ion-accordion-group.accordion-group-expand-inset.md > ion-accordion.accordion-expanded:first-of-type {
   margin-top: 0;
 }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number see internal ticket and https://twitter.com/schlimmson/status/1466015536253480960

The global accordion styles are too general and result in nested accordion groups getting impacts by the state of a parent accordion group. For example, if a parent accordion group is expanded, the icons in a nested accordion group will all be in the expanded state, even if the accordions themselves are not expanded

There was also an issue with keyboard navigation where you could jump between accordion groups by pressing the arrow keys.



## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Styles targeting icons only apply to the direct descendant in the "header" slot.
- Styles targeting accordions only target direct descendants of accordion groups
- Arrow keys now stay within a single accordion group. To jump to the next/prev group users can use Tab or Shift + Tab
- I also moved some spec tests to E2E due to limitations in Sizzle, a library stencil uses under the hood. Sizzle does not support `:scope` so it was causing errors when the new query selector got run.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
