### PR TITLE
fix(button): ensure button text doesn't trigger pointer events when button is disabled

### DIFF
--- a/core/src/components/button/button.scss
+++ b/core/src/components/button/button.scss
@@ -209,6 +209,10 @@
   z-index: 1;
 }
 
+.button-inner {
+  pointer-events: none;
+}
+
 
 // Button Icons
 // --------------------------------------------------

--- a/core/src/components/button/button.scss
+++ b/core/src/components/button/button.scss
@@ -202,15 +202,12 @@
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
+  pointer-events: none;
 
   width: 100%;
   height: 100%;
 
   z-index: 1;
-}
-
-.button-inner {
-  pointer-events: none;
 }
 
 

--- a/core/src/components/button/test/basic/index.html
+++ b/core/src/components/button/test/basic/index.html
@@ -10,7 +10,7 @@
   <script src="../../../../../scripts/testing/scripts.js"></script>
   <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
   <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script></head>
-  
+
 <body>
   <ion-app>
 

--- a/core/src/components/button/test/basic/index.html
+++ b/core/src/components/button/test/basic/index.html
@@ -10,7 +10,7 @@
   <script src="../../../../../scripts/testing/scripts.js"></script>
   <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
   <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script></head>
-
+  
 <body>
   <ion-app>
 
@@ -87,6 +87,7 @@
 
       <p>
         <ion-button expand="block" id="disabledButton" disabled onclick="clickedButton(event)">Button Disabled</ion-button>
+        <ion-button expand="block" id="disabledButton2" onclick="clickedButton(event)">12345</ion-button>
         <ion-button expand="block" color="secondary" disabled>Secondary Disabled</ion-button>
         <ion-button expand="block" color="tertiary" style="--opacity: 1" disabled>Disabled opacity: 1</ion-button>
       </p>
@@ -121,9 +122,11 @@
     }
 
     function toggleDisabled() {
-      var buttonEl = document.getElementById('disabledButton');
-      console.log(buttonEl);
-      buttonEl.disabled = !buttonEl.disabled;
+      ['disabledButton', 'disabledButton2'].forEach(id => {
+        var buttonEl = document.getElementById(id);
+        console.log(buttonEl);
+        buttonEl.disabled = !buttonEl.disabled;
+      });
     }
 
     function clickedButton(ev) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Under certain conditions, the button text in an `ion-button` will trigger pointer events (hover styling, click listeners) even when the button is disabled. So far, it looks like these conditions are:

- Safari only (issue reporter replicated in 14, I confirmed in 15)
- The button was set to `disabled` programmatically -- if the button was disabled from the start, the bug doesn't show
- The button text can only contain numbers (issue reporter said it's short text only, but this seems like a coincidence; I'm able to replicate the bug with any text length as long as there aren't any letters)

The clickable area of the disabled button is only on the text. Clicking the padding around the text does not trigger the bug. Additionally, opening the dev tools will sometimes stop the bug from happening until the page is refreshed.

Steps to replicate, using the "Button - Basic" test:

1. Click "Toggle Disabled" at the bottom of the page. Note that the "12345" button goes from enabled to disabled.
2. Click "12345" on the text itself. Note that the click listener fires and logs to the console. (Also note that hover styling is applied to the button.)
3. Click the "12345" button in the area around the text. Note that the click listener does not fire.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: Resolves https://github.com/ionic-team/ionic-framework/issues/23865


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The button text now explicitly blocks pointer events. While CSS inheritance should make this redundant, there seems to be a quirk in Safari preventing the rule from propagating under all conditions.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Unsure

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

Current fix seems overly broad and may cause as-of-yet unknown side effects.


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

While the current fix works, for whatever reason, this does not:
```
:host(.button-disabled) .button-inner {
  pointer-events: none;
}
```

Adding a class to `.button-inner` when the `disabled` prop is `true` and applying the CSS indirectly that way also didn't work.

Everything about the conditions that trigger this bug says "Webkit issue" to me, but I haven't been able to replicate with a native `<button>` in a way that only happens on Webkit. My attempts that were of most interest were:

1. `<div><button><span>12345</span></button></div>` with the `button` set to `disabled` and a click listener on the `div`. This showed a similar behavior to the bug -- clicking the button text, i.e. the `span`, would fire the click listener. However, this also replicated in Chrome, so it seems to be an unrelated quirk of event bubbling.
2. The same HTML setup as above, but with the `button` in a shadow DOM, and `pointer-events: none` set on the `div` rather than `disabled` on the `button`. The bug did not trigger in Safari or Chrome.