### PR TITLE
fix(input): only use selection range on supported types

### DIFF
--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -241,11 +241,7 @@ export class Input implements ComponentInterface {
        * Used for patterns such as input trimming (removing whitespace),
        * or input masking.
        */
-       const { selectionStart, selectionEnd } = this.nativeInput;
-       this.nativeInput.value = this.getValue();
-       // TODO: FW-727 Remove this when we drop support for iOS 15.3
-       // Set the cursor position back to where it was before the value change
-       this.nativeInput.setSelectionRange(selectionStart, selectionEnd);
+      this.setNativeInputValue();
     }
     this.emitStyle();
     this.ionChange.emit({ value: this.value == null ? this.value : this.value.toString() });
@@ -317,6 +313,24 @@ export class Input implements ComponentInterface {
   @Method()
   getInputElement(): Promise<HTMLInputElement> {
     return Promise.resolve(this.nativeInput!);
+  }
+
+  private setNativeInputValue() {
+    const { nativeInput, type } = this;
+
+    if (nativeInput) {
+      // Only use `setSelectionRange` if the type supports it:
+      // https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange
+      if (type === 'text' || type === 'search' || type === 'url' || type === 'tel' || type === 'password') {
+        const { selectionStart, selectionEnd } = nativeInput;
+        nativeInput.value = this.getValue();
+        // TODO: FW-727 Remove this when we drop support for iOS 15.3
+        // Set the cursor position back to where it was before the value change
+        nativeInput.setSelectionRange(selectionStart, selectionEnd);
+      } else {
+        nativeInput.value = this.getValue();
+      }
+    }
   }
 
   private shouldClearOnEdit() {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`setSelectionRange` isn't supported on all input types and will error when developers use `ion-input` with a type other than: `text`, `url`, `search`, `tel`, or `password`. 


<!-- Issues are required for both bug fixes and features. -->
Issue Number: #24753


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Adds additional checks to validate that `setSelectionRange` is supported on the input type, prior to setting the range.

Fixes error resulting in:
> Failed to execute 'setSelectionRange' on 'HTMLInputElement': The input element's type ('number') does not support selection.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
