### PR TITLE
docs(router-outlet): clarify usage when not using a framework

### DIFF
--- a/core/src/components/router-outlet/readme.md
+++ b/core/src/components/router-outlet/readme.md
@@ -1,11 +1,8 @@
 # ion-router-outlet
 
-Router outlet is a component used in routing within an Angular, React, or Vue app. It behaves in a similar way to Angular's built-in router outlet component and Vue's router view component, but contains the logic for providing a stacked navigation, and animating views in and out.
-
-> Note: this component should only be used with Angular, React, and Vue projects. For vanilla or Stencil JavaScript projects, use [`ion-router`](../router) and [`ion-route`](../route).
+The router outlet behaves in a similar way to Angular's built-in router outlet component and Vue's router view component, but contains the logic for providing a stacked navigation, and animating views in and out.
 
 Although router outlet has methods for navigating around, it's recommended to use the navigation methods in your framework's router.
-
 
 ## Life Cycle Hooks
 

--- a/core/src/components/router/readme.md
+++ b/core/src/components/router/readme.md
@@ -7,9 +7,9 @@ The router is a component for handling routing inside vanilla and Stencil JavaSc
 Apps should have a single `ion-router` component in the codebase.
 This component controls all interactions with the browser history and it aggregates updates through an event system.
 
-`ion-router` is just a URL coordinator for the navigation outlets of ionic: `ion-nav` and `ion-tabs`.
+`ion-router` is just a URL coordinator for the navigation outlets of ionic: `ion-nav`, `ion-tabs`, and `ion-router-outlet`.
 
-That means the `ion-router` never touches the DOM, it does NOT show the components or emit any kind of lifecycle events, it just tells `ion-nav` and `ion-tabs` what and when to "show" based on the browser's URL.
+That means the `ion-router` never touches the DOM, it does NOT show the components or emit any kind of lifecycle events, it just tells `ion-nav`, `ion-tabs`, and `ion-router-outlet` what and when to "show" based on the browser's URL.
 
 In order to configure this relationship between components (to load/select) and URLs, `ion-router` uses a declarative syntax using JSX/HTML to define a tree of routes.
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe): 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The router outlet can be used without any framework (see the [test app](https://github.com/ionic-team/ionic-framework/tree/main/core/src/components/router-outlet/test/basic)) so the document was misleading and this PR removes the part saying otherwise.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The documentation is still not quite right because the standalone version of the router outlet is quite different from the versions available for the different framework. The standalone version is a simple outlet that only can load a component.

I am wondering how to document components that are different standalone vs framework. Do you have guidelines/examples ? In the meantime I think this PR is still valuable as I think most users would use the router outlet when using the ionic router because it's much more lightweight than a ion-nav.

The parts of the docs that are not applicable to the standalone version:

> but contains the logic for providing a stacked navigation

This is not true for the standalone router-outlet. It might be true for the framework version ?

The document events `ionView...` do not exists on the standalone router outlet.

> Although router outlet has methods for navigating around

This is not true for the standalone version of the router outlet. 