### PR TITLE
fix(datetime): persist minutes column on hour change

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -83,6 +83,7 @@ export class Datetime implements ComponentInterface {
   private inputId = `ion-dt-${datetimeIds++}`;
   private calendarBodyRef?: HTMLElement;
   private popoverRef?: HTMLIonPopoverElement;
+  private minutesPickerColumnRef?: HTMLIonPickerColumnInternalElement;
   private clearFocusVisible?: () => void;
   private overlayIsPresenting = false;
 
@@ -1345,7 +1346,7 @@ export class Datetime implements ComponentInterface {
     ampmItems: PickerColumnItem[],
     use24Hour: boolean
   ) {
-    const { color, activePartsClone, workingParts } = this;
+    const { color, activePartsClone, workingParts, minutesPickerColumnRef } = this;
 
     return (
       <ion-picker-internal>
@@ -1364,10 +1365,20 @@ export class Datetime implements ComponentInterface {
               hour: ev.detail.value
             });
 
+            if (minutesPickerColumnRef) {
+              raf(() => {
+                // When the time picker is re-rendered, the minutes columns does not
+                // scroll to the correct position. This is a workaround to ensure
+                // that the minutes column displays the correct value.
+                minutesPickerColumnRef!.scrollActiveItemIntoView();
+              });
+            }
+
             ev.stopPropagation();
           }}
         ></ion-picker-column-internal>
         <ion-picker-column-internal
+          ref={ref => this.minutesPickerColumnRef = ref}
           color={color}
           value={activePartsClone.minute}
           items={minutesItems}

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -83,7 +83,6 @@ export class Datetime implements ComponentInterface {
   private inputId = `ion-dt-${datetimeIds++}`;
   private calendarBodyRef?: HTMLElement;
   private popoverRef?: HTMLIonPopoverElement;
-  private minutesPickerColumnRef?: HTMLIonPickerColumnInternalElement;
   private clearFocusVisible?: () => void;
   private overlayIsPresenting = false;
 
@@ -1346,7 +1345,7 @@ export class Datetime implements ComponentInterface {
     ampmItems: PickerColumnItem[],
     use24Hour: boolean
   ) {
-    const { color, activePartsClone, workingParts, minutesPickerColumnRef } = this;
+    const { color, activePartsClone, workingParts } = this;
 
     return (
       <ion-picker-internal>
@@ -1365,20 +1364,10 @@ export class Datetime implements ComponentInterface {
               hour: ev.detail.value
             });
 
-            if (minutesPickerColumnRef) {
-              raf(() => {
-                // When the time picker is re-rendered, the minutes columns does not
-                // scroll to the correct position. This is a workaround to ensure
-                // that the minutes column displays the correct value.
-                minutesPickerColumnRef!.scrollActiveItemIntoView();
-              });
-            }
-
             ev.stopPropagation();
           }}
         ></ion-picker-column-internal>
         <ion-picker-column-internal
-          ref={ref => this.minutesPickerColumnRef = ref}
           color={color}
           value={activePartsClone.minute}
           items={minutesItems}

--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -118,6 +118,26 @@ export class PickerColumnInternal implements ComponentInterface {
     }
   }
 
+  componentDidRender() {
+    const { activeItem, el, items, isColumnVisible, value } = this;
+
+    if (isColumnVisible) {
+      if (activeItem) {
+        if (el.scrollTop !== this.getScrollTopPositionForElement(activeItem)) {
+          // Scroll the active item into the view if after rendering
+          // it is still not visible
+          this.scrollActiveItemIntoView();
+        }
+      } else if (items[0].value !== value) {
+        // If the picker column does not have an active item and the current value
+        // does not match the first item in the picker column, that means
+        // the value is out of bounds. In this case, we assign the value to the
+        // first item to match the scroll position of the column.
+        this.value = items[0].value;
+      }
+    }
+  }
+
   /** @internal  */
   @Method()
   async scrollActiveItemIntoView() {
@@ -128,10 +148,14 @@ export class PickerColumnInternal implements ComponentInterface {
     }
   }
 
