### PR TITLE
fix(datetime): add top padding to MD calendar month grid

### DIFF
--- a/core/src/components/datetime/datetime.md.scss
+++ b/core/src/components/datetime/datetime.md.scss
@@ -54,7 +54,12 @@
 // Calendar / Body
 // -----------------------------------
 :host .calendar-body .calendar-month .calendar-month-grid {
-  @include padding(0px, 10px, 0px, 10px);
+  /**
+   * 3px top padding adds enough spacing at
+   * the top of the container for the selected
+   * day box shadow to display without clipping.
+   */
+  @include padding(3px, 10px, 0px, 10px);
 
   /**
    * Calendar on MD will show an empty row


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The selected day in the MD mode for datetime will clip the box shadow appearance.

Issue Number: Resolves #24408


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The calendar month grid has extra padding to no longer clip the selected day in the first row.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

|Before|After|
|---|---|
|<img width="412" alt="Screen Shot 2022-01-05 at 11 38 04 PM" src="https://user-images.githubusercontent.com/13732623/148328935-ca5682bf-ec2c-442b-a3c5-18c3e27bdf5a.png">|<img width="410" alt="Screen Shot 2022-01-05 at 11 36 43 PM" src="https://user-images.githubusercontent.com/13732623/148328826-cc732b3e-b357-4d0f-8d5b-dcce9763fe10.png">|


