### PR TITLE
fix(datetime): update active day styling when day is selected

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1264,7 +1264,7 @@ export class Datetime implements ComponentInterface {
               ...workingParts,
               hour: ev.detail.value
             });
-            this.setActiveParts({
+            this.setActiveParts(this.activePartsClone = {
               ...activePartsClone,
               hour: ev.detail.value
             });
@@ -1282,7 +1282,7 @@ export class Datetime implements ComponentInterface {
               ...workingParts,
               minute: ev.detail.value
             });
-            this.setActiveParts({
+            this.setActiveParts(this.activePartsClone = {
               ...activePartsClone,
               minute: ev.detail.value
             });
@@ -1303,7 +1303,7 @@ export class Datetime implements ComponentInterface {
               hour
             });
 
-            this.setActiveParts({
+            this.setActiveParts(this.activePartsClone = {
               ...activePartsClone,
               ampm: ev.detail.value,
               hour

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -273,6 +273,11 @@ export class Datetime implements ComponentInterface {
     this.parsedMinuteValues = convertToArrayOfNumbers(this.minuteValues);
   }
 
+  @Watch('activeParts')
+  protected activePartsChanged() {
+    this.activePartsClone = this.activeParts;
+  }
+
   /**
    * The locale to use for `ion-datetime`. This
    * impacts month and day name formatting.
@@ -944,7 +949,7 @@ export class Datetime implements ComponentInterface {
       ampm: hour >= 12 ? 'pm' : 'am'
     }
 
-    this.activePartsClone = this.activeParts = {
+    this.activeParts = {
       month,
       day,
       year,
@@ -1201,7 +1206,7 @@ export class Datetime implements ComponentInterface {
                     year
                   });
 
-                  this.setActiveParts(this.activePartsClone = {
+                  this.setActiveParts({
                     ...this.activeParts,
                     month,
                     day,
@@ -1264,7 +1269,7 @@ export class Datetime implements ComponentInterface {
               ...workingParts,
               hour: ev.detail.value
             });
-            this.setActiveParts(this.activePartsClone = {
+            this.setActiveParts({
               ...activePartsClone,
               hour: ev.detail.value
             });
@@ -1282,7 +1287,7 @@ export class Datetime implements ComponentInterface {
               ...workingParts,
               minute: ev.detail.value
             });
-            this.setActiveParts(this.activePartsClone = {
+            this.setActiveParts({
               ...activePartsClone,
               minute: ev.detail.value
             });
@@ -1303,7 +1308,7 @@ export class Datetime implements ComponentInterface {
               hour
             });
 
-            this.setActiveParts(this.activePartsClone = {
+            this.setActiveParts({
               ...activePartsClone,
               ampm: ev.detail.value,
               hour

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -802,14 +802,14 @@ export class Datetime implements ComponentInterface {
       startIO = new IntersectionObserver(ev => ioCallback('start', ev), {
         threshold: mode === 'ios' ? [0.7, 1] : 1,
         root: calendarBodyRef
-       });
+      });
       startIO.observe(startMonth);
 
       this.destroyCalendarIO = () => {
         endIO?.disconnect();
         startIO?.disconnect();
       }
-   });
+    });
   }
 
   connectedCallback() {
@@ -1201,12 +1201,12 @@ export class Datetime implements ComponentInterface {
                     year
                   });
 
-                  this.setActiveParts({
+                  this.setActiveParts(this.activePartsClone = {
                     ...this.activeParts,
                     month,
                     day,
                     year
-                  })
+                  });
                 }}
               >{day}</button>
             )
@@ -1249,7 +1249,7 @@ export class Datetime implements ComponentInterface {
     minutesItems: PickerColumnItem[],
     ampmItems: PickerColumnItem[],
     use24Hour: boolean
-   ) {
+  ) {
     const { color, activePartsClone, workingParts } = this;
 
     return (
@@ -1290,7 +1290,7 @@ export class Datetime implements ComponentInterface {
             ev.stopPropagation();
           }}
         ></ion-picker-column-internal>
-        { !use24Hour && <ion-picker-column-internal
+        {!use24Hour && <ion-picker-column-internal
           color={color}
           value={activePartsClone.ampm}
           items={ampmItems}
@@ -1311,7 +1311,7 @@ export class Datetime implements ComponentInterface {
 
             ev.stopPropagation();
           }}
-        ></ion-picker-column-internal> }
+        ></ion-picker-column-internal>}
       </ion-picker-internal>
     )
   }
@@ -1321,7 +1321,7 @@ export class Datetime implements ComponentInterface {
     minutesItems: PickerColumnItem[],
     ampmItems: PickerColumnItem[],
     use24Hour: boolean
-   ) {
+  ) {
     return [
       <div class="time-header">
         {this.renderTimeLabel()}
@@ -1411,7 +1411,7 @@ export class Datetime implements ComponentInterface {
 
     return (
       <div class="datetime-time">
-          {timeOnlyPresentation ? this.renderTimePicker(hoursItems, minutesItems, ampmItems, use24Hour) : this.renderTimeOverlay(hoursItems, minutesItems, ampmItems, use24Hour)}
+        {timeOnlyPresentation ? this.renderTimePicker(hoursItems, minutesItems, ampmItems, use24Hour) : this.renderTimeOverlay(hoursItems, minutesItems, ampmItems, use24Hour)}
       </div>
     )
   }

--- a/core/src/components/datetime/test/basic/e2e.ts
+++ b/core/src/components/datetime/test/basic/e2e.ts
@@ -79,3 +79,25 @@ describe('Footer', () => {
 });
 
 
+describe('datetime: selecting a day', () => {
+
+  it('should update the active day', async () => {
+    const page = await newE2EPage({
+      html: `
+        <ion-datetime show-default-buttons="true" value="2021-12-25T12:40:00.000Z"></ion-datetime>
+      `
+    });
+
+    const activeDay = await page.find('ion-datetime >>> .calendar-day-active');
+
+    expect(activeDay.innerText).toEqual('25');
+
+    const dayBtn = await page.find('ion-datetime >>> .calendar-day[data-day="13"][data-month="12"]');
+    dayBtn.click();
+    await page.waitForChanges();
+
+    const newActiveDay = await page.find('ion-datetime >>> .calendar-day-active');
+
+    expect(newActiveDay.innerText).toEqual('13');
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Selecting a new day value in the calendar will update the local value, but will not update the visual "active day" of the calendar.

Issue Number: Resolves #24414, #24451


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

When a new day value is selected, the active day will render correctly.

- The `activePartsClone` which is used for the `isActive` calculation, is now updated with the value of the `activeParts` new value.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Introduced in #24414

- https://github.com/sean-perkins/gh-24414-datetime-active-day/tree/main (issue is present)
- https://github.com/sean-perkins/gh-24414-datetime-active-day/tree/fix (issue is resolved)

|Before|After|
|---|---|
|<video src="https://user-images.githubusercontent.com/13732623/147128163-7aa0edb7-1b03-436b-a8de-e4fa7a5cea34.mp4"></video>| <video src="https://user-images.githubusercontent.com/13732623/147127978-7bc0bff6-c74f-4e4e-b151-0c2b3255d2a0.mp4"></video>|