### PR TITLE
fix(input): cursor position does not jump to end

### DIFF
--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -240,7 +240,10 @@ export class Input implements ComponentInterface {
        * Used for patterns such as input trimming (removing whitespace),
        * or input masking.
        */
-      this.nativeInput.value = this.getValue();
+       const { selectionStart, selectionEnd } = this.nativeInput;
+       this.nativeInput.value = this.getValue();
+       // Set the cursor position back to where it was before the value change
+       this.nativeInput.setSelectionRange(selectionStart, selectionEnd);
     }
     this.emitStyle();
     this.ionChange.emit({ value: this.value == null ? this.value : this.value.toString() });

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -242,6 +242,7 @@ export class Input implements ComponentInterface {
        */
        const { selectionStart, selectionEnd } = this.nativeInput;
        this.nativeInput.value = this.getValue();
+       // TODO: FW-727 Remove this when we drop support for iOS 15.3
        // Set the cursor position back to where it was before the value change
        this.nativeInput.setSelectionRange(selectionStart, selectionEnd);
     }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Setting the cursor position to the middle of an `ion-input` with an existing value and typing a new character, would result in the cursor position to reset to the end of the input.

<!-- Issues are required for both bug fixes and features. -->
Issue Number: #24727

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

When assigning the native input value, persist the cursor position so that the cursor stays in place and no longer jumps to the end of the line.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
