### PR TITLE
fix(angular-server): publish only the dist directory to avoid import errors

### DIFF
--- a/packages/angular-server/package.json
+++ b/packages/angular-server/package.json
@@ -19,6 +19,9 @@
   "bugs": {
     "url": "https://github.com/ionic-team/ionic/issues"
   },
+  "publishConfig": {
+    "directory": "dist"
+  },
   "homepage": "https://ionicframework.com/",
   "scripts": {
     "prepublishOnly": "npm run build.prod",

--- a/packages/angular-server/tsconfig.json
+++ b/packages/angular-server/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig",
   "compilerOptions": {
     "baseUrl": "./packages/angular-server",
-    "module": "commonjs",
+    "module": "es2015",
     "rootDir": "src",
     "outDir": "dist"
   },


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves #24605

Similar to the Angular package, the Angular Server package expects only the dist directory to be published at the root, otherwise files will fail to load.

Additionally, with the Angular 12 build (https://github.com/ionic-team/ionic-framework/commit/3451a34ad0c893be0b6c17dc91ac9a75d2b9b52c) we now pass in tsconfig.json to `ng-packagr`. The tsconfig.json tells the compiler to build for Common JS, instead of ES2015 (what the @ionic/angular package currently does). This CJS instruction has been around for a while, but up until that commit we never passed tsconfig to ng-packagr

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updated the package.json config to only publish `dist` as the root in @ionic/angular-server.
- @ionic/angular-server is now build for es2015, just like @ionic/angular

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
