### PR TITLE
fix(react): backdrop for inline modal/popover overlay

### DIFF
--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -35,9 +35,6 @@ const createController = <Opts extends object, HTMLElm extends any>(tagName: str
     },
     async getTop(): Promise<HTMLElm | undefined> {
       return getOverlay(document, tagName) as any;
-    },
-    defineCustomElements() {
-      return registerOverlayComponents(tagName, customElement, childrenCustomElements);
     }
   };
 };

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -60,26 +60,22 @@ export const prepareOverlay = <T extends HTMLIonOverlayElement>(el: T) => {
 };
 
 const registerOverlayComponents = (tagName: string, customElement: any, childrenCustomElements?: ChildCustomElementDefinition[]): Promise<any> => {
-  /* tslint:disable-next-line */
-  if (typeof window !== 'undefined' && typeof window.customElements !== 'undefined') {
-    const { customElements } = window;
-    if (!customElements.get(tagName)) {
-      customElements.define(tagName, customElement);
-    }
-    /**
-     * If the parent element has nested usage of custom elements,
-     * we need to manually define those custom elements.
-     */
-    if (childrenCustomElements) {
-      for (const customElementDefinition of childrenCustomElements) {
-        if (!customElements.get(customElementDefinition.tagName)) {
-          customElements.define(customElementDefinition.tagName, customElementDefinition.customElement);
-        }
+  const { customElements } = window;
+  if (!customElements.get(tagName)) {
+    customElements.define(tagName, customElement);
+  }
+  /**
+   * If the parent element has nested usage of custom elements,
+   * we need to manually define those custom elements.
+   */
+  if (childrenCustomElements) {
+    for (const customElementDefinition of childrenCustomElements) {
+      if (!customElements.get(customElementDefinition.tagName)) {
+        customElements.define(customElementDefinition.tagName, customElementDefinition.customElement);
       }
     }
-    return customElements.whenDefined(tagName);
   }
-  return Promise.resolve() as any;
+  return customElements.whenDefined(tagName);
 }
 
 export const createOverlay = <T extends HTMLIonOverlayElement>(tagName: string, opts: object | undefined, customElement?: any, childrenCustomElements?: ChildCustomElementDefinition[]): Promise<T> => {

--- a/packages/react/src/components/IonActionSheet.tsx
+++ b/packages/react/src/components/IonActionSheet.tsx
@@ -3,17 +3,17 @@ import {
   ActionSheetOptions as ActionSheetOptionsCore,
   actionSheetController as actionSheetControllerCore,
 } from '@ionic/core/components';
-import { IonActionSheet as IonActionSheetCmp } from '@ionic/core/components/ion-action-sheet.js';
+import { defineCustomElement } from '@ionic/core/components/ion-action-sheet.js';
 
 import { createOverlayComponent } from './createOverlayComponent';
 
 export interface ActionSheetButton extends Omit<ActionSheetButtonCore, 'icon'> {
   icon?:
-    | {
-        ios: string;
-        md: string;
-      }
-    | string;
+  | {
+    ios: string;
+    md: string;
+  }
+  | string;
 }
 
 export interface ActionSheetOptions extends Omit<ActionSheetOptionsCore, 'buttons'> {
@@ -30,4 +30,4 @@ const actionSheetController = {
 export const IonActionSheet = /*@__PURE__*/ createOverlayComponent<
   ActionSheetOptions,
   HTMLIonActionSheetElement
->('ion-action-sheet', actionSheetController, IonActionSheetCmp);
+>('ion-action-sheet', actionSheetController, defineCustomElement);

--- a/packages/react/src/components/IonModal.tsx
+++ b/packages/react/src/components/IonModal.tsx
@@ -1,9 +1,8 @@
-import { JSX } from '@ionic/core/components';
-import { IonModal as IonModalCmp } from '@ionic/core/components/ion-modal.js';
+import { JSX, modalController } from '@ionic/core/components';
 
 import { createInlineOverlayComponent } from './createInlineOverlayComponent'
 
 export const IonModal = /*@__PURE__*/ createInlineOverlayComponent<
   JSX.IonModal,
   HTMLIonModalElement
->('ion-modal', IonModalCmp);
+>('ion-modal', modalController);

--- a/packages/react/src/components/IonModal.tsx
+++ b/packages/react/src/components/IonModal.tsx
@@ -3,10 +3,7 @@ import { defineCustomElement } from '@ionic/core/components/ion-modal.js';
 
 import { createInlineOverlayComponent } from './createInlineOverlayComponent'
 
-export const IonModal = /*@__PURE__*/ () => {
-  defineCustomElement();
-  return createInlineOverlayComponent<
-    JSX.IonModal,
-    HTMLIonModalElement
-  >('ion-modal')
-};
+export const IonModal = /*@__PURE__*/ createInlineOverlayComponent<
+  JSX.IonModal,
+  HTMLIonModalElement
+>('ion-modal', defineCustomElement);

--- a/packages/react/src/components/IonModal.tsx
+++ b/packages/react/src/components/IonModal.tsx
@@ -1,8 +1,12 @@
-import { JSX, modalController } from '@ionic/core/components';
+import { JSX } from '@ionic/core/components';
+import { defineCustomElement } from '@ionic/core/components/ion-modal.js';
 
 import { createInlineOverlayComponent } from './createInlineOverlayComponent'
 
-export const IonModal = /*@__PURE__*/ createInlineOverlayComponent<
-  JSX.IonModal,
-  HTMLIonModalElement
->('ion-modal', modalController);
+export const IonModal = /*@__PURE__*/ () => {
+  defineCustomElement();
+  return createInlineOverlayComponent<
+    JSX.IonModal,
+    HTMLIonModalElement
+  >('ion-modal')
+};

--- a/packages/react/src/components/IonPopover.tsx
+++ b/packages/react/src/components/IonPopover.tsx
@@ -1,5 +1,6 @@
 import { JSX } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-popover.js';
+
 import { createInlineOverlayComponent } from './createInlineOverlayComponent'
 
 export const IonPopover = /*@__PURE__*/ () => {

--- a/packages/react/src/components/IonPopover.tsx
+++ b/packages/react/src/components/IonPopover.tsx
@@ -1,9 +1,8 @@
-import { JSX } from '@ionic/core/components';
-import { IonPopover as IonPopoverCmp } from '@ionic/core/components/ion-popover.js';
+import { JSX, popoverController } from '@ionic/core/components';
 
 import { createInlineOverlayComponent } from './createInlineOverlayComponent'
 
 export const IonPopover = /*@__PURE__*/ createInlineOverlayComponent<
   JSX.IonPopover,
   HTMLIonPopoverElement
->('ion-popover', IonPopoverCmp);
+>('ion-popover', popoverController);

--- a/packages/react/src/components/IonPopover.tsx
+++ b/packages/react/src/components/IonPopover.tsx
@@ -3,10 +3,7 @@ import { defineCustomElement } from '@ionic/core/components/ion-popover.js';
 
 import { createInlineOverlayComponent } from './createInlineOverlayComponent'
 
-export const IonPopover = /*@__PURE__*/ () => {
-  defineCustomElement();
-  return createInlineOverlayComponent<
-    JSX.IonPopover,
-    HTMLIonPopoverElement
-  >('ion-popover')
-};
+export const IonPopover = /*@__PURE__*/ createInlineOverlayComponent<
+  JSX.IonPopover,
+  HTMLIonPopoverElement
+>('ion-popover', defineCustomElement);

--- a/packages/react/src/components/IonPopover.tsx
+++ b/packages/react/src/components/IonPopover.tsx
@@ -1,8 +1,11 @@
-import { JSX, popoverController } from '@ionic/core/components';
-
+import { JSX } from '@ionic/core/components';
+import { defineCustomElement } from '@ionic/core/components/ion-popover.js';
 import { createInlineOverlayComponent } from './createInlineOverlayComponent'
 
-export const IonPopover = /*@__PURE__*/ createInlineOverlayComponent<
-  JSX.IonPopover,
-  HTMLIonPopoverElement
->('ion-popover', popoverController);
+export const IonPopover = /*@__PURE__*/ () => {
+  defineCustomElement();
+  return createInlineOverlayComponent<
+    JSX.IonPopover,
+    HTMLIonPopoverElement
+  >('ion-popover')
+};

--- a/packages/react/src/components/createInlineOverlayComponent.tsx
+++ b/packages/react/src/components/createInlineOverlayComponent.tsx
@@ -17,7 +17,6 @@ type InlineOverlayState = {
 interface IonicReactInternalProps<ElementType> extends React.HTMLAttributes<ElementType> {
   forwardedRef?: React.ForwardedRef<ElementType>;
   ref?: React.Ref<any>;
-  children?: React.ReactNode;
   onDidDismiss?: (event: CustomEvent<OverlayEventDetail>) => void;
   onDidPresent?: (event: CustomEvent<OverlayEventDetail>) => void;
   onWillDismiss?: (event: CustomEvent<OverlayEventDetail>) => void;

--- a/packages/react/src/components/createInlineOverlayComponent.tsx
+++ b/packages/react/src/components/createInlineOverlayComponent.tsx
@@ -5,7 +5,6 @@ import {
   attachProps,
   camelToDashCase,
   dashToPascalCase,
-  defineCustomElement,
   isCoveredByReact,
   mergeRefs,
 } from './react-component-lib/utils';
@@ -26,9 +25,9 @@ interface IonicReactInternalProps<ElementType> extends React.HTMLAttributes<Elem
 
 export const createInlineOverlayComponent = <PropType, ElementType>(
   tagName: string,
-  customElement?: any
+  controller: { defineCustomElements: () => Promise<any> }
 ) => {
-  defineCustomElement(tagName, customElement);
+  controller.defineCustomElements();
 
   const displayName = dashToPascalCase(tagName);
   const ReactComponent = class extends React.Component<IonicReactInternalProps<PropType>, InlineOverlayState> {

--- a/packages/react/src/components/createInlineOverlayComponent.tsx
+++ b/packages/react/src/components/createInlineOverlayComponent.tsx
@@ -25,7 +25,7 @@ interface IonicReactInternalProps<ElementType> extends React.HTMLAttributes<Elem
 
 export const createInlineOverlayComponent = <PropType, ElementType>(
   tagName: string,
-  defineCustomElement?: any
+  defineCustomElement?: () => void
 ) => {
   if (defineCustomElement) {
     defineCustomElement();

--- a/packages/react/src/components/createInlineOverlayComponent.tsx
+++ b/packages/react/src/components/createInlineOverlayComponent.tsx
@@ -17,6 +17,7 @@ type InlineOverlayState = {
 interface IonicReactInternalProps<ElementType> extends React.HTMLAttributes<ElementType> {
   forwardedRef?: React.ForwardedRef<ElementType>;
   ref?: React.Ref<any>;
+  children?: React.ReactNode;
   onDidDismiss?: (event: CustomEvent<OverlayEventDetail>) => void;
   onDidPresent?: (event: CustomEvent<OverlayEventDetail>) => void;
   onWillDismiss?: (event: CustomEvent<OverlayEventDetail>) => void;
@@ -25,7 +26,11 @@ interface IonicReactInternalProps<ElementType> extends React.HTMLAttributes<Elem
 
 export const createInlineOverlayComponent = <PropType, ElementType>(
   tagName: string,
+  defineCustomElement?: any
 ) => {
+  if (defineCustomElement) {
+    defineCustomElement();
+  }
   const displayName = dashToPascalCase(tagName);
   const ReactComponent = class extends React.Component<IonicReactInternalProps<PropType>, InlineOverlayState> {
     ref: React.RefObject<HTMLElement>;

--- a/packages/react/src/components/createInlineOverlayComponent.tsx
+++ b/packages/react/src/components/createInlineOverlayComponent.tsx
@@ -25,10 +25,7 @@ interface IonicReactInternalProps<ElementType> extends React.HTMLAttributes<Elem
 
 export const createInlineOverlayComponent = <PropType, ElementType>(
   tagName: string,
-  controller: { defineCustomElements: () => Promise<any> }
 ) => {
-  controller.defineCustomElements();
-
   const displayName = dashToPascalCase(tagName);
   const ReactComponent = class extends React.Component<IonicReactInternalProps<PropType>, InlineOverlayState> {
     ref: React.RefObject<HTMLElement>;

--- a/packages/react/src/components/createOverlayComponent.tsx
+++ b/packages/react/src/components/createOverlayComponent.tsx
@@ -2,7 +2,7 @@ import { OverlayEventDetail } from '@ionic/core/components';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { attachProps, dashToPascalCase, defineCustomElement, setRef } from './react-component-lib/utils';
+import { attachProps, dashToPascalCase, setRef } from './react-component-lib/utils';
 
 interface OverlayElement extends HTMLElement {
   present: () => Promise<void>;
@@ -24,9 +24,11 @@ export const createOverlayComponent = <
 >(
   tagName: string,
   controller: { create: (options: any) => Promise<OverlayType> },
-  customElement?: any
+  defineCustomElement?: any
 ) => {
-  defineCustomElement(tagName, customElement);
+  if (defineCustomElement) {
+    defineCustomElement();
+  }
 
   const displayName = dashToPascalCase(tagName);
   const didDismissEventName = `on${displayName}DidDismiss`;

--- a/packages/react/src/components/createOverlayComponent.tsx
+++ b/packages/react/src/components/createOverlayComponent.tsx
@@ -24,9 +24,9 @@ export const createOverlayComponent = <
 >(
   tagName: string,
   controller: { create: (options: any) => Promise<OverlayType> },
-  defineCustomElement?: any
+  defineCustomElement?: () => void
 ) => {
-  if (defineCustomElement) {
+  if (defineCustomElement !== undefined) {
     defineCustomElement();
   }
 

--- a/packages/vue/scripts/copy-overlays.js
+++ b/packages/vue/scripts/copy-overlays.js
@@ -46,7 +46,9 @@ function generateOverlays() {
     const docsBlock = getDocsBlock(component.tag);
     const props = getPropsFromDocsBlock(docsBlock);
 
-    componentImports.push(`import { ${component.name} as ${component.name}Cmp } from '@ionic/core/components/${component.tag}.js'`);
+    const defineCustomElementFn = `define${component.name}CustomElement`;
+
+    componentImports.push(`import { defineCustomElement as ${defineCustomElementFn} } from '@ionic/core/components/${component.tag}.js'`);
 
     if (component.controller) {
       controllerImports.push(component.controller);
@@ -55,7 +57,7 @@ function generateOverlays() {
     const controllerParam = (component.controller) ? `, ${component.controller}` : '';
 
     componentDefinitions.push(`
-export const ${component.name} = /*@__PURE__*/ defineOverlayContainer<JSX.${component.name}>('${component.tag}', ${component.name}Cmp, [${props.join(', ')}]${controllerParam});
+export const ${component.name} = /*@__PURE__*/ defineOverlayContainer<JSX.${component.name}>('${component.tag}', ${defineCustomElementFn}, [${props.join(', ')}]${controllerParam});
     `);
   });
 

--- a/packages/vue/src/components/Overlays.ts
+++ b/packages/vue/src/components/Overlays.ts
@@ -9,27 +9,27 @@ import {
   toastController,
 } from '@ionic/core/components';
 
-import { IonActionSheet as IonActionSheetCmp } from '@ionic/core/components/ion-action-sheet.js'
-import { IonAlert as IonAlertCmp } from '@ionic/core/components/ion-alert.js'
-import { IonLoading as IonLoadingCmp } from '@ionic/core/components/ion-loading.js'
-import { IonPicker as IonPickerCmp } from '@ionic/core/components/ion-picker.js'
-import { IonToast as IonToastCmp } from '@ionic/core/components/ion-toast.js'
-import { IonModal as IonModalCmp } from '@ionic/core/components/ion-modal.js'
-import { IonPopover as IonPopoverCmp } from '@ionic/core/components/ion-popover.js'
+import { defineCustomElement as defineActionSheetCustomElement } from '@ionic/core/components/ion-action-sheet.js'
+import { defineCustomElement as defineAlertCustomElement } from '@ionic/core/components/ion-alert.js'
+import { defineCustomElement as defineLoadingCustomElement } from '@ionic/core/components/ion-loading.js'
+import { defineCustomElement as definePickerCustomElement } from '@ionic/core/components/ion-picker.js'
+import { defineCustomElement as defineToastCustomElement } from '@ionic/core/components/ion-toast.js'
+import { defineCustomElement as defineModalCustomElement } from '@ionic/core/components/ion-modal.js'
+import { defineCustomElement as definePopoverCustomElement } from '@ionic/core/components/ion-popover.js'
 
 import { defineOverlayContainer } from '../vue-component-lib/overlays';
 
-export const IonActionSheet = /*@__PURE__*/ defineOverlayContainer<JSX.IonActionSheet>('ion-action-sheet', IonActionSheetCmp, ['animated', 'backdropDismiss', 'buttons', 'cssClass', 'enterAnimation', 'header', 'htmlAttributes', 'keyboardClose', 'leaveAnimation', 'mode', 'subHeader', 'translucent'], actionSheetController);
-    
-export const IonAlert = /*@__PURE__*/ defineOverlayContainer<JSX.IonAlert>('ion-alert', IonAlertCmp, ['animated', 'backdropDismiss', 'buttons', 'cssClass', 'enterAnimation', 'header', 'htmlAttributes', 'inputs', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'subHeader', 'translucent'], alertController);
-    
-export const IonLoading = /*@__PURE__*/ defineOverlayContainer<JSX.IonLoading>('ion-loading', IonLoadingCmp, ['animated', 'backdropDismiss', 'cssClass', 'duration', 'enterAnimation', 'htmlAttributes', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'showBackdrop', 'spinner', 'translucent'], loadingController);
-    
-export const IonPicker = /*@__PURE__*/ defineOverlayContainer<JSX.IonPicker>('ion-picker', IonPickerCmp, ['animated', 'backdropDismiss', 'buttons', 'columns', 'cssClass', 'duration', 'enterAnimation', 'htmlAttributes', 'keyboardClose', 'leaveAnimation', 'mode', 'showBackdrop'], pickerController);
-    
-export const IonToast = /*@__PURE__*/ defineOverlayContainer<JSX.IonToast>('ion-toast', IonToastCmp, ['animated', 'buttons', 'color', 'cssClass', 'duration', 'enterAnimation', 'header', 'htmlAttributes', 'icon', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'position', 'translucent'], toastController);
-    
-export const IonModal = /*@__PURE__*/ defineOverlayContainer<JSX.IonModal>('ion-modal', IonModalCmp, ['animated', 'backdropBreakpoint', 'backdropDismiss', 'breakpoints', 'enterAnimation', 'handle', 'htmlAttributes', 'initialBreakpoint', 'isOpen', 'keyboardClose', 'leaveAnimation', 'mode', 'presentingElement', 'showBackdrop', 'swipeToClose', 'trigger']);
-    
-export const IonPopover = /*@__PURE__*/ defineOverlayContainer<JSX.IonPopover>('ion-popover', IonPopoverCmp, ['alignment', 'animated', 'arrow', 'backdropDismiss', 'component', 'componentProps', 'dismissOnSelect', 'enterAnimation', 'event', 'htmlAttributes', 'isOpen', 'keyboardClose', 'leaveAnimation', 'mode', 'reference', 'showBackdrop', 'side', 'size', 'translucent', 'trigger', 'triggerAction']);
-    
+export const IonActionSheet = /*@__PURE__*/ defineOverlayContainer<JSX.IonActionSheet>('ion-action-sheet', defineActionSheetCustomElement, ['animated', 'backdropDismiss', 'buttons', 'cssClass', 'enterAnimation', 'header', 'htmlAttributes', 'keyboardClose', 'leaveAnimation', 'mode', 'subHeader', 'translucent'], actionSheetController);
+
+export const IonAlert = /*@__PURE__*/ defineOverlayContainer<JSX.IonAlert>('ion-alert', defineAlertCustomElement, ['animated', 'backdropDismiss', 'buttons', 'cssClass', 'enterAnimation', 'header', 'htmlAttributes', 'inputs', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'subHeader', 'translucent'], alertController);
+
+export const IonLoading = /*@__PURE__*/ defineOverlayContainer<JSX.IonLoading>('ion-loading', defineLoadingCustomElement, ['animated', 'backdropDismiss', 'cssClass', 'duration', 'enterAnimation', 'htmlAttributes', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'showBackdrop', 'spinner', 'translucent'], loadingController);
+
+export const IonPicker = /*@__PURE__*/ defineOverlayContainer<JSX.IonPicker>('ion-picker', definePickerCustomElement, ['animated', 'backdropDismiss', 'buttons', 'columns', 'cssClass', 'duration', 'enterAnimation', 'htmlAttributes', 'keyboardClose', 'leaveAnimation', 'mode', 'showBackdrop'], pickerController);
+
+export const IonToast = /*@__PURE__*/ defineOverlayContainer<JSX.IonToast>('ion-toast', defineToastCustomElement, ['animated', 'buttons', 'color', 'cssClass', 'duration', 'enterAnimation', 'header', 'htmlAttributes', 'icon', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'position', 'translucent'], toastController);
+
+export const IonModal = /*@__PURE__*/ defineOverlayContainer<JSX.IonModal>('ion-modal', defineModalCustomElement, ['animated', 'backdropBreakpoint', 'backdropDismiss', 'breakpoints', 'enterAnimation', 'handle', 'htmlAttributes', 'initialBreakpoint', 'isOpen', 'keyboardClose', 'leaveAnimation', 'mode', 'presentingElement', 'showBackdrop', 'swipeToClose', 'trigger']);
+
+export const IonPopover = /*@__PURE__*/ defineOverlayContainer<JSX.IonPopover>('ion-popover', definePopoverCustomElement, ['alignment', 'animated', 'arrow', 'backdropDismiss', 'component', 'componentProps', 'dismissOnSelect', 'enterAnimation', 'event', 'htmlAttributes', 'isOpen', 'keyboardClose', 'leaveAnimation', 'mode', 'reference', 'showBackdrop', 'side', 'size', 'translucent', 'trigger', 'triggerAction']);
+

--- a/packages/vue/src/components/Overlays.ts
+++ b/packages/vue/src/components/Overlays.ts
@@ -9,27 +9,27 @@ import {
   toastController,
 } from '@ionic/core/components';
 
-import { defineCustomElement as defineActionSheetCustomElement } from '@ionic/core/components/ion-action-sheet.js'
-import { defineCustomElement as defineAlertCustomElement } from '@ionic/core/components/ion-alert.js'
-import { defineCustomElement as defineLoadingCustomElement } from '@ionic/core/components/ion-loading.js'
-import { defineCustomElement as definePickerCustomElement } from '@ionic/core/components/ion-picker.js'
-import { defineCustomElement as defineToastCustomElement } from '@ionic/core/components/ion-toast.js'
-import { defineCustomElement as defineModalCustomElement } from '@ionic/core/components/ion-modal.js'
-import { defineCustomElement as definePopoverCustomElement } from '@ionic/core/components/ion-popover.js'
+import { defineCustomElement as defineIonActionSheetCustomElement } from '@ionic/core/components/ion-action-sheet.js'
+import { defineCustomElement as defineIonAlertCustomElement } from '@ionic/core/components/ion-alert.js'
+import { defineCustomElement as defineIonLoadingCustomElement } from '@ionic/core/components/ion-loading.js'
+import { defineCustomElement as defineIonPickerCustomElement } from '@ionic/core/components/ion-picker.js'
+import { defineCustomElement as defineIonToastCustomElement } from '@ionic/core/components/ion-toast.js'
+import { defineCustomElement as defineIonModalCustomElement } from '@ionic/core/components/ion-modal.js'
+import { defineCustomElement as defineIonPopoverCustomElement } from '@ionic/core/components/ion-popover.js'
 
 import { defineOverlayContainer } from '../vue-component-lib/overlays';
 
-export const IonActionSheet = /*@__PURE__*/ defineOverlayContainer<JSX.IonActionSheet>('ion-action-sheet', defineActionSheetCustomElement, ['animated', 'backdropDismiss', 'buttons', 'cssClass', 'enterAnimation', 'header', 'htmlAttributes', 'keyboardClose', 'leaveAnimation', 'mode', 'subHeader', 'translucent'], actionSheetController);
-
-export const IonAlert = /*@__PURE__*/ defineOverlayContainer<JSX.IonAlert>('ion-alert', defineAlertCustomElement, ['animated', 'backdropDismiss', 'buttons', 'cssClass', 'enterAnimation', 'header', 'htmlAttributes', 'inputs', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'subHeader', 'translucent'], alertController);
-
-export const IonLoading = /*@__PURE__*/ defineOverlayContainer<JSX.IonLoading>('ion-loading', defineLoadingCustomElement, ['animated', 'backdropDismiss', 'cssClass', 'duration', 'enterAnimation', 'htmlAttributes', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'showBackdrop', 'spinner', 'translucent'], loadingController);
-
-export const IonPicker = /*@__PURE__*/ defineOverlayContainer<JSX.IonPicker>('ion-picker', definePickerCustomElement, ['animated', 'backdropDismiss', 'buttons', 'columns', 'cssClass', 'duration', 'enterAnimation', 'htmlAttributes', 'keyboardClose', 'leaveAnimation', 'mode', 'showBackdrop'], pickerController);
-
-export const IonToast = /*@__PURE__*/ defineOverlayContainer<JSX.IonToast>('ion-toast', defineToastCustomElement, ['animated', 'buttons', 'color', 'cssClass', 'duration', 'enterAnimation', 'header', 'htmlAttributes', 'icon', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'position', 'translucent'], toastController);
-
-export const IonModal = /*@__PURE__*/ defineOverlayContainer<JSX.IonModal>('ion-modal', defineModalCustomElement, ['animated', 'backdropBreakpoint', 'backdropDismiss', 'breakpoints', 'enterAnimation', 'handle', 'htmlAttributes', 'initialBreakpoint', 'isOpen', 'keyboardClose', 'leaveAnimation', 'mode', 'presentingElement', 'showBackdrop', 'swipeToClose', 'trigger']);
-
-export const IonPopover = /*@__PURE__*/ defineOverlayContainer<JSX.IonPopover>('ion-popover', definePopoverCustomElement, ['alignment', 'animated', 'arrow', 'backdropDismiss', 'component', 'componentProps', 'dismissOnSelect', 'enterAnimation', 'event', 'htmlAttributes', 'isOpen', 'keyboardClose', 'leaveAnimation', 'mode', 'reference', 'showBackdrop', 'side', 'size', 'translucent', 'trigger', 'triggerAction']);
-
+export const IonActionSheet = /*@__PURE__*/ defineOverlayContainer<JSX.IonActionSheet>('ion-action-sheet', defineIonActionSheetCustomElement, ['animated', 'backdropDismiss', 'buttons', 'cssClass', 'enterAnimation', 'header', 'htmlAttributes', 'keyboardClose', 'leaveAnimation', 'mode', 'subHeader', 'translucent'], actionSheetController);
+    
+export const IonAlert = /*@__PURE__*/ defineOverlayContainer<JSX.IonAlert>('ion-alert', defineIonAlertCustomElement, ['animated', 'backdropDismiss', 'buttons', 'cssClass', 'enterAnimation', 'header', 'htmlAttributes', 'inputs', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'subHeader', 'translucent'], alertController);
+    
+export const IonLoading = /*@__PURE__*/ defineOverlayContainer<JSX.IonLoading>('ion-loading', defineIonLoadingCustomElement, ['animated', 'backdropDismiss', 'cssClass', 'duration', 'enterAnimation', 'htmlAttributes', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'showBackdrop', 'spinner', 'translucent'], loadingController);
+    
+export const IonPicker = /*@__PURE__*/ defineOverlayContainer<JSX.IonPicker>('ion-picker', defineIonPickerCustomElement, ['animated', 'backdropDismiss', 'buttons', 'columns', 'cssClass', 'duration', 'enterAnimation', 'htmlAttributes', 'keyboardClose', 'leaveAnimation', 'mode', 'showBackdrop'], pickerController);
+    
+export const IonToast = /*@__PURE__*/ defineOverlayContainer<JSX.IonToast>('ion-toast', defineIonToastCustomElement, ['animated', 'buttons', 'color', 'cssClass', 'duration', 'enterAnimation', 'header', 'htmlAttributes', 'icon', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'position', 'translucent'], toastController);
+    
+export const IonModal = /*@__PURE__*/ defineOverlayContainer<JSX.IonModal>('ion-modal', defineIonModalCustomElement, ['animated', 'backdropBreakpoint', 'backdropDismiss', 'breakpoints', 'enterAnimation', 'handle', 'htmlAttributes', 'initialBreakpoint', 'isOpen', 'keyboardClose', 'leaveAnimation', 'mode', 'presentingElement', 'showBackdrop', 'swipeToClose', 'trigger']);
+    
+export const IonPopover = /*@__PURE__*/ defineOverlayContainer<JSX.IonPopover>('ion-popover', defineIonPopoverCustomElement, ['alignment', 'animated', 'arrow', 'backdropDismiss', 'component', 'componentProps', 'dismissOnSelect', 'enterAnimation', 'event', 'htmlAttributes', 'isOpen', 'keyboardClose', 'leaveAnimation', 'mode', 'reference', 'showBackdrop', 'side', 'size', 'translucent', 'trigger', 'triggerAction']);
+    

--- a/packages/vue/src/vue-component-lib/overlays.ts
+++ b/packages/vue/src/vue-component-lib/overlays.ts
@@ -1,5 +1,4 @@
 import { defineComponent, h, ref, VNode, onMounted } from 'vue';
-import { defineCustomElement } from '../utils';
 
 export interface OverlayProps {
   isOpen?: boolean;
@@ -8,7 +7,7 @@ export interface OverlayProps {
 const EMPTY_PROP = Symbol();
 const DEFAULT_EMPTY_PROP = { default: EMPTY_PROP };
 
-export const defineOverlayContainer = <Props extends object>(name: string, customElement: any, componentProps: string[] = [], controller?: any) => {
+export const defineOverlayContainer = <Props extends object>(name: string, defineCustomElement: any, componentProps: string[] = [], controller?: any) => {
 
   const createControllerComponent = () => {
     return defineComponent<Props & OverlayProps>((props, { slots, emit }) => {
@@ -19,7 +18,9 @@ export const defineOverlayContainer = <Props extends object>(name: string, custo
         { componentEv: `${name}-did-dismiss`, frameworkEv: 'didDismiss' },
       ];
 
-      defineCustomElement(name, customElement);
+      if (defineCustomElement) {
+        defineCustomElement();
+      }
 
       const overlay = ref();
       const onVnodeMounted = async () => {
@@ -131,7 +132,9 @@ export const defineOverlayContainer = <Props extends object>(name: string, custo
   };
   const createInlineComponent = () => {
     return defineComponent((props, { slots }) => {
-      defineCustomElement(name, customElement);
+      if (defineCustomElement) {
+        defineCustomElement();
+      }
       const isOpen = ref(false);
       const elementRef = ref();
 

--- a/packages/vue/src/vue-component-lib/overlays.ts
+++ b/packages/vue/src/vue-component-lib/overlays.ts
@@ -7,7 +7,7 @@ export interface OverlayProps {
 const EMPTY_PROP = Symbol();
 const DEFAULT_EMPTY_PROP = { default: EMPTY_PROP };
 
-export const defineOverlayContainer = <Props extends object>(name: string, defineCustomElement: any, componentProps: string[] = [], controller?: any) => {
+export const defineOverlayContainer = <Props extends object>(name: string, defineCustomElement: () => void, componentProps: string[] = [], controller?: any) => {
 
   const createControllerComponent = () => {
     return defineComponent<Props & OverlayProps>((props, { slots, emit }) => {
@@ -18,7 +18,7 @@ export const defineOverlayContainer = <Props extends object>(name: string, defin
         { componentEv: `${name}-did-dismiss`, frameworkEv: 'didDismiss' },
       ];
 
-      if (defineCustomElement) {
+      if (defineCustomElement !== undefined) {
         defineCustomElement();
       }
 
@@ -132,7 +132,7 @@ export const defineOverlayContainer = <Props extends object>(name: string, defin
   };
   const createInlineComponent = () => {
     return defineComponent((props, { slots }) => {
-      if (defineCustomElement) {
+      if (defineCustomElement !== undefined) {
         defineCustomElement();
       }
       const isOpen = ref(false);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the React target, inline overlays (`ion-popover` and `ion-modal`) will not define their nested children custom elements (`ion-backdrop`), when in a production tree-shaken build.

Issue Number: #24449


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Inline overlays will share the same custom element definition logic as the regular overlays. This correctly defines `ion-backdrop` for popover/modal inline overlays.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
