### PR TITLE
fix(menu): focus trapping with menu and overlays no longer results in errors

### DIFF
--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -7,7 +7,7 @@ import { getTimeGivenProgression } from '../../utils/animation/cubic-bezier';
 import { GESTURE_CONTROLLER } from '../../utils/gesture';
 import { assert, clamp, inheritAttributes, isEndSide as isEnd } from '../../utils/helpers';
 import { menuController } from '../../utils/menu-controller';
-import { FOCUSABLE_OVERLAY_TAGNAMES } from '../../utils/overlays';
+import { getOverlay } from '../../utils/overlays';
 
 const iosEasing = 'cubic-bezier(0.32,0.72,0,1)';
 const mdEasing = 'cubic-bezier(0.0,0.0,0.2,1)';
@@ -49,9 +49,12 @@ export class Menu implements ComponentInterface, MenuI {
     /**
      * Overlays have their own focus trapping listener
      * so we do not want the two listeners to conflict
-     * with each other.
+     * with each other. If the top-most overlay that is
+     * open does not contain this ion-menu, then ion-menu's
+     * focus trapping should not run.
      */
-    if (ev.target && FOCUSABLE_OVERLAY_TAGNAMES.includes((ev.target as HTMLElement).tagName)) {
+    const lastOverlay = getOverlay(document);
+    if (lastOverlay && !lastOverlay.contains(this.el)) {
       return;
     }
 

--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -7,6 +7,7 @@ import { getTimeGivenProgression } from '../../utils/animation/cubic-bezier';
 import { GESTURE_CONTROLLER } from '../../utils/gesture';
 import { assert, clamp, inheritAttributes, isEndSide as isEnd } from '../../utils/helpers';
 import { menuController } from '../../utils/menu-controller';
+import { FOCUSABLE_OVERLAY_TAGNAMES } from '../../utils/overlays';
 
 const iosEasing = 'cubic-bezier(0.32,0.72,0,1)';
 const mdEasing = 'cubic-bezier(0.0,0.0,0.2,1)';
@@ -44,7 +45,18 @@ export class Menu implements ComponentInterface, MenuI {
 
   private inheritedAttributes: { [k: string]: any } = {};
 
-  private handleFocus = (ev: Event) => this.trapKeyboardFocus(ev, document);
+  private handleFocus = (ev: FocusEvent) => {
+    /**
+     * Overlays have their own focus trapping listener
+     * so we do not want the two listeners to conflict
+     * with each other.
+     */
+    if (ev.target && FOCUSABLE_OVERLAY_TAGNAMES.includes((ev.target as HTMLElement).tagName)) {
+      return;
+    }
+
+    this.trapKeyboardFocus(ev, document);
+  }
 
   @Element() el!: HTMLIonMenuElement;
 

--- a/core/src/components/menu/test/focus-trap/e2e.ts
+++ b/core/src/components/menu/test/focus-trap/e2e.ts
@@ -32,3 +32,28 @@ test('menu: focus trap with overlays', async () => {
 
   expect(await getActiveElementID(page)).toEqual('open-modal-button');
 });
+
+test('menu: focus trap with content inside overlays', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/menu/test/focus-trap?ionic:_testing=true'
+  });
+
+  const ionDidOpen = await page.spyOnEvent('ionDidOpen');
+  const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+  const ionModalDidDismiss= await page.spyOnEvent('ionModalDidDismiss');
+
+  const menu = await page.find('ion-menu');
+  await menu.callMethod('open');
+  await ionDidOpen.next();
+
+  expect(await getActiveElementID(page)).toEqual('open-modal-button');
+
+  const openModal = await page.find('#open-modal-button');
+  await openModal.click();
+  await ionModalDidPresent.next();
+
+  const button = await page.find('#other-button');
+  await button.click();
+
+  expect(await getActiveElementID(page)).toEqual('other-button');
+});

--- a/core/src/components/menu/test/focus-trap/e2e.ts
+++ b/core/src/components/menu/test/focus-trap/e2e.ts
@@ -1,0 +1,34 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+const getActiveElementID = async (page) => {
+  const activeElement = await page.evaluateHandle(() => document.activeElement);
+  return await page.evaluate(el => el && el.id, activeElement);
+}
+
+test('menu: focus trap with overlays', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/menu/test/focus-trap?ionic:_testing=true'
+  });
+
+  const ionDidOpen = await page.spyOnEvent('ionDidOpen');
+  const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+  const ionModalDidDismiss= await page.spyOnEvent('ionModalDidDismiss');
+
+  const menu = await page.find('ion-menu');
+  await menu.callMethod('open');
+  await ionDidOpen.next();
+
+  expect(await getActiveElementID(page)).toEqual('open-modal-button');
+
+  const openModal = await page.find('#open-modal-button');
+  await openModal.click();
+  await ionModalDidPresent.next();
+
+  expect(await getActiveElementID(page)).toEqual('modal-element');
+
+  const modal = await page.find('ion-modal');
+  await modal.callMethod('dismiss');
+  await ionModalDidDismiss.next();
+
+  expect(await getActiveElementID(page)).toEqual('open-modal-button');
+});

