### PR TITLE
fix(vue): ensure that only tab pages get added to the tab navigation stack

### DIFF
--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -65,7 +65,6 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
 
   let currentRouteInfo: RouteInfo;
   let incomingRouteParams: RouteParams;
-  let currentTab: string | undefined;
 
   // TODO types
   let historyChangeListeners: any[] = [];
@@ -238,8 +237,7 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
         if (action === 'replace') {
           incomingRouteParams = {
             routerAction: 'replace',
-            routerDirection: 'none',
-            tab: currentTab
+            routerDirection: 'none'
           }
         } else if (action === 'pop') {
           const routeInfo = locationHistory.current(initialHistoryPosition, currentHistoryPosition - delta);
@@ -254,8 +252,7 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
           } else {
             incomingRouteParams = {
               routerAction: 'pop',
-              routerDirection: 'none',
-              tab: currentTab
+              routerDirection: 'none'
             }
           }
         }
@@ -475,8 +472,6 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
    * then IonTabs will not invoke this.
    */
   const handleSetCurrentTab = (tab: string) => {
-    currentTab = tab;
-
     const ri = { ...locationHistory.last() };
     if (ri.tab !== tab) {
       ri.tab = tab;

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -256,11 +256,7 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
             }
           }
         }
-        /**
-         * If there are no incomingRouteParams,
-         * then we should assume that we are pushing
-         * a page in a forward direction.
-         */
+
         if (!incomingRouteParams) {
           incomingRouteParams = {
             routerAction: 'push',

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -259,11 +259,15 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
             }
           }
         }
+        /**
+         * If there are no incomingRouteParams,
+         * then we should assume that we are pushing
+         * a page in a forward direction.
+         */
         if (!incomingRouteParams) {
           incomingRouteParams = {
             routerAction: 'push',
-            routerDirection: direction || 'forward',
-            tab: currentTab
+            routerDirection: direction || 'forward'
           }
         }
       }
@@ -288,7 +292,6 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
         }
 
         if (isPushed) {
-          routeInfo.tab = leavingLocationInfo.tab;
           routeInfo.pushedByRoute = (leavingLocationInfo.pathname !== '') ? leavingLocationInfo.pathname : undefined;
         } else if (routeInfo.routerAction === 'pop') {
           const route = locationHistory.findLastLocation(routeInfo);
@@ -460,6 +463,17 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
     }
   }
 
