### PR TITLE
fix(datetime): wheel picker shows correct column order in rtl

### DIFF
--- a/core/src/components/picker-internal/picker-internal.scss
+++ b/core/src/components/picker-internal/picker-internal.scss
@@ -11,6 +11,9 @@
   align-items: center;
   justify-content: center;
 
+  width: 100%;
+  height: 200px;
+
   /**
    * Picker columns should display
    * in the order in which developers
@@ -18,9 +21,6 @@
    * LTR vs RTL directions.
    */
   direction: ltr;
-
-  width: 100%;
-  height: 200px;
 
   /**
    * This is required otherwise the

--- a/core/src/components/picker-internal/picker-internal.scss
+++ b/core/src/components/picker-internal/picker-internal.scss
@@ -11,6 +11,14 @@
   align-items: center;
   justify-content: center;
 
+  /**
+   * Picker columns should display
+   * in the order in which developers
+   * added them and should ignore
+   * LTR vs RTL directions.
+   */
+  direction: ltr;
+
   width: 100%;
   height: 200px;
 

--- a/core/src/components/picker/test/basic/index.html
+++ b/core/src/components/picker/test/basic/index.html
@@ -117,7 +117,7 @@
         }],
         htmlAttributes: {
           'data-testid': 'basic-picker'
-        }
+        },
         cssClass: customClass
       });
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/24378


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added `direction: ltr` to the picker component to force columns to preserve their direction. This is the same technique employed by the public picker: https://github.com/ionic-team/ionic-framework/blob/main/core/src/components/picker/picker.scss#L123
- When comparing with the public picker I also found a typo in the test file, so I fixed that.

Note: Screenshot tests automatically run all tests in RTL mode in addition to LTR mode, so the existing tests written for picker-internal should now capture this layout fix.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
