### PR TITLE
fix(datetime): month picker no longer gives duplicate months on ios 14 and older

### DIFF
--- a/core/src/components/datetime/test/format.spec.ts
+++ b/core/src/components/datetime/test/format.spec.ts
@@ -75,7 +75,15 @@ describe('getMonthAndYear()', () => {
     expect(getMonthAndYear('en-US', { month: 5, day: 11, year: 2021 })).toEqual('May 2021');
   });
 
-  it('should return mar, 11 may', () => {
+  it('should return mayo de 2021', () => {
     expect(getMonthAndYear('es-ES', { month: 5, day: 11, year: 2021 })).toEqual('mayo de 2021');
+  });
+
+  it('should return April 2006', () => {
+    expect(getMonthAndYear('en-US', { month: 4, day: 1, year: 2006 })).toEqual('April 2006');
+  });
+
+  it('should return abril de 2006', () => {
+    expect(getMonthAndYear('es-ES', { month: 4, day: 1, year: 2006 })).toEqual('abril de 2006');
   });
 })

--- a/core/src/components/datetime/test/format.spec.ts
+++ b/core/src/components/datetime/test/format.spec.ts
@@ -27,6 +27,11 @@ describe('generateDayAriaLabel()', () => {
 
     expect(generateDayAriaLabel('en-US', false, reference)).toEqual('Monday, May 31');
   });
