### PR TITLE
fix(react, vue): scroll is no longer interrupted on ios

### DIFF
--- a/core/src/css/structure.scss
+++ b/core/src/css/structure.scss
@@ -46,22 +46,6 @@ body {
   height: 100%;
   max-height: 100%;
 
-  text-rendering: optimizeLegibility;
-
-  overflow: hidden;
-
-  touch-action: manipulation;
-
-  -webkit-user-drag: none;
-
-  -ms-content-zooming: none;
-
-  word-wrap: break-word;
-
-  overscroll-behavior-y: none;
-
-  text-size-adjust: none;
-
   /**
    * Because body has position: fixed,
    * it should be promoted to its own
@@ -83,4 +67,20 @@ body {
    * happen, so the additional re-paint does not occur.
    */
   transform: translateZ(0);
+
+  text-rendering: optimizeLegibility;
+
+  overflow: hidden;
+
+  touch-action: manipulation;
+
+  -webkit-user-drag: none;
+
+  -ms-content-zooming: none;
+
+  word-wrap: break-word;
+
+  overscroll-behavior-y: none;
+
+  text-size-adjust: none;
 }

--- a/core/src/css/structure.scss
+++ b/core/src/css/structure.scss
@@ -61,4 +61,22 @@ body {
   overscroll-behavior-y: none;
 
   text-size-adjust: none;
+
+  /**
+   * WebKit does not always promote
+   * the body to its own layer on page
+   * load in Ionic apps. Once scrolling on
+   * ion-content starts, WebKit will promote
+   * body. Unfortunately, this causes a re-paint
+   * which results in scrolling being halted
+   * until the next user gesture.
+   *
+   * This impacts the Custom Elements build.
+   * The lazy loaded build causes the browser to
+   * re-paint during hydration which causes WebKit
+   * to promote body to its own layer.
+   * In the CE Build, this hydration does not
+   * happen, so the additional re-paint does not occur.
+   */
+  transform: translateZ(0);
 }

--- a/core/src/css/structure.scss
+++ b/core/src/css/structure.scss
@@ -63,6 +63,10 @@ body {
   text-size-adjust: none;
 
   /**
+   * Because body has position: fixed,
+   * it should be promoted to its own
+   * layer.
+   *
    * WebKit does not always promote
    * the body to its own layer on page
    * load in Ionic apps. Once scrolling on


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/24435


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- body is now always promoted to its own layer. It was supposed to be its own layer even before this change, but there is a quirk in WebKit where this does not always happen.
Typically we do not want to "force" layer promotion but given this is an instance where `body` is truly supposed to be its own layer, this seems like an acceptable exclusion to the rule.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
