### PR TITLE
fix(modal): re-enable swipe gestures when modal is dismissed

### DIFF
--- a/core/src/components/menu/test/focus-trap/e2e.ts
+++ b/core/src/components/menu/test/focus-trap/e2e.ts
@@ -12,7 +12,7 @@ test('menu: focus trap with overlays', async () => {
 
   const ionDidOpen = await page.spyOnEvent('ionDidOpen');
   const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
-  const ionModalDidDismiss= await page.spyOnEvent('ionModalDidDismiss');
+  const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
 
   const menu = await page.find('ion-menu');
   await menu.callMethod('open');
@@ -40,7 +40,6 @@ test('menu: focus trap with content inside overlays', async () => {
 
   const ionDidOpen = await page.spyOnEvent('ionDidOpen');
   const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
-  const ionModalDidDismiss= await page.spyOnEvent('ionModalDidDismiss');
 
   const menu = await page.find('ion-menu');
   await menu.callMethod('open');
@@ -56,4 +55,37 @@ test('menu: focus trap with content inside overlays', async () => {
   await button.click();
 
   expect(await getActiveElementID(page)).toEqual('other-button');
+});
+
+test('menu: should work with swipe gestures after modal is dismissed', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/menu/test/focus-trap?ionic:_testing=true'
+  });
+
+  const ionDidOpen = await page.spyOnEvent('ionDidOpen');
+  const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+  const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
+
+  const menu = await page.find('ion-menu');
+  await menu.callMethod('open');
+  await ionDidOpen.next();
+
+  const openModal = await page.find('#open-modal-button');
+  await openModal.click();
+  await ionModalDidPresent.next();
+
+  const modal = await page.find('ion-modal');
+  await modal.callMethod('dismiss');
+  await ionModalDidDismiss.next();
+
+  await page.mouse.move(30, 168);
+  await page.mouse.down();
+
+  await page.mouse.move(384, 168);
+  await page.mouse.up();
+
+  await page.waitForChanges();
+
+  expect(menu.classList.contains('show-menu')).toBeTruthy();
+
 });

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -527,6 +527,8 @@ export class Modal implements ComponentInterface, OverlayInterface {
       const { delegate } = this.getDelegate();
       await detachComponent(delegate, this.usersElement);
 
+      writeTask(() => this.el.classList.remove('show-modal'));
+
       if (this.animation) {
         this.animation.destroy();
       }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When a modal is opened, the `.show-modal` class is applied. This class prevents the gesture for opening `ion-menu`. The class is never removed when a modal is dismissed, so when the modal is closed, users are unable to open menus through swipe gestures. 

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #24817


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

When the modal is dismissed, the `.show-modal` class is removed from the host element. This allows the menu to be opened through a swipe gesture when the modal is dismissed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Confirmed in the reproduction app with dev build `6.0.10-dev.1645727760.16b0a89`.
