### PR TITLE
fix(vue): routing history is correctly replaced when overwriting browser history

### DIFF
--- a/packages/vue-router/src/locationHistory.ts
+++ b/packages/vue-router/src/locationHistory.ts
@@ -85,11 +85,19 @@ export const createLocationHistory = () => {
     locationHistory.push(routeInfo);
   }
 
-  const clearHistory = () => {
-    locationHistory.length = 0;
+  const clearHistory = (routeInfo?: RouteInfo) => {
     Object.keys(tabsHistory).forEach(key => {
       tabsHistory[key] = [];
     });
+
+    if (routeInfo) {
+      const existingRouteIndex = locationHistory.findIndex(r => r.position === routeInfo.position);
+      if (existingRouteIndex === -1) return;
+
+      locationHistory.splice(existingRouteIndex);
+    } else {
+      locationHistory.length = 0;
+    }
   }
   const getTabsHistory = (tab: string): RouteInfo[] => {
     let history;
@@ -104,17 +112,6 @@ export const createLocationHistory = () => {
   }
 
   const size = () => locationHistory.length;
-
-  const updateByHistoryPosition = (routeInfo: RouteInfo, updateEntries: boolean) => {
-    const existingRouteIndex = locationHistory.findIndex(r => r.position === routeInfo.position);
-    if (existingRouteIndex === -1) return;
-
-    locationHistory[existingRouteIndex].pathname = routeInfo.pathname;
-
-    if (updateEntries) {
-      locationHistory[existingRouteIndex].pushedByRoute = routeInfo.pushedByRoute;
-    }
-  }
 
   /**
    * Finds and returns the location history item
@@ -205,7 +202,6 @@ export const createLocationHistory = () => {
 
   return {
     current,
-    updateByHistoryPosition,
     size,
     last,
     previous,

--- a/packages/vue-router/src/locationHistory.ts
+++ b/packages/vue-router/src/locationHistory.ts
@@ -85,6 +85,12 @@ export const createLocationHistory = () => {
     locationHistory.push(routeInfo);
   }
 
+  /**
+   * Wipes the location history arrays.
+   * You can optionally provide a routeInfo
+   * object which will wipe that entry
+   * and every entry that appears after it.
+   */
   const clearHistory = (routeInfo?: RouteInfo) => {
     Object.keys(tabsHistory).forEach(key => {
       tabsHistory[key] = [];

--- a/packages/vue-router/src/locationHistory.ts
+++ b/packages/vue-router/src/locationHistory.ts
@@ -214,6 +214,7 @@ export const createLocationHistory = () => {
     update,
     getFirstRouteInfoForTab,
     getCurrentRouteInfoForTab,
-    findLastLocation
+    findLastLocation,
+    clearHistory
   }
 }

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -324,19 +324,21 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
        */
       if (historySize > historyDiff && routeInfo.tab === undefined) {
         /**
-         * When going from /a --> /a/1 --> /b, then going
-         * back to /a, then going /a --> /a/2 --> /b, clicking
-         * the ion-back-button should return us to /a/2, not /a/1.
-         * However, since the route entry for /b already exists,
-         * we need to update other information such as the "pushedByRoute"
-         * so we know which route pushed this new route.
+         * When navigating back through the history,
+         * if users then push a new route the future
+         * history stack is no longer relevant. As
+         * a result, we need to clear out all entries
+         * that appear after the current routeInfo
+         * so that we can then append the new history.
          *
-         * However, when using router.go with a stride of >1 or <-1,
-         * we should not update this additional information because
-         * we are traversing through the history, not pushing new states.
-         * Going from /a --> /b --> /c, then doing router.go(-2), then doing
-         * router.go(2) to go from /a --> /c should not update the route
-         * listing to say that /c was pushed by /a.
+         * This does not apply when using router.go
+         * as that is traversing through the history,
+         * not altering it.
+         *
+         * Previously we had only updated the existing route
+         * and then left the future history alone. That
+         * worked for some use cases but was not sufficient
+         * in other scenarios.
          */
 
           if (routeInfo.routerAction === 'push' && delta === undefined) {

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -345,20 +345,21 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
          * in other scenarios.
          */
 
-          if (routeInfo.routerAction === 'push' && delta === undefined) {
-            locationHistory.clearHistory(routeInfo);
-            locationHistory.add(routeInfo);
-
-            if (locationHistory.size() === 1) {
-              initialHistoryPosition = routeInfo.position;
-            }
-          }
+        if (routeInfo.routerAction === 'push' && delta === undefined) {
+          locationHistory.clearHistory(routeInfo);
+          locationHistory.add(routeInfo);
+        }
       } else {
         locationHistory.add(routeInfo);
+      }
 
-        if (locationHistory.size() === 1) {
-          initialHistoryPosition = routeInfo.position;
-        }
+      /**
+       * If we recently reset the location history
+       * then we also need to update the initial
+       * history position.
+       */
+      if (locationHistory.size() === 1) {
+        initialHistoryPosition = routeInfo.position;
       }
 
       currentRouteInfo = routeInfo;

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -199,21 +199,20 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
           locationHistory.clearHistory();
         }
       } else {
-          /**
-           * If the routerDirection was specified as "root", then
-           * we are replacing the initial state of location history
-           * with this incoming route. As a result, the leaving
-           * history info is stored at the same location as
-           * where the incoming history location will be stored.
-           *
-           * Otherwise, we can assume this is just another route
-           * that will be pushed onto the end of location history,
-           * so we can grab the previous item in history relative
-           * to where the history state currently is.
-           */
-          const position = (incomingRouteParams.routerDirection === 'root') ? currentHistoryPosition : currentHistoryPosition - 1;
-          leavingLocationInfo = locationHistory.current(initialHistoryPosition, position);
-        }
+        /**
+         * If the routerDirection was specified as "root", then
+         * we are replacing the initial state of location history
+         * with this incoming route. As a result, the leaving
+         * history info is stored at the same location as
+         * where the incoming history location will be stored.
+         *
+         * Otherwise, we can assume this is just another route
+         * that will be pushed onto the end of location history,
+         * so we can grab the previous item in history relative
+         * to where the history state currently is.
+         */
+        const position = (incomingRouteParams.routerDirection === 'root') ? currentHistoryPosition : currentHistoryPosition - 1;
+        leavingLocationInfo = locationHistory.current(initialHistoryPosition, position);
       }
     } else {
       leavingLocationInfo = currentRouteInfo;

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -159,6 +159,9 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
         leavingLocationInfo = locationHistory.previous();
       } else if (incomingRouteParams.routerAction === 'pop') {
         leavingLocationInfo = locationHistory.current(initialHistoryPosition, currentHistoryPosition + 1);
+        if (action === 'replace') {
+          locationHistory.clearHistory();
+        }
       } else {
         leavingLocationInfo = locationHistory.current(initialHistoryPosition, currentHistoryPosition - 1);
       }

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -199,10 +199,20 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
           locationHistory.clearHistory();
         }
       } else {
-        if (incomingRouteParams.routerDirection === 'root') {
+          /**
+           * If the routerDirection was specified as "root", then
+           * we are replacing the initial state of location history
+           * with this incoming route. As a result, the leaving
+           * history info is stored at the same location as
+           * where the incoming history location will be stored.
+           *
+           * Otherwise, we can assume this is just another route
+           * that will be pushed onto the end of location history,
+           * so we can grab the previous item in history relative
+           * to where the history state currently is.
+           */
+          const position = (incomingRouteParams.routerDirection === 'root') ? currentHistoryPosition : currentHistoryPosition - 1;
           leavingLocationInfo = locationHistory.current(initialHistoryPosition, currentHistoryPosition);
-        } else {
-          leavingLocationInfo = locationHistory.current(initialHistoryPosition, currentHistoryPosition - 1);
         }
       }
     } else {

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -339,10 +339,9 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
          * listing to say that /c was pushed by /a.
          */
 
-          if (routeInfo.routerAction === 'push' && delta === undefined
-          ) {
-           locationHistory.clearHistory(routeInfo);
-           locationHistory.add(routeInfo);
+          if (routeInfo.routerAction === 'push' && delta === undefined) {
+            locationHistory.clearHistory(routeInfo);
+            locationHistory.add(routeInfo);
           }
       } else {
         locationHistory.add(routeInfo);

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -322,7 +322,10 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
        * is navigating within the history without pushing
        * new items within the stack.
        */
-      if (historySize > historyDiff && routeInfo.tab === undefined) {
+      if (
+        historySize > historyDiff &&
+        routeInfo.tab === undefined
+      ) {
         /**
          * When going from /a --> /a/1 --> /b, then going
          * back to /a, then going /a --> /a/2 --> /b, clicking
@@ -338,12 +341,17 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
          * router.go(2) to go from /a --> /c should not update the route
          * listing to say that /c was pushed by /a.
          */
-        const hasDeltaStride = delta !== undefined && Math.abs(delta) !== 1;
-        locationHistory.updateByHistoryPosition(routeInfo, !hasDeltaStride);
-      } else {
-        locationHistory.add(routeInfo);
+
+          if (
+            routeInfo.routerAction === 'push' &&
+            delta === undefined
+          ) {
+           locationHistory.clearHistory(routeInfo);
+           locationHistory.add(routeInfo);
+          }
       }
 
+      locationHistory.add(routeInfo);
       currentRouteInfo = routeInfo;
     }
     incomingRouteParams = undefined;

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -60,7 +60,7 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
    * new pages or updating history via the forward
    * and back browser buttons.
    */
-  const initialHistoryPosition = opts.history.state.position as number;
+  let initialHistoryPosition = opts.history.state.position as number;
   let currentHistoryPosition = opts.history.state.position as number;
 
   let currentRouteInfo: RouteInfo;
@@ -199,7 +199,11 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
           locationHistory.clearHistory();
         }
       } else {
-        leavingLocationInfo = locationHistory.current(initialHistoryPosition, currentHistoryPosition - 1);
+        if (incomingRouteParams.routerDirection === 'root') {
+          leavingLocationInfo = locationHistory.current(initialHistoryPosition, currentHistoryPosition);
+        } else {
+          leavingLocationInfo = locationHistory.current(initialHistoryPosition, currentHistoryPosition - 1);
+        }
       }
     } else {
       leavingLocationInfo = currentRouteInfo;
@@ -344,9 +348,17 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
           if (routeInfo.routerAction === 'push' && delta === undefined) {
             locationHistory.clearHistory(routeInfo);
             locationHistory.add(routeInfo);
+
+            if (locationHistory.size() === 1) {
+              initialHistoryPosition = routeInfo.position;
+            }
           }
       } else {
         locationHistory.add(routeInfo);
+
+        if (locationHistory.size() === 1) {
+          initialHistoryPosition = routeInfo.position;
+        }
       }
 
       currentRouteInfo = routeInfo;

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -349,9 +349,10 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
            locationHistory.clearHistory(routeInfo);
            locationHistory.add(routeInfo);
           }