+  private getScrollTopPositionForElement(target: HTMLElement) {
+    // (Vertical offset from parent) - (three empty picker rows) + (half the height of the target to ensure the scroll triggers)
+    return target.offsetTop - (3 * target.clientHeight) + (target.clientHeight / 2);
+  }
+
   private centerPickerItemInView = (target: HTMLElement, smooth = true) => {
     this.el.scroll({
-      // (Vertical offset from parent) - (three empty picker rows) + (half the height of the target to ensure the scroll triggers)
-      top: target.offsetTop - (3 * target.clientHeight) + (target.clientHeight / 2),
+      top: this.getScrollTopPositionForElement(target),
       left: 0,
       behavior: smooth ? 'smooth' : undefined
     });
@@ -160,6 +184,7 @@ export class PickerColumnInternal implements ComponentInterface {
 
     this.isActive = true;
   }
+
 
   /**
    * When the column scrolls, the component

--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -185,7 +185,6 @@ export class PickerColumnInternal implements ComponentInterface {
     this.isActive = true;
   }
 
-
   /**
    * When the column scrolls, the component
    * needs to determine which item is centered

--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -131,7 +131,7 @@ export class PickerColumnInternal implements ComponentInterface {
            */
           this.scrollActiveItemIntoView();
         }
-      } else if (items[0].value !== value) {
+      } else if (items[0]?.value !== value) {
         /**
          * If the picker column does not have an active item and the current value
          * does not match the first item in the picker column, that means

--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -124,15 +124,21 @@ export class PickerColumnInternal implements ComponentInterface {
     if (isColumnVisible) {
       if (activeItem) {
         if (el.scrollTop !== this.getScrollTopPositionForElement(activeItem)) {
-          // Scroll the active item into the view if after rendering
-          // it is still not visible
+          /**
+           * Scroll the active item into the view if after rendering
+           * it is still not visible
+           *
+           */
           this.scrollActiveItemIntoView();
         }
       } else if (items[0].value !== value) {
-        // If the picker column does not have an active item and the current value
-        // does not match the first item in the picker column, that means
-        // the value is out of bounds. In this case, we assign the value to the
-        // first item to match the scroll position of the column.
+        /**
+         * If the picker column does not have an active item and the current value
+         * does not match the first item in the picker column, that means
+         * the value is out of bounds. In this case, we assign the value to the
+         * first item to match the scroll position of the column.
+         *
+         */
         this.value = items[0].value;
       }
     }

