### PR TITLE
fix(angular): defer control value accessor write until after hydration

### DIFF
--- a/angular/src/app-initialize.ts
+++ b/angular/src/app-initialize.ts
@@ -6,6 +6,25 @@ import { Config } from './providers/config';
 import { IonicWindow } from './types/interfaces';
 import { raf } from './util/util';
 
+interface ZoneEventTarget extends EventTarget {
+  /**
+   * Zone.js Monkey-patch for addEventListener.
+   */
+  __zone_symbol__addEventListener: (
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: AddEventListenerOptions | boolean
+  ) => void;
+  /**
+   * Zone.js Monkey-patch for removeEventListener.
+   */
+  __zone_symbol__removeEventListener: (
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: EventListenerOptions | boolean
+  ) => void;
+}
+
 export const appInitialize = (config: Config, doc: Document, zone: NgZone) => {
   return (): any => {
     const win: IonicWindow | undefined = doc.defaultView as any;
@@ -15,8 +34,15 @@ export const appInitialize = (config: Config, doc: Document, zone: NgZone) => {
         _zoneGate: (h: any) => zone.run(h),
       });
 
+      // Use Zone.js implementation for addEventListener if present.
       const aelFn =
         '__zone_symbol__addEventListener' in (doc.body as any) ? '__zone_symbol__addEventListener' : 'addEventListener';
+
+      // Use Zone.js implementation for removeEventListener if present.
+      const relFn =
+        '__zone_symbol__removeEventListener' in (doc.body as any)
+          ? '__zone_symbol__removeEventListener'
+          : 'removeEventListener';
 
       return applyPolyfills().then(() => {
         return defineCustomElements(win, {
@@ -25,10 +51,10 @@ export const appInitialize = (config: Config, doc: Document, zone: NgZone) => {
           raf,
           jmp: (h: any) => zone.runOutsideAngular(h),
           ael(elm, eventName, cb, opts) {
-            (elm as any)[aelFn](eventName, cb, opts);
+            (elm as ZoneEventTarget)[aelFn](eventName, cb, opts);
           },
           rel(elm, eventName, cb, opts) {
-            elm.removeEventListener(eventName, cb, opts);
+            (elm as ZoneEventTarget)[relFn](eventName, cb, opts);
           },
         });
       });

--- a/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
@@ -1,17 +1,10 @@
 import { Directive, HostListener, ElementRef, Injector } from '@angular/core';
-import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import { ValueAccessor, setIonicClasses } from './value-accessor';
+import { ValueAccessor, setIonicClasses, valueAccessorProvider } from './value-accessor';
 
 @Directive({
   selector: 'ion-checkbox,ion-toggle',
-  providers: [
-    {
-      provide: NG_VALUE_ACCESSOR,
-      useExisting: BooleanValueAccessorDirective,
-      multi: true,
-    },
-  ],
+  providers: [valueAccessorProvider(BooleanValueAccessorDirective)],
 })
 export class BooleanValueAccessorDirective extends ValueAccessor {
   constructor(injector: Injector, el: ElementRef) {

--- a/angular/src/directives/control-value-accessors/numeric-value-accesssor.ts
+++ b/angular/src/directives/control-value-accessors/numeric-value-accesssor.ts
@@ -1,17 +1,10 @@
 import { Directive, HostListener, ElementRef, Injector } from '@angular/core';
-import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import { ValueAccessor } from './value-accessor';
+import { ValueAccessor, valueAccessorProvider } from './value-accessor';
 
 @Directive({
   selector: 'ion-input[type=number]',
-  providers: [
-    {
-      provide: NG_VALUE_ACCESSOR,
-      useExisting: NumericValueAccessorDirective,
-      multi: true,
-    },
-  ],
+  providers: [valueAccessorProvider(NumericValueAccessorDirective)],
 })
 export class NumericValueAccessorDirective extends ValueAccessor {
   constructor(injector: Injector, el: ElementRef) {

--- a/angular/src/directives/control-value-accessors/radio-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/radio-value-accessor.ts
@@ -1,18 +1,11 @@
 import { ElementRef, Injector, Directive, HostListener } from '@angular/core';
-import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import { ValueAccessor } from './value-accessor';
+import { ValueAccessor, valueAccessorProvider } from './value-accessor';
 
 @Directive({
   /* tslint:disable-next-line:directive-selector */
   selector: 'ion-radio',
-  providers: [
-    {
-      provide: NG_VALUE_ACCESSOR,
-      useExisting: RadioValueAccessorDirective,
-      multi: true,
-    },
-  ],
+  providers: [valueAccessorProvider(RadioValueAccessorDirective)],
 })
 export class RadioValueAccessorDirective extends ValueAccessor {
   constructor(injector: Injector, el: ElementRef) {

--- a/angular/src/directives/control-value-accessors/select-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/select-value-accessor.ts
@@ -1,18 +1,11 @@
 import { ElementRef, Injector, Directive, HostListener } from '@angular/core';
-import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import { ValueAccessor } from './value-accessor';
+import { ValueAccessor, valueAccessorProvider } from './value-accessor';
 
 @Directive({
   /* tslint:disable-next-line:directive-selector */
   selector: 'ion-range, ion-select, ion-radio-group, ion-segment, ion-datetime',
-  providers: [
-    {
-      provide: NG_VALUE_ACCESSOR,
-      useExisting: SelectValueAccessorDirective,
-      multi: true,
-    },
-  ],
+  providers: [valueAccessorProvider(SelectValueAccessorDirective)],
 })
 export class SelectValueAccessorDirective extends ValueAccessor {
   constructor(injector: Injector, el: ElementRef) {

--- a/angular/src/directives/control-value-accessors/text-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/text-value-accessor.ts
@@ -1,18 +1,11 @@
 import { ElementRef, Injector, Directive, HostListener } from '@angular/core';
-import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import { ValueAccessor } from './value-accessor';
+import { ValueAccessor, valueAccessorProvider } from './value-accessor';
 
 @Directive({
   /* tslint:disable-next-line:directive-selector */
   selector: 'ion-input:not([type=number]),ion-textarea,ion-searchbar',
-  providers: [
-    {
-      provide: NG_VALUE_ACCESSOR,
-      useExisting: TextValueAccessorDirective,
-      multi: true,
-    },
-  ],
+  providers: [valueAccessorProvider(TextValueAccessorDirective)],
 })
 export class TextValueAccessorDirective extends ValueAccessor {
   constructor(injector: Injector, el: ElementRef) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil hydrated web components can delay the execution timing for the `connectedCallback()` on first initialization. This results in the Angular control value accessors writing the value to the element before it is initialized. 

In the event of using Angular forms with a form control that has an existing value; this will mean that the control will be initialized without a value. The `emitStyle()` from our Ionic form controls will update the `ion-item` appearance, without the appropriate `item-has-value` class. Then, before `attributeChangedCallback()` is registered, the value will be assigned to the web component. This results in the inner control displaying with a value, but the side-effect behavior that `ion-item` is out of sync.

This wasn't an issue before https://github.com/angular/angular-cli/commit/22e0208a9ee6257213b3bf93ac61a2c3d4ac9504, as likely the connectedCallback behavior in Stencil was benefiting from the defect in Zone.js.

Issue Number: Resolves #23809


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The Ionic custom control value accessors will delay the `writeValue` operation (assigning the value to the element), until after both the custom element is defined and the `componentOnReady` life cycle method has completed. 

This aligns the Ionic web components with native web component behavior that the operations will occur in this order for each initialization of the component:
1. `connectedCallback()`
2. `controlValueAccessor.#writeValue()`

Updates the `removeEventListener` implementation for Stencil hydrated web components to make use of the monkey-patch method, just as the `addEventListener` operates. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
