### PR TITLE
fix(item-sliding): close() will maintain disabled state

### DIFF
--- a/core/src/components/item-sliding/item-sliding.tsx
+++ b/core/src/components/item-sliding/item-sliding.tsx
@@ -408,7 +408,7 @@ export class ItemSliding implements ComponentInterface {
         this.state = SlidingState.Disabled;
         this.tmr = undefined;
         if (this.gesture) {
-          this.gesture.enable(true);
+          this.gesture.enable(!this.disabled);
         }
       }, 600) as any;
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When calling the `close()` API, it will always re-enable the swipe gesture regardless of the disabled state. This is undesired behavior, as it will make disabled items interactive. 

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #24747


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

When closing items, the API will set the state of the gesture to the opposite of the disabled state. This is consistent with the behavior of the disabled changed behavior. This keeps disabled items disabled from swiping.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Writing a test for this behavior was unsuccessful, open to input/suggestions. Tried to write an extension of the interactive test that disables all items, closes all items and then attempts to swipe to check if there is an active item. Doing this test, I could not get the test case to fail (with the old and current code). Exploring the test in the browser, I was unable to get the same behavior.

```
test('item-sliding: should remain disabled when programmatically closed', async () => {
  const page = await newE2EPage({
    url: '/src/components/item-sliding/test/interactive?ionic:_testing=true'
  });

  const disableBtn = await page.find('#disable-btn');
  const closeBtn = await page.find('#close-btn');

  await disableBtn.click();

  await page.waitForChanges();

  await closeBtn.click();

  await page.waitForChanges();

  await openItemSliding('#item-0', page);

  const item = await page.find('#item-0');

  expect(item.classList.contains('item-sliding-active-slide')).toBe(false);

});
```
