### PR TITLE
fix(toast): toast is now correctly excluded from focus trapping

### DIFF
--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -140,9 +140,7 @@ export class Toast implements ComponentInterface, OverlayInterface {
   @Event({ eventName: 'ionToastDidDismiss' }) didDismiss!: EventEmitter<OverlayEventDetail>;
 
   connectedCallback() {
-    prepareOverlay(this.el, {
-      trapKeyboardFocus: false
-    });
+    prepareOverlay(this.el);
   }
 
   /**

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -31,16 +31,10 @@ export const pickerController = /*@__PURE__*/createController<PickerOptions, HTM
 export const popoverController = /*@__PURE__*/createController<PopoverOptions, HTMLIonPopoverElement>('ion-popover');
 export const toastController = /*@__PURE__*/createController<ToastOptions, HTMLIonToastElement>('ion-toast');
 
-export interface OverlayListenerOptions {
-  trapKeyboardFocus: boolean;
-}
-
-export const prepareOverlay = <T extends HTMLIonOverlayElement>(el: T, options: OverlayListenerOptions = {
-  trapKeyboardFocus: true
-}) => {
+export const prepareOverlay = <T extends HTMLIonOverlayElement>(el: T) => {
   /* tslint:disable-next-line */
   if (typeof document !== 'undefined') {
-    connectListeners(document, options);
+    connectListeners(document);
   }
   const overlayIndex = lastId++;
   el.overlayIndex = overlayIndex;
@@ -119,7 +113,7 @@ const focusLastDescendant = (ref: Element, overlay: HTMLIonOverlayElement) => {
  * Should NOT include: Toast
  */
 const trapKeyboardFocus = (ev: Event, doc: Document) => {
-  const lastOverlay = getOverlay(doc);
+  const lastOverlay = getOverlay(doc, 'ion-alert,ion-action-sheet,ion-loading,ion-modal,ion-picker,ion-popover');
   const target = ev.target as HTMLElement | null;
 
   /**
@@ -256,22 +250,12 @@ const trapKeyboardFocus = (ev: Event, doc: Document) => {
   }
 };
 
-const connectListeners = (doc: Document, options: OverlayListenerOptions) => {
+const connectListeners = (doc: Document) => {
   if (lastId === 0) {
     lastId = 1;
-    if (options.trapKeyboardFocus) {
-      doc.addEventListener('focus', (ev: FocusEvent) => {
-        /**
-         * ion-menu has its own focus trapping listener
-         * so we do not want the two listeners to conflict
-         * with each other.
-         */
-        if (ev.target && (ev.target as HTMLElement).tagName === 'ION-MENU') {
-          return;
-        }
-        trapKeyboardFocus(ev, doc);
-      }, true);
-    }
+    doc.addEventListener('focus', (ev: FocusEvent) => {
+      trapKeyboardFocus(ev, doc);
+    }, true);
 
     // handle back-button click
     doc.addEventListener('ionBackButton', ev => {

--- a/core/src/utils/test/overlays/index.html
+++ b/core/src/utils/test/overlays/index.html
@@ -10,8 +10,9 @@
   <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
   <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   <script type="module">
-    import { modalController, createAnimation } from '../../../../../dist/ionic/index.esm.js';
+    import { modalController, toastController, createAnimation } from '../../../../../dist/ionic/index.esm.js';
     window.modalController = modalController;
+    window.toastController = toastController;
   </script>
 </head>
 
@@ -30,11 +31,17 @@
       </ion-header>
 
       <ion-content class="ion-padding">
+        <ion-item>
+          <ion-label>Text Input</ion-label>
+          <ion-input id="root-input"></ion-input>
+        </ion-item>
+
         <ion-button id="create" onclick="createModal()">Create a Modal</ion-button>
         <ion-button id="create-nested" onclick="createNestedOverlayModal()">Create Nested Overlay Modal</ion-button>
         <ion-button id="present" onclick="presentHiddenModal()">Present a Hidden Modal</ion-button>
         <ion-button id="create-and-present" onclick="createAndPresentModal()">Create and Present a Modal</ion-button>
         <ion-button id="simulate" onclick="backButton()">Simulate Hardware Back Button</ion-button>
+        <ion-button id="create-and-present-toast" onclick="createAndPresentToast()">Create and Present Toast</ion-button>
       </ion-content>
     </div>
   </ion-app>
@@ -51,8 +58,14 @@
           <ion-content class="ion-padding">
             Modal Content
 
+            <ion-item>
+              <ion-label>Text Input</ion-label>
+              <ion-input id="modal-input"></ion-input>
+            </ion-item>
+
             <ion-button id="modal-create">Create a Modal</ion-button>
             <ion-button id="modal-simulate">Simulate Hardware Back Button</ion-button>
+            <ion-button id="modal-toast">Present a Toast</ion-button>
 
           </ion-content>
         `;
@@ -65,6 +78,11 @@
       const simulateButton = div.querySelector('ion-button#modal-simulate');
       simulateButton.onclick = () => {
         backButton();
+      }
+
+      const presentToast = div.querySelector('ion-button#modal-toast');
+      presentToast.onclick = () => {
+        createAndPresentToast();
       }
 
       const modal = await modalController.create({
@@ -89,6 +107,14 @@
       if (modal) {
         modal.present();
       }
+    }
+
+    const createAndPresentToast = async () => {
+      const toast = await toastController.create({
+        message: 'This is a toast!'
+      });
+
+      await toast.present();
     }
 
     const createNestedOverlayModal = async () => {

--- a/core/src/utils/test/overlays/index.html
+++ b/core/src/utils/test/overlays/index.html
@@ -47,8 +47,11 @@
   </ion-app>
 
   <script>
+    let modals = 0;
     const createModal = async () => {
       const div = document.createElement('div');
+      const id = modals++;
+      div.classList.add(`modal-${id}`);
       div.innerHTML = `
           <ion-header>
             <ion-toolbar>
@@ -60,10 +63,11 @@
 
             <ion-item>
               <ion-label>Text Input</ion-label>
-              <ion-input id="modal-input"></ion-input>
+              <ion-input class="modal-input modal-input-${id}"></ion-input>
             </ion-item>
 
             <ion-button id="modal-create">Create a Modal</ion-button>
+            <ion-button id="modal-create-and-present">Create and Present a Modal</ion-button>
             <ion-button id="modal-simulate">Simulate Hardware Back Button</ion-button>
             <ion-button id="modal-toast">Present a Toast</ion-button>
 
@@ -73,6 +77,11 @@
       const createButton = div.querySelector('ion-button#modal-create');
       createButton.onclick = () => {
         createModal();
+      }
+
+      const createAndPresentButton = div.querySelector('ion-button#modal-create-and-present');
+      createAndPresentButton.onclick = () => {
+        createAndPresentModal();
       }
 
       const simulateButton = div.querySelector('ion-button#modal-simulate');

--- a/core/src/utils/test/overlays/overlays.e2e.ts
+++ b/core/src/utils/test/overlays/overlays.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { getActiveElementTagName } from '../utils';
 
 test('overlays: hardware back button: should dismiss a presented overlay', async () => {
   const page = await newE2EPage({ url: '/src/utils/test/overlays?ionic:_testing=true' });
@@ -126,11 +127,6 @@ test('overlays: Nested: should dismiss the top overlay', async () => {
   const modals = await page.$$('ion-modal');
   expect(modals.length).toEqual(0);
 });
-
-const getActiveElementTagName = async (page) => {
-  const activeElement = await page.evaluateHandle(() => document.activeElement);
-  return await page.evaluate(el => el && el.tagName, activeElement);
-}
 
 test('toast should not cause focus trapping', async () => {
   const page = await newE2EPage({ url: '/src/utils/test/overlays?ionic:_testing=true' });

--- a/core/src/utils/test/utils.ts
+++ b/core/src/utils/test/utils.ts
@@ -1,6 +1,11 @@
 import { E2EElement, E2EPage } from '@stencil/core/testing';
 import { ElementHandle } from 'puppeteer';
 
+export const getActiveElementTagName = async (page) => {
+  const activeElement = await page.evaluateHandle(() => document.activeElement);
+  return await page.evaluate(el => el && el.tagName, activeElement);
+}
+
 export const generateE2EUrl = (component: string, type: string, rtl = false): string => {
   let url = `/src/components/${component}/test/${type}?ionic:_testing=true`;
   if (rtl) {

--- a/core/src/utils/test/utils.ts
+++ b/core/src/utils/test/utils.ts
@@ -1,9 +1,23 @@
 import { E2EElement, E2EPage } from '@stencil/core/testing';
 import { ElementHandle } from 'puppeteer';
 
-export const getActiveElementTagName = async (page) => {
+/**
+ * page.evaluate can only return a serializable value,
+ * so it is not possible to return the full element.
+ * Instead, we return an object with some common
+ * properties that you may want to access in a test.
+ */
+export const getActiveElementParent = async (page) => {
   const activeElement = await page.evaluateHandle(() => document.activeElement);
-  return await page.evaluate(el => el && el.tagName, activeElement);
+  return await page.evaluate(el => {
+    const { parentElement } = el;
+    const { className, tagName, id } = parentElement;
+    return {
+      className,
+      tagName,
+      id
+    }
+  }, activeElement);
 }
 
 export const generateE2EUrl = (component: string, type: string, rtl = false): string => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/24733

There are a few issues here:

1. Opening an overlay adds a global `focus` event listener that activates focus trapping. However, we had special logic to prevent toast from adding that global listener. The problem is that this listener is added once globally, so if you open a focus trapping overlay before you open toast, you can defeat this special logic.

2. The focus trapping utility doesn't actually exclude ion-toast like it says it should.

3. The `ion-menu` check in `overlays.ts` was redundant because focus trapping there only ever runs on overlay components.



## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed the `OverlayListenerOptions` options as it was easily defeated given the scenario above.
- Updated focus trapping to run on the top-most, presented non-toast overlay (previously it included toast)
- Removed the `ion-menu` specific check. There are tests in `menu/test/focus-trap` that verify that menu focus trapping with overlays still works.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
