### PR TITLE
fix(toggle): setting dir on ion-toggle to enable rtl mode now supported

### DIFF
--- a/core/src/components/toggle/test/rtl/e2e.ts
+++ b/core/src/components/toggle/test/rtl/e2e.ts
@@ -1,0 +1,11 @@
+
+import { newE2EPage } from '@stencil/core/testing';
+
+test('toggle: RTL', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/toggle/test/rtl?ionic:_testing=true'
+  });
+
+  const compare = await page.compareScreenshot();
+  expect(compare).toMatchScreenshot();
+});

--- a/core/src/components/toggle/test/rtl/index.html
+++ b/core/src/components/toggle/test/rtl/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Toggle - RTL</title>
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
+  <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+  <script src="../../../../../scripts/testing/scripts.js"></script>
+  <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+</head>
+
+<body>
+  <ion-app>
+
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Toggle - RTL</ion-title>
+        <ion-buttons slot="primary">
+          <ion-toggle aria-label="Toggle"></ion-toggle>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content id="content">
+
+      <ion-list>
+        <ion-item>
+          <ion-label>Toggle</ion-label>
+          <ion-toggle dir="rtl" slot="start" name="item-1" checked></ion-toggle>
+        </ion-item>
+
+    </ion-content>
+
+  </ion-app>
+</body>
+
+</html>

--- a/core/src/components/toggle/toggle.tsx
+++ b/core/src/components/toggle/toggle.tsx
@@ -4,6 +4,7 @@ import { getIonMode } from '../../global/ionic-global';
 import { Color, Gesture, GestureDetail, StyleEventDetail, ToggleChangeEventDetail } from '../../interface';
 import { getAriaLabel, renderHiddenInput } from '../../utils/helpers';
 import { hapticSelection } from '../../utils/native/haptic';
+import { isRTL } from '../../utils/rtl';
 import { createColorClasses, hostContext } from '../../utils/theme';
 
 /**
@@ -138,7 +139,7 @@ export class Toggle implements ComponentInterface {
   }
 
   private onMove(detail: GestureDetail) {
-    if (shouldToggle(document, this.checked, detail.deltaX, -10)) {
+    if (shouldToggle(isRTL(this.el), this.checked, detail.deltaX, -10)) {
       this.checked = !this.checked;
       hapticSelection();
     }
@@ -224,9 +225,7 @@ export class Toggle implements ComponentInterface {
   }
 }
 
-const shouldToggle = (doc: HTMLDocument, checked: boolean, deltaX: number, margin: number): boolean => {
-  const isRTL = doc.dir === 'rtl';
-
+const shouldToggle = (isRTL: boolean, checked: boolean, deltaX: number, margin: number): boolean => {
   if (checked) {
     return (!isRTL && (margin > deltaX)) ||
       (isRTL && (- margin < deltaX));


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`ion-toggle` only supports RTL when the direction is set at the document level.

Issue Number: Tech Debt


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `ion-toggle` will respect dir specified on the host element (overrides the document value)
- `ion-toggle` uses the isRTL utility

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
