### PR TITLE
fix(datetime): fix scrolling issue (#24500)

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -794,13 +794,13 @@ export class Datetime implements ComponentInterface {
        * something WebKit does.
        */
       endIO = new IntersectionObserver(ev => ioCallback('end', ev), {
-        threshold: mode === 'ios' ? [0.7, 1] : 1,
+        threshold: mode === 'ios' ? [0.7, 1] : 0.99,
         root: calendarBodyRef
       });
       endIO.observe(endMonth);
 
       startIO = new IntersectionObserver(ev => ioCallback('start', ev), {
-        threshold: mode === 'ios' ? [0.7, 1] : 1,
+        threshold: mode === 'ios' ? [0.7, 1] : 0.99,
         root: calendarBodyRef
        });
       startIO.observe(startMonth);
@@ -1474,6 +1474,7 @@ export class Datetime implements ComponentInterface {
   }
 
   render() {
+    console.log('render datetime');
     const { name, value, disabled, el, color, isPresented, readonly, showMonthAndYear, presentation, size } = this;
     const mode = getIonMode(this);
     const isMonthAndYearPresentation = presentation === 'year' || presentation === 'month' || presentation === 'month-year';


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
ion-datetime:
If you scroll horizontally or use the buttons to swipe, no new panels were created and you can no select a day from other months.
The date panel has only the current, previous and next month, because the IntersectionObserver was not fired.

I changed the threshold to 0.99 instead of 1 and it works.
This behavior is only in Chrome and Android WebView. In Firefox works both 1 and 0.99 correctly.

Issue Number: #24500


## What is the new behavior?
If you scroll horizontally or use the buttons to swipe, the other months appear.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
