### PR TITLE
fix(item): remove empty padding space for item bottom

### DIFF
--- a/core/src/components/item/item.ios.scss
+++ b/core/src/components/item/item.ios.scss
@@ -225,13 +225,6 @@
   --padding-start: 0;
 }
 
-// Item Bottom
-// --------------------------------------------------
-
-:host(.item-has-start-slot) .item-bottom {
-  --bottom-padding-start: 48px;
-}
-
 // FROM TEXTAREA
 // iOS Stacked & Floating Textarea
 // --------------------------------------------------

--- a/core/src/components/item/item.md.scss
+++ b/core/src/components/item/item.md.scss
@@ -471,4 +471,3 @@
     --border-color: #{$item-md-input-fill-border-color-hover};
   }
 }
-

--- a/core/src/components/item/item.md.scss
+++ b/core/src/components/item/item.md.scss
@@ -471,3 +471,4 @@
     --border-color: #{$item-md-input-fill-border-color-hover};
   }
 }
+

--- a/core/src/components/item/item.scss
+++ b/core/src/components/item/item.scss
@@ -63,7 +63,6 @@
   --inner-padding-start: 0px;
   --inner-padding-end: 0px;
   --inner-box-shadow: none;
-  --bottom-padding-start: 0px;
   --show-full-highlight: 0;
   --show-inset-highlight: 0;
   --detail-icon-color: initial;
@@ -292,7 +291,7 @@ button, a {
     0,
     var(--inner-padding-end),
     0,
-    calc(var(--padding-start) + var(--ion-safe-area-left, 0px) + var(--bottom-padding-start))
+    calc(var(--padding-start) + var(--ion-safe-area-left, 0px))
   );
 
   display: flex;

--- a/core/src/components/item/item.scss
+++ b/core/src/components/item/item.scss
@@ -49,7 +49,6 @@
    * @prop --highlight-color-focused: The color of the highlight on the item when focused
    * @prop --highlight-color-valid: The color of the highlight on the item when valid
    * @prop --highlight-color-invalid: The color of the highlight on the item when invalid
-   *
    */
   --border-radius: 0px;
   --border-width: 0px;

--- a/core/src/components/item/item.scss
+++ b/core/src/components/item/item.scss
@@ -49,6 +49,7 @@
    * @prop --highlight-color-focused: The color of the highlight on the item when focused
    * @prop --highlight-color-valid: The color of the highlight on the item when valid
    * @prop --highlight-color-invalid: The color of the highlight on the item when invalid
+   *
    */
   --border-radius: 0px;
   --border-width: 0px;
@@ -63,6 +64,7 @@
   --inner-padding-start: 0px;
   --inner-padding-end: 0px;
   --inner-box-shadow: none;
+  --bottom-padding-start: 0px;
   --show-full-highlight: 0;
   --show-inset-highlight: 0;
   --detail-icon-color: initial;
@@ -281,6 +283,26 @@ button, a {
   box-sizing: border-box;
 }
 
+
+// Item Bottom
+// --------------------------------------------------
+
+.item-bottom {
+  @include margin(0);
+  @include padding(
+    0,
+    var(--inner-padding-end),
+    0,
+    calc(var(--padding-start) + var(--ion-safe-area-left, 0px) + var(--bottom-padding-start))
+  );
+
+  display: flex;
+
+  justify-content: space-between;
+
+}
+
+
 // Item Detail Icon
 // --------------------------------------------------
 
@@ -488,22 +510,6 @@ button, a {
 
 ion-ripple-effect {
   color: var(--ripple-color);
-}
-
-// Item Button Ripple effect
-// --------------------------------------------------
-
-.item-bottom {
-  @include margin(0);
-  @include padding(
-    var(--padding-top),
-    var(--inner-padding-end),
-    var(--padding-bottom),
-    calc(var(--padding-start) + var(--ion-safe-area-left, 0px) + var(--bottom-padding-start, 0px))
-  );
-  display: flex;
-
-  justify-content: space-between;
 }
 
 :host(.item-fill-solid) ::slotted([slot="start"]),

--- a/core/src/components/item/item.tsx
+++ b/core/src/components/item/item.tsx
@@ -326,7 +326,7 @@ export class Item implements ComponentInterface, AnchorInterface, ButtonInterfac
     // Only set onClick if the item is clickable to prevent screen
     // readers from reading all items as clickable
     const clickFn = clickable ? {
-      onClick: (ev: Event) => {openURL(href, ev, routerDirection, routerAnimation); }
+      onClick: (ev: Event) => { openURL(href, ev, routerDirection, routerAnimation); }
     } : {};
     const showDetail = detail !== undefined ? detail : mode === 'ios' && clickable;
     this.itemStyles.forEach(value => {

--- a/core/src/components/item/test/css-variables/e2e.ts
+++ b/core/src/components/item/test/css-variables/e2e.ts
@@ -1,0 +1,10 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+test('item: CSS variables', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/item/test/css-variables?ionic:_testing=true'
+  });
+
+  const compare = await page.compareScreenshot();
+  expect(compare).toMatchScreenshot();
+});

--- a/core/src/components/item/test/css-variables/index.html
+++ b/core/src/components/item/test/css-variables/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Item - CSS Variables</title>
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
+  <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+  <script src="../../../../../scripts/testing/scripts.js"></script>
+  <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+</head>
+
+<style>
+  ion-item {
+    --padding-top: 20px;
+    --background: #eee;
+  }
+</style>
+
+<body>
+  <ion-app>
+
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Item CSS variables</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content class="ion-padding-vertical">
+      <ion-list class="basic">
+        <ion-item>
+          <ion-label>Item 1</ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Item 2</ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Item 3</ion-label>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ion-app>
+
+</body>
+
+</html>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `.item-bottom` implementation for `ion-item`, incorrectly pushes the item's contents regardless if help/error text is present.

![Screen Shot 2021-12-06 at 3 45 40 PM](https://user-images.githubusercontent.com/13732623/144919907-5a37bc86-92fc-4848-b64b-bc77f7e0c545.png)

Issue Number: Resolves #23892


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The reserved space for the help/error text will not push the container space when the slot is unused.

![Screen Shot 2021-12-06 at 3 39 34 PM](https://user-images.githubusercontent.com/13732623/144919933-af43ee03-87b9-416c-9e0f-0fb2b0b07b38.png)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Changes for help/error text and the item bottom container were introduced with: #23354