### PR TITLE
fix(datetime): presentation time emits ionChange once 

### DIFF
--- a/core/src/components/datetime/test/presentation/e2e.ts
+++ b/core/src/components/datetime/test/presentation/e2e.ts
@@ -1,4 +1,4 @@
-import { newE2EPage } from '@stencil/core/testing';
+import { newE2EPage, E2EPage } from '@stencil/core/testing';
 
 test('presentation', async () => {
   const page = await newE2EPage({
@@ -12,4 +12,38 @@ test('presentation', async () => {
   for (const screenshotCompare of screenshotCompares) {
     expect(screenshotCompare).toMatchScreenshot();
   }
+});
+
+describe('presentation: time', () => {
+
+  let page: E2EPage;
+
+  beforeEach(async () => {
+    page = await newE2EPage({
+      url: '/src/components/datetime/test/presentation?ionic:_testing=true'
+    });
+  });
+
+  describe('when the time picker is visible in the view', () => {
+
+    it('manually setting the value should emit ionChange once', async () => {
+      const datetime = await page.find('ion-datetime[presentation="time"]');
+      const didChange = await datetime.spyOnEvent('ionChange');
+
+      await page.$eval('ion-datetime[presentation="time"]', (el: any) => {
+        el.scrollIntoView();
+      });
+
+      await page.$eval('ion-datetime[presentation="time"]', (el: any) => {
+        el.value = '06:02:40';
+      });
+
+      await page.waitForChanges();
+
+      expect(didChange).toHaveReceivedEventTimes(1);
+      expect(didChange).toHaveReceivedEventDetail({ value: '06:02:40' });
+    });
+
+  });
+
 });

--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -67,16 +67,10 @@ export class PickerColumnInternal implements ComponentInterface {
   valueChange() {
     if (this.isColumnVisible) {
       /**
-       * Only scroll the active item into view and emit the value
-       * change, when the picker column is actively visible to the user.
+       * Only scroll the active item into view when the picker column
+       * is actively visible to the user.
        */
-      const { items, value } = this;
       this.scrollActiveItemIntoView();
-
-      const findItem = items.find(item => item.value === value);
-      if (findItem) {
-        this.ionChange.emit(findItem);
-      }
     }
   }
 
@@ -134,6 +128,7 @@ export class PickerColumnInternal implements ComponentInterface {
          *
          */
         this.value = items[0].value;
+        this.emitIonChange();
       }
     }
   }
@@ -145,6 +140,14 @@ export class PickerColumnInternal implements ComponentInterface {
 
     if (activeEl) {
       this.centerPickerItemInView(activeEl, false);
+    }
+  }
+
+  private emitIonChange() {
+    const { items, value } = this;
+    const findItem = items.find(item => item.value === value);
+    if (findItem) {
+      this.ionChange.emit(findItem);
     }
   }
 
@@ -251,6 +254,7 @@ export class PickerColumnInternal implements ComponentInterface {
 
           if (selectedItem.value !== this.value) {
             this.value = selectedItem.value;
+            this.emitIonChange();
             hapticSelectionEnd();
             this.hapticsStarted = false;
           }

--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -127,8 +127,7 @@ export class PickerColumnInternal implements ComponentInterface {
          * first item to match the scroll position of the column.
          *
          */
-        this.value = items[0].value;
-        this.emitIonChange();
+        this.setValue(items[0].value);
       }
     }
   }
@@ -143,8 +142,9 @@ export class PickerColumnInternal implements ComponentInterface {
     }
   }
 
-  private emitIonChange() {
-    const { items, value } = this;
+  private setValue(value?: string | number) {
+    const { items } = this;
+    this.value = value;
     const findItem = items.find(item => item.value === value);
     if (findItem) {
       this.ionChange.emit(findItem);
@@ -253,8 +253,7 @@ export class PickerColumnInternal implements ComponentInterface {
           const selectedItem = this.items[index];
 
           if (selectedItem.value !== this.value) {
-            this.value = selectedItem.value;
-            this.emitIonChange();
+            this.setValue(selectedItem.value);
             hapticSelectionEnd();
             this.hapticsStarted = false;
           }

--- a/core/src/components/picker-column-internal/test/basic/e2e.ts
+++ b/core/src/components/picker-column-internal/test/basic/e2e.ts
@@ -55,8 +55,19 @@ describe('picker-column-internal', () => {
       const pickerColumn = await page.find('#default');
       const ionChangeSpy = await pickerColumn.spyOnEvent('ionChange');
 
-      await page.$eval('ion-picker-column-internal#default', (el: any) => {
+      await page.$eval('#default', (el: any) => {
         el.value = '12';
+      });
+
+      expect(ionChangeSpy).not.toHaveReceivedEvent();
+    });
+
+    it('should emit ionChange when the picker is scrolled', async () => {
+      const pickerColumn = await page.find('#default');
+      const ionChangeSpy = await pickerColumn.spyOnEvent('ionChange');
+
+      await page.$eval('#default', (el: any) => {
+        el.scrollTo(0, 300);
       });
 
       expect(ionChangeSpy).not.toHaveReceivedEvent();

--- a/core/src/components/picker-column-internal/test/basic/e2e.ts
+++ b/core/src/components/picker-column-internal/test/basic/e2e.ts
@@ -70,7 +70,9 @@ describe('picker-column-internal', () => {
         el.scrollTo(0, 300);
       });
 
-      expect(ionChangeSpy).not.toHaveReceivedEvent();
+      await ionChangeSpy.next();
+
+      expect(ionChangeSpy).toHaveReceivedEvent();
     });
 
   });

--- a/core/src/components/picker-column-internal/test/basic/e2e.ts
+++ b/core/src/components/picker-column-internal/test/basic/e2e.ts
@@ -51,6 +51,17 @@ describe('picker-column-internal', () => {
       expect(activeColumn.innerText).toEqual('23');
     });
 
+    it('should not emit ionChange when the value is modified externally', async () => {
+      const pickerColumn = await page.find('#default');
+      const ionChangeSpy = await pickerColumn.spyOnEvent('ionChange');
+
+      await page.$eval('ion-picker-column-internal#default', (el: any) => {
+        el.value = '12';
+      });
+
+      expect(ionChangeSpy).not.toHaveReceivedEvent();
+    });
+
   });
 
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When modifying the value of an `ion-datetime[presentation="time"]` with the picker wheel visible in the viewport; the datetime component will emit 4 `ionChange` events, resulting in an incorrect value and in Angular, an incorrect display of the picker wheel.

For example, when setting the value to `06:02:40`, the emitted events will be:
```
{ value: '06:02:40' }
{ value: '2022-03-20T06:57:00-04:00' }
{ value: '2022-03-20T00:02:00-04:00' }
{ value: '00:02' }
```

This corresponds to:
- The first emission is the `ion-datetime` watch callback for the value being modified/ionChange.
- The second emission is the `ion-picker-column-internal` hour column detecting a change/modifying the value.
- The third emission is the `ion-picker-column-internal` minute column detecting a change/modifying the value.
- The fourth emission is the `ion-picker-column-internal` am/pm column detecting a change/modifying the value.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #24967


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

`ion-datetime[presentation="time"]` will only emit a single `ionChange` event when the value is modified, regardless if the picker wheel is visible in the viewport or not. 

This results in the value correctly reflecting the new datetime value and the display of the component to be correct.

The `ion-picker-column-internal` will not emit `ionChange` events when the value is modified externally. It will only emit change events as a result of selecting a new value or the fallback setting the initial value. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