--- a/core/src/components/menu/test/focus-trap/index.html
+++ b/core/src/components/menu/test/focus-trap/index.html
@@ -25,6 +25,7 @@
             <ion-content class="ion-padding">
               Modal content
               <ion-button onclick="dismissModal()">Dismiss Modal</ion-button>
+              <ion-button id="other-button">Other Button</ion-button>
             </ion-content>
           </ion-modal>
         </ion-content>

--- a/core/src/components/menu/test/focus-trap/index.html
+++ b/core/src/components/menu/test/focus-trap/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8">
+    <title>Menu - Focus Trap</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+    <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
+    <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+    <script src="../../../../../scripts/testing/scripts.js"></script>
+    <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+  </head>
+  <body>
+    <ion-app>
+      <ion-menu content-id="main">
+        <ion-header>
+          <ion-toolbar>
+            <ion-title>Menu</ion-title>
+          </ion-toolbar>
+        </ion-header>
+        <ion-content class="ion-padding">
+          <ion-item>
+            <ion-button id="open-modal-button">Open Modal</ion-button>
+          </ion-item>
+          <ion-modal id="modal-element" trigger="open-modal-button">
+            <ion-content class="ion-padding">
+              Modal content
+              <ion-button onclick="dismissModal()">Dismiss Modal</ion-button>
+            </ion-content>
+          </ion-modal>
+        </ion-content>
+      </ion-menu>
+
+      <div class="ion-page" id="main">
+        <ion-header>
+          <ion-toolbar>
+            <ion-title>Menu - Basic</ion-title>
+          </ion-toolbar>
+        </ion-header>
+        <ion-content class="ion-padding">
+          <ion-button onclick="openMenu()" id="open-menu-button">Open Menu</ion-button>
+        </ion-content>
+      </div>
+    </ion-app>
+    <script>
+      const menu = document.querySelector('ion-menu');
+      const modal = document.querySelector('ion-modal');
+      const openMenu = () => {
+        menu.open();
+      }
+      const dismissModal = () => {
+        modal.dismiss();
+      }
+    </script>
+  </body>
+</html>

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -596,7 +596,3 @@ export const safeCall = (handler: any, arg?: any) => {
 
 export const BACKDROP = 'backdrop';
 export const FOCUSABLE_OVERLAY_TAGNAMES = ['ION-MODAL', 'ION-POPOVER', 'ION-ALERT', 'ION-ACTION-SHEET', 'ION-LOADING', 'ION-PICKER'];
-
-
-
-

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -295,7 +295,17 @@ const connectListeners = (doc: Document, options: OverlayListenerOptions) => {
   if (lastId === 0) {
     lastId = 1;
     if (options.trapKeyboardFocus) {
-      doc.addEventListener('focus', ev => trapKeyboardFocus(ev, doc), true);
+      doc.addEventListener('focus', (ev: FocusEvent) => {
+        /**
+         * ion-menu has its own focus trapping listener
+         * so we do not want the two listeners to conflict
+         * with each other.
+         */
+        if (ev.target && (ev.target as HTMLElement).tagName === 'ION-MENU') {
+          return;
+        }
+        trapKeyboardFocus(ev, doc);
+      }, true);
     }
 
     // handle back-button click
@@ -585,3 +595,8 @@ export const safeCall = (handler: any, arg?: any) => {
 };
 
 export const BACKDROP = 'backdrop';
+export const FOCUSABLE_OVERLAY_TAGNAMES = ['ION-MODAL', 'ION-POPOVER', 'ION-ALERT', 'ION-ACTION-SHEET', 'ION-LOADING', 'ION-PICKER'];
+
+
+
+

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -353,7 +353,7 @@ export const getOverlays = (doc: Document, selector?: string): HTMLIonOverlayEle
  * @param id The unique identifier for the overlay instance.
  * @returns The overlay element or `undefined` if no overlay element is found.
  */
-const getOverlay = (doc: Document, overlayTag?: string, id?: string): HTMLIonOverlayElement | undefined => {
+export const getOverlay = (doc: Document, overlayTag?: string, id?: string): HTMLIonOverlayElement | undefined => {
   const overlays = getOverlays(doc, overlayTag).filter(o => !isOverlayHidden(o));
   return (id === undefined)
     ? overlays[overlays.length - 1]
@@ -595,4 +595,3 @@ export const safeCall = (handler: any, arg?: any) => {
 };
 
 export const BACKDROP = 'backdrop';
-export const FOCUSABLE_OVERLAY_TAGNAMES = ['ION-MODAL', 'ION-POPOVER', 'ION-ALERT', 'ION-ACTION-SHEET', 'ION-LOADING', 'ION-PICKER'];


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/24491 resolves https://github.com/ionic-team/ionic-framework/issues/24361
There are two issues in one here.

1. The overlay focus trapping code was firing whenever the menu was focus, but it should have only been firing on the overlay that was open. This resulted in the focus trapping code continually firing (cause of the infinite loop).
2. Even after this was resolved, the menu focus trapping code was always firing on an overlay. So even if you got the overlay to open, focus would never be moved to it since menu would keep claiming it.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Overlay focus trapping does not fire if `ion-menu` is focused.
- Menu focus trapping does not fire is overlays are focused.
- Menu allows focus to be relinquished when it is being moved to an overlay (except toast).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: 6.0.4-dev.1642703076.3d49fbe