### PR TITLE
fix(vue): correct route is replaced when using router.replace

### DIFF
--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -238,7 +238,19 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
           const lastRoute = locationHistory.getCurrentRouteInfoForTab(routeInfo.tab);
           routeInfo.pushedByRoute = lastRoute?.pushedByRoute;
         } else if (routeInfo.routerAction === 'replace') {
-          const currentRouteInfo = locationHistory.last();
+
+          /**
+           * When replacing a route, we want to make sure we select the current route
+           * that we are on, not the last route in the stack. The last route in the stack
+           * is not always the current route.
+           * Example:
+           * Given the following history: /page1 --> /page2
+           * Doing router.go(-1) would bring you to /page1.
+           * If you then did router.replace('/page3'), /page1 should
+           * be replaced with /page3 even though /page2 is the last
+           * item in the stack/
+           */
+          const currentRouteInfo = locationHistory.current(initialHistoryPosition, currentHistoryPosition);
 
           /**
            * If going from /home to /child, then replacing from

--- a/packages/vue/test-app/tests/e2e/specs/routing.js
+++ b/packages/vue/test-app/tests/e2e/specs/routing.js
@@ -379,6 +379,27 @@ describe('Routing', () => {
     cy.ionPageVisible('routingparameterview');
     cy.ionPageDoesNotExist('routingchild');
   })
+
+  // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/24226
+  it('should correctly replace a route after popping', () => {
+    cy.visit('http://localhost:8080');
+
+    cy.routerPush('/routing');
+    cy.ionPageVisible('routing');
+    cy.ionPageHidden('home');
+
+    cy.routerGo(-1);
+    cy.ionPageVisible('home');
+    cy.ionPageDoesNotExist('routing');
+
+    cy.routerReplace('/inputs');
+    cy.ionPageVisible('inputs');
+    cy.ionPageDoesNotExist('home');
+
+    cy.routerPush('/');
+    cy.ionPageVisible('home');
+    cy.ionPageHidden('inputs');
+  })
 });
 
 describe('Routing - Swipe to Go Back', () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/24226

Previously I had thought that issue was related to ion-router-outlet not waiting for the previous transition to finish. This finding was incorrect. The real issue was that the replace logic inside of `IonRouter` was replacing the wrong route.

Currently, IonRouter gets the last item in the Location History array for the route that should be replaced: https://github.com/ionic-team/ionic-framework/blob/77f8412b746222793cd9d17f12f50d512ab5e886/packages/vue-router/src/router.ts#L241

This line (incorrectly) assumes that the last item in the Location History is the current route. Consider the following example:

History: `/page1` --> `/page2`.

If you do `router.go(-1)`, you will now be on `/page1`. If you were to then do `router.replace('/page3'`) one would expect Ionic to replace `/page1` with `/page3`. However, since it was grabbing the last item in the Location History, Ionic was replacing `/page2` with `/page3`.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Router now gets the current route according to calculated deltas rather than grabbing the last item in the array.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
