### PR TITLE
fix(datetime): timepicker popover will position relative to click target

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -901,7 +901,7 @@ ion-popover,prop,triggerAction,"click" | "context-menu" | "hover",'click',false,
 ion-popover,method,dismiss,dismiss(data?: any, role?: string | undefined, dismissParentPopover?: boolean) => Promise<boolean>
 ion-popover,method,onDidDismiss,onDidDismiss<T = any>() => Promise<OverlayEventDetail<T>>
 ion-popover,method,onWillDismiss,onWillDismiss<T = any>() => Promise<OverlayEventDetail<T>>
-ion-popover,method,present,present(event?: MouseEvent | TouchEvent | PointerEvent | undefined) => Promise<void>
+ion-popover,method,present,present(event?: MouseEvent | TouchEvent | PointerEvent | CustomEvent<any> | undefined) => Promise<void>
 ion-popover,event,didDismiss,OverlayEventDetail<any>,true
 ion-popover,event,didPresent,void,true
 ion-popover,event,ionPopoverDidDismiss,OverlayEventDetail<any>,true

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -1823,6 +1823,7 @@ export namespace Components {
           * If `true`, tapping the picker will reveal a number input keyboard that lets the user type in values for each picker column. This is useful when working with time pickers.
          */
         "numericInput": boolean;
+        "scrollActiveItemIntoView": () => Promise<void>;
         /**
           * The selected option in the picker.
          */
@@ -1918,7 +1919,7 @@ export namespace Components {
         /**
           * Present the popover overlay after it has been created. Developers can pass a mouse, touch, or pointer event to position the popover relative to where that event was dispatched.
          */
-        "present": (event?: MouseEvent | TouchEvent | PointerEvent | undefined) => Promise<void>;
+        "present": (event?: MouseEvent | TouchEvent | PointerEvent | CustomEvent<any> | undefined) => Promise<void>;
         /**
           * When opening a popover from a trigger, we should not be modifying the `event` prop from inside the component. Additionally, when pressing the "Right" arrow key, we need to shift focus to the first descendant in the newly presented popover.
          */

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1345,9 +1345,13 @@ export class Datetime implements ComponentInterface {
           const { popoverRef } = this;
 
           if (popoverRef) {
-
             this.isTimePopoverOpen = true;
-            popoverRef.present(ev);
+
+            popoverRef.present(new CustomEvent('ionShadowTarget', {
+              detail: {
+                ionShadowTarget: ev.target
+              }
+            }));
 
             await popoverRef.onWillDismiss();
 
@@ -1362,6 +1366,18 @@ export class Datetime implements ComponentInterface {
         translucent
         overlayIndex={1}
         arrow={false}
+        onWillPresent={ev => {
+          /**
+           * Intersection Observers do not consistently fire between Blink and Webkit
+           * when toggling the visibility of the popover and trying to scroll the picker
+           * column to the correct time value.
+           *
+           * This will correctly scroll the element position to the correct time value,
+           * before the popover is fully presented.
+           */
+          const cols = (ev.target! as HTMLElement).querySelectorAll('ion-picker-column-internal');
+          cols.forEach(col => col.scrollActiveItemIntoView());
+        }}
         style={{
           '--offset-y': '-10px'
         }}

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1376,6 +1376,7 @@ export class Datetime implements ComponentInterface {
            * before the popover is fully presented.
            */
           const cols = (ev.target! as HTMLElement).querySelectorAll('ion-picker-column-internal');
+          // TODO (FW-615): Potentially remove this when intersection observers are fixed in picker column
           cols.forEach(col => col.scrollActiveItemIntoView());
         }}
         style={{

--- a/core/src/components/datetime/test/position/e2e.ts
+++ b/core/src/components/datetime/test/position/e2e.ts
@@ -1,0 +1,27 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('datetime: position', () => {
+
+  it('should position the time picker relative to the click target', async () => {
+    const page = await newE2EPage({
+      url: '/src/components/datetime/test/position?ionic:_testing=true'
+    });
+    const screenshotCompares = [];
+
+    const openDateTimeBtn = await page.find('ion-button');
+    await openDateTimeBtn.click();
+
+    screenshotCompares.push(await page.compareScreenshot());
+
+    const timepickerBtn = await page.find('ion-datetime >>> .time-body');
+    await timepickerBtn.click();
+
+    screenshotCompares.push(await page.compareScreenshot());
+
+    for (const screenshotCompare of screenshotCompares) {
+      expect(screenshotCompare).toMatchScreenshot();
+    }
+
+  });
+
+});

--- a/core/src/components/datetime/test/position/index.html
+++ b/core/src/components/datetime/test/position/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Datetime - Position</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
+  <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+  <script src="../../../../../scripts/testing/scripts.js"></script>
+  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+</head>
+
+<body>
+  <ion-app>
+    <ion-header translucent="true">
+      <ion-toolbar>
+        <ion-title>Datetime - Position</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+
+      <ion-button onclick="presentPopover(defaultPopover, event)">Present Popover</ion-button>
+      <ion-popover class="datetime-popover" id="default-popover">
+        <ion-datetime></ion-datetime>
+      </ion-popover>
+
+    </ion-content>
+
+    <script>
+      const defaultPopover = document.querySelector('ion-popover#default-popover');
+      const presentPopover = (popover, ev) => {
+        popover.event = ev;
+        popover.showBackdrop = false;
+        popover.isOpen = true;
+
+        const dismiss = () => {
+          popover.isOpen = false;
+          popover.event = undefined;
+
+          popover.removeEventListener('didDismiss', dismiss);
+        }
+
+        popover.addEventListener('didDismiss', dismiss);
+      }
+    </script>
+
+  </ion-app>
+</body>
+
+</html>

--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -1,4 +1,4 @@
-import { Component, ComponentInterface, Element, Event, EventEmitter, Host, Prop, State, Watch, h } from '@stencil/core';
+import { Component, ComponentInterface, Element, Event, EventEmitter, Host, Method, Prop, State, Watch, h } from '@stencil/core';
 
 import { getIonMode } from '../../global/ionic-global';
 import { Color } from '../../interface';
@@ -118,7 +118,9 @@ export class PickerColumnInternal implements ComponentInterface {
     }
   }
 
-  scrollActiveItemIntoView() {
+  /** @internal  */
+  @Method()
+  async scrollActiveItemIntoView() {
     const activeEl = this.activeItem;
 
     if (activeEl) {

--- a/core/src/components/popover/popover.tsx
+++ b/core/src/components/popover/popover.tsx
@@ -372,7 +372,7 @@ export class Popover implements ComponentInterface, PopoverInterface {
    * was dispatched.
    */
   @Method()
-  async present(event?: MouseEvent | TouchEvent | PointerEvent): Promise<void> {
+  async present(event?: MouseEvent | TouchEvent | PointerEvent | CustomEvent): Promise<void> {
     if (this.presented) {
       return;
     }

--- a/core/src/components/popover/readme.md
+++ b/core/src/components/popover/readme.md
@@ -1022,7 +1022,7 @@ Type: `Promise<OverlayEventDetail<T>>`
 
 
 
-### `present(event?: MouseEvent | TouchEvent | PointerEvent | undefined) => Promise<void>`
+### `present(event?: MouseEvent | TouchEvent | PointerEvent | CustomEvent<any> | undefined) => Promise<void>`
 
 Present the popover overlay after it has been created.
 Developers can pass a mouse, touch, or pointer event


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The popover positioning within datetime can result in the popover element being placed outside of the trigger/click target. Additionally, rapidly opening the timepicker within the datetime, can result in the timepicker not scrolling to the correct time.

Issue Number: #24531, #24415


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Presenting the popover within datetime will use the internal API for `ionShadowTarget` to consistently position the popover when the click target/trigger is within a shadow DOM.
- Rapidly toggling the timepicker popover will consistently scroll the picker columns to the correct time.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Extension of #24535 (will close in favor of this, if accepted).

### Popover positioning
|Before|After|
|---|---|
|<video src="https://user-images.githubusercontent.com/13732623/150420320-3d9f1287-1415-4720-880a-fd0dc1f7ca90.mp4"></video>|<video src="https://user-images.githubusercontent.com/13732623/150420456-806edada-1b6c-44ae-be14-90b4f0b102bd.mp4"></video>|

### Timepicker columns (combined with above fix)
|Before|After|
|---|---|
| <video src="https://user-images.githubusercontent.com/13732623/150419923-576a9cd1-06f7-47f0-8d86-316aa052c10f.mp4"></video> | <video src="https://user-images.githubusercontent.com/13732623/150419587-e1a7dd04-0e42-4ae0-a573-56f58b36457c.mp4"></video>|












