### PR TITLE
test(playwright): add event spies

### DIFF
--- a/core/src/utils/test/playwright/eventSpy.ts
+++ b/core/src/utils/test/playwright/eventSpy.ts
@@ -1,0 +1,100 @@
+import type { IonicPage } from './fixtures';
+
+/**
+ * The EventSpy class allows
+ * developers to listen for
+ * a particular event emission and
+ * pass/fail the test based on whether
+ * or not the event was emitted.
+ * Based off https://github.com/ionic-team/stencil/blob/16b8ea4dabb22024872a38bc58ba1dcf1c7cc25b/src/testing/puppeteer/puppeteer-events.ts#L64
+ */
+export class EventSpy {
+  /**
+   * Keeping track of a cursor
+   * ensures that no two spy.next()
+   * calls point to the same event.
+   */
+  private cursor = 0;
+  private queuedHandler: (() => void)[] = [];
+  public events: Event[] = [];
+
+  constructor(public eventName: string) {}
+
+  get length() {
+    return this.events.length;
+  }
+
+  public next() {
+    const { cursor } = this;
+    this.cursor++;
+
+    const next = this.events[cursor];
+    if (next) {
+      return Promise.resolve(next);
+    } else {
+      /**
+       * If the event has not already been
+       * emitted, then add it to the queuedHandler.
+       * When the event is emitted, the push
+       * method is called which results in the
+       * Promise below being resolved.
+       */
+      let resolve: () => void;
+      const promise = new Promise<void>((r) => (resolve = r));
+      // @ts-ignore
+      this.queuedHandler.push(resolve);
+
+      return promise.then(() => this.events[cursor]);
+    }
+  }
+
+  public push(ev: Event) {
+    this.events.push(ev);
+    const next = this.queuedHandler.shift();
+    if (next) {
+      next();
+    }
+  }
+}
+
+/**
+ * Initializes information required to
+ * spy on events.
+ * The ionicOnEvent function is called in the
+ * context of the current page. This lets us
+ * respond to an event listener created within
+ * the page itself.
+ */
+export const initPageEvents = async (page: IonicPage) => {
+  page._e2eEventsIds = 0;
+  page._e2eEvents = new Map();
+
+  await page.exposeFunction('ionicOnEvent', (id: number, ev: any) => {
+    const context = page._e2eEvents.get(id);
+    if (context) {
+      context.callback(ev);
+    }
+  });
+};
+
+/**
+ * Adds a new event listener in the current
+ * page context to updates the _e2eEvents map
+ * when an event is fired.
+ */
+export const addE2EListener = async (page: IonicPage, eventName: string, callback: (ev: any) => void) => {
+  const id = page._e2eEventsIds++;
+  page._e2eEvents.set(id, {
+    eventName,
+    callback,
+  });
+
+  await page.evaluate(
+    ([eventName, id]) => {
+      window.addEventListener(eventName as string, (ev: Event) => {
+        (window as any).ionicOnEvent(id, ev);
+      });
+    },
+    [eventName, id]
+  );
+};

--- a/core/src/utils/test/playwright/fixtures.ts
+++ b/core/src/utils/test/playwright/fixtures.ts
@@ -8,11 +8,15 @@ import type {
   TestInfo,
 } from '@playwright/test';
 import { test as base } from '@playwright/test';
+import { EventSpy, initPageEvents, addE2EListener } from './eventSpy';
 
-type IonicPage = Page & {
+export type IonicPage = Page & {
   goto: (url: string) => Promise<null | Response>;
   setIonViewport: () => Promise<void>;
   getSnapshotSettings: () => string;
+  spyOnEvent: (eventName: string) => Promise<EventSpy>;
+  _e2eEventsIds: number;
+  _e2eEvents: Map<number, any>;
 };
 
 type CustomTestArgs = PlaywrightTestArgs &
@@ -123,6 +127,27 @@ export const test = base.extend<CustomFixtures>({
         height,
       });
     };
+
+    /**
+     * Creates a new EventSpy and listens
+     * on the window for an event.
+     * The test will timeout if the event
+     * never fires.
+     *
+     * Usage:
+     * const ionChange = await page.spyOnEvent('ionChange');
+     * ...
+     * await ionChange.next();
+     */
+    page.spyOnEvent = async (eventName: string): Promise<EventSpy> => {
+      const spy = new EventSpy(eventName);
+
+      await addE2EListener(page, eventName, (ev: Event) => spy.push(ev));
+
+      return spy;
+    };
+
+    initPageEvents(page);
 
     await use(page);
   },

--- a/core/src/utils/test/playwright/fixtures.ts
+++ b/core/src/utils/test/playwright/fixtures.ts
@@ -8,6 +8,7 @@ import type {
   TestInfo,
 } from '@playwright/test';
 import { test as base } from '@playwright/test';
+
 import { EventSpy, initPageEvents, addE2EListener } from './eventSpy';
 
 export type IonicPage = Page & {

--- a/core/src/utils/test/playwright/index.ts
+++ b/core/src/utils/test/playwright/index.ts
@@ -1,0 +1,2 @@
+export * from './fixtures';
+export * from './eventSpy';


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
There is no easy way to wait for CustomEvents in order to fail/pass a test.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a new spy functionality to our custom `test` fixture. It is based off the event spy found in Stencil's puppeteer E2E testing.
- I also created a `playwright` directory that exports multiple utilities to make things easier to manage as we add more utils. The import path is the same.

Usage:

```js
const ionPopoverDidPresent = await page.spyOnEvent('ionPopoverDidPresent');

// click a button to present the popover

await ionPopoverDidPresent.next();
```

If `ionPopoverDidPresent` is never emitted, the `ionPopoverDidPresent.next()` check times out, and the test fails.

Note: Currently this is limited to listening on `window`, but listening on an arbitrary element should be pretty easy to do down the road.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
