### PR TITLE
fix(datetime): disable intersection observer during month update

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -723,6 +723,7 @@ export class Datetime implements ComponentInterface {
           minParts: this.minParts,
           maxParts: this.maxParts
         })) {
+          console.log('this being called');
           return;
         }
 
@@ -771,17 +772,26 @@ export class Datetime implements ComponentInterface {
          */
         writeTask(() => {
 
-          this.setWorkingParts({
-            ...this.workingParts,
-            month,
-            day: day!,
-            year
-          });
+          // Disconnect all active intersection observers
+          // to avoid a re-render causing a duplicate event.
+          if (this.destroyCalendarIO) {
+            this.destroyCalendarIO();
+          }
 
           raf(() => {
+            this.setWorkingParts({
+              ...this.workingParts,
+              month,
+              day: day!,
+              year
+            });
+
             calendarBodyRef.scrollLeft = workingMonth.clientWidth * (isRTL(this.el) ? -1 : 1);
             calendarBodyRef.style.removeProperty('overflow');
             calendarBodyRef.style.removeProperty('pointer-events');
+
+            endIO?.observe(endMonth);
+            startIO?.observe(startMonth);
           });
 
           /**

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -723,7 +723,6 @@ export class Datetime implements ComponentInterface {
           minParts: this.minParts,
           maxParts: this.maxParts
         })) {
-          console.log('this being called');
           return;
         }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The next/previous buttons in the datetime is offset by 2 months. This is because the intersection observer is pre-maturely firing twice, during the re-render of the navigation to the desired month.

<!-- Issues are required for both bug fixes and features. -->
Issue Number: #24712


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The intersection observer is disconnected before the state update/re-render and re-attached after the render and scroll offset has completed. This allows the swipe gesture behavior to operate correctly and fixes the issue for next/previous button to navigate to the desired month (1 month offset).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
