### PR TITLE
build(lerna): split release and next builds out into separate tasks

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -29,6 +29,11 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16
+      - name: Configure Identity
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+        shell: bash
       - name: Install Dependencies
         run: npm ci --no-package-lock && lerna bootstrap --ignore-scripts -- --legacy-peer-deps
         shell: bash

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,4 +1,4 @@
-name: 'Ionic Production Release'
+name: 'Ionic Pre-Release'
 
 on:
   workflow_dispatch:
@@ -8,17 +8,18 @@ on:
         type: choice
         description: Which version should be published?
         options:
-          - patch
-          - minor
-          - major
-      tag:
+          - prepatch
+          - preminor
+          - premajor
+      prefix:
         required: true
         type: choice
-        description: Which npm tag should this be published to?
+        description: What kind of pre-release is this?
+        default: beta
         options:
-          - latest
-          - v5-lts
-          - v4-lts
+          - alpha
+          - beta
+          - rc
 
 jobs:
   build-ionic:
@@ -38,5 +39,5 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Release
         run: |
-          HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag latest --no-git-tag-version --no-push --skip-npm
+          HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag next --no-git-tag-version --no-push --skip-npm --preid $(echo "${{ github.events.inputs.prefix }}")
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ on:
           - beta
           - rc
 jobs:
-  build:
+  release-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
         shell: bash
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Release
+      - name: Pre-Release
         if: ${{ github.events.inputs.prefix != '' }}
         run: |
           HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag $(echo "${{ github.events.inputs.tag }}") --no-git-tag-version --no-push --skip-npm --preid $(echo "${{ github.events.inputs.prefix }}")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,9 @@ on:
       prefix:
         type: choice
         description: For pre-releases, what kind of pre-release is this?
-        default: ''
+        default: none
         options:
-          - ''
+          - none
           - alpha
           - beta
           - rc
@@ -48,12 +48,12 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Pre-Release
-        if: ${{ github.events.inputs.prefix != '' }}
+        if: ${{ github.events.inputs.prefix != none }}
         run: |
           HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag $(echo "${{ github.events.inputs.tag }}") --no-git-tag-version --no-push --skip-npm --preid $(echo "${{ github.events.inputs.prefix }}")
         shell: bash
       - name: Release
-        if: ${{ github.events.inputs.prefix == '' }}
+        if: ${{ github.events.inputs.prefix == none }}
         run: |
           HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag $(echo "${{ github.events.inputs.tag }}") --no-git-tag-version --no-push --skip-npm
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,5 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Release
         run: |
-          HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag latest --no-git-tag-version --no-push --skip-npm
+          HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag $(echo "${{ github.events.inputs.tag }}") --no-git-tag-version --no-push --skip-npm
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,12 +48,12 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Pre-Release
-        if: ${{ github.events.inputs.prefix != none }}
+        if: ${{ github.events.inputs.prefix != 'none' }}
         run: |
           HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag $(echo "${{ github.events.inputs.tag }}") --no-git-tag-version --no-push --skip-npm --preid $(echo "${{ github.events.inputs.prefix }}")
         shell: bash
       - name: Release
-        if: ${{ github.events.inputs.prefix == none }}
+        if: ${{ github.events.inputs.prefix == 'none' }}
         run: |
           HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag $(echo "${{ github.events.inputs.tag }}") --no-git-tag-version --no-push --skip-npm
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,5 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Release
         run: |
-          HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag $(echo "${{ github.events.inputs.tag }}") --no-git-tag-version --no-push --skip-npm
+          HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag $(echo "${{ github.event.inputs.tag }}") --no-git-tag-version --no-push --skip-npm
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,11 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16
+      - name: Configure Identity
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+        shell: bash
       - name: Install Dependencies
         run: npm ci --no-package-lock && lerna bootstrap --ignore-scripts -- --legacy-peer-deps
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,16 +22,19 @@ on:
           - latest
           - next
           - dev
+          - v4-lts
+          - v5-lts
       prefix:
         type: choice
         description: For pre-releases, what kind of pre-release is this?
         default: ''
         options:
+          - ''
           - alpha
           - beta
           - rc
 jobs:
-  dev-build:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -47,6 +50,12 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Release
+        if: ${{ github.events.inputs.prefix != '' }}
         run: |
           HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag $(echo "${{ github.events.inputs.tag }}") --no-git-tag-version --no-push --skip-npm --preid $(echo "${{ github.events.inputs.prefix }}")
         shell: bash
+    - name: Release
+      if: ${{ github.events.inputs.prefix == '' }}
+      run: |
+        HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag $(echo "${{ github.events.inputs.tag }}") --no-git-tag-version --no-push --skip-npm
+      shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ on:
         description: For pre-releases, what kind of pre-release is this?
         default: ''
         options:
+          - ''
           - alpha
           - beta
           - rc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,19 +22,16 @@ on:
           - latest
           - next
           - dev
-          - v4-lts
-          - v5-lts
       prefix:
         type: choice
         description: For pre-releases, what kind of pre-release is this?
         default: ''
         options:
-          - ''
           - alpha
           - beta
           - rc
 jobs:
-  release-build:
+  production-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -54,8 +51,8 @@ jobs:
         run: |
           HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag $(echo "${{ github.events.inputs.tag }}") --no-git-tag-version --no-push --skip-npm --preid $(echo "${{ github.events.inputs.prefix }}")
         shell: bash
-    - name: Release
-      if: ${{ github.events.inputs.prefix == '' }}
-      run: |
-        HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag $(echo "${{ github.events.inputs.tag }}") --no-git-tag-version --no-push --skip-npm
-      shell: bash
+      - name: Release
+        if: ${{ github.events.inputs.prefix == '' }}
+        run: |
+          HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ github.event.inputs.version }}") --no-verify-access --yes --force-publish='*' --dist-tag $(echo "${{ github.events.inputs.tag }}") --no-git-tag-version --no-push --skip-npm
+        shell: bash


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

To do a alpha/beta/rc release, we need to pass `--preid` to lerna. For stable releases, there is no `preid` but lerna does not accept undefined as a value for `--preid`. 

Rather than try to do some condition logic with the build file, I decided to split things out into 2 separate files.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Created a file for doing stable releases of Ionic
- Created a file for doing pre-release versions of Ionic (beta/rc not dev build)
- Configured the git identity for each script. GitHub Actions comes with a built in token under the "github-actions" user, so I am using that.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
