### PR TITLE
fix(refresher): refresher can be used inside any fixed slot container

### DIFF
--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -414,8 +414,8 @@ export class Refresher implements ComponentInterface {
   }
 
   async connectedCallback() {
-    if (this.el.getAttribute('slot') !== 'fixed') {
-      console.error('Make sure you use: <ion-refresher slot="fixed">');
+    if (this.el.closest('[slot="fixed"]') === null) {
+      console.error('<ion-refresher> must be used inside of slot="fixed" with <ion-content>.');
       return;
     }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/24774

Currently you cannot place multiple items in the fixed slot if using an `ion-refresher`. This is because refresher expects `slot="fixed"` to be placed on the refresher host and errors if you do not do that.

This is desirable when you have other things be `position: fixed` along with the refresher. There is a bug in WebKit with how `position: fixed` content is handled in non-body scrollable containers, so the only way to get `position: fixed` content to work properly is to put it in the `fixed` slot.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Allows developers to wrap refresher in a fixed slot and use it that way. Devs will likely need to set `width: 100%` on the container.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