+  it('should return Saturday, April 1', () => {
+    const reference = { month: 4, day: 1, year: 2006 };
+
+    expect(generateDayAriaLabel('en-US', false, reference)).toEqual('Saturday, April 1');
+  });
 });
 
 describe('getMonthAndDay()', () => {

--- a/core/src/components/datetime/test/format.spec.ts
+++ b/core/src/components/datetime/test/format.spec.ts
@@ -47,10 +47,6 @@ describe('getMonthAndDay()', () => {
     expect(getMonthAndDay('en-US', { month: 4, day: 1, year: 2006 })).toEqual('Sat, Apr 1');
   });
 
-  it('should return mar, 11 may', () => {
-    expect(getMonthAndDay('es-ES', { month: 5, day: 11, year: 2021 })).toEqual('mar, 11 may');
-  });
-
   it('should return sáb, 1 abr', () => {
     expect(getMonthAndDay('es-ES', { month: 4, day: 1, year: 2006 })).toEqual('sáb, 1 abr');
   });

--- a/core/src/components/datetime/test/format.spec.ts
+++ b/core/src/components/datetime/test/format.spec.ts
@@ -37,6 +37,18 @@ describe('getMonthAndDay()', () => {
   it('should return mar, 11 may', () => {
     expect(getMonthAndDay('es-ES', { month: 5, day: 11, year: 2021 })).toEqual('mar, 11 may');
   });
+
+  it('should return Sat, Apr 1', () => {
+    expect(getMonthAndDay('en-US', { month: 4, day: 1, year: 2006 })).toEqual('Sat, Apr 1');
+  });
+
+  it('should return mar, 11 may', () => {
+    expect(getMonthAndDay('es-ES', { month: 5, day: 11, year: 2021 })).toEqual('mar, 11 may');
+  });
+
+  it('should return sáb, 1 abr', () => {
+    expect(getMonthAndDay('es-ES', { month: 4, day: 1, year: 2006 })).toEqual('sáb, 1 abr');
+  });
 })
 
 describe('getFormattedHour()', () => {

--- a/core/src/components/datetime/utils/data.ts
+++ b/core/src/components/datetime/utils/data.ts
@@ -294,7 +294,7 @@ export const getPickerMonths = (
     for (let i = minMonth; i <= maxMonth; i++) {
 
       /**
-       * TODO(FW-801) - Revert to `${i}/1/${year} when iOS 14 is dropped.
+       * TODO(FW-801) - Revert to `${i}/1/${year}` when iOS 14 is dropped.
        *
        * There is a bug on iOS 14 where
        * Intl.DateTimeFormat can return

--- a/core/src/components/datetime/utils/data.ts
+++ b/core/src/components/datetime/utils/data.ts
@@ -282,7 +282,7 @@ export const getPickerMonths = (
     }
 
     processedMonths.forEach(processedMonth => {
-      const date = new Date(`${processedMonth}/1/${year}`);
+      const date = new Date(`${processedMonth}/1/${year} GMT+0000`);
 
       const monthString = new Intl.DateTimeFormat(locale, { month: 'long', timeZone: 'UTC' }).format(date);
       months.push({ text: monthString, value: processedMonth });
@@ -307,8 +307,17 @@ export const getPickerMonths = (
        * Example:
        * new Intl.DateTimeFormat('en-US', { month: 'long' }).format(new Date('Sat Apr 01 2006 00:00:00 GMT-0400 (EDT)')) // "March"
        * new Intl.DateTimeFormat('en-US', { month: 'long', timeZone: 'UTC' }).format(new Date('Sat Apr 01 2006 00:00:00 GMT-0400 (EDT)')) // "April"
+       *
+       * In certain timezones, iOS 14 shows the wrong
+       * date for .toUTCString(). To combat this, we
+       * force all of the timezones to GMT+0000 (UTC).
+       *
+       * Example:
+       * Time Zone: Central European Standard Time
+       * new Date('1/1/1992').toUTCString() // "Tue, 31 Dec 1991 23:00:00 GMT"
+       * new Date('1/1/1992 GMT+0000').toUTCString() // "Wed, 01 Jan 1992 00:00:00 GMT"
        */
-      const date = new Date(`${i}/1/${year}`);
+      const date = new Date(`${i}/1/${year} GMT+0000`);
 
       const monthString = new Intl.DateTimeFormat(locale, { month: 'long', timeZone: 'UTC' }).format(date);
       months.push({ text: monthString, value: i });

--- a/core/src/components/datetime/utils/data.ts
+++ b/core/src/components/datetime/utils/data.ts
@@ -294,6 +294,8 @@ export const getPickerMonths = (
     for (let i = minMonth; i <= maxMonth; i++) {
 
       /**
+       * TODO(FW-801) - Revert to `${i}/1/${year} when iOS 14 is dropped.
+       *
        * There is a bug on iOS 14 where
        * Intl.DateTimeFormat can return
        * the name of the previous month

--- a/core/src/components/datetime/utils/data.ts
+++ b/core/src/components/datetime/utils/data.ts
@@ -284,7 +284,7 @@ export const getPickerMonths = (
     processedMonths.forEach(processedMonth => {
       const date = new Date(`${processedMonth}/1/${year}`);
 
-      const monthString = new Intl.DateTimeFormat(locale, { month: 'long' }).format(date);
+      const monthString = new Intl.DateTimeFormat(locale, { month: 'long', timeZone: 'UTC' }).format(date);
       months.push({ text: monthString, value: processedMonth });
     });
   } else {
@@ -294,25 +294,23 @@ export const getPickerMonths = (
     for (let i = minMonth; i <= maxMonth; i++) {
 
       /**
-       * TODO(FW-801) - Revert to `${i}/1/${year}` when iOS 14 is dropped.
        *
        * There is a bug on iOS 14 where
-       * Intl.DateTimeFormat can return
-       * the name of the previous month
-       * when the date is 00:00 on the first
-       * of a particular month.
+       * Intl.DateTimeFormat takes into account
+       * the local timezone offset when formatting dates.
        *
-       * Setting the date below to the
-       * 2nd day of the month avoids
-       * this issue.
+       * Forcing the timezone to 'UTC' fixes the issue. However,
+       * we should keep this workaround as it safer. In the event
+       * this breaks in another browser, we will not be impacted
+       * because all dates will be interpreted in UTC.
        *
        * Example:
        * new Intl.DateTimeFormat('en-US', { month: 'long' }).format(new Date('Sat Apr 01 2006 00:00:00 GMT-0400 (EDT)')) // "March"
-       * new Intl.DateTimeFormat('en-US', { month: 'long' }).format(new Date('Sat Apr 02 2006 00:00:00 GMT-0400 (EDT)')) // "April"
+       * new Intl.DateTimeFormat('en-US', { month: 'long', timeZone: 'UTC' }).format(new Date('Sat Apr 01 2006 00:00:00 GMT-0400 (EDT)')) // "April"
        */
-      const date = new Date(`${i}/2/${year}`);
+      const date = new Date(`${i}/1/${year}`);
 
-      const monthString = new Intl.DateTimeFormat(locale, { month: 'long' }).format(date);
+      const monthString = new Intl.DateTimeFormat(locale, { month: 'long', timeZone: 'UTC' }).format(date);
       months.push({ text: monthString, value: i });
     }
   }

--- a/core/src/components/datetime/utils/data.ts
+++ b/core/src/components/datetime/utils/data.ts
@@ -300,7 +300,7 @@ export const getPickerMonths = (
        * the local timezone offset when formatting dates.
        *
        * Forcing the timezone to 'UTC' fixes the issue. However,
-       * we should keep this workaround as it safer. In the event
+       * we should keep this workaround as it is safer. In the event
        * this breaks in another browser, we will not be impacted
        * because all dates will be interpreted in UTC.
        *

--- a/core/src/components/datetime/utils/data.ts
+++ b/core/src/components/datetime/utils/data.ts
@@ -292,7 +292,23 @@ export const getPickerMonths = (
     const minMonth = minParts && minParts.year === year ? minParts.month : 1;
 
     for (let i = minMonth; i <= maxMonth; i++) {
-      const date = new Date(`${i}/1/${year}`);
+
+      /**
+       * There is a bug on iOS 14 where
+       * Intl.DateTimeFormat can return
+       * the name of the previous month
+       * when the date is 00:00 on the first
+       * of a particular month.
+       *
+       * Setting the date below to the
+       * 2nd day of the month avoids
+       * this issue.
+       *
+       * Example:
+       * new Intl.DateTimeFormat('en-US', { month: 'long' }).format(new Date('Sat Apr 01 2006 00:00:00 GMT-0400 (EDT)')) // "March"
+       * new Intl.DateTimeFormat('en-US', { month: 'long' }).format(new Date('Sat Apr 02 2006 00:00:00 GMT-0400 (EDT)')) // "April"
+       */
+      const date = new Date(`${i}/2/${year}`);
 
       const monthString = new Intl.DateTimeFormat(locale, { month: 'long' }).format(date);
       months.push({ text: monthString, value: i });

--- a/core/src/components/datetime/utils/format.ts
+++ b/core/src/components/datetime/utils/format.ts
@@ -70,9 +70,18 @@ export const generateDayAriaLabel = (locale: string, today: boolean, refParts: D
 /**
  * Gets the day of the week, month, and day
  * Used for the header in MD mode.
+ *
+ * TODO(FW-801) - Revert to `${refParts.month}/${refParts.day}/${refParts.year}` when iOS 14 is dropped.
+ *
+ * See getPickerMonths() in data.ts for more info.
+ * The getPickerMonths workaround of setting the day is not
+ * acceptable here because this function needs to return the
+ * accurate day. Instead, we set the time to 12:00 so that
+ * the combination of this bug + timezone can never shift
+ * the day.
  */
 export const getMonthAndDay = (locale: string, refParts: DatetimeParts) => {
-  const date = new Date(`${refParts.month}/${refParts.day}/${refParts.year}`);
+  const date = new Date(`${refParts.month}/${refParts.day}/${refParts.year} 12:00`);
   return new Intl.DateTimeFormat(locale, { weekday: 'short', month: 'short', day: 'numeric' }).format(date);
 }
 
@@ -81,8 +90,12 @@ export const getMonthAndDay = (locale: string, refParts: DatetimeParts) => {
  * return a formatted string that includes
  * the month name and full year.
  * Example: May 2021
+ *
+ * TODO(FW-801) - Revert to `${refParts.month}/${refParts.day}/${refParts.year}` when iOS 14 is dropped.
+ *
+ * See getPickerMonths() in data.ts for more info.
  */
 export const getMonthAndYear = (locale: string, refParts: DatetimeParts) => {
-  const date = new Date(`${refParts.month}/${refParts.day}/${refParts.year}`);
+  const date = new Date(`${refParts.month}/2/${refParts.year}`);
   return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(date);
 }

--- a/core/src/components/datetime/utils/format.ts
+++ b/core/src/components/datetime/utils/format.ts
@@ -84,6 +84,5 @@ export const getMonthAndDay = (locale: string, refParts: DatetimeParts) => {
  */
 export const getMonthAndYear = (locale: string, refParts: DatetimeParts) => {
   const date = new Date(`${refParts.month}/${refParts.day}/${refParts.year} GMT+0000`);
-  console.log('hello', refParts, locale)
   return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric', timeZone: 'UTC' }).format(date);
 }

--- a/core/src/components/datetime/utils/format.ts
+++ b/core/src/components/datetime/utils/format.ts
@@ -56,7 +56,7 @@ export const generateDayAriaLabel = (locale: string, today: boolean, refParts: D
   /**
    * MM/DD/YYYY will return midnight in the user's timezone.
    */
-  const date = new Date(`${refParts.month}/${refParts.day}/${refParts.year}`);
+  const date = new Date(`${refParts.month}/${refParts.day}/${refParts.year} GMT+0000`);
 
   const labelString = new Intl.DateTimeFormat(locale, { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC' }).format(date);
 
@@ -72,7 +72,7 @@ export const generateDayAriaLabel = (locale: string, today: boolean, refParts: D
  * Used for the header in MD mode.
  */
 export const getMonthAndDay = (locale: string, refParts: DatetimeParts) => {
-  const date = new Date(`${refParts.month}/${refParts.day}/${refParts.year}`);
+  const date = new Date(`${refParts.month}/${refParts.day}/${refParts.year} GMT+0000`);
   return new Intl.DateTimeFormat(locale, { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'UTC' }).format(date);
 }
 
@@ -83,6 +83,7 @@ export const getMonthAndDay = (locale: string, refParts: DatetimeParts) => {
  * Example: May 2021
  */
 export const getMonthAndYear = (locale: string, refParts: DatetimeParts) => {
-  const date = new Date(`${refParts.month}/${refParts.day}/${refParts.year}`);
+  const date = new Date(`${refParts.month}/${refParts.day}/${refParts.year} GMT+0000`);
+  console.log('hello', refParts, locale)
   return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric', timeZone: 'UTC' }).format(date);
 }

--- a/core/src/components/datetime/utils/format.ts
+++ b/core/src/components/datetime/utils/format.ts
@@ -83,6 +83,6 @@ export const getMonthAndDay = (locale: string, refParts: DatetimeParts) => {
  * Example: May 2021
  */
 export const getMonthAndYear = (locale: string, refParts: DatetimeParts) => {
-  const date = new Date(`${refParts.month}/1/${refParts.year}`);
+  const date = new Date(`${refParts.month}/${refParts.day}/${refParts.year}`);
   return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric', timeZone: 'UTC' }).format(date);
 }

--- a/core/src/components/datetime/utils/format.ts
+++ b/core/src/components/datetime/utils/format.ts
@@ -58,7 +58,7 @@ export const generateDayAriaLabel = (locale: string, today: boolean, refParts: D
    */
   const date = new Date(`${refParts.month}/${refParts.day}/${refParts.year}`);
 
-  const labelString = new Intl.DateTimeFormat(locale, { weekday: 'long', month: 'long', day: 'numeric' }).format(date);
+  const labelString = new Intl.DateTimeFormat(locale, { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC' }).format(date);
 
   /**
    * If date is today, prepend "Today" so screen readers indicate
@@ -70,19 +70,10 @@ export const generateDayAriaLabel = (locale: string, today: boolean, refParts: D
 /**
  * Gets the day of the week, month, and day
  * Used for the header in MD mode.
- *
- * TODO(FW-801) - Revert to `${refParts.month}/${refParts.day}/${refParts.year}` when iOS 14 is dropped.
- *
- * See getPickerMonths() in data.ts for more info.
- * The getPickerMonths workaround of setting the day is not
- * acceptable here because this function needs to return the
- * accurate day. Instead, we set the time to 12:00 so that
- * the combination of this bug + timezone can never shift
- * the day.
  */
 export const getMonthAndDay = (locale: string, refParts: DatetimeParts) => {
-  const date = new Date(`${refParts.month}/${refParts.day}/${refParts.year} 12:00`);
-  return new Intl.DateTimeFormat(locale, { weekday: 'short', month: 'short', day: 'numeric' }).format(date);
+  const date = new Date(`${refParts.month}/${refParts.day}/${refParts.year}`);
+  return new Intl.DateTimeFormat(locale, { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'UTC' }).format(date);
 }
 
 /**
@@ -90,12 +81,8 @@ export const getMonthAndDay = (locale: string, refParts: DatetimeParts) => {
  * return a formatted string that includes
  * the month name and full year.
  * Example: May 2021
- *
- * TODO(FW-801) - Revert to `${refParts.month}/${refParts.day}/${refParts.year}` when iOS 14 is dropped.
- *
- * See getPickerMonths() in data.ts for more info.
  */
 export const getMonthAndYear = (locale: string, refParts: DatetimeParts) => {
-  const date = new Date(`${refParts.month}/2/${refParts.year}`);
-  return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(date);
+  const date = new Date(`${refParts.month}/1/${refParts.year}`);
+  return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric', timeZone: 'UTC' }).format(date);
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/24663


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Force all timezones to be interpreted as UTC when formatting.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
