### PR TITLE
fix(router): pop to previous route with params

### DIFF
--- a/core/src/components/router/test/matching.spec.tsx
+++ b/core/src/components/router/test/matching.spec.tsx
@@ -44,9 +44,9 @@ describe('matchesIDs', () => {
     const ids = [{ id: 'my-page', params: { s1: 'a', s2: 'b' } }];
 
     expect(matchesIDs(ids, [{ id: 'my-page', path: [''], params: {} }])).toBe(1);
-    expect(matchesIDs(ids, [{ id: 'my-page', path: [':s1'], params: {} }])).toBe(2);
+    expect(matchesIDs(ids, [{ id: 'my-page', path: [':s1'], params: {} }])).toBe(1);
     expect(matchesIDs(ids, [{ id: 'my-page', path: [':s1', ':s2'], params: {} }])).toBe(3);
-    expect(matchesIDs(ids, [{ id: 'my-page', path: [':s1', ':s2', ':s3'], params: {} }])).toBe(3);
+    expect(matchesIDs(ids, [{ id: 'my-page', path: [':s1', ':s2', ':s3'], params: {} }])).toBe(1);
   })
 });
 

--- a/core/src/components/router/test/matching.spec.tsx
+++ b/core/src/components/router/test/matching.spec.tsx
@@ -30,15 +30,24 @@ const CHAIN_3: RouteChain = [
 describe('matchesIDs', () => {
   it('should match simple set of ids', () => {
     const chain: RouteChain = CHAIN_1;
-    expect(matchesIDs(['2'], chain)).toBe(1);
-    expect(matchesIDs(['2', '1'], chain)).toBe(2);
-    expect(matchesIDs(['2', '1', '3'], chain)).toBe(3);
-    expect(matchesIDs(['2', '1', '3', '4'], chain)).toBe(4);
-    expect(matchesIDs(['2', '1', '3', '4', '5'], chain)).toBe(4);
+    expect(matchesIDs([{ id: '2' }], chain)).toBe(1);
+    expect(matchesIDs([{ id: '2' }, { id: '1' }], chain)).toBe(2);
+    expect(matchesIDs([{ id: '2' }, { id: '1' }, { id: '3' }], chain)).toBe(3);
+    expect(matchesIDs([{ id: '2' }, { id: '1' }, { id: '3' }, { id: '4' }], chain)).toBe(4);
+    expect(matchesIDs([{ id: '2' }, { id: '1' }, { id: '3' }, { id: '4' }, { id: '5' }], chain)).toBe(4);
 
     expect(matchesIDs([], chain)).toBe(0);
-    expect(matchesIDs(['1'], chain)).toBe(0);
+    expect(matchesIDs([{ id: '1' }], chain)).toBe(0);
   });
+
+  it('should match path with params', () => {
+    const ids = [{ id: 'my-page', params: { s1: 'a', s2: 'b' } }];
+
+    expect(matchesIDs(ids, [{ id: 'my-page', path: [''], params: {} }])).toBe(1);
+    expect(matchesIDs(ids, [{ id: 'my-page', path: [':s1'], params: {} }])).toBe(2);
+    expect(matchesIDs(ids, [{ id: 'my-page', path: [':s1', ':s2'], params: {} }])).toBe(3);
+    expect(matchesIDs(ids, [{ id: 'my-page', path: [':s1', ':s2', ':s3'], params: {} }])).toBe(3);
+  })
 });
 
 describe('matchesPath', () => {
@@ -227,7 +236,7 @@ describe('mergeParams', () => {
 });
 
 describe('RouterSegments', () => {
-  it ('should initialize with empty array', () => {
+  it('should initialize with empty array', () => {
     const s = new RouterSegments([]);
     expect(s.next()).toEqual('');
     expect(s.next()).toEqual('');
@@ -236,7 +245,7 @@ describe('RouterSegments', () => {
     expect(s.next()).toEqual('');
   });
 
-  it ('should initialize with array', () => {
+  it('should initialize with array', () => {
     const s = new RouterSegments(['', 'path', 'to', 'destination']);
     expect(s.next()).toEqual('');
     expect(s.next()).toEqual('path');

--- a/core/src/components/router/utils/matching.ts
+++ b/core/src/components/router/utils/matching.ts
@@ -32,16 +32,58 @@ export const findRouteRedirect = (path: string[], redirects: RouteRedirect[]) =>
   return redirects.find(redirect => matchesRedirect(path, redirect));
 };
 
-export const matchesIDs = (ids: string[], chain: RouteChain): number => {
+export const matchesIDs = (ids: Pick<RouteID, 'id' | 'params'>[], chain: RouteChain): number => {
   const len = Math.min(ids.length, chain.length);
-  let i = 0;
-  for (; i < len; i++) {
-    if (ids[i].toLowerCase() !== chain[i].id) {
+
+  let score = 0;
+
+  for (let i = 0; i < len; i++) {
+    const routeId = ids[i];
+    const routeChain = chain[i];
+    // Skip results where the route id does not match the chain at the same index
+    if (routeId.id.toLowerCase() !== routeChain.id) {
       break;
     }
+    if (routeId.params) {
+      /**
+       * Maps the route's params into a path based on the path variable names,
+       * to compare against the route chain format.
+       *
+       * Before:
+       * ```ts
+       * {
+       *  params: {
+       *    s1: 'a',
+       *    s2: 'b'
+       *  }
+       * }
+       * ```
+       *
+       * After:
+       * ```ts
+       * [':s1',':s2']
+       * ```
+       */
+      const pathWithParams = Object.keys(routeId.params).map(key => `:${key}`);
+      /**
+       * Takes the lower length of the constructed path or the chain's path, to
+       * avoid comparisons that exceed the bounds.
+       */
+      const paramLen = Math.min(pathWithParams.length, routeChain.path.length);
+      for (let j = 0; j < paramLen; j++) {
+        // Skip results where the path variable is not a match
+        if (pathWithParams[j].toLowerCase() !== routeChain.path[j]) {
+          break;
+        }
+        // Weight path matches for the same index higher.
+        score++;
+      }
+    }
+    // Weight id matches
+    score++;
   }
-  return i;
-};
+  return score;
+}
 
 export const matchesPath = (inputPath: string[], chain: RouteChain): RouteChain | null => {
   const segments = new RouterSegments(inputPath);
@@ -90,16 +132,16 @@ export const matchesPath = (inputPath: string[], chain: RouteChain): RouteChain 
 
 // Merges the route parameter objects.
 // Returns undefined when both parameters are undefined.
-export const mergeParams = (a: {[key: string]: any} | undefined, b: {[key: string]: any} | undefined): {[key: string]: any} | undefined => {
+export const mergeParams = (a: { [key: string]: any } | undefined, b: { [key: string]: any } | undefined): { [key: string]: any } | undefined => {
   return a || b ? { ...a, ...b } : undefined;
 };
 
 export const routerIDsToChain = (ids: RouteID[], chains: RouteChain[]): RouteChain | null => {
   let match: RouteChain | null = null;
   let maxMatches = 0;
-  const plainIDs = ids.map(i => i.id);
+
   for (const chain of chains) {
-    const score = matchesIDs(plainIDs, chain);
+    const score = matchesIDs(ids, chain);
     if (score > maxMatches) {
       match = chain;
       maxMatches = score;

--- a/core/src/components/router/utils/matching.ts
+++ b/core/src/components/router/utils/matching.ts
@@ -66,17 +66,17 @@ export const matchesIDs = (ids: Pick<RouteID, 'id' | 'params'>[], chain: RouteCh
        */
       const pathWithParams = Object.keys(routeId.params).map(key => `:${key}`);
       /**
-       * Takes the lower length of the constructed path or the chain's path, to
-       * avoid comparisons that exceed the bounds.
+       * Only compare routes with the chain that have the same number of parameters.
        */
-      const paramLen = Math.min(pathWithParams.length, routeChain.path.length);
-      for (let j = 0; j < paramLen; j++) {
-        // Skip results where the path variable is not a match
-        if (pathWithParams[j].toLowerCase() !== routeChain.path[j]) {
-          break;
+      if (pathWithParams.length === routeChain.path.length) {
+        for (let j = 0; j < pathWithParams.length; j++) {
+          // Skip results where the path variable is not a match
+          if (pathWithParams[j].toLowerCase() !== routeChain.path[j]) {
+            break;
+          }
+          // Weight path matches for the same index higher.
+          score++;
         }
-        // Weight path matches for the same index higher.
-        score++;
       }
     }
     // Weight id matches


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The function used to determine the correct path to resolve for `ion-router` does not take route parameters into consideration. It only compares the route ids, with the first definition always taking priority over all other routes. This means that if a router has multiple routes sharing the same component, the first definition will always be the route that is determined when running the matching algorithm.

i.e.:
```html
<ion-route url="/" component="my-page" />
<ion-route url="/:s1" component="my-page" />
<ion-route url="/:s1/:s2" component="my-page" />
<ion-route url="/:s1/:s2/:s3" component="my-page" />
```

`/` will always resolve as the path when determining the route to navigate to when going back to `my-page` component.

Issue Number: #24223

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

When calculating the best matched route in the chain, routes that both match the active route's id (page component match) and match the definition of route params will be weighted higher.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
