### PR TITLE
fix(angular): routerLink allows opening in a new tab for link elements

### DIFF
--- a/angular/src/directives/navigation/router-link-delegate.ts
+++ b/angular/src/directives/navigation/router-link-delegate.ts
@@ -5,6 +5,12 @@ import { AnimationBuilder, RouterDirection } from '@ionic/core';
 
 import { NavController } from '../../providers/nav-controller';
 
+/**
+ * Adds support for Ionic routing directions and animations to the base Angular router link directive.
+ *
+ * When the router link is clicked, the directive will assign the direction and
+ * animation so that the routing integration will transition correctly.
+ */
 @Directive({
   selector: '[routerLink]',
 })
@@ -31,19 +37,15 @@ export class RouterLinkDelegateDirective implements OnInit, OnChanges {
     this.updateTargetUrlAndHref();
   }
 
+  @HostListener('click')
+  onClick(): void {
+    this.navCtrl.setDirection(this.routerDirection, undefined, undefined, this.routerAnimation);
+  }
+
   private updateTargetUrlAndHref() {
     if (this.routerLink?.urlTree) {
       const href = this.locationStrategy.prepareExternalUrl(this.router.serializeUrl(this.routerLink.urlTree));
       this.elementRef.nativeElement.href = href;
     }
-  }
-
-  /**
-   * @internal
-   */
-  @HostListener('click', ['$event'])
-  onClick(ev: UIEvent): void {
-    this.navCtrl.setDirection(this.routerDirection, undefined, undefined, this.routerAnimation);
-    ev.preventDefault();
   }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Users are unable to ctrl/CMD + click on link elements (`<a routerLink="/">`) to open a link in a new tab.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #24413


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Removes preventing the default behavior on the click event, to re-add support for ctrl/CMD + clicking on a link element to open the URL in a new tab.

Note: Angular's router link directive [source code can be found here](https://github.com/angular/angular/blob/master/packages/router/src/directives/router_link.ts). There is no behavior that prevents the event, so I am uncertain why we did in the first place.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Closing #24440 in favor of this PR (co-authored-by applied to the commit).

Cypress test support for CTRL/CMD + click is pretty tricky/finicky. Opted for not writing tests on this behavior at this time. 

If we would like to support this behavior on our Ionic components in the future, we will likely need to render an `a` tag around the element or swap the inner element to an `a` tag to support the browser default behaviors.
