### PR TITLE
fix(datetime): time picker now scrolls to correct value

### DIFF
--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -91,6 +91,7 @@ export class PickerColumnInternal implements ComponentInterface {
       const ev = entries[0];
 
       if (ev.isIntersecting) {
+        this.isColumnVisible = true;
         /**
          * Because this initial call to scrollActiveItemIntoView has to fire before
          * the scroll listener is set up, we need to manage the active class manually.
@@ -101,13 +102,13 @@ export class PickerColumnInternal implements ComponentInterface {
         this.activeItem?.classList.add(PICKER_COL_ACTIVE);
 
         this.initializeScrollListener();
-        this.isColumnVisible = true;
       } else {
+        this.isColumnVisible = false;
+
         if (this.destroyScrollListener) {
           this.destroyScrollListener();
           this.destroyScrollListener = undefined;
         }
-        this.isColumnVisible = false;
       }
     }
     new IntersectionObserver(visibleCallback, { threshold: 0.01 }).observe(this.el);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/24878

The problem is that `scrollActiveItemIntoView` is called before `isColumnVisible` is set to `true`: https://github.com/ionic-team/ionic-framework/blob/main/core/src/components/picker-column-internal/picker-column-internal.tsx#L100

This did not used to be a problem, but with the introduction of the `isColumnVisible` check in https://github.com/ionic-team/ionic-framework/blob/main/core/src/components/picker-column-internal/picker-column-internal.tsx#L152, this caused the initial scroll to no longer happen.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Moved `isColumnVisible` to be set to `true` before calling the scroll operation.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I opted not to add a new test as we do already have a test for this, but the test suite that checks is not working. I am working on fixing the test suite with my Playwright migration.