### PR TITLE
fix(css): inline css source in source maps

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -77,7 +77,7 @@
     "clean": "node scripts/clean.js",
     "cdnloader": "node scripts/copy-cdn-loader.js",
     "css.minify": "cleancss -O2 -o ./css/ionic.bundle.css ./css/ionic.bundle.css",
-    "css.sass": "sass src/css:./css",
+    "css.sass": "sass --embed-sources src/css:./css",
     "lint": "npm run lint.ts && npm run lint.sass",
     "lint.fix": "npm run lint.ts.fix && npm run lint.sass.fix",
     "lint.sass": "stylelint \"src/**/*.scss\"",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves #24441

The CSS source maps referenced the original .scss source files in the maps, but the .scss files were never shipped with built versions of Ionic. Accessing the source is necessary for source maps to work correctly.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- While we could ship the source files, this would still break for our framework integrations as the map files sources would need to be updated again to reference the sources inside of @ionic/core. Alternatively, we could ship the source SCSS files inside of each framework integration, but that seems wasteful.
- I decided the better approach would be to inline the source CSS inside of each map file so that no reference urls need to be updated/kept track of.
- While this does increase the size of the map files, these map files are only used for debugging/error logging purposes and should not have any impact on the end user.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev Build for testing: 6.0.1-dev.1641402215.4472d1d

**Before:**

https://user-images.githubusercontent.com/2721089/148259695-f5ad42dc-22c7-440f-80e7-c80370f33fbe.mov


**After:**

https://user-images.githubusercontent.com/2721089/148259721-1161c0b7-a85a-4d91-9372-791dd2641f31.mov




