### PR TITLE
fix(react-router): remove page transition flicker on outlet mounting

### DIFF
--- a/packages/react-router/src/ReactRouter/IonRouteInner.tsx
+++ b/packages/react-router/src/ReactRouter/IonRouteInner.tsx
@@ -9,6 +9,12 @@ export class IonRouteInner extends React.PureComponent<IonRouteProps> {
         path={this.props.path}
         exact={this.props.exact}
         render={this.props.render}
+        /**
+         * `computedMatch` is a private API in react-router v5 that
+         * has been removed in v6.
+         *
+         * This needs to be removed when we support v6.
+         */
         computedMatch={(this.props as any).computedMatch}
       />
     );

--- a/packages/react-router/src/ReactRouter/IonRouteInner.tsx
+++ b/packages/react-router/src/ReactRouter/IonRouteInner.tsx
@@ -14,6 +14,8 @@ export class IonRouteInner extends React.PureComponent<IonRouteProps> {
          * has been removed in v6.
          *
          * This needs to be removed when we support v6.
+         *
+         * TODO: FW-647
          */
         computedMatch={(this.props as any).computedMatch}
       />

--- a/packages/react-router/src/ReactRouter/StackManager.tsx
+++ b/packages/react-router/src/ReactRouter/StackManager.tsx
@@ -29,6 +29,8 @@ export class StackManager extends React.PureComponent<StackManagerProps, StackMa
     isInOutlet: () => true,
   };
 