+      } else {
+        locationHistory.add(routeInfo);
       }
 
-      locationHistory.add(routeInfo);
       currentRouteInfo = routeInfo;
     }
     incomingRouteParams = undefined;

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -212,7 +212,7 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
            * to where the history state currently is.
            */
           const position = (incomingRouteParams.routerDirection === 'root') ? currentHistoryPosition : currentHistoryPosition - 1;
-          leavingLocationInfo = locationHistory.current(initialHistoryPosition, currentHistoryPosition);
+          leavingLocationInfo = locationHistory.current(initialHistoryPosition, position);
         }
       }
     } else {

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -322,10 +322,7 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
        * is navigating within the history without pushing
        * new items within the stack.
        */
-      if (
-        historySize > historyDiff &&
-        routeInfo.tab === undefined
-      ) {
+      if (historySize > historyDiff && routeInfo.tab === undefined) {
         /**
          * When going from /a --> /a/1 --> /b, then going
          * back to /a, then going /a --> /a/2 --> /b, clicking
@@ -342,9 +339,7 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
          * listing to say that /c was pushed by /a.
          */
 
-          if (
-            routeInfo.routerAction === 'push' &&
-            delta === undefined
+          if (routeInfo.routerAction === 'push' && delta === undefined
           ) {
            locationHistory.clearHistory(routeInfo);
            locationHistory.add(routeInfo);

--- a/packages/vue/test-app/src/App.vue
+++ b/packages/vue/test-app/src/App.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts">
-import { IonApp, IonRouterOutlet } from '@ionic/vue';
+import { IonApp, IonRouterOutlet, useIonRouter } from '@ionic/vue';
 import { defineComponent } from 'vue';
 
 export default defineComponent({
@@ -13,6 +13,9 @@ export default defineComponent({
   components: {
     IonApp,
     IonRouterOutlet
+  },
+  setup() {
+    (window as any).debugIonRouter = useIonRouter();
   }
 });
 </script>

--- a/packages/vue/test-app/tests/e2e/specs/routing.js
+++ b/packages/vue/test-app/tests/e2e/specs/routing.js
@@ -401,7 +401,6 @@ describe('Routing', () => {
     cy.ionPageHidden('inputs');
   })
 
-
   // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/23873
   it('should correctly show pages after going back to defaultHref page', () => {
     cy.visit('http://localhost:8080/default-href');

--- a/packages/vue/test-app/tests/e2e/specs/routing.js
+++ b/packages/vue/test-app/tests/e2e/specs/routing.js
@@ -433,6 +433,46 @@ describe('Routing', () => {
     cy.ionPageDoesNotExist('defaulthref');
     cy.ionPageVisible('home');
   })
+
+  it('should correctly update location history after rewriting past state', () => {
+    cy.visit('http://localhost:8080');
+
+    cy.routerPush('/routing');
+    cy.ionPageVisible('routing');
+    cy.ionPageHidden('home');
+
+    cy.routerPush('/inputs');
+    cy.ionPageVisible('inputs');
+    cy.ionPageHidden('routing');
+
+    cy.ionBackClick('inputs');
+    cy.ionPageVisible('routing');
+    cy.ionPageDoesNotExist('inputs');
+
+    cy.ionBackClick('routing');
+    cy.ionPageVisible('home');
+    cy.ionPageDoesNotExist('routing');
+
+    cy.routerPush('default-href');
+    cy.ionPageVisible('defaulthref');
+    cy.ionPageHidden('home');
+
+    cy.routerPush('/routing');
+    cy.ionPageVisible('routing');
+    cy.ionPageHidden('defaulthref');
+
+    cy.routerPush('/inputs');
+    cy.ionPageVisible('inputs');
+    cy.ionPageHidden('routing');
+
+    cy.ionBackClick('inputs');
+    cy.ionPageVisible('routing');
+    cy.ionPageDoesNotExist('inputs');
+
+    cy.ionBackClick('routing');
+    cy.ionPageVisible('defaulthref');
+    cy.ionPageDoesNotExist('routing');
+  })
 });
 
 describe('Routing - Swipe to Go Back', () => {

--- a/packages/vue/test-app/tests/e2e/specs/routing.js
+++ b/packages/vue/test-app/tests/e2e/specs/routing.js
@@ -473,6 +473,46 @@ describe('Routing', () => {
     cy.ionPageVisible('defaulthref');
     cy.ionPageDoesNotExist('routing');
   })
+
+  it('should correctly update location history after setting root state', () => {
+    cy.visit('http://localhost:8080');
+
+    cy.routerPush('/routing');
+    cy.ionPageVisible('routing');
+    cy.ionPageHidden('home');
+
+    cy.routerPush('/routing/1');
+    cy.ionPageVisible('routingparameter-1');
+    cy.ionPageHidden('routing');
+
+    cy.ionBackClick('routingparameter-1');
+    cy.ionPageVisible('routing');
+    cy.ionPageDoesNotExist('routingparameter-1');
+
+    cy.ionBackClick('routing');
+    cy.ionPageVisible('home');
+    cy.ionPageDoesNotExist('routing');
+
+    cy.ionRouterNavigate('/inputs', 'root')
+    cy.ionPageVisible('inputs');
+    cy.ionPageDoesNotExist('home');
+
+    cy.routerPush('/routing');
+    cy.ionPageVisible('routing');
+    cy.ionPageHidden('inputs');
+
+    cy.routerPush('/routing/1');
+    cy.ionPageVisible('routingparameter-1');
+    cy.ionPageHidden('routing');
+
+    cy.ionBackClick('routingparameter-1');
+    cy.ionPageVisible('routing');
+    cy.ionPageDoesNotExist('routingparameter-1');
+
+    cy.ionBackClick('routing');
+    cy.ionPageVisible('inputs');
+    cy.ionPageDoesNotExist('routing');
+  })
 });
 
 describe('Routing - Swipe to Go Back', () => {

--- a/packages/vue/test-app/tests/e2e/specs/routing.js
+++ b/packages/vue/test-app/tests/e2e/specs/routing.js
@@ -400,6 +400,40 @@ describe('Routing', () => {
     cy.ionPageVisible('home');
     cy.ionPageHidden('inputs');
   })
+
+
+  // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/23873
+  it('should correctly show pages after going back to defaultHref page', () => {
+    cy.visit('http://localhost:8080/default-href');
+
+    cy.routerPush('/routing');
+    cy.ionPageVisible('routing');
+    cy.ionPageHidden('defaulthref');
+
+    cy.ionBackClick('routing');
+    cy.ionPageDoesNotExist('routing');
+    cy.ionPageVisible('defaulthref');
+
+    cy.ionBackClick('defaulthref');
+    cy.ionPageDoesNotExist('defaulthref');
+    cy.ionPageVisible('home');
+
+    cy.routerPush('/default-href');
+    cy.ionPageVisible('defaulthref');
+    cy.ionPageHidden('home');
+
+    cy.routerPush('/routing');
+    cy.ionPageVisible('routing');
+    cy.ionPageHidden('defaulthref');
+
+    cy.ionBackClick('routing');
+    cy.ionPageDoesNotExist('routing');
+    cy.ionPageVisible('defaulthref');
+
+    cy.ionBackClick('defaulthref');
+    cy.ionPageDoesNotExist('defaulthref');
+    cy.ionPageVisible('home');
+  })
 });
 
 describe('Routing - Swipe to Go Back', () => {

--- a/packages/vue/test-app/tests/e2e/support/commands.js
+++ b/packages/vue/test-app/tests/e2e/support/commands.js
@@ -82,6 +82,12 @@ Cypress.Commands.add('routerGo', (n) => {
   });
 });
 
+Cypress.Commands.add('ionRouterNavigate', (...args) => {
+  cy.window().then(win => {
+    win.debugIonRouter.navigate(...args);
+  });
+});
+
 Cypress.Commands.add('ionBackButtonHidden', (pageId) => {
   cy.get(`div.ion-page[data-pageid=${pageId}]`)
     .should('be.visible', true)

--- a/packages/vue/test-app/tests/unit/routing.spec.ts
+++ b/packages/vue/test-app/tests/unit/routing.spec.ts
@@ -312,6 +312,124 @@ describe('Routing', () => {
     expect(cmpAgain[0].props()).toEqual({ title: 'xyz' });
   });
 
+  /**
+   * TODO(FW-653) Either Ionic Vue or Vue Test Utils
+   * is leaking routing information between tests. Moving these tests
+   * to the end cause them to fail. Need to figure out what the root cause is.
+   */
+  // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/24109
+  it('canGoBack() should return the correct value', async () => {
+    const Page = {
+      components: { IonPage },
+      template: `<ion-page></ion-page>`
+    }
+    const Page2 = {
+      components: { IonPage },
+      template: `<ion-page></ion-page>`
+    }
+    const AppWithInject = {
+      components: { IonApp, IonRouterOutlet },
+      template: '<ion-app><ion-router-outlet /></ion-app>',
+      setup() {
+        const ionRouter = useIonRouter();
+        return { ionRouter }
+      }
+    }
+
+    const router = createRouter({
+      history: createWebHistory(process.env.BASE_URL),
+      routes: [
+        { path: '/', component: Page }
+        { path: '/page2', component: Page2 }
+      ]
+    });
+
+    router.push('/');
+    await router.isReady();
+    const wrapper = mount(AppWithInject, {
+      global: {
+        plugins: [router, IonicVue]
+      }
+    });
+
+    const ionRouter = wrapper.vm.ionRouter;
+    expect(ionRouter.canGoBack()).toEqual(false);
+
+    router.push('/page2');
+    await waitForRouter();
+
+    expect(ionRouter.canGoBack()).toEqual(true);
+
+    router.back();
+    await waitForRouter();
+
+    expect(ionRouter.canGoBack()).toEqual(false);
+  });
+
+  // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/24109
+  it('canGoBack() should return the correct value when using router.go', async () => {
+    const Page = {
+      components: { IonPage },
+      template: `<ion-page></ion-page>`
+    }
+    const Page2 = {
+      components: { IonPage },
+      template: `<ion-page></ion-page>`
+    }
+    const Page3 = {
+      components: { IonPage },
+      template: `<ion-page></ion-page>`
+    }
+    const AppWithInject = {
+      components: { IonApp, IonRouterOutlet },
+      template: '<ion-app><ion-router-outlet /></ion-app>',
+      setup() {
+        const ionRouter = useIonRouter();
+        return { ionRouter }
+      }
+    }
+
+    const router = createRouter({
+      history: createWebHistory(process.env.BASE_URL),
+      routes: [
+        { path: '/', component: Page }
+        { path: '/page2', component: Page2 },
+        { path: '/page3', component: Page3 },
+      ]
+    });
+
+    router.push('/');
+    await router.isReady();
+    const wrapper = mount(AppWithInject, {
+      global: {
+        plugins: [router, IonicVue]
+      }
+    });
+
+    const ionRouter = wrapper.vm.ionRouter;
+    expect(ionRouter.canGoBack()).toEqual(false);
+
+    router.push('/page2');
+    await waitForRouter();
+
+    expect(ionRouter.canGoBack()).toEqual(true);
+
+    router.push('/page3');
+    await waitForRouter();
+
+    expect(ionRouter.canGoBack()).toEqual(true);
+
+    router.go(-2);
+    await waitForRouter();
+
+    expect(ionRouter.canGoBack()).toEqual(false);
+
+    router.go(2);
+    await waitForRouter();
+
+    expect(ionRouter.canGoBack()).toEqual(true);
+  });
+
   // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/23043
   it('should call the props function again when params change', async () => {
     const Page1 = {
@@ -548,118 +666,5 @@ describe('Routing', () => {
     expect(wrapper.findComponent(Page).exists()).toBe(true);
     expect(wrapper.findComponent(Page2).exists()).toBe(false);
     expect(wrapper.findComponent(Page3).exists()).toBe(false);
-  });
-
-  // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/24109
-  it('canGoBack() should return the correct value', async () => {
-    const Page = {
-      components: { IonPage },
-      template: `<ion-page></ion-page>`
-    }
-    const Page2 = {
-      components: { IonPage },
-      template: `<ion-page></ion-page>`
-    }
-    const AppWithInject = {
-      components: { IonApp, IonRouterOutlet },
-      template: '<ion-app><ion-router-outlet /></ion-app>',
-      setup() {
-        const ionRouter = useIonRouter();
-        return { ionRouter }
-      }
-    }
-
-    const router = createRouter({
-      history: createWebHistory(process.env.BASE_URL),
-      routes: [
-        { path: '/', component: Page }
-        { path: '/page2', component: Page2 }
-      ]
-    });
-
-    router.push('/');
-    await router.isReady();
-    const wrapper = mount(AppWithInject, {
-      global: {
-        plugins: [router, IonicVue]
-      }
-    });
-
-    const ionRouter = wrapper.vm.ionRouter;
-    expect(ionRouter.canGoBack()).toEqual(false);
-
-    router.push('/page2');
-    await waitForRouter();
-
-    expect(ionRouter.canGoBack()).toEqual(true);
-
-    router.back();
-    await waitForRouter();
-
-    expect(ionRouter.canGoBack()).toEqual(false);
-  });
-
-  // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/24109
-  it('canGoBack() should return the correct value when using router.go', async () => {
-    const Page = {
-      components: { IonPage },
-      template: `<ion-page></ion-page>`
-    }
-    const Page2 = {
-      components: { IonPage },
-      template: `<ion-page></ion-page>`
-    }
-    const Page3 = {
-      components: { IonPage },
-      template: `<ion-page></ion-page>`
-    }
-    const AppWithInject = {
-      components: { IonApp, IonRouterOutlet },
-      template: '<ion-app><ion-router-outlet /></ion-app>',
-      setup() {
-        const ionRouter = useIonRouter();
-        return { ionRouter }
-      }
-    }
-
-    const router = createRouter({
-      history: createWebHistory(process.env.BASE_URL),
-      routes: [
-        { path: '/', component: Page }
-        { path: '/page2', component: Page2 },
-        { path: '/page3', component: Page3 },
-      ]
-    });
-
-    router.push('/');
-    await router.isReady();
-    const wrapper = mount(AppWithInject, {
-      global: {
-        plugins: [router, IonicVue]
-      }
-    });
-
-    const ionRouter = wrapper.vm.ionRouter;
-    expect(ionRouter.canGoBack()).toEqual(false);
-
-    router.push('/page2');
-    await waitForRouter();
-
-    expect(ionRouter.canGoBack()).toEqual(true);
-
-    router.push('/page3');
-    await waitForRouter();
-
-    expect(ionRouter.canGoBack()).toEqual(true);
-
-    router.go(-2);
-    await waitForRouter();
-
-    expect(ionRouter.canGoBack()).toEqual(false);
-
-    router.go(2);
-    await waitForRouter();
-
-    expect(ionRouter.canGoBack()).toEqual(true);
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/23873


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- After going "back" to a new route that previously never existed, Ionic Vue will clear the future location history as it is no longer relevant.
- When pushing new history after going back, Ionic Vue now clears out future location history items as they are no longer relevant. This also applies when setting the "root" route (I.e. routerDirection="root") as the first item in the location history array is being replaced. As a result, everything after that is no longer relevant.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