--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -119,18 +119,11 @@ export class PickerColumnInternal implements ComponentInterface {
   }
 
   componentDidRender() {
-    const { activeItem, el, items, isColumnVisible, value } = this;
+    const { activeItem, items, isColumnVisible, value } = this;
 
     if (isColumnVisible) {
       if (activeItem) {
-        if (el.scrollTop !== this.getScrollTopPositionForElement(activeItem)) {
-          /**
-           * Scroll the active item into the view if after rendering
-           * it is still not visible
-           *
-           */
-          this.scrollActiveItemIntoView();
-        }
+        this.scrollActiveItemIntoView();
       } else if (items[0]?.value !== value) {
         /**
          * If the picker column does not have an active item and the current value
@@ -154,17 +147,20 @@ export class PickerColumnInternal implements ComponentInterface {
     }
   }
 
-  private getScrollTopPositionForElement(target: HTMLElement) {
-    // (Vertical offset from parent) - (three empty picker rows) + (half the height of the target to ensure the scroll triggers)
-    return target.offsetTop - (3 * target.clientHeight) + (target.clientHeight / 2);
-  }
-
   private centerPickerItemInView = (target: HTMLElement, smooth = true) => {
-    this.el.scroll({
-      top: this.getScrollTopPositionForElement(target),
-      left: 0,
-      behavior: smooth ? 'smooth' : undefined
-    });
+    const { el, isColumnVisible } = this;
+    if (isColumnVisible) {
+      // (Vertical offset from parent) - (three empty picker rows) + (half the height of the target to ensure the scroll triggers)
+      const top = target.offsetTop - (3 * target.clientHeight) + (target.clientHeight / 2);
+
+      if (el.scrollTop !== top) {
+        el.scroll({
+          top,
+          left: 0,
+          behavior: smooth ? 'smooth' : undefined
+        });
+      }
+    }
   }
 
   /**

--- a/core/src/components/picker-column-internal/test/basic/e2e.ts
+++ b/core/src/components/picker-column-internal/test/basic/e2e.ts
@@ -1,0 +1,54 @@
+import { E2EPage, newE2EPage } from '@stencil/core/testing';
+
+
+describe('picker-column-internal', () => {
+
+  let page: E2EPage;
+
+  describe('default', () => {
+
+    beforeEach(async () => {
+      page = await newE2EPage({
+        url: '/src/components/picker-column-internal/test/basic?ionic:_testing=true'
+      });
+    });
+
+    it('should render a picker item for each item', async () => {
+      const columns = await page.findAll('ion-picker-column-internal >>> .picker-item:not(.picker-item-empty)');
+      expect(columns.length).toEqual(24);
+    });
+
+    it('should render 6 empty picker items', async () => {
+      const columns = await page.findAll('ion-picker-column-internal >>> .picker-item-empty');
+      expect(columns.length).toEqual(6);
+    });
+
+    it('should not have an active item when value is not set', async () => {
+      const activeColumn = await page.findAll('ion-picker-column-internal >>> .picker-item-active');
+      expect(activeColumn.length).toEqual(0);
+    });
+
+    it('should have an active item when value is set', async () => {
+      await page.$eval('ion-picker-column-internal#default', (el: any) => {
+        el.value = '12';
+      });
+      await page.waitForChanges();
+
+      const activeColumn = await page.find('ion-picker-column-internal >>> .picker-item-active');
+
+      expect(activeColumn).not.toBeNull();
+    });
+
+    it('scrolling should change the active item', async () => {
+      await page.$eval('ion-picker-column-internal#default', (el: any) => {
+        el.scrollTop = 801;
+      });
+
+      const activeColumn = await page.find('ion-picker-column-internal >>> .picker-item-active');
+
+      expect(activeColumn.innerText).toEqual('23');
+    });
+
+  });
+
+});

--- a/core/src/components/picker-column-internal/test/basic/e2e.ts
+++ b/core/src/components/picker-column-internal/test/basic/e2e.ts
@@ -44,6 +44,8 @@ describe('picker-column-internal', () => {
         el.scrollTop = 801;
       });
 
+      await page.waitForChanges();
+
       const activeColumn = await page.find('ion-picker-column-internal >>> .picker-item-active');
 
       expect(activeColumn.innerText).toEqual('23');

--- a/core/src/components/picker-column-internal/test/basic/index.html
+++ b/core/src/components/picker-column-internal/test/basic/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Picker Column Internal - Basic</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
+  <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+  <script src="../../../../../scripts/testing/scripts.js"></script>
+  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+  <style>
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(250px, 1fr));
+      grid-row-gap: 20px;
+      grid-column-gap: 20px;
+    }
+
+    h2 {
+      font-size: 12px;
+      font-weight: normal;
+
+      color: #6f7378;
+
+      margin-top: 10px;
+      margin-left: 5px;
+    }
+
+    @media screen and (max-width: 800px) {
+      .grid {
+        grid-template-columns: 1fr;
+        padding: 0;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-header translucent="true">
+      <ion-toolbar>
+        <ion-title>Picker Column Internal - Basic</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <div class="grid">
+        <div class="grid-item">
+          <h2>Default</h2>
+          <ion-picker-internal>
+            <ion-picker-column-internal id="default"></ion-picker-column-internal>
+          </ion-picker-internal>
+        </div>
+      </div>
+    </ion-content>
+    <script>
+      const defaultPickerColumn = document.getElementById('default');
+
+      const items = Array(24).fill().map((_, i) => ({
+        text: `${i}`,
+        value: i
+      }));
+
+      defaultPickerColumn.items = items;
+    </script>
+  </ion-app>
+</body>
+
+</html>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When using a `min` value on `ion-datetime` and changing the hour value, the state of the component is updated and re-renders. This causes the minutes column to become disconnected from the actual selected minutes value. This results in the displayed time value being different than the column picker display.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #24821


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

When the picker column is re-rendered, if the value is out of bounds or not scrolled correctly in the view, the picker will attempt to set the active item or scroll the active item into view.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
