### PR TITLE
chore(playwright): screenshots are now ignored locally

### DIFF
--- a/.github/workflows/actions/update-reference-screenshots/action.yml
+++ b/.github/workflows/actions/update-reference-screenshots/action.yml
@@ -25,10 +25,16 @@ runs:
       # Configure user as Ionitron
       # and push only the changed .png snapshots
       # to the remote branch.
+      # Screenshots are in .gitignore
+      # to prevent local screenshots from getting
+      # pushed to Git. As a result, we need --force
+      # here so that CI generated screenshots can
+      # get added to git. Screenshot ground truths
+      # should only be added via this CI process.
       run: |
         git config user.name ionitron
         git config user.email hi@ionicframework.com
-        git add src/\*.png
+        git add src/\*.png --force
         git commit -m "chore(): add updated snapshots"
         git push
       shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,6 @@ angular/build/
 # playwright
 core/test-results/
 core/playwright-report/
+core/**/*-snapshots
 
 .npmrc


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Screenshot files are not gitignored. This means that users testing screenshots locally can accidentally push screenshots to git. We only want screenshots generated by CI allowed on git.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- All files in `core/**/*-snapshots` directories (I.e. the directories that playwright puts screenshots in) are now gitignored
- the GH actions task that updates screenshots now uses `--force` when doing `git add` to ensure that CI generated screenshots are added to the repo.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
