### PR TITLE
fix(angular, react,  vue): overlays no longer throw errors when used inside tests

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -50,7 +50,10 @@ Below is an example of importing `ion-badge`, and initializing Ionic so it is ab
 import { defineCustomElement } from "@ionic/core/components/ion-badge.js";
 import { initialize } from "@ionic/core/components";
 
+// Initializes the Ionic config and `mode` behavior
 initialize();
+
+//  Defines the `ion-badge` web component
 defineCustomElement();
 ```
 
@@ -64,7 +67,10 @@ For example, if you wanted to use `ion-modal`, you would do the following:
 import { defineCustomElement } from "@ionic/core/components/ion-modal.js";
 import { initialize } from "@ionic/core/components";
 
+// Initializes the Ionic config and `mode` behavior
 initialize();
+
+//  Defines the `ion-modal` and child `ion-backdrop` web components.
 defineCustomElement();
 ```
 

--- a/core/README.md
+++ b/core/README.md
@@ -44,19 +44,49 @@ The `@ionic/core` package can be used in simple HTML, or by vanilla JavaScript w
 
 In addition to the default, self lazy-loading components built by Stencil, this package also comes with each component exported as a stand-alone custom element within `@ionic/core/components`. Each component extends `HTMLElement`, and does not lazy-load itself. Instead, this package is useful for projects already using a bundler such as Webpack or Rollup. While all components are available to be imported, the custom elements build also ensures bundlers only import what's used, and tree-shakes any unused components.
 
-Below is an example of importing `ion-toggle`, and initializing Ionic so it's able to correctly load the "mode", such as Material Design or iOS. Additionally, the `initialize({...})` function can receive the Ionic config.
+Below is an example of importing `ion-badge`, and initializing Ionic so it is able to correctly load the "mode", such as Material Design or iOS. Additionally, the `initialize({...})` function can receive the Ionic config.
 
 ```typescript
-import { IonBadge } from "@ionic/core/components/ion-badge";
+import { defineCustomElement } from "@ionic/core/components/ion-badge.js";
 import { initialize } from "@ionic/core/components";
 
 initialize();
-
-customElements.define("ion-badge", IonBadge);
+defineCustomElement();
 ```
 
-Notice how `IonBadge` is imported from `@ionic/core/components/ion-badge` rather than just `@ionic/core/components`. Additionally, the `initialize` function is imported from `@ionic/core/components` rather than `@ionic/core`. All of this helps to ensure bundlers do not pull in more code than is needed.
+Notice how we import from `@ionic/core/components` as opposed to `@ionic/core`. This helps bundlers pull in only the code that is needed.
 
+In the example above, you could also import `IonBadge` and call `customElements.define('ion-badge', IonBadge)`, but we recommend importing the `defineCustomElement` function and calling that instead. This `defineCustomElement` function will automatically define the component as well as any child components that may be required.
+
+For example, if you wanted to use `ion-modal`, you would do the following:
+
+```typescript
+import { defineCustomElement } from "@ionic/core/components/ion-modal.js";
+import { initialize } from "@ionic/core/components";
+
+initialize();
+defineCustomElement();
+```
+
+The `defineCustomElement` function will define `ion-modal`, but it will also define `ion-backdrop`, which is a component that `ion-modal` uses internally.
+
+### Using Overlay Controllers
+
+When using an overlay controller, developers will need to define the overlay component before it can be used. Below is an example of using `modalController`:
+
+```typescript
+import { defineCustomElement } from '@ionic/core/components/ion-modal.js';
+import { initialize, modalController } from '@ionic/core/components';
+
+initialize();
+defineCustomElement();
+
+const showModal = async () => {
+  const modal = await modalController.create({ ... });
+  
+  ...
+}
+```
 
 ## How to contribute
 

--- a/core/README.md
+++ b/core/README.md
@@ -59,7 +59,7 @@ defineCustomElement();
 
 Notice how we import from `@ionic/core/components` as opposed to `@ionic/core`. This helps bundlers pull in only the code that is needed.
 
