### PR TITLE
fix(input): IME composition mode

### DIFF
--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -262,11 +262,12 @@ export class Input implements ComponentInterface {
   }
 
   componentDidLoad() {
-    if (this.nativeInput) {
-      // TODO: Update to JSX bindings when Stencil resolves bug with:
+    const nativeInput = this.nativeInput;
+    if (nativeInput) {
+      // TODO: FW-729 Update to JSX bindings when Stencil resolves bug with:
       // https://github.com/ionic-team/stencil/issues/3235
-      this.nativeInput.addEventListener('compositionstart', this.onCompositionStart);
-      this.nativeInput.addEventListener('compositionend', this.onCompositionEnd);
+      nativeInput.addEventListener('compositionstart', this.onCompositionStart);
+      nativeInput.addEventListener('compositionend', this.onCompositionEnd);
     }
   }
 
@@ -276,9 +277,10 @@ export class Input implements ComponentInterface {
         detail: this.el
       }));
     }
-    if (this.nativeInput) {
-      this.nativeInput.removeEventListener('compositionstart', this.onCompositionStart);
-      this.nativeInput.removeEventListener('compositionEnd', this.onCompositionEnd);
+    const nativeInput = this.nativeInput;
+    if (nativeInput) {
+      nativeInput.removeEventListener('compositionstart', this.onCompositionStart);
+      nativeInput.removeEventListener('compositionEnd', this.onCompositionEnd);
     }
   }
 

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -22,6 +22,7 @@ export class Input implements ComponentInterface {
   private inputId = `ion-input-${inputIds++}`;
   private didBlurAfterEdit = false;
   private inheritedAttributes: { [k: string]: any } = {};
+  private isComposing = false;
 
   /**
    * This is required for a WebKit bug which requires us to
@@ -231,7 +232,7 @@ export class Input implements ComponentInterface {
    */
   @Watch('value')
   protected valueChanged() {
-    if (this.nativeInput) {
+    if (this.nativeInput && !this.isComposing) {
       /**
        * Assigning the native input's value on attribute
        * value change, allows `ionInput` implementations
@@ -260,11 +261,24 @@ export class Input implements ComponentInterface {
     }
   }
 
+  componentDidLoad() {
+    if (this.nativeInput) {
+      // TODO: Update to JSX bindings when Stencil resolves bug with:
+      // https://github.com/ionic-team/stencil/issues/3235
+      this.nativeInput.addEventListener('compositionstart', this.onCompositionStart);
+      this.nativeInput.addEventListener('compositionend', this.onCompositionEnd);
+    }
+  }
+
   disconnectedCallback() {
     if (Build.isBrowser) {
       document.dispatchEvent(new CustomEvent('ionInputDidUnload', {
         detail: this.el
       }));
+    }
+    if (this.nativeInput) {
+      this.nativeInput.removeEventListener('compositionstart', this.onCompositionStart);
+      this.nativeInput.removeEventListener('compositionEnd', this.onCompositionEnd);
     }
   }
 
@@ -362,6 +376,14 @@ export class Input implements ComponentInterface {
       // Reset the flag
       this.didBlurAfterEdit = false;
     }
+  }
+
+  private onCompositionStart = () => {
+    this.isComposing = true;
+  }
+
+  private onCompositionEnd = () => {
+    this.isComposing = false;
   }
 
   private clearTextOnEnter = (ev: KeyboardEvent) => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

IMEs (input method editors) intercept keyboard events and conflict with the patch in #24606, since both are assigning a value to the native input, resulting in duplicate values on keypress. This also breaks the back button behavior (observed in Japanese IME). 

<!-- Issues are required for both bug fixes and features. -->
Issue Number: #24669

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

To prevent conflicts with IMEs and preserve the patch from the PR that introduced the new issue, it is recommended that we bind event listeners to `compositionstart` and `compositionend` to detect when a composition event from an IME is occurring and skip writing the value to the native input control while the event is in flight (inspired from: https://github.com/ng-select/ng-select/pull/1274)

- Usage of Japanese IME does not result in duplicate values
- Japanese IME usage of the back button/delete key is restored

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

While triaging this issue, a Stencil bug was discovered (https://github.com/ionic-team/stencil/issues/3235) that prevents using the JSX bindings for the composition events. 

To verify this issue, you can temporarily add a Japanese keyboard to your iOS device and open the basic input test in the browser. A guide on how to add the keyboard is available here: https://techwiser.com/use-japanese-keyboard-iphone.
