### PR TITLE
Allow ion-tab to work with router-view 

### DIFF
--- a/packages/vue/src/components/IonTabs.ts
+++ b/packages/vue/src/components/IonTabs.ts
@@ -16,7 +16,7 @@ export const IonTabs = /*@__PURE__*/ defineComponent({
      * inside of ion-tabs.
      */
     if (slottedContent && slottedContent.length > 0) {
-      routerOutlet = slottedContent.find((child: VNode) => child.type && ((child.type as any).name === 'IonRouterOutlet' || child.type as any).name === 'RouterView');
+      routerOutlet = slottedContent.find((child: VNode) => child.type && ((child.type as any).name === 'IonRouterOutlet' || (child.type as any).name === 'RouterView'));
     }
 
     if (!routerOutlet) {

--- a/packages/vue/src/components/IonTabs.ts
+++ b/packages/vue/src/components/IonTabs.ts
@@ -2,6 +2,7 @@ import { h, defineComponent, VNode } from 'vue';
 
 const WILL_CHANGE = 'ionTabsWillChange';
 const DID_CHANGE = 'ionTabsDidChange';
+const ALLOWED_ROUTER_OUTLET = ['IonRouterOutlet', 'RouterView'];
 
 export const IonTabs = /*@__PURE__*/ defineComponent({
   name: 'IonTabs',
@@ -16,13 +17,16 @@ export const IonTabs = /*@__PURE__*/ defineComponent({
      * inside of ion-tabs.
      */
     if (slottedContent && slottedContent.length > 0) {
-      routerOutlet = slottedContent.find((child: VNode) => child.type && ((child.type as any).name === 'IonRouterOutlet' || (child.type as any).name === 'RouterView'));
+      routerOutlet = slottedContent.find((child: VNode) => child.type && ALLOWED_ROUTER_OUTLET.includes((child.type as any).name));
     }
+
 
     if (!routerOutlet) {
-      throw new Error('IonTabs must contain an IonRouterOutlet or RouterView. See https://ionicframework.com/docs/vue/navigation#working-with-tabs for more information.');
+      throw new Error('IonTabs must contain an IonRouterOutlet at best or RouterView. See https://ionicframework.com/docs/vue/navigation#working-with-tabs for more information.');
     }
-
+    if (!inject('navManager')) { 
+      throw new Error('Your app must use `import { createRouter, createWebHistory } from \'vue-router\'` as router. \n For best transition experience IonTabs must contain an IonRouterOutlet. See https://ionicframework.com/docs/vue/navigation#working-with-tabs for more information.')
+    }
     let childrenToRender = [
       h('div', {
         class: 'tabs-inner',
@@ -46,7 +50,7 @@ export const IonTabs = /*@__PURE__*/ defineComponent({
        */
       const filteredContent = slottedContent.filter((child: VNode) => (
         !child.type ||
-        (child.type && (child.type as any).name !== 'IonRouterOutlet')
+        (child.type && ALLOWED_ROUTER_OUTLET.includes((child.type as any).name))
       ));
 
       const slottedTabBar = filteredContent.find((child: VNode) => child.type && (child.type as any).name === 'IonTabBar');

--- a/packages/vue/src/components/IonTabs.ts
+++ b/packages/vue/src/components/IonTabs.ts
@@ -24,6 +24,10 @@ export const IonTabs = /*@__PURE__*/ defineComponent({
     if (!routerOutlet) {
       throw new Error('IonTabs must contain an IonRouterOutlet at best or RouterView. See https://ionicframework.com/docs/vue/navigation#working-with-tabs for more information.');
     }
+    if (routerOutlet.type.name === 'RouterView') {
+      console.warn('IonTabs must contain an IonRouterOutlet, with RouterView transitions will not work as expected')
+    }
+
     if (!inject('navManager')) { 
       throw new Error('Your app must use `import { createRouter, createWebHistory } from \'@ionic/vue-router\'` as router. \n For best transition experience IonTabs must contain an IonRouterOutlet. See https://ionicframework.com/docs/vue/navigation#working-with-tabs for more information.')
     }

--- a/packages/vue/src/components/IonTabs.ts
+++ b/packages/vue/src/components/IonTabs.ts
@@ -12,15 +12,18 @@ export const IonTabs = /*@__PURE__*/ defineComponent({
     let routerOutlet;
 
     /**
-     * Developers must pass an ion-router-outlet
+     * Developers must pass an ion-router-outlet or router-view
      * inside of ion-tabs.
      */
     if (slottedContent && slottedContent.length > 0) {
       routerOutlet = slottedContent.find((child: VNode) => child.type && (child.type as any).name === 'IonRouterOutlet');
+      if (!routerOutlet) {
+        routerOutlet = slottedContent.find((child: VNode) => child.type && (child.type as any).name === 'RouterView');
+      }
     }
 
     if (!routerOutlet) {
-      throw new Error('IonTabs must contain an IonRouterOutlet. See https://ionicframework.com/docs/vue/navigation#working-with-tabs for more information.');
+      throw new Error('IonTabs must contain an IonRouterOutlet or RouterView. See https://ionicframework.com/docs/vue/navigation#working-with-tabs for more information.');
     }
 
     let childrenToRender = [

--- a/packages/vue/src/components/IonTabs.ts
+++ b/packages/vue/src/components/IonTabs.ts
@@ -16,10 +16,7 @@ export const IonTabs = /*@__PURE__*/ defineComponent({
      * inside of ion-tabs.
      */
     if (slottedContent && slottedContent.length > 0) {
-      routerOutlet = slottedContent.find((child: VNode) => child.type && (child.type as any).name === 'IonRouterOutlet');
-      if (!routerOutlet) {
-        routerOutlet = slottedContent.find((child: VNode) => child.type && (child.type as any).name === 'RouterView');
-      }
+      routerOutlet = slottedContent.find((child: VNode) => child.type && ((child.type as any).name === 'IonRouterOutlet' || child.type as any).name === 'RouterView'));
     }
 
     if (!routerOutlet) {

--- a/packages/vue/src/components/IonTabs.ts
+++ b/packages/vue/src/components/IonTabs.ts
@@ -25,7 +25,7 @@ export const IonTabs = /*@__PURE__*/ defineComponent({
       throw new Error('IonTabs must contain an IonRouterOutlet at best or RouterView. See https://ionicframework.com/docs/vue/navigation#working-with-tabs for more information.');
     }
     if (!inject('navManager')) { 
-      throw new Error('Your app must use `import { createRouter, createWebHistory } from \'vue-router\'` as router. \n For best transition experience IonTabs must contain an IonRouterOutlet. See https://ionicframework.com/docs/vue/navigation#working-with-tabs for more information.')
+      throw new Error('Your app must use `import { createRouter, createWebHistory } from \'@ionic/vue-router\'` as router. \n For best transition experience IonTabs must contain an IonRouterOutlet. See https://ionicframework.com/docs/vue/navigation#working-with-tabs for more information.')
     }
     let childrenToRender = [
       h('div', {

--- a/packages/vue/src/components/IonTabs.ts
+++ b/packages/vue/src/components/IonTabs.ts
@@ -16,7 +16,7 @@ export const IonTabs = /*@__PURE__*/ defineComponent({
      * inside of ion-tabs.
      */
     if (slottedContent && slottedContent.length > 0) {
-      routerOutlet = slottedContent.find((child: VNode) => child.type && ((child.type as any).name === 'IonRouterOutlet' || child.type as any).name === 'RouterView'));
+      routerOutlet = slottedContent.find((child: VNode) => child.type && ((child.type as any).name === 'IonRouterOutlet' || child.type as any).name === 'RouterView');
     }
 
     if (!routerOutlet) {

--- a/packages/vue/src/components/IonTabs.ts
+++ b/packages/vue/src/components/IonTabs.ts
@@ -50,7 +50,7 @@ export const IonTabs = /*@__PURE__*/ defineComponent({
        */
       const filteredContent = slottedContent.filter((child: VNode) => (
         !child.type ||
-        (child.type && ALLOWED_ROUTER_OUTLET.includes((child.type as any).name))
+        (child.type && !ALLOWED_ROUTER_OUTLET.includes((child.type as any).name))
       ));
 
       const slottedTabBar = filteredContent.find((child: VNode) => child.type && (child.type as any).name === 'IonTabBar');


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
i don't use ion-vue-router in my project, but i cannot use ion-tab without it, instead of hacking routing it made possible to use it without. 
The only change is there are no animation any more.
To work the 

Issue Number: [24192](https://github.com/ionic-team/ionic-framework/issues/24192)


## What is the new behavior?

- Allow use of ion-tab with basic routing component

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


## Other information