-In the example above, you could also import `IonBadge` and call `customElements.define('ion-badge', IonBadge)`, but we recommend importing the `defineCustomElement` function and calling that instead. This `defineCustomElement` function will automatically define the component as well as any child components that may be required.
+The `defineCustomElement` function will automatically define the component as well as any child components that may be required.
 
 For example, if you wanted to use `ion-modal`, you would do the following:
 

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -1,14 +1,3 @@
-import { ActionSheet } from '../components/action-sheet/action-sheet';
-import { Alert } from '../components/alert/alert';
-import { Backdrop } from '../components/backdrop/backdrop';
-import { Loading } from '../components/loading/loading';
-import { Modal } from '../components/modal/modal';
-import { PickerColumnCmp } from '../components/picker-column/picker-column';
-import { Picker } from '../components/picker/picker';
-import { Popover } from '../components/popover/popover';
-import { RippleEffect } from '../components/ripple-effect/ripple-effect';
-import { Spinner } from '../components/spinner/spinner';
-import { Toast } from '../components/toast/toast';
 import { config } from '../global/config';
 import { getIonMode } from '../global/ionic-global';
 import { ActionSheetOptions, AlertOptions, Animation, AnimationBuilder, BackButtonEvent, HTMLIonOverlayElement, IonicConfig, LoadingOptions, ModalOptions, OverlayInterface, PickerOptions, PopoverOptions, ToastOptions } from '../interface';
@@ -20,15 +9,10 @@ let lastId = 0;
 
 export const activeAnimations = new WeakMap<OverlayInterface, Animation[]>();
 