+  private pendingPageTransition = false;
+
   constructor(props: StackManagerProps) {
     super(props);
     this.registerIonPage = this.registerIonPage.bind(this);
@@ -46,8 +48,9 @@ export class StackManager extends React.PureComponent<StackManagerProps, StackMa
   }
 
   componentDidUpdate(prevProps: StackManagerProps) {
-    if (this.props.routeInfo.pathname !== prevProps.routeInfo.pathname) {
+    if (this.props.routeInfo.pathname !== prevProps.routeInfo.pathname || this.pendingPageTransition) {
       this.handlePageTransition(this.props.routeInfo);
+      this.pendingPageTransition = false;
     }
   }
 
@@ -59,7 +62,18 @@ export class StackManager extends React.PureComponent<StackManagerProps, StackMa
   async handlePageTransition(routeInfo: RouteInfo) {
     // If routerOutlet isn't quite ready, give it another try in a moment
     if (!this.routerOutletElement || !this.routerOutletElement.commit) {
-      setTimeout(() => this.handlePageTransition(routeInfo), 10);
+      /**
+       * The route outlet has not mounted yet. We need to wait for it to render
+       * before we can transition the page.
+       *
+       * Set a flag to indicate that we should transition the page after
+       * the component has updated.
+       */
+      this.pendingPageTransition = true;
+
+      this.setState({
+        routeInfo
+      });
     } else {
       let enteringViewItem = this.context.findViewItemByRouteInfo(routeInfo, this.id);
       let leavingViewItem = this.context.findLeavingViewItemByRouteInfo(routeInfo, this.id);

--- a/packages/react-router/src/ReactRouter/StackManager.tsx
+++ b/packages/react-router/src/ReactRouter/StackManager.tsx
@@ -60,7 +60,6 @@ export class StackManager extends React.PureComponent<StackManagerProps, StackMa
   }
 
   async handlePageTransition(routeInfo: RouteInfo) {
-    // If routerOutlet isn't quite ready, give it another try in a moment
     if (!this.routerOutletElement || !this.routerOutletElement.commit) {
       /**
        * The route outlet has not mounted yet. We need to wait for it to render
@@ -70,10 +69,6 @@ export class StackManager extends React.PureComponent<StackManagerProps, StackMa
        * the component has updated.
        */
       this.pendingPageTransition = true;
-
-      this.setState({
-        routeInfo
-      });
     } else {
       let enteringViewItem = this.context.findViewItemByRouteInfo(routeInfo, this.id);
       let leavingViewItem = this.context.findLeavingViewItemByRouteInfo(routeInfo, this.id);

--- a/packages/react/src/components/navigation/IonTabs.tsx
+++ b/packages/react/src/components/navigation/IonTabs.tsx
@@ -99,7 +99,7 @@ export const IonTabs = /*@__PURE__*/ (() =>
           return;
         }
         if (child.type === IonRouterOutlet || child.type.isRouterOutlet) {
-          outlet = React.cloneElement(child, { tabs: true });
+          outlet = React.cloneElement(child);
         } else if (child.type === Fragment && child.props.children[0].type === IonRouterOutlet) {
           outlet = child.props.children[0];
         }

--- a/packages/react/test-app/src/App.tsx
+++ b/packages/react/test-app/src/App.tsx
@@ -24,6 +24,7 @@ import './theme/variables.css';
 import Main from './pages/Main';
 import OverlayHooks from './pages/overlay-hooks/OverlayHooks';
 import OverlayComponents from './pages/overlay-components/OverlayComponents';
+import Tabs from './pages/Tabs';
 
 setupIonicReact();
 
@@ -33,6 +34,7 @@ const App: React.FC = () => (
       <Route path="/" component={Main} />
       <Route path="/overlay-hooks" component={OverlayHooks} />
       <Route path="/overlay-components" component={OverlayComponents} />
+      <Route path="/tabs" component={Tabs} />
     </IonReactRouter>
   </IonApp>
 );

--- a/packages/react/test-app/src/pages/Tabs.tsx
+++ b/packages/react/test-app/src/pages/Tabs.tsx
@@ -1,0 +1,60 @@
+
+import { IonContent, IonHeader, IonLabel, IonPage, IonRouterOutlet, IonTabBar, IonTabButton, IonTabs, IonTitle, IonToolbar } from '@ionic/react';
+import React from 'react';
+import { Redirect, Route } from 'react-router';
+
+const Tab1: React.FC = () => (
+  <IonPage>
+    <IonHeader>
+      <IonToolbar>
+        <IonTitle>
+          Tab 1
+        </IonTitle>
+      </IonToolbar>
+    </IonHeader>
+    <IonContent fullscreen>
+      <IonLabel>Tab 1 page</IonLabel>
+    </IonContent>
+  </IonPage>
+);
+
+const Tab2: React.FC = () => (
+<IonPage>
+    <IonHeader>
+      <IonToolbar>
+        <IonTitle>
+          Tab 2
+        </IonTitle>
+      </IonToolbar>
+    </IonHeader>
+    <IonContent fullscreen>
+      <IonLabel>Tab 2 page</IonLabel>
+    </IonContent>
+  </IonPage>
+  );
+
+const Tabs: React.FC = () => (
+  <IonTabs>
+    <IonRouterOutlet>
+      <Route exact path="/tabs/tab1">
+        <Tab1 />
+      </Route>
+      <Route exact path="/tabs/tab2">
+        <Tab2 />
+      </Route>
+      <Route exact path="/tabs">
+        <Redirect to ="/tabs/tab1" />
+      </Route>
+    </IonRouterOutlet>
+    <IonTabBar slot="bottom">
+      <IonTabButton tab="tab1" href="/tabs/tab1">
+        <IonLabel>Tab 1</IonLabel>
+      </IonTabButton>
+      <IonTabButton tab="tab2" href="/tabs/tab2">
+        <IonLabel>Tab 2</IonLabel>
+      </IonTabButton>
+    </IonTabBar>
+  </IonTabs>
+)
+
+export default Tabs;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

On initial load, when using nested router outlets with React, another outlet can briefly display before the enter view & outlet has mounted.

Issue Number: #24666


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Page transitions that are deferred as a result of the outlet not being rendered yet, happen immediately after the outlet is mounted.
- Add note about using a deprecated private API from react-router (`computedMatch`) that is no longer available in v6.
- Removes `tabs` attribute when cloning the page element
  - Cannot find a single reference to why we have this code. Looks like carry over from the Angular router integration, which also has no functional code tied to it.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

|Before|After|
|---|---|
|<video src="https://user-images.githubusercontent.com/13732623/151272903-e969a074-51cb-4e7d-8daa-c621c12d22b1.mp4"></video>|<video src="https://user-images.githubusercontent.com/13732623/151272877-170d1949-6e74-452f-8b0e-de2b416fa3ad.mp4"></video>

Note: I am refreshing the browser in both examples.
