### PR TITLE
fix(modal): native keyboard will dismiss when bottom sheet is dragged

### DIFF
--- a/core/src/utils/gesture/index.ts
+++ b/core/src/utils/gesture/index.ts
@@ -231,6 +231,9 @@ export const createGesture = (config: GestureConfig): Gesture => {
     destroy() {
       gesture.destroy();
       pointerEvents.destroy();
+      if (config.onDestroy !== undefined) {
+        config.onDestroy();
+      }
     }
   };
 };
@@ -325,6 +328,11 @@ export interface GestureConfig {
   onStart?: GestureCallback;
   onMove?: GestureCallback;
   onEnd?: GestureCallback;
+  /**
+   * Callback to extend the behavior when a gesture
+   * handler is destroyed.
+   */
+  onDestroy?: () => void;
   notCaptured?: GestureCallback;
 }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The swipe gesture for the modal bottom sheet will trigger when a form element (input, textarea, etc.) receives focus and opens the native keyboard. This causes the sheet gesture to become unresponsive and free scroll. 

Issue Number: Resolves #23878

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Swipe gestures will be disabled when the keyboard is immediately open (form element has focus).
- Swipe gestures will be re-enabled on the next frame (after the keyboard has repositioned the view)
- The swipe gesture for the sheet modal will dismiss any active keyboards (this aligns with native behavior, see: Maps sheet implementation on iOS)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

|Before|After|
|---|---|
|<video src="https://user-images.githubusercontent.com/13732623/150849156-0a8ed91f-4c5e-49ea-a1ef-ab88bc31815d.mp4"></video>|<video src="https://user-images.githubusercontent.com/13732623/150849184-5f07511f-1cad-452e-8518-16e61139a7f1.mp4"></video>|

Behavior is easier to feel on device than from a video:
1. Update the sheet example test to render an `<ion-input></ion-input>` for each item
2. Run Core
3. Open the test on your mobile device
4. Present the modal sheet and play with the gesture, breakpoints and keyboard focus



