### PR TITLE
fix(radio): fix radio not showing checked state when not in a group

### DIFF
--- a/core/src/components/item/test/disabled/index.html
+++ b/core/src/components/item/test/disabled/index.html
@@ -116,6 +116,24 @@
         </ion-item>
 
         <ion-item>
+          <ion-radio disabled slot="start"></ion-radio>
+          <ion-checkbox slot="start"></ion-checkbox>
+          <ion-label>Radio + Checkbox</ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-radio slot="start"></ion-radio>
+          <ion-checkbox disabled slot="start"></ion-checkbox>
+          <ion-label>Radio + Checkbox, disabled input second</ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-checkbox slot="start"></ion-checkbox>
+          <ion-radio disabled slot="start"></ion-radio>
+          <ion-label>Checkbox + Radio, disabled input second</ion-label>
+        </ion-item>
+
+        <ion-item>
           <ion-label>Disabled Selects</ion-label>
           <ion-select placeholder="month">
             <ion-select-option value="1">January</ion-select-option>

--- a/core/src/components/item/test/disabled/index.html
+++ b/core/src/components/item/test/disabled/index.html
@@ -116,24 +116,6 @@
         </ion-item>
 
         <ion-item>
-          <ion-radio disabled slot="start"></ion-radio>
-          <ion-checkbox slot="start"></ion-checkbox>
-          <ion-label>Radio + Checkbox</ion-label>
-        </ion-item>
-
-        <ion-item>
-          <ion-radio slot="start"></ion-radio>
-          <ion-checkbox disabled slot="start"></ion-checkbox>
-          <ion-label>Radio + Checkbox, disabled input second</ion-label>
-        </ion-item>
-
-        <ion-item>
-          <ion-checkbox slot="start"></ion-checkbox>
-          <ion-radio disabled slot="start"></ion-radio>
-          <ion-label>Checkbox + Radio, disabled input second</ion-label>
-        </ion-item>
-
-        <ion-item>
           <ion-label>Disabled Selects</ion-label>
           <ion-select placeholder="month">
             <ion-select-option value="1">January</ion-select-option>

--- a/core/src/components/radio/radio.tsx
+++ b/core/src/components/radio/radio.tsx
@@ -22,6 +22,7 @@ import { createColorClasses, hostContext } from '../../utils/theme';
 export class Radio implements ComponentInterface {
   private inputId = `ion-rb-${radioButtonIds++}`;
   private radioGroup: HTMLIonRadioGroupElement | null = null;
+  private nativeInput!: HTMLInputElement;
 
   @Element() el!: HTMLIonRadioElement;
 
@@ -128,6 +129,10 @@ export class Radio implements ComponentInterface {
     }
   }
 
+  private onClick = () => {
+    this.checked = this.nativeInput.checked;
+  };
+
   private onFocus = () => {
     this.ionFocus.emit();
   }
@@ -150,6 +155,7 @@ export class Radio implements ComponentInterface {
         tabindex={buttonTabindex}
         onFocus={this.onFocus}
         onBlur={this.onBlur}
+        onClick={this.onClick}
         class={createColorClasses(color, {
           [mode]: true,
           'in-item': hostContext('ion-item', el),
@@ -171,6 +177,7 @@ export class Radio implements ComponentInterface {
           disabled={disabled}
           tabindex="-1"
           id={inputId}
+          ref={el => this.nativeInput = el as HTMLInputElement}
         />
       </Host>
     );

--- a/core/src/components/radio/test/basic/e2e.ts
+++ b/core/src/components/radio/test/basic/e2e.ts
@@ -7,6 +7,14 @@ test('radio: basic', async () => {
 
   const compare = await page.compareScreenshot();
   expect(compare).toMatchScreenshot();
+
+  const groupedRadio = await page.find('#groupedRadio');
+  await groupedRadio.click();
+  expect(groupedRadio).toHaveClass('radio-checked');
+
+  const ungroupedRadio = await page.find('#ungroupedRadio');
+  await ungroupedRadio.click();
+  expect(ungroupedRadio).toHaveClass('radio-checked');
 });
 
 test('radio:rtl: basic', async () => {

--- a/core/src/components/radio/test/basic/index.html
+++ b/core/src/components/radio/test/basic/index.html
@@ -27,7 +27,7 @@
           </ion-item-divider>
           <ion-item>
             <ion-label>Pepperoni</ion-label>
-            <ion-radio slot="start" value="pepperoni"></ion-radio>
+            <ion-radio slot="start" value="pepperoni" id="groupedRadio"></ion-radio>
           </ion-item>
 
           <ion-item>
@@ -137,7 +137,7 @@
         </ion-list-header>
         <ion-item>
           <ion-label>Kiwi, (ionChange) Secondary color</ion-label>
-          <ion-radio slot="start" color="secondary"></ion-radio>
+          <ion-radio slot="start" color="secondary" id="ungroupedRadio"></ion-radio>
         </ion-item>
 
         <ion-item>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic-framework/issues/24291

If an `ion-radio` is not part of an `ion-radio-group`, clicking it does not apply the `radio-checked` class, making it look like nothing happened. However, the native `input` *does* get correctly set to `checked=true`.

This bug looks to be masquerading as the one described in the issue linked above. While having multiple inputs in an `ion-item` and disabling one of them does *not* currently disable the other inputs, using an `ion-radio` as the enabled input can make it look that way.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The `checked` property of the `ion-radio` component is updated on click to match the native input. This is then picked up by the existing `@Watch('checked')`, which applies the proper styling.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build posted on the original issue to be definitively sure that the source was this bug.