### PR TITLE
fix(react): add useRef wrapper to useIonOverlay state to avoid stale references

### DIFF
--- a/packages/react/src/components/IonOverlayManager.tsx
+++ b/packages/react/src/components/IonOverlayManager.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 
 import { ReactComponentOrElement } from '../models';
@@ -25,12 +25,29 @@ export const IonOverlayManager: React.FC<IonOverlayManagerProps> = ({
   onAddOverlay,
   onRemoveOverlay,
 }) => {
-  const [overlays, setOverlays] = useState<{
+  type OverlaysList = {
     [key: string]: {
       component: any;
       containerElement: HTMLDivElement;
     };
-  }>({});
+  };
+
+  /**
+   * Because of the way we're passing around the addOverlay and removeOverlay
+   * callbacks, by the time they finally get called, they use a stale reference
+   * to the state that only has the initial values. So if two overlays are opened
+   * at the same time, both using useIonModal or similar (such as through nesting),
+   * the second will erase the first from the overlays list. This causes the content
+   * of the first overlay to unmount.
+   *
+   * We wrap the state in useRef to ensure the two callbacks always use the most
+   * up-to-date version.
+   *
+   * Further reading: https://stackoverflow.com/a/56554056
+   */
+  const [overlays, setOverlays] = useState<OverlaysList>({});
+  const overlaysRef = useRef<OverlaysList>({});
+  overlaysRef.current = overlays;
 
   useEffect(() => {
     /* Setup the callbacks that get called from <IonApp /> */
@@ -43,13 +60,13 @@ export const IonOverlayManager: React.FC<IonOverlayManagerProps> = ({
     component: ReactComponentOrElement,
     containerElement: HTMLDivElement
   ) => {
-    const newOverlays = { ...overlays };
+    const newOverlays = { ...overlaysRef.current };
     newOverlays[id] = { component, containerElement };
     setOverlays(newOverlays);
   };
 
   const removeOverlay = (id: string) => {
-    const newOverlays = { ...overlays };
+    const newOverlays = { ...overlaysRef.current };
     delete newOverlays[id];
     setOverlays(newOverlays);
   };


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Resolves https://github.com/ionic-team/ionic-framework/issues/24349

(This is a recreation of https://github.com/ionic-team/ionic-framework/pull/24544 to attempt to get around a Github Actions error separate from these code updates.)

If two modals are open at the same time, both using `useIonModal` (doesn't happen with any other frameworks/modal implementations), the contents of the first modal are unmounted. This is most obvious with nested modals, but can also be seen by opening the second modal via the console while the first is still open even if they are at the same level of nesting.

This happens because when the second modal is opened, the `overlays` state in `IonOverlayManager` is empty, when it should have a reference to the first modal. So when the state is updated for the second modal, the first modal is removed from the list.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The `overlays` state in `IonOverlayManager` is now wrapped in a `ref`, to avoid stale references to the state when `addOverlay` and `removeOverlay` are called.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Minimal repo for testing: https://github.com/amandaesmith3/sandbox-ionic-react/tree/FW-410