### PR TITLE
fix(modal): inline modals inherit ion-page styling

### DIFF
--- a/core/src/components/modal/test/inline/e2e.ts
+++ b/core/src/components/modal/test/inline/e2e.ts
@@ -12,6 +12,10 @@ test('modal: inline', async () => {
   expect(modal).not.toBe(null);
   await modal.waitForVisible();
 
+  const container = await modal.find('.ion-page');
+
+  expect(container).not.toBe(null);
+
   screenshotCompares.push(await page.compareScreenshot());
 
   await modal.callMethod('dismiss');

--- a/core/src/utils/framework-delegate.ts
+++ b/core/src/utils/framework-delegate.ts
@@ -96,7 +96,6 @@ export const CoreDelegate = () => {
       cssClasses.forEach(c => el.classList.add(c));
       // Move each child from the original template to the new parent element.
       el.append(...BaseComponent.children);
-      
       // Append the new parent element to the original parent element.
       BaseComponent.appendChild(el);
     }

--- a/core/src/utils/framework-delegate.ts
+++ b/core/src/utils/framework-delegate.ts
@@ -92,14 +92,13 @@ export const CoreDelegate = () => {
     } else {
       // If there is no component, then we need to create a new parent
       // element to apply the css classes to.
-      const el: HTMLElement = BaseComponent.ownerDocument && BaseComponent.ownerDocument.createElement('div');
+      const el = BaseComponent.ownerDocument && BaseComponent.ownerDocument.createElement('div');
       cssClasses.forEach(c => el.classList.add(c));
       // Move each child from the original template to the new parent element.
-      while (BaseComponent.hasChildNodes()) {
-        el.appendChild(BaseComponent.firstChild);
-      }
+      el.append(...BaseComponent.children);
+      
       // Append the new parent element to the original parent element.
-      (BaseComponent as HTMLElement).appendChild(el);
+      BaseComponent.appendChild(el);
     }
 
     /**

--- a/core/src/utils/framework-delegate.ts
+++ b/core/src/utils/framework-delegate.ts
@@ -89,6 +89,17 @@ export const CoreDelegate = () => {
       BaseComponent.appendChild(el);
 
       await new Promise(resolve => componentOnReady(el, resolve));
+    } else {
+      // If there is no component, then we need to create a new parent
+      // element to apply the css classes to.
+      const el: HTMLElement = BaseComponent.ownerDocument && BaseComponent.ownerDocument.createElement('div');
+      cssClasses.forEach(c => el.classList.add(c));
+      // Move each child from the original template to the new parent element.
+      while (BaseComponent.hasChildNodes()) {
+        el.appendChild(BaseComponent.firstChild);
+      }
+      // Append the new parent element to the original parent element.
+      (BaseComponent as HTMLElement).appendChild(el);
     }
 
     /**


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Inline modals do not inherit CSS classes that are forwarded when the modal is presented. This results in implementations that make use of an `ion-header`, `ion-content` with overflow scroll, inside an inline modal, are unable to reach the end of the contents.

<!-- Issues are required for both bug fixes and features. -->
Issue Number: #24706


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Inline modals now inherit CSS classes that are forwarded when the modal is presented (aligning with the controller implementation).

This results in the user being able to correctly scroll to the end of the contents, when using the above scenario.

- Inline modal templates are appended to a new parent element that inherits the CSS classes
- Inline modal template is replaced with the new parent element

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This only appears to affect modal implementations (can be seen in our inline modal example when adding overflow). Was not able to replicate the same issue with popover usages. 