+  /**
+   * This method is invoked by the IonTabs component
+   * during a history change callback. It is responsible
+   * for ensuring that tabbed routes have the correct
+   * "tab" field in its routeInfo object.
+   *
+   * IonTabs will determine if the current route
+   * is in tabs and assign it the correct tab.
+   * If the current route is not in tabs,
+   * then IonTabs will not invoke this.
+   */
   const handleSetCurrentTab = (tab: string) => {
     currentTab = tab;
 

--- a/packages/vue/test-app/tests/e2e/specs/tabs.js
+++ b/packages/vue/test-app/tests/e2e/specs/tabs.js
@@ -448,7 +448,7 @@ describe('Tabs', () => {
   })
 
   // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/24859
-  it.only('should go back to the root page after navigating between tab and non tab outlets', () => {
+  it('should go back to the root page after navigating between tab and non tab outlets', () => {
     cy.visit('http://localhost:8080');
 
     cy.routerPush('/tabs/tab1');
@@ -480,6 +480,36 @@ describe('Tabs', () => {
     cy.ionPageVisible('tabs');
     cy.ionPageVisible('tab2');
     cy.ionPageDoesNotExist('routing');
+
+    cy.ionBackClick('tab2');
+    cy.ionPageVisible('home');
+    cy.ionPageDoesNotExist('tabs');
+  });
+
+  // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/24859
+  it('should go back to the root page after navigating between tab and non tab outlets', () => {
+    cy.visit('http://localhost:8080');
+
+    cy.routerPush('/tabs/tab1');
+    cy.ionPageVisible('tab1');
+    cy.ionPageHidden('home');
+
+    cy.get('ion-tab-button#tab-button-tab2').click();
+    cy.ionPageHidden('tab1');
+    cy.ionPageVisible('tab2');
+
+    cy.routerPush('/routing');
+    cy.ionPageVisible('routing');
+    cy.ionPageHidden('tabs');
+
+    cy.routerPush('/tabs/tab1');
+    cy.ionPageVisible('tabs');
+    cy.ionPageVisible('tab1');
+    cy.ionPageHidden('routing');
+
+    cy.get('ion-tab-button#tab-button-tab2').click();
+    cy.ionPageHidden('tab1');
+    cy.ionPageVisible('tab2');
 
     cy.ionBackClick('tab2');
     cy.ionPageVisible('home');

--- a/packages/vue/test-app/tests/e2e/specs/tabs.js
+++ b/packages/vue/test-app/tests/e2e/specs/tabs.js
@@ -435,7 +435,7 @@ describe('Tabs', () => {
   });
 
   // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/24432
-  it('should correct replace a route in a child tab route', () => {
+  it('should correctly replace a route in a child tab route', () => {
     cy.visit('http://localhost:8080/tabs');
 
     cy.routerPush('/tabs/tab1/childone');
@@ -446,6 +446,45 @@ describe('Tabs', () => {
     cy.ionPageVisible('tab1');
     cy.ionPageDoesNotExist('tab1childone');
   })
+
+  // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/24859
+  it.only('should go back to the root page after navigating between tab and non tab outlets', () => {
+    cy.visit('http://localhost:8080');
+
+    cy.routerPush('/tabs/tab1');
+    cy.ionPageVisible('tab1');
+    cy.ionPageHidden('home');
+
+    cy.get('ion-tab-button#tab-button-tab2').click();
+    cy.ionPageHidden('tab1');
+    cy.ionPageVisible('tab2');
+
+    cy.routerPush('/routing');
+    cy.ionPageVisible('routing');
+    cy.ionPageHidden('tabs');
+
+    cy.routerPush('/tabs/tab1');
+    cy.ionPageVisible('tabs');
+    cy.ionPageVisible('tab1');
+    cy.ionPageHidden('routing');
+
+    cy.get('ion-tab-button#tab-button-tab2').click();
+    cy.ionPageHidden('tab1');
+    cy.ionPageVisible('tab2');
+
+    cy.routerPush('/routing');
+    cy.ionPageVisible('routing');
+    cy.ionPageHidden('tabs');
+
+    cy.ionBackClick('routing');
+    cy.ionPageVisible('tabs');
+    cy.ionPageVisible('tab2');
+    cy.ionPageDoesNotExist('routing');
+
+    cy.ionBackClick('tab2');
+    cy.ionPageVisible('home');
+    cy.ionPageDoesNotExist('tabs');
+  });
 })
 
 describe('Tabs - Swipe to Go Back', () => {

--- a/packages/vue/test-app/tests/e2e/specs/tabs.js
+++ b/packages/vue/test-app/tests/e2e/specs/tabs.js
@@ -472,45 +472,6 @@ describe('Tabs', () => {
     cy.ionPageHidden('tab1');
     cy.ionPageVisible('tab2');
 
-    cy.routerPush('/routing');
-    cy.ionPageVisible('routing');
-    cy.ionPageHidden('tabs');
-
-    cy.ionBackClick('routing');
-    cy.ionPageVisible('tabs');
-    cy.ionPageVisible('tab2');
-    cy.ionPageDoesNotExist('routing');
-
-    cy.ionBackClick('tab2');
-    cy.ionPageVisible('home');
-    cy.ionPageDoesNotExist('tabs');
-  });
-
-  // Verifies fix for https://github.com/ionic-team/ionic-framework/issues/24859
-  it('should go back to the root page after navigating between tab and non tab outlets', () => {
-    cy.visit('http://localhost:8080');
-
-    cy.routerPush('/tabs/tab1');
-    cy.ionPageVisible('tab1');
-    cy.ionPageHidden('home');
-
-    cy.get('ion-tab-button#tab-button-tab2').click();
-    cy.ionPageHidden('tab1');
-    cy.ionPageVisible('tab2');
-
-    cy.routerPush('/routing');
-    cy.ionPageVisible('routing');
-    cy.ionPageHidden('tabs');
-
-    cy.routerPush('/tabs/tab1');
-    cy.ionPageVisible('tabs');
-    cy.ionPageVisible('tab1');
-    cy.ionPageHidden('routing');
-
-    cy.get('ion-tab-button#tab-button-tab2').click();
-    cy.ionPageHidden('tab1');
-    cy.ionPageVisible('tab2');
-
     cy.ionBackClick('tab2');
     cy.ionPageVisible('home');
     cy.ionPageDoesNotExist('tabs');


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/24859


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- This PR ensures that only IonTabs updated `routeInfo` to add the correct `tab` information. This treats IonTabs as the source of truth for which tab is active so IonRouter does not need to worry about that.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
