### PR TITLE
fix(item): error slot visible in Safari

### DIFF
--- a/core/src/components/item/item.scss
+++ b/core/src/components/item/item.scss
@@ -433,6 +433,12 @@ button, a {
   display: none;
 }
 
+::slotted([slot="error"]) {
+  display: none;
+
+  color: var(--highlight-color-invalid);
+}
+
 :host(.item-interactive.ion-invalid) ::slotted([slot="error"]) {
   display: block;
 }
@@ -525,12 +531,6 @@ ion-ripple-effect {
   font-size: 12px;
 
   z-index: 1;
-}
-
-::slotted([slot="error"]) {
-  display: none;
-
-  color: var(--highlight-color-invalid);
 }
 
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The error slot of the `ion-item` is never visible in Safari. 

Issue Number: #24575


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Adjusts the style ordering so that the error slot display overrides correctly on all browser targets.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

You can verify this change by running the Core project:
- http://localhost:3333/src/components/item/test/bottom
- Toggle the "Toggle Error" control
- See that the error slot becomes visible 
