### PR TITLE
fix(accordion-group): only allow keyboard interaction if header is focused

### DIFF
--- a/core/src/components/accordion-group/accordion-group.tsx
+++ b/core/src/components/accordion-group/accordion-group.tsx
@@ -102,9 +102,10 @@ export class AccordionGroup implements ComponentInterface {
     }
 
     /**
-     * Make sure focus is in the header, not the body. This ensures that if there are any
-     * interactable elements in the body, their keyboard interaction doesn't get stolen
-     * by the accordion. Example: using up/down keys in ion-textarea.
+     * Make sure focus is in the header, not the body, of the accordion. This ensures
+     * that if there are any interactable elements in the body, their keyboard
+     * interaction doesn't get stolen by the accordion. Example: using up/down keys
+     * in ion-textarea.
      */
     const activeAccordionHeader = activeElement.closest('ion-accordion [slot="header"]');
     if(!activeAccordionHeader) {

--- a/core/src/components/accordion-group/accordion-group.tsx
+++ b/core/src/components/accordion-group/accordion-group.tsx
@@ -101,6 +101,16 @@ export class AccordionGroup implements ComponentInterface {
       return;
     }
 
+    /**
+     * Make sure focus is in the header, not the body. This ensures that if there are any
+     * interactable elements in the body, their keyboard interaction doesn't get stolen
+     * by the accordion. Example: using up/down keys in ion-textarea.
+     */
+    const activeAccordionHeader = activeElement.closest('ion-accordion [slot="header"]');
+    if(!activeAccordionHeader) {
+      return;
+    }
+
     const accordionEl =
       activeElement.tagName === 'ION-ACCORDION' ? activeElement : activeElement.closest('ion-accordion');
     if (!accordionEl) {

--- a/core/src/components/accordion-group/accordion-group.tsx
+++ b/core/src/components/accordion-group/accordion-group.tsx
@@ -108,7 +108,7 @@ export class AccordionGroup implements ComponentInterface {
      * in ion-textarea.
      */
     const activeAccordionHeader = activeElement.closest('ion-accordion [slot="header"]');
-    if(!activeAccordionHeader) {
+    if (!activeAccordionHeader) {
       return;
     }
 

--- a/core/src/components/accordion/test/a11y/e2e.ts
+++ b/core/src/components/accordion/test/a11y/e2e.ts
@@ -5,6 +5,11 @@ const getActiveElementText = async (page) => {
   return page.evaluate((el) => el?.innerText, activeElement);
 };
 
+const getActiveInputID = async (page) => {
+  const activeElement = await page.evaluateHandle(() => document.activeElement);
+  return page.evaluate((el) => el?.closest('ion-input')?.id, activeElement);
+};
+
 test('accordion: a11y', async () => {
   const page = await newE2EPage({
     url: '/src/components/accordion/test/a11y?ionic:_testing=true',
@@ -42,4 +47,17 @@ test('accordion: keyboard navigation', async () => {
 
   await page.keyboard.press('ArrowUp');
   expect(await getActiveElementText(page)).toEqual('Shipping Address');
+
+  // open Shipping Address accordion and move focus to the input inside it
+  await page.keyboard.press('Enter');
+  await page.waitForChanges();
+  await page.keyboard.press('Tab');
+
+  const activeID = await getActiveInputID(page);
+  expect(activeID).toEqual('address1');
+
+  // ensure keyboard interaction doesn't move focus from body
+  await page.keyboard.press('ArrowDown');
+  const activeIDAgain = await getActiveInputID(page);
+  expect(activeIDAgain).toEqual('address1');
 });

--- a/core/src/components/accordion/test/a11y/index.html
+++ b/core/src/components/accordion/test/a11y/index.html
@@ -86,7 +86,7 @@
             <ion-list slot="content">
               <ion-item>
                 <ion-label>Address 1</ion-label>
-                <ion-input type="text"></ion-input>
+                <ion-input id="address1" type="text"></ion-input>
               </ion-item>
               <ion-item>
                 <ion-label>Address 2</ion-label>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Keyboard interaction on accordions applies when focus is in the accordion body. This causes conflicts with form controls and other interactable elements. For example, if you have an `ion-textarea` in the accordion body, hitting the up/down arrow keys to move the textarea cursor will instead move focus between accordions.

The docs say that keyboard controls should only apply when focus is in the header: https://ionicframework.com/docs/api/accordion#keyboard-navigation

<!-- Issues are required for both bug fixes and features. -->
Issue URL: https://github.com/ionic-team/ionic-framework/issues/24819


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Keyboard controls only apply when focus is in the accordion's header.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
