### PR TITLE
fix(breadcrumb): support routerLink on breadcrumb

### DIFF
--- a/core/stencil.config.ts
+++ b/core/stencil.config.ts
@@ -77,6 +77,7 @@ export const config: Config = {
         'ion-router-link',
         'ion-router-outlet',
         'ion-back-button',
+        'ion-breadcrumb',
         'ion-tab-button',
         'ion-tabs',
         'ion-tab-bar',

--- a/packages/react/src/components/proxies.ts
+++ b/packages/react/src/components/proxies.ts
@@ -10,7 +10,6 @@ import { defineCustomElement as defineIonAccordionGroup } from '@ionic/core/comp
 import { defineCustomElement as defineIonAvatar } from '@ionic/core/components/ion-avatar.js';
 import { defineCustomElement as defineIonBackdrop } from '@ionic/core/components/ion-backdrop.js';
 import { defineCustomElement as defineIonBadge } from '@ionic/core/components/ion-badge.js';
-import { defineCustomElement as defineIonBreadcrumb } from '@ionic/core/components/ion-breadcrumb.js';
 import { defineCustomElement as defineIonBreadcrumbs } from '@ionic/core/components/ion-breadcrumbs.js';
 import { defineCustomElement as defineIonButtons } from '@ionic/core/components/ion-buttons.js';
 import { defineCustomElement as defineIonCardContent } from '@ionic/core/components/ion-card-content.js';
@@ -78,7 +77,6 @@ export const IonAccordionGroup = /*@__PURE__*/createReactComponent<JSX.IonAccord
 export const IonAvatar = /*@__PURE__*/createReactComponent<JSX.IonAvatar, HTMLIonAvatarElement>('ion-avatar', undefined, undefined, defineIonAvatar);
 export const IonBackdrop = /*@__PURE__*/createReactComponent<JSX.IonBackdrop, HTMLIonBackdropElement>('ion-backdrop', undefined, undefined, defineIonBackdrop);
 export const IonBadge = /*@__PURE__*/createReactComponent<JSX.IonBadge, HTMLIonBadgeElement>('ion-badge', undefined, undefined, defineIonBadge);
-export const IonBreadcrumb = /*@__PURE__*/createReactComponent<JSX.IonBreadcrumb, HTMLIonBreadcrumbElement>('ion-breadcrumb', undefined, undefined, defineIonBreadcrumb);
 export const IonBreadcrumbs = /*@__PURE__*/createReactComponent<JSX.IonBreadcrumbs, HTMLIonBreadcrumbsElement>('ion-breadcrumbs', undefined, undefined, defineIonBreadcrumbs);
 export const IonButtons = /*@__PURE__*/createReactComponent<JSX.IonButtons, HTMLIonButtonsElement>('ion-buttons', undefined, undefined, defineIonButtons);
 export const IonCardContent = /*@__PURE__*/createReactComponent<JSX.IonCardContent, HTMLIonCardContentElement>('ion-card-content', undefined, undefined, defineIonCardContent);

--- a/packages/react/src/components/routing-proxies.ts
+++ b/packages/react/src/components/routing-proxies.ts
@@ -1,4 +1,5 @@
 import type { JSX } from '@ionic/core/components';
+import { IonBreadcrumb as IonBreadcrumbCmp } from '@ionic/core/components/ion-breadcrumb.js';
 import { IonButton as IonButtonCmp } from '@ionic/core/components/ion-button.js';
 import { IonCard as IonCardCmp } from '@ionic/core/components/ion-card.js';
 import { IonFabButton as IonFabButtonCmp } from '@ionic/core/components/ion-fab-button.js';
@@ -38,3 +39,8 @@ export const IonItemOption = /*@__PURE__*/ createRoutingComponent<
   HrefProps<JSX.IonItemOption>,
   HTMLIonItemOptionElement
 >('ion-item-option', IonItemOptionCmp);
+
+export const IonBreadcrumb = /*@__PURE__*/ createRoutingComponent<
+  HrefProps<JSX.IonBreadcrumb>,
+  HTMLIonBreadcrumbElement
+>('ion-breadcrumb', IonBreadcrumbCmp);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`ion-breadcrumb` does not support the routable behaviors of similar components (i.e. `routerLink`) and `href` causes a full refresh.

Issue Number: Resolves #24493


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

`ion-breadcrumb` is treated as a routable component for React and now supports `routerLink`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
