### PR TITLE
fix(select): value is selected when given array

### DIFF
--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -248,7 +248,7 @@ export class Select implements ComponentInterface {
       const optClass = `${OPTION_CLASS} ${copyClasses}`;
 
       return {
-        role: (isOptionSelected(value, selectValue, this.compareWith) ? 'selected' : ''),
+        role: (isOptionSelected(selectValue, value, this.compareWith) ? 'selected' : ''),
         text: option.textContent,
         cssClass: optClass,
         handler: () => {
@@ -282,7 +282,7 @@ export class Select implements ComponentInterface {
         cssClass: optClass,
         label: option.textContent || '',
         value,
-        checked: isOptionSelected(value, selectValue, this.compareWith),
+        checked: isOptionSelected(selectValue, value, this.compareWith),
         disabled: option.disabled
       };
     });
@@ -302,7 +302,7 @@ export class Select implements ComponentInterface {
         text: option.textContent || '',
         cssClass: optClass,
         value,
-        checked: isOptionSelected(value, selectValue, this.compareWith),
+        checked: isOptionSelected(selectValue, value, this.compareWith),
         disabled: option.disabled,
         handler: (selected: any) => {
           this.value = selected;

--- a/core/src/components/select/test/compare-with/e2e.ts
+++ b/core/src/components/select/test/compare-with/e2e.ts
@@ -1,0 +1,37 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+test('select: compareWith', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/select/test/compare-with?ionic:_testing=true'
+  });
+
+  const compares = [];
+  compares.push(await page.compareScreenshot());
+
+  const selectMultiple = await page.find('#multiple');
+  await selectMultiple.click();
+
+  let alert = await page.find('ion-alert');
+  await alert.waitForVisible();
+  await page.waitForTimeout(250);
+
+  compares.push(await page.compareScreenshot('should open select[multiple] with option selected'));
+
+  await alert.callMethod('dismiss');
+
+  const selectSingle = await page.find('#single');
+  await selectSingle.click();
+
+  alert = await page.find('ion-alert');
+  await alert.waitForVisible();
+  await page.waitForTimeout(250);
+
+  compares.push(await page.compareScreenshot('should open select with option selected'));
+
+  await alert.callMethod('dismiss');
+
+  for (const compare of compares) {
+    expect(compare).toMatchScreenshot();
+  }
+
+});

--- a/core/src/components/select/test/compare-with/index.html
+++ b/core/src/components/select/test/compare-with/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Select - compareWith</title>
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
+  <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+  <script src="../../../../../scripts/testing/scripts.js"></script>
+  <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+</head>
+
+<body>
+  <ion-app>
+
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Select - compareWith</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content>
+      <ion-list>
+        <ion-item>
+          <ion-label>Select multiple using objects and compareWith</ion-label>
+          <ion-select id="multiple"></ion-select>
+        </ion-item>
+        <ion-item>
+          <ion-label>Select using objects and compareWith</ion-label>
+          <ion-select id="single" multiple="true"></ion-select>
+        </ion-item>
+      </ion-list>
+
+    </ion-content>
+
+    <script>
+      function compareWithFn(a, b) {
+        return a.value === b.value;
+      }
+
+      let objectOptions = [{
+        label: 'selected by default', value: '1'
+      }, {
+        label: 'not selected by default', value: '2'
+      }];
+
+      document.querySelectorAll('ion-select').forEach(select => {
+        select.compareWith = compareWithFn;
+
+        objectOptions.forEach((option) => {
+          let selectOption = document.createElement('ion-select-option');
+          selectOption.value = option;
+          selectOption.textContent = option.label;
+
+          select.appendChild(selectOption)
+        });
+
+      });
+
+      let objectSelectMultipleElement = document.getElementById('multiple');
+      objectSelectMultipleElement.value = [objectOptions[0]];
+
+      let objectSelectElement = document.getElementById('single');
+      objectSelectElement.value = objectOptions[0];
+    </script>
+  </ion-app>
+</body>
+
+</html>


### PR DESCRIPTION
This commit fixes an issue that caused selected options to not be selected when using the `multiple` option.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Matching options are not selected by default if an array `value` is passed with `multiple` set to `true`.

Issue Number: #24742


## What is the new behavior?
Matching options are selected by default if an array `value` is passed with `multiple` set to `true`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The first two argument names and their argument types for `isOptionSelected(currentValue: any | any[], compareValue: any, compareWith`) was the main indicator aside from the apparent bug that the parameters were out of order.