### PR TITLE
fix(vue): replacing routes now updates location state correctly

### DIFF
--- a/packages/vue-router/__tests__/locationHistory.spec.ts
+++ b/packages/vue-router/__tests__/locationHistory.spec.ts
@@ -69,15 +69,12 @@ describe('Location History', () => {
     expect(first.pathname).toEqual('/tabs/tab1/child/1');
   });
 
-  it('should correctly get current and previous routes', () => {
+  it('should correctly get last route', () => {
     locationHistory.add({ pathname: '/home' });
     locationHistory.add({ pathname: '/login' });
 
     const current = locationHistory.last();
     expect(current.pathname).toEqual('/login');
-
-    const previous = locationHistory.previous();
-    expect(previous.pathname).toEqual('/home');
   });
 
   it('should correctly determine if we can go back', () => {

--- a/packages/vue-router/src/locationHistory.ts
+++ b/packages/vue-router/src/locationHistory.ts
@@ -134,7 +134,6 @@ export const createLocationHistory = () => {
     const index = currentHistory - initialHistory;
     return locationHistory[index] || last();
   }
-  const previous = () => locationHistory[locationHistory.length - 2] || last();
   const last = () => locationHistory[locationHistory.length - 1];
 
   /**
@@ -210,7 +209,6 @@ export const createLocationHistory = () => {
     current,
     size,
     last,
-    previous,
     add,
     canGoBack,
     update,

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -334,8 +334,13 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
        * item for this route. In other words, a user
        * is navigating within the history without pushing
        * new items within the stack.
+       *
+       * If the historySize === historyDiff,
+       * then we are still re-writing history
+       * by replacing the current route state
+       * with a new route state.
        */
-      if (historySize > historyDiff && routeInfo.tab === undefined) {
+      if (historySize >= historyDiff) {
         /**
          * When navigating back through the history,
          * if users then push a new route the future

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -371,7 +371,10 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
          * in other scenarios.
          */
 
-        if (routeInfo.routerAction === 'push' && delta === undefined) {
+        if (
+          (routeInfo.routerAction === 'push' || routeInfo.routerAction === 'replace') &&
+          delta === undefined
+        ) {
           locationHistory.clearHistory(routeInfo);
           locationHistory.add(routeInfo);
         }

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -155,8 +155,15 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
   ) => {
     let leavingLocationInfo: RouteInfo;
     if (incomingRouteParams) {
+
+      /**
+       * If we are replacing the state of a route
+       * with another route, the "leaving" route
+       * is at the same position in location history
+       * as where the replaced route will exist.
+       */
       if (incomingRouteParams.routerAction === 'replace') {
-        leavingLocationInfo = locationHistory.previous();
+        leavingLocationInfo = locationHistory.current(initialHistoryPosition, currentHistoryPosition);
       } else if (incomingRouteParams.routerAction === 'pop') {
         leavingLocationInfo = locationHistory.current(initialHistoryPosition, currentHistoryPosition + 1);
 
@@ -338,9 +345,14 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
        * If the historySize === historyDiff,
        * then we are still re-writing history
        * by replacing the current route state
-       * with a new route state.
+       * with a new route state. The initial
+       * action when loading an app is
+       * going to be replace operation, so
+       * we want to make sure we exclude that
+       * action by ensuring historySize > 0.
        */
-      if (historySize >= historyDiff) {
+      const isReplacing = historySize === historyDiff && historySize > 0 && action === 'replace';
+      if (historySize > historyDiff || isReplacing) {
         /**
          * When navigating back through the history,
          * if users then push a new route the future

--- a/packages/vue/test-app/tests/e2e/specs/routing.js
+++ b/packages/vue/test-app/tests/e2e/specs/routing.js
@@ -3,10 +3,8 @@ describe('Routing', () => {
     cy.visit('http://localhost:8080');
     cy.get('ion-item#routing').click();
 
-    cy.wait(500)
-
-    cy.ionPageVisible('routing')
-    cy.ionPageHidden('home')
+    cy.ionPageVisible('routing');
+    cy.ionPageHidden('home');
   });
 
   it('should set query params and keep view in stack', () => {

--- a/packages/vue/test-app/tests/e2e/specs/tabs.js
+++ b/packages/vue/test-app/tests/e2e/specs/tabs.js
@@ -365,6 +365,27 @@ describe('Tabs', () => {
     cy.ionPageVisible('tab1childtwo');
     cy.ionPageVisible('tabs');
   })
+
+  // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/24432
+  it('should properly reset location history when switching tabs after going back', () => {
+    cy.visit('http://localhost:8080/tabs');
+
+    cy.routerPush('/tabs/tab1/childone');
+    cy.ionPageVisible('tab1childone');
+    cy.ionPageHidden('tab1');
+
+    cy.ionRouterBack();
+    cy.ionPageVisible('tab1');
+    cy.ionPageDoesNotExist('tab1childone');
+
+    cy.get('ion-tab-button#tab-button-tab2').click();
+    cy.ionPageVisible('tab2');
+    cy.ionPageHidden('tab1');
+
+    cy.ionRouterBack();
+    cy.ionPageVisible('tab1');
+    cy.ionPageDoesNotExist('tab2');
+  });
 })
 
 describe('Tabs - Swipe to Go Back', () => {
@@ -386,7 +407,7 @@ describe('Tabs - Swipe to Go Back', () => {
     cy.ionPageVisible('tab1');
   });*/
 
-  it.skip('should swipe and go back to home', () => {
+  it('should swipe and go back to home', () => {
     cy.ionSwipeToGoBack(true);
     cy.ionPageVisible('home');
 
@@ -405,7 +426,7 @@ describe('Tabs - Swipe to Go Back', () => {
     cy.ionPageVisible('tab1childone');
   });
 
-  it.skip('should swipe and go back within a tab', () => {
+  it('should swipe and go back within a tab', () => {
     cy.get('#child-one').click();
     cy.ionPageVisible('tab1childone');
     cy.ionPageHidden('tab1');
@@ -416,7 +437,7 @@ describe('Tabs - Swipe to Go Back', () => {
     cy.ionPageDoesNotExist('tab1childone');
   });
 
-  it.skip('should swipe and go back to correct tab after switching tabs', () => {
+  it('should swipe and go back to correct tab after switching tabs', () => {
     cy.get('#child-one').click();
     cy.ionPageVisible('tab1childone');
     cy.ionPageHidden('tab1');

--- a/packages/vue/test-app/tests/e2e/specs/tabs.js
+++ b/packages/vue/test-app/tests/e2e/specs/tabs.js
@@ -386,6 +386,19 @@ describe('Tabs', () => {
     cy.ionPageVisible('tab1');
     cy.ionPageDoesNotExist('tab2');
   });
+
+  // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/24432
+  it('should correct replace a route in a child tab route', () => {
+    cy.visit('http://localhost:8080/tabs');
+
+    cy.routerPush('/tabs/tab1/childone');
+    cy.ionPageVisible('tab1childone');
+    cy.ionPageHidden('tab1');
+
+    cy.ionRouterReplace('/tabs/tab1');
+    cy.ionPageVisible('tab1');
+    cy.ionPageDoesNotExist('tab1childone');
+  })
 })
 
 describe('Tabs - Swipe to Go Back', () => {

--- a/packages/vue/test-app/tests/e2e/specs/tabs.js
+++ b/packages/vue/test-app/tests/e2e/specs/tabs.js
@@ -420,7 +420,7 @@ describe('Tabs - Swipe to Go Back', () => {
     cy.ionPageVisible('tab1');
   });*/
 
-  it('should swipe and go back to home', () => {
+  it.skip('should swipe and go back to home', () => {
     cy.ionSwipeToGoBack(true);
     cy.ionPageVisible('home');
 
@@ -439,7 +439,7 @@ describe('Tabs - Swipe to Go Back', () => {
     cy.ionPageVisible('tab1childone');
   });
 
-  it('should swipe and go back within a tab', () => {
+  it.skip('should swipe and go back within a tab', () => {
     cy.get('#child-one').click();
     cy.ionPageVisible('tab1childone');
     cy.ionPageHidden('tab1');
@@ -450,7 +450,7 @@ describe('Tabs - Swipe to Go Back', () => {
     cy.ionPageDoesNotExist('tab1childone');
   });
 
-  it('should swipe and go back to correct tab after switching tabs', () => {
+  it.skip('should swipe and go back to correct tab after switching tabs', () => {
     cy.get('#child-one').click();
     cy.ionPageVisible('tab1childone');
     cy.ionPageHidden('tab1');

--- a/packages/vue/test-app/tests/e2e/support/commands.js
+++ b/packages/vue/test-app/tests/e2e/support/commands.js
@@ -88,6 +88,12 @@ Cypress.Commands.add('ionRouterNavigate', (...args) => {
   });
 });
 
+Cypress.Commands.add('ionRouterBack', () => {
+  cy.window().then(win => {
+    win.debugIonRouter.back();
+  });
+});
+
 Cypress.Commands.add('ionBackButtonHidden', (pageId) => {
   cy.get(`div.ion-page[data-pageid=${pageId}]`)
     .should('be.visible', true)

--- a/packages/vue/test-app/tests/e2e/support/commands.js
+++ b/packages/vue/test-app/tests/e2e/support/commands.js
@@ -94,6 +94,12 @@ Cypress.Commands.add('ionRouterBack', () => {
   });
 });
 
+Cypress.Commands.add('ionRouterReplace', (path) => {
+  cy.window().then(win => {
+    win.debugIonRouter.replace(path);
+  });
+});
+
 Cypress.Commands.add('ionBackButtonHidden', (pageId) => {
   cy.get(`div.ion-page[data-pageid=${pageId}]`)
     .should('be.visible', true)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/24432

There are a few related issues:

1. When the incoming route had `routeAction === 'replace'` Ionic Vue would determine the leaving location by getting the second to last item in location history. This was fine when popping would remove items from location history automatically (I.e. what Ionic React does), but when you support `router.go(n)` you cannot do that. As a result, the `locationHistory.previous()` call was not always returning the correct previous route based on where the user was in location history.

2. The `routeInfo.tab === undefined` check was actually a bandaid for an issue I had run into when calling the old `updateByHistoryPosition` method (See: https://github.com/ionic-team/ionic-framework/blob/a09d7d4ab6dd0d90204015eaaf232ed190753c56/packages/vue-router/src/router.ts#L294). However, it was later determined in https://github.com/ionic-team/ionic-framework/commit/0b18260da64334d8211c5a0cd806f7416274fc5e that  this was not the correct solution for the problem that it tried to solve. Now that we have the correct solution in place, this bandaid is no longer needed.

3. When re-writing history, Ionic Vue never considered the case where you wanted to replace the current state of the route with another route and as a result, the location history was not being updated/wiped appropriately. This worked fine when you navigated backwards and then did a `router.replace`, but if you just did a `router.replace` on its own, location history did not update properly.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed the `.previous` method in favor of calling `.current` which takes into account your location within history. I also removed the `previous` method in general as it is no longer used in the codebase.
- Removed the `routeInfo.tab` bandaid.
- Added a check to account for when doing `router.replace` in order to determine if we should wipe the location history.
- Unrelated to the PR, but there was a stray `cy.wait` that was not needed. I removed that.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
