### PR TITLE
test(picker-column-internal): emit ionChange on scroll

### DIFF
--- a/core/src/components/picker-column-internal/test/basic/e2e.ts
+++ b/core/src/components/picker-column-internal/test/basic/e2e.ts
@@ -67,7 +67,7 @@ describe('picker-column-internal', () => {
       const ionChangeSpy = await pickerColumn.spyOnEvent('ionChange');
 
       await page.$eval('#default', (el: any) => {
-        el.scrollTo(0, 300);
+        el.scrollTo(0, el.scrollHeight);
       });
 
       await ionChangeSpy.next();


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Flaky e2e test


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The test for validating that `ionChange` is emitting when `ion-picker-column-internal` is scrolled, will occasionally fail. 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Scroll the element to the bottom of the container to force `ionChange` to emit consistently 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I had issues with getting the test case to fail prior (locally). Ran the updated test 10+ times with passing results. Will see if it passes in CI as well. 
