### PR TITLE
fix(popover): allow arrow configuration with controller approach

### DIFF
--- a/core/src/components/popover/popover-interface.ts
+++ b/core/src/components/popover/popover-interface.ts
@@ -30,12 +30,13 @@ export interface PopoverOptions<T extends ComponentRef = ComponentRef> {
   reference?: PositionReference;
   side?: PositionSide;
   align?: PositionAlign;
+  arrow?: boolean;
 
   trigger?: string;
   triggerAction?: string;
 }
 
-export interface PopoverAttributes extends JSXBase.HTMLAttributes<HTMLElement> {}
+export interface PopoverAttributes extends JSXBase.HTMLAttributes<HTMLElement> { }
 
 export type PopoverSize = 'cover' | 'auto';
 

--- a/core/src/components/popover/readme.md
+++ b/core/src/components/popover/readme.md
@@ -108,6 +108,7 @@ interface PopoverOptions {
   reference?: PositionReference;
   side?: PositionSide;
   align?: PositionAlign;
+  arrow?: boolean;
 }
 ```
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

You are unable to turn off the arrow when using the controller approach for displaying a popover.

Issue Number: Resolves #24487


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

You can specify to disable the arrow from displaying when displaying a popover with the controller approach:

```ts
.create({
  component: ExampleComponent,
  arrow: false
});
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Technically this is supported today, if you type cast on top of the `.create` props type signature. This PR corrects the missing type configuration.