### PR TITLE
fix(popover): fixes key handling in popover textarea

### DIFF
--- a/core/src/components/popover/test/basic/index.html
+++ b/core/src/components/popover/test/basic/index.html
@@ -36,6 +36,7 @@
       <ion-button id="custom-class-popover" expand="block" color="tertiary" onclick="presentPopover({ component: 'translucent-page', event: event, cssClass: 'my-custom-class' })">Custom Class Popover</ion-button>
       <ion-button id="header-popover" expand="block" onclick="presentPopover({ component: 'header-page' })">Popover With Header</ion-button>
       <ion-button id="translucent-header-popover" expand="block" onclick="presentPopover({ component: 'translucent-header-page' })">Popover With Translucent Header</ion-button>
+      <ion-button id="popover-with-textarea" expand="block" onclick="presentPopover({ component: 'textarea-page' })">Popover With textarea</ion-button>
     </ion-content>
 
     <ion-footer>
@@ -178,6 +179,23 @@
     }
 
     customElements.define('translucent-header-page', TranslucentHeaderPage);
+
+    class TextAreaPage extends HTMLElement {
+      constructor() {
+        super();
+      }
+
+      connectedCallback() {
+        this.innerHTML = `
+          <ion-content>
+            <ion-textarea rows="4" value="the cursor in this <ion-textarea>\nmust be able to be moved\nwith the arrow keys and\nhome and end keys"></ion-textarea>
+            <textarea rows="4" style="display:block;width: 100%;border: 0;padding: 8px;">the cursor in this <textarea>\nmust be able to be moved\nwith the arrow keys and\nhome and end keys</textarea>
+          </ion-content>
+        `;
+      }
+    }
+
+    customElements.define('textarea-page', TextAreaPage);
   </script>
 </body>
 

--- a/core/src/components/popover/utils.ts
+++ b/core/src/components/popover/utils.ts
@@ -335,6 +335,13 @@ export const configureKeyboardInteraction = (
 ) => {
 
   const callback = async (ev: KeyboardEvent) => {
+    if (ev.target instanceof HTMLTextAreaElement) {
+      /**
+       * Do not interfere with keys pressed in a textarea
+       * Fixes issue #24633
+       */
+      return;
+    }
     const activeElement = document.activeElement as HTMLElement | null;
     let items: HTMLIonItemElement[] = [];
 


### PR DESCRIPTION
Fixes ArrowDown, ArrowUp, Home and End keys not moving the cursor in a textarea when used in popover
content

fix #24633

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 24633


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- arrow, home and end keys can now be used to move the cursor in textarea and ion-textarea elements in a popover

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
