### PR TITLE
chore(modal): typo for variable / undefined check

### DIFF
--- a/core/src/components/modal/gestures/sheet.ts
+++ b/core/src/components/modal/gestures/sheet.ts
@@ -165,21 +165,21 @@ export const createSheetGesture = (
     const initialStep = 1 - currentBreakpoint;
     const secondToLastBreakpoint = breakpoints.length > 1 ? 1 - breakpoints[1] : undefined;
     const step = initialStep + (detail.deltaY / height);
-    const isAttempingDismissWithCanDismiss = secondToLastBreakpoint !== undefined && step >= secondToLastBreakpoint && canDismissBlocksGesture;
+    const isAttemptingDismissWithCanDismiss = secondToLastBreakpoint !== undefined && step >= secondToLastBreakpoint && canDismissBlocksGesture;
 
     /**
      * If we are blocking the gesture from dismissing,
      * set the max step value so that the sheet cannot be
      * completely hidden.
      */
-    const maxStep = isAttempingDismissWithCanDismiss ? canDismissMaxStep : 0.9999;
+    const maxStep = isAttemptingDismissWithCanDismiss ? canDismissMaxStep : 0.9999;
 
     /**
      * If we are blocking the gesture from
      * dismissing, calculate the spring modifier value
      * this will be added to the starting breakpoint
      * value to give the gesture a spring-like feeling.
-     * Note that when isAttempingDismissWithCanDismiss is true,
+     * Note that when isAttemptingDismissWithCanDismiss is true,
      * the modifier is always added to the breakpoint that
      * appears right after the 0 breakpoint.
      *
@@ -188,7 +188,7 @@ export const createSheetGesture = (
      * why we subtract secondToLastBreakpoint. This lets us get
      * the result as a value from 0 to 1.
      */
-    const processedStep = isAttempingDismissWithCanDismiss ? secondToLastBreakpoint + calculateSpringStep((step - secondToLastBreakpoint) / (maxStep - secondToLastBreakpoint)) : step;
+    const processedStep = isAttemptingDismissWithCanDismiss && secondToLastBreakpoint !== undefined ? secondToLastBreakpoint + calculateSpringStep((step - secondToLastBreakpoint) / (maxStep - secondToLastBreakpoint)) : step;
 
     offset = clamp(0.0001, processedStep, maxStep);
     animation.progressStep(offset);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When building the library, you will receive an error:
> [ ERROR ]  TypeScript: ./src/components/modal/gestures/sheet.ts:191:62
>           Object is possibly 'undefined'.
>
>    L190:       */
>    L191:      const processedStep = isAttempingDismissWithCanDismiss ? secondToLastBreakpoint + calculateSpringStep((st
> [17:58.9]  build failed in 11.12 s


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes spelling of a variable
- Adds undefined check 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
