### PR TITLE
chore(dev-build): bump patch version for lerna dev builds

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           echo "HASH=$(git log -1 --format=%H | cut -c 1-7)" >> $GITHUB_ENV
           echo "TIMESTAMP=$(date +%s)" >> $GITHUB_ENV
-          echo "CURRENT_VERSION=$(node ../../.scripts/bump-version.js)" >> $GITHUB_ENV
+          echo "CURRENT_VERSION=$(node ./.scripts/bump-version.js)" >> $GITHUB_ENV
         shell: bash
       - name: Create Dev Build
         run: |

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           echo "HASH=$(git log -1 --format=%H | cut -c 1-7)" >> $GITHUB_ENV
           echo "TIMESTAMP=$(date +%s)" >> $GITHUB_ENV
-          echo "CURRENT_VERSION=$(node -p -e "require('./core/package.json').version")" >> $GITHUB_ENV
+          echo "CURRENT_VERSION=$(node ../../.scripts/bump-version.js)" >> $GITHUB_ENV
         shell: bash
       - name: Create Dev Build
         run: |

--- a/.scripts/bump-version.js
+++ b/.scripts/bump-version.js
@@ -1,0 +1,10 @@
+const semver = require('semver');
+
+const getDevVersion = () => {
+  const originalVersion = require('../lerna.json').version;
+  const baseVersion = semver.inc(originalVersion, 'patch');
+
+  return baseVersion;
+}
+
+console.log(getDevVersion());


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Lerna expects that the version number changes in between releases, even if you are adding a string to the end of the version to make it unique. This means that if you are currently on 6.0.2, then a dev build need to have 6.0.3 (plus whatever unique string you add).

Previously, the `lerna.json` file had `6.0.0` as the version because we used the old release scripts to release `6.0.1`, so `lerna.json` never got updated. As a result, whenever we tried to do a dev build we released `6.0.1-[dev hash]` that passed because lerna looks to `lerna.json` for the version (which in this case was `6.0.0`).

Starting with 6.0.2, we release using the lerna scripts so the version in `lerna.json` was correctly updated to `6.0.2` resulting in dev builds failing to create due to:

```
ERR! lerna bump must be an explicit version string _or_ one of: 'major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', 'prerelease', 'from-git', or 'from-package'.
```

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Ensures that the dev build uses a newer version that the current version. In this case I made it use the next patch release, so if current version is 6.0.2 the dev build will be 6.0.3-[dev hash]

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
