### PR TITLE
docs(datetime): remove duplicate timezone info

### DIFF
--- a/core/src/components/datetime/readme.md
+++ b/core/src/components/datetime/readme.md
@@ -147,22 +147,6 @@ const zonedTime = dateFnsTz.utcToZonedTime(date, userTimeZone);
 format(zonedTime, 'yyyy-MM-dd HH:mm:ssXXX', { timeZone: userTimeZone });
 ```
 
-## Timezones
-
-### Assigning Date Values
-
-`ion-datetime` does not manipulate or read timezones. Developers will need to pass in a valid ISO-8601 string that is already configured for the user's timezone when assigning a value. If no value is provided, `ion-datetime` will default to the time specified on the user's machine (which will already be in the user's timezone). We recommend using [date-fns](https://date-fns.org) to format the date to ISO-8601.
-
-```typescript
-import { formatISO } from 'date-fns';
-
-const dateString = '2021-01-14T15:00:00.000Z';
-const formattedDateValue = formatISO(new Date(dateString));
-
-// Assign `formattedDateValue` to your `ion-datetime` value.
-
-```
-
 ### Parsing Date Values
 
 The `ionChange` event will emit the date value as an ISO-8601 string in the event payload. It is the developer's responsibility to format it based on their application needs. We recommend using [date-fns](https://date-fns.org) to format the date value.


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


We have two time zone docs. https://github.com/ionic-team/ionic-framework/blob/main/core/src/components/datetime/readme.md#time-zones and https://github.com/ionic-team/ionic-framework/blob/main/core/src/components/datetime/readme.md#timezones.

The first one has more detail so we should stick with that one.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed the duplicate time zone docs

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