-type ChildCustomElementDefinition = {
-  tagName: string;
-  customElement: any;
-}
-
-const createController = <Opts extends object, HTMLElm extends any>(tagName: string, customElement?: any, childrenCustomElements?: ChildCustomElementDefinition[]) => {
+const createController = <Opts extends object, HTMLElm extends any>(tagName: string) => {
   return {
     create(options: Opts): Promise<HTMLElm> {
-      return createOverlay(tagName, options, customElement, childrenCustomElements) as any;
+      return createOverlay(tagName, options) as any;
     },
     dismiss(data?: any, role?: string, id?: string) {
       return dismissOverlay(document, data, role, tagName, id);
@@ -39,13 +23,13 @@ const createController = <Opts extends object, HTMLElm extends any>(tagName: str
   };
 };
 
-export const alertController = /*@__PURE__*/createController<AlertOptions, HTMLIonAlertElement>('ion-alert', Alert, [{ tagName: 'ion-backdrop', customElement: Backdrop }]);
-export const actionSheetController = /*@__PURE__*/createController<ActionSheetOptions, HTMLIonActionSheetElement>('ion-action-sheet', ActionSheet, [{ tagName: 'ion-backdrop', customElement: Backdrop }, { tagName: 'ion-ripple-effect', customElement: RippleEffect }]);
-export const loadingController = /*@__PURE__*/createController<LoadingOptions, HTMLIonLoadingElement>('ion-loading', Loading, [{ tagName: 'ion-backdrop', customElement: Backdrop }, { tagName: 'ion-spinner', customElement: Spinner }]);
-export const modalController = /*@__PURE__*/createController<ModalOptions, HTMLIonModalElement>('ion-modal', Modal, [{ tagName: 'ion-backdrop', customElement: Backdrop }]);
-export const pickerController = /*@__PURE__*/createController<PickerOptions, HTMLIonPickerElement>('ion-picker', Picker, [{ tagName: 'ion-picker-column', customElement: PickerColumnCmp }, { tagName: 'ion-backdrop', customElement: Backdrop }]);
-export const popoverController = /*@__PURE__*/createController<PopoverOptions, HTMLIonPopoverElement>('ion-popover', Popover, [{ tagName: 'ion-backdrop', customElement: Backdrop }]);
-export const toastController = /*@__PURE__*/createController<ToastOptions, HTMLIonToastElement>('ion-toast', Toast, [{ tagName: 'ion-ripple-effect', customElement: RippleEffect }]);
+export const alertController = /*@__PURE__*/createController<AlertOptions, HTMLIonAlertElement>('ion-alert');
+export const actionSheetController = /*@__PURE__*/createController<ActionSheetOptions, HTMLIonActionSheetElement>('ion-action-sheet', );
+export const loadingController = /*@__PURE__*/createController<LoadingOptions, HTMLIonLoadingElement>('ion-loading');
+export const modalController = /*@__PURE__*/createController<ModalOptions, HTMLIonModalElement>('ion-modal');
+export const pickerController = /*@__PURE__*/createController<PickerOptions, HTMLIonPickerElement>('ion-picker');
+export const popoverController = /*@__PURE__*/createController<PopoverOptions, HTMLIonPopoverElement>('ion-popover');
+export const toastController = /*@__PURE__*/createController<ToastOptions, HTMLIonToastElement>('ion-toast');
 
 export interface OverlayListenerOptions {
   trapKeyboardFocus: boolean;
@@ -65,29 +49,10 @@ export const prepareOverlay = <T extends HTMLIonOverlayElement>(el: T, options: 
   }
 };
 
-const registerOverlayComponents = (tagName: string, customElement: any, childrenCustomElements?: ChildCustomElementDefinition[]): Promise<any> => {
-  const { customElements } = window;
-  if (!customElements.get(tagName)) {
-    customElements.define(tagName, customElement);
-  }
-  /**
-   * If the parent element has nested usage of custom elements,
-   * we need to manually define those custom elements.
-   */
-  if (childrenCustomElements) {
-    for (const customElementDefinition of childrenCustomElements) {
-      if (!customElements.get(customElementDefinition.tagName)) {
-        customElements.define(customElementDefinition.tagName, customElementDefinition.customElement);
-      }
-    }
-  }
-  return customElements.whenDefined(tagName);
-}
-
-export const createOverlay = <T extends HTMLIonOverlayElement>(tagName: string, opts: object | undefined, customElement?: any, childrenCustomElements?: ChildCustomElementDefinition[]): Promise<T> => {
+export const createOverlay = <T extends HTMLIonOverlayElement>(tagName: string, opts: object | undefined): Promise<T> => {
   /* tslint:disable-next-line */
   if (typeof window !== 'undefined' && typeof window.customElements !== 'undefined') {
-    return registerOverlayComponents(tagName, customElement, childrenCustomElements).then(() => {
+    return window.customElements.whenDefined(tagName).then(() => {
       const element = document.createElement(tagName) as HTMLIonOverlayElement;
       element.classList.add('overlay-hidden');
 

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -24,7 +24,7 @@ const createController = <Opts extends object, HTMLElm extends any>(tagName: str
 };
 
 export const alertController = /*@__PURE__*/createController<AlertOptions, HTMLIonAlertElement>('ion-alert');
-export const actionSheetController = /*@__PURE__*/createController<ActionSheetOptions, HTMLIonActionSheetElement>('ion-action-sheet', );
+export const actionSheetController = /*@__PURE__*/createController<ActionSheetOptions, HTMLIonActionSheetElement>('ion-action-sheet');
 export const loadingController = /*@__PURE__*/createController<LoadingOptions, HTMLIonLoadingElement>('ion-loading');
 export const modalController = /*@__PURE__*/createController<ModalOptions, HTMLIonModalElement>('ion-modal');
 export const pickerController = /*@__PURE__*/createController<PickerOptions, HTMLIonPickerElement>('ion-picker');

--- a/packages/react/src/hooks/useController.ts
+++ b/packages/react/src/hooks/useController.ts
@@ -12,7 +12,8 @@ interface OverlayBase extends HTMLElement {
 
 export function useController<OptionsType, OverlayType extends OverlayBase>(
   displayName: string,
-  controller: { create: (options: OptionsType) => Promise<OverlayType> }
+  controller: { create: (options: OptionsType) => Promise<OverlayType> },
+  defineCustomElement: () => void
 ) {
   const overlayRef = useRef<OverlayType>();
   const didDismissEventName = useMemo(() => `on${displayName}DidDismiss`, [displayName]);
@@ -25,6 +26,9 @@ export function useController<OptionsType, OverlayType extends OverlayBase>(
       if (overlayRef.current) {
         return;
       }
+
+      defineCustomElement();
+
       const { onDidDismiss, onWillDismiss, onDidPresent, onWillPresent, ...rest } = options;
 
       const handleDismiss = (event: CustomEvent<OverlayEventDetail<any>>) => {

--- a/packages/react/src/hooks/useController.ts
+++ b/packages/react/src/hooks/useController.ts
@@ -21,13 +21,13 @@ export function useController<OptionsType, OverlayType extends OverlayBase>(
   const willDismissEventName = useMemo(() => `on${displayName}WillDismiss`, [displayName]);
   const willPresentEventName = useMemo(() => `on${displayName}WillPresent`, [displayName]);
 
+  defineCustomElement();
+
   const present = useCallback(
     async (options: OptionsType & HookOverlayOptions) => {
       if (overlayRef.current) {
         return;
       }
-
-      defineCustomElement();
 
       const { onDidDismiss, onWillDismiss, onDidPresent, onWillPresent, ...rest } = options;
 

--- a/packages/react/src/hooks/useIonActionSheet.ts
+++ b/packages/react/src/hooks/useIonActionSheet.ts
@@ -1,5 +1,5 @@
 import { ActionSheetButton, ActionSheetOptions, actionSheetController } from '@ionic/core/components';
-import { defineCustomElement } from '@ionic/core/components/ion-modal.js';
+import { defineCustomElement } from '@ionic/core/components/ion-action-sheet.js';
 import { useCallback } from 'react';
 
 import { HookOverlayOptions } from './HookOverlayOptions';

--- a/packages/react/src/hooks/useIonActionSheet.ts
+++ b/packages/react/src/hooks/useIonActionSheet.ts
@@ -1,4 +1,5 @@
 import { ActionSheetButton, ActionSheetOptions, actionSheetController } from '@ionic/core/components';
+import { defineCustomElement } from '@ionic/core/components/ion-modal.js';
 import { useCallback } from 'react';
 
 import { HookOverlayOptions } from './HookOverlayOptions';
@@ -11,7 +12,8 @@ import { useController } from './useController';
 export function useIonActionSheet(): UseIonActionSheetResult {
   const controller = useController<ActionSheetOptions, HTMLIonActionSheetElement>(
     'IonActionSheet',
-    actionSheetController
+    actionSheetController,
+    defineCustomElement
   );
 
   const present = useCallback(

--- a/packages/react/src/hooks/useIonAlert.ts
+++ b/packages/react/src/hooks/useIonAlert.ts
@@ -1,4 +1,6 @@
 import { AlertButton, AlertOptions, alertController } from '@ionic/core/components';
+import { defineCustomElement } from '@ionic/core/components/ion-alert.js';
+
 import { useCallback } from 'react';
 
 import { HookOverlayOptions } from './HookOverlayOptions';
@@ -9,7 +11,7 @@ import { useController } from './useController';
  * @returns Returns the present and dismiss methods in an array
  */
 export function useIonAlert(): UseIonAlertResult {
-  const controller = useController<AlertOptions, HTMLIonAlertElement>('IonAlert', alertController);
+  const controller = useController<AlertOptions, HTMLIonAlertElement>('IonAlert', alertController, defineCustomElement);
 
   const present = useCallback(
     (messageOrOptions: string | (AlertOptions & HookOverlayOptions), buttons?: AlertButton[]) => {

--- a/packages/react/src/hooks/useIonAlert.ts
+++ b/packages/react/src/hooks/useIonAlert.ts
@@ -1,6 +1,5 @@
 import { AlertButton, AlertOptions, alertController } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-alert.js';
-
 import { useCallback } from 'react';
 
 import { HookOverlayOptions } from './HookOverlayOptions';

--- a/packages/react/src/hooks/useIonLoading.tsx
+++ b/packages/react/src/hooks/useIonLoading.tsx
@@ -1,4 +1,6 @@
 import { LoadingOptions, SpinnerTypes, loadingController } from '@ionic/core/components';
+import { defineCustomElement } from '@ionic/core/components/ion-loading.js';
+
 import { useCallback } from 'react';
 
 import { HookOverlayOptions } from './HookOverlayOptions';
@@ -11,7 +13,8 @@ import { useController } from './useController';
 export function useIonLoading(): UseIonLoadingResult {
   const controller = useController<LoadingOptions, HTMLIonLoadingElement>(
     'IonLoading',
-    loadingController
+    loadingController,
+    defineCustomElement
   );
 
   const present = useCallback(

--- a/packages/react/src/hooks/useIonLoading.tsx
+++ b/packages/react/src/hooks/useIonLoading.tsx
@@ -1,6 +1,5 @@
 import { LoadingOptions, SpinnerTypes, loadingController } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-loading.js';
-
 import { useCallback } from 'react';
 
 import { HookOverlayOptions } from './HookOverlayOptions';

--- a/packages/react/src/hooks/useIonModal.ts
+++ b/packages/react/src/hooks/useIonModal.ts
@@ -1,6 +1,5 @@
 import { ModalOptions, modalController } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-modal.js';
-
 import { useCallback } from 'react';
 
 import { ReactComponentOrElement } from '../models/ReactComponentOrElement';

--- a/packages/react/src/hooks/useIonModal.ts
+++ b/packages/react/src/hooks/useIonModal.ts
@@ -1,4 +1,6 @@
 import { ModalOptions, modalController } from '@ionic/core/components';
+import { defineCustomElement } from '@ionic/core/components/ion-modal.js';
+
 import { useCallback } from 'react';
 
 import { ReactComponentOrElement } from '../models/ReactComponentOrElement';
@@ -19,6 +21,7 @@ export function useIonModal(
   const controller = useOverlay<ModalOptions, HTMLIonModalElement>(
     'IonModal',
     modalController,
+    defineCustomElement,
     component,
     componentProps
   );

--- a/packages/react/src/hooks/useIonPicker.tsx
+++ b/packages/react/src/hooks/useIonPicker.tsx
@@ -4,6 +4,8 @@ import {
   PickerOptions,
   pickerController,
 } from '@ionic/core/components';
+import { defineCustomElement } from '@ionic/core/components/ion-picker.js';
+
 import { useCallback } from 'react';
 
 import { HookOverlayOptions } from './HookOverlayOptions';
@@ -16,7 +18,8 @@ import { useController } from './useController';
 export function useIonPicker(): UseIonPickerResult {
   const controller = useController<PickerOptions, HTMLIonPickerElement>(
     'IonPicker',
-    pickerController
+    pickerController,
+    defineCustomElement
   );
 
   const present = useCallback((

--- a/packages/react/src/hooks/useIonPicker.tsx
+++ b/packages/react/src/hooks/useIonPicker.tsx
@@ -5,7 +5,6 @@ import {
   pickerController,
 } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-picker.js';
-
 import { useCallback } from 'react';
 
 import { HookOverlayOptions } from './HookOverlayOptions';

--- a/packages/react/src/hooks/useIonPopover.ts
+++ b/packages/react/src/hooks/useIonPopover.ts
@@ -1,4 +1,6 @@
 import { PopoverOptions, popoverController } from '@ionic/core/components';
+import { defineCustomElement } from '@ionic/core/components/ion-popover.js';
+
 import { useCallback } from 'react';
 
 import { ReactComponentOrElement } from '../models/ReactComponentOrElement';
@@ -16,6 +18,7 @@ export function useIonPopover(component: ReactComponentOrElement, componentProps
   const controller = useOverlay<PopoverOptions, HTMLIonPopoverElement>(
     'IonPopover',
     popoverController,
+    defineCustomElement,
     component,
     componentProps
   );

--- a/packages/react/src/hooks/useIonPopover.ts
+++ b/packages/react/src/hooks/useIonPopover.ts
@@ -1,6 +1,5 @@
 import { PopoverOptions, popoverController } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-popover.js';
-
 import { useCallback } from 'react';
 
 import { ReactComponentOrElement } from '../models/ReactComponentOrElement';

--- a/packages/react/src/hooks/useIonToast.ts
+++ b/packages/react/src/hooks/useIonToast.ts
@@ -1,4 +1,6 @@
 import { ToastOptions, toastController } from '@ionic/core/components';
+import { defineCustomElement } from '@ionic/core/components/ion-toast.js';
+
 import { useCallback } from 'react';
 
 import { HookOverlayOptions } from './HookOverlayOptions';
@@ -11,7 +13,8 @@ import { useController } from './useController';
 export function useIonToast(): UseIonToastResult {
   const controller = useController<ToastOptions, HTMLIonToastElement>(
     'IonToast',
-    toastController
+    toastController,
+    defineCustomElement
   );
 
   const present = useCallback((messageOrOptions: string | ToastOptions & HookOverlayOptions, duration?: number) => {

--- a/packages/react/src/hooks/useIonToast.ts
+++ b/packages/react/src/hooks/useIonToast.ts
@@ -1,6 +1,5 @@
 import { ToastOptions, toastController } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-toast.js';
-
 import { useCallback } from 'react';
 
 import { HookOverlayOptions } from './HookOverlayOptions';

--- a/packages/react/src/hooks/useOverlay.ts
+++ b/packages/react/src/hooks/useOverlay.ts
@@ -30,6 +30,8 @@ export function useOverlay<OptionsType, OverlayType extends OverlayBase>(
   const ionContext = useContext(IonContext);
   const [overlayId] = useState(generateId('overlay'));
 
+  defineCustomElement();
+
   useEffect(() => {
     if (isOpen && component && containerElRef.current) {
       if (React.isValidElement(component)) {
@@ -45,8 +47,6 @@ export function useOverlay<OptionsType, OverlayType extends OverlayBase>(
     if (overlayRef.current) {
       return;
     }
-
-    defineCustomElement();
 
     const { onDidDismiss, onWillDismiss, onDidPresent, onWillPresent, ...rest } = options;
 

--- a/packages/react/src/hooks/useOverlay.ts
+++ b/packages/react/src/hooks/useOverlay.ts
@@ -16,6 +16,7 @@ interface OverlayBase extends HTMLElement {
 export function useOverlay<OptionsType, OverlayType extends OverlayBase>(
   displayName: string,
   controller: { create: (options: OptionsType) => Promise<OverlayType> },
+  defineCustomElement: () => void,
   component: ReactComponentOrElement,
   componentProps?: any
 ) {
@@ -44,6 +45,8 @@ export function useOverlay<OptionsType, OverlayType extends OverlayBase>(
     if (overlayRef.current) {
       return;
     }
+
+    defineCustomElement();
 
     const { onDidDismiss, onWillDismiss, onDidPresent, onWillPresent, ...rest } = options;
 

--- a/packages/vue/src/controllers.ts
+++ b/packages/vue/src/controllers.ts
@@ -7,17 +7,16 @@ import {
   pickerController as pickerCtrl,
   toastController as toastCtrl,
 } from '@ionic/core/components';
-import { defineCustomElement } from './utils';
 
 import { VueDelegate } from './framework-delegate';
 
-import { IonModal } from '@ionic/core/components/ion-modal.js';
-import { IonPopover } from '@ionic/core/components/ion-popover.js'
-import { IonAlert } from '@ionic/core/components/ion-alert.js'
-import { IonActionSheet } from '@ionic/core/components/ion-action-sheet.js'
-import { IonLoading } from '@ionic/core/components/ion-loading.js'
-import { IonPicker } from '@ionic/core/components/ion-picker.js'
-import { IonToast } from '@ionic/core/components/ion-toast.js'
+import { defineCustomElement as defineIonActionSheetCustomElement } from '@ionic/core/components/ion-action-sheet.js'
+import { defineCustomElement as defineIonAlertCustomElement } from '@ionic/core/components/ion-alert.js'
+import { defineCustomElement as defineIonLoadingCustomElement } from '@ionic/core/components/ion-loading.js'
+import { defineCustomElement as defineIonPickerCustomElement } from '@ionic/core/components/ion-picker.js'
+import { defineCustomElement as defineIonToastCustomElement } from '@ionic/core/components/ion-toast.js'
+import { defineCustomElement as defineIonModalCustomElement } from '@ionic/core/components/ion-modal.js'
+import { defineCustomElement as defineIonPopoverCustomElement } from '@ionic/core/components/ion-popover.js'
 
 /**
  * Wrap the controllers export from @ionic/core
@@ -25,12 +24,12 @@ import { IonToast } from '@ionic/core/components/ion-toast.js'
  * (optionally) provide a framework delegate.
  */
 const createController: {
-  <T>(tagName: string, customElement: any, oldController: T, useDelegate?: boolean): T
-} = (tagName: string, customElement: any, oldController: any, useDelegate = false) => {
+  <T>(defineCustomElement: () => void, oldController: T, useDelegate?: boolean): T
+} = (defineCustomElement: () => void, oldController: any, useDelegate = false) => {
   const delegate = useDelegate ? VueDelegate() : undefined;
   const oldCreate = oldController.create.bind(oldController);
   oldController.create = (options: any) => {
-    defineCustomElement(tagName, customElement);
+    defineCustomElement();
 
     return oldCreate({
       ...options,
@@ -41,13 +40,13 @@ const createController: {
   return oldController;
 }
 
-const modalController = /*@__PURE__*/ createController('ion-modal', IonModal, modalCtrl, true);
-const popoverController = /*@__PURE__*/ createController('ion-popover', IonPopover, popoverCtrl, true);
-const alertController = /*@__PURE__*/ createController('ion-alert', IonAlert, alertCtrl);
-const actionSheetController = /*@__PURE__*/ createController('ion-action-sheet', IonActionSheet, actionSheetCtrl);
-const loadingController = /*@__PURE__*/ createController('ion-loading', IonLoading, loadingCtrl);
-const pickerController = /*@__PURE__*/ createController('ion-picker', IonPicker, pickerCtrl);
-const toastController = /*@__PURE__*/ createController('ion-toast', IonToast, toastCtrl);
+const modalController = /*@__PURE__*/ createController(defineIonModalCustomElement, modalCtrl, true);
+const popoverController = /*@__PURE__*/ createController(defineIonPopoverCustomElement, popoverCtrl, true);
+const alertController = /*@__PURE__*/ createController(defineIonAlertCustomElement, alertCtrl);
+const actionSheetController = /*@__PURE__*/ createController(defineIonActionSheetCustomElement, actionSheetCtrl);
+const loadingController = /*@__PURE__*/ createController(defineIonLoadingCustomElement, loadingCtrl);
+const pickerController = /*@__PURE__*/ createController(defineIonPickerCustomElement, pickerCtrl);
+const toastController = /*@__PURE__*/ createController(defineIonToastCustomElement, toastCtrl);
 
 export {
   modalController,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves #24549, resolves #24590

In order to get custom elements defined when using controllers, we import the source component which would trick Stencil into including the compiled components in the overlays file. From there, we would register those compiled components with the Custom Elements Registry.

Unfortunately, this resulted in two issues:

1. Action Sheet was being initialized after it was referenced by its controller (https://github.com/ionic-team/ionic-framework/issues/24549).
2. Registering the components this way assumed that everyone was using the custom elements build. This resulted in controllers breaking for Angular users (https://github.com/ionic-team/ionic-framework/issues/24590). When the controller was created, the custom elements version of the overlay was created before the lazy loaded version was created. However, Stencil was expecting the lazy loaded version as it contained additional information it needed.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Rather than try and build on the previous bandaid, I feel it would be better to have the React and Vue integrations register their over overlay components.
- This allows Angular to work with lazy loaded and React/Vue to work with custom elements.
- When Angular switches over to use custom elements, it will need to do something similar to what is done for React/Vue in this PR.
- The one tradeoff is people using @ionic/core and custom elements build will need to import and define the overlay component before they can use the controller. However, this aligns with what is expected when using core + CE build anyways. Developers need to call `initialize()` when using core directly, but this will be called for them when using a framework integration.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev Build: 6.0.5-dev.1643732746.a377f15