### PR TITLE
fix(angular): popover will respect side attribute value

### DIFF
--- a/angular/src/directives/overlays/popover.ts
+++ b/angular/src/directives/overlays/popover.ts
@@ -66,6 +66,7 @@ export declare interface IonPopover extends Components.IonPopover {
     'triggerAction',
     'reference',
     'size',
+    'side',
   ],
   methods: ['present', 'dismiss', 'onDidDismiss', 'onWillDismiss'],
 })
@@ -92,6 +93,7 @@ export declare interface IonPopover extends Components.IonPopover {
     'triggerAction',
     'reference',
     'size',
+    'side',
   ],
 })
 export class IonPopover {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `side` property for `ion-popover` is not being passed to the HTML element with the Angular proxies.

Issue Number: Resolves #24466


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Adds missing `side` input binding for the `ion-popover` Angular proxies.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
