### PR TITLE
fix(datetime): navigate to month within min range

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1238,6 +1238,9 @@ export class Datetime implements ComponentInterface {
       year,
       day: null
     }, {
+      // The day is not used when checking if a month is disabled.
+      // Users should be able to access the min or max month, even if the
+      // min/max date is out of bounds (e.g. min is set to Feb 15, Feb should not be disabled).
       minParts: { ...this.minParts, day: null },
       maxParts: { ...this.maxParts, day: null }
     });

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -720,8 +720,8 @@ export class Datetime implements ComponentInterface {
         const { month, year, day } = refMonthFn(this.workingParts);
 
         if (isMonthDisabled({ month, year, day: null }, {
-          minParts: this.minParts,
-          maxParts: this.maxParts
+          minParts: { ...this.minParts, day: null },
+          maxParts: { ...this.maxParts, day: null }
         })) {
           return;
         }
@@ -1238,8 +1238,8 @@ export class Datetime implements ComponentInterface {
       year,
       day: null
     }, {
-      minParts: this.minParts,
-      maxParts: this.maxParts
+      minParts: { ...this.minParts, day: null },
+      maxParts: { ...this.maxParts, day: null }
     });
     // The working month should never have swipe disabled.
     // Otherwise the CSS scroll snap will not work and the user

--- a/core/src/components/datetime/test/minmax/e2e.ts
+++ b/core/src/components/datetime/test/minmax/e2e.ts
@@ -47,3 +47,17 @@ test('datetime: minmax navigation disabled', async () => {
   expect(navButtons[1]).toHaveAttribute('disabled');
 
 });
+
+test('datetime: min including day should not disable month', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/datetime/test/minmax?ionic:_testing=true'
+  });
+
+  const calendarMonths = await page.findAll('ion-datetime#min-with-day >>> .calendar-month');
+
+  await page.waitForChanges();
+
+  expect(calendarMonths[0]).toHaveClass('calendar-month-disabled');
+  expect(calendarMonths[1]).not.toHaveClass('calendar-month-disabled');
+  expect(calendarMonths[2]).not.toHaveClass('calendar-month-disabled');
+})

--- a/core/src/components/datetime/test/minmax/index.html
+++ b/core/src/components/datetime/test/minmax/index.html
@@ -62,6 +62,10 @@
           <h2>locale: en-GB</h2>
           <ion-datetime locale="en-GB" presentation="time" min="19:30" value="20:30" max="20:40"></ion-datetime>
         </div>
+        <div class="grid-item">
+          <h2>Min with year/month/day</h2>
+          <ion-datetime id="min-with-day" min="2022-02-09" value="2022-02-09"></ion-datetime>
+        </div>
       </div>
     </ion-content>
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When providing a `min` value to `ion-datetime` that includes a day, the month of the `min` value will be disabled and once you have navigated away from it, you will be unable to return to it. 

This is because the `isBefore`/`isAfter` checks additionally compare the day value, when min/max includes it. This is correct for date comparisons, but isn't a 1:1 with rules surrounding disabling months.

<!-- Issues are required for both bug fixes and features. -->
Issue Number: #24757

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Users can navigate to min/max months, when the `min`/`max` value includes a day constraint. 

i.e.: If the `min` is `2022-02-09`, users should still be able to navigate to February, since days 10-28 are enabled.  

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
