### PR TITLE
fix(datetime): account for 30 and 45 minute timezones when getting current date

### DIFF
--- a/core/src/components/datetime/utils/data.ts
+++ b/core/src/components/datetime/utils/data.ts
@@ -27,7 +27,24 @@ export const getToday = () => {
    * there was a net change of zero hours from the
    * local date.
    */
-  date.setHours(date.getHours() - tzOffset / 60);
+  const adjustedHours = date.getHours() - tzOffset / 60;
+
+  /**
+   * Some timezones have include minute adjustments
+   * such as 30 or 45 minutes.
+   * Example: India Standard Time
+   * Timezone offset: -330 = -5.5 hours.
+   *
+   * As a result, we need to make sure we also
+   * increment the minutes as well.
+   * List of timezones with 30 and 45 minute timezones:
+   * https://www.timeanddate.com/time/time-zones-interesting.html
+   */
+  const minutesRemainder = adjustedHours % 1;
+  const adjustedMinutes = date.getMinutes() + minutesRemainder * 60;
+  date.setHours(adjustedHours);
+  date.setMinutes(adjustedMinutes);
+
   return date.toISOString();
 };
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/25112

The `getToday` function always assumes timezones contain hour offsets. However, there are some timezones that includes minute offsets of either 30 or 45 minutes: https://www.timeanddate.com/time/time-zones-interesting.html

Ionic was not account for these minutes, so the `getToday` value was always off by either 30 or 45 minutes for users in the relevant timezones.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- We now check the minute remainder of the timezone offset:

1. We take the timezone offset in minutes and divide by 60 to get the hours. 
2. From there we take the result mod 1 do get the fractional result. 
3. We multiply this result by 60 to get the fractional result in minutes. 
4. From there we add this to the existing date object.

The date object is smart enough to increment the hour one more time if we give it a value > 60. For example, doing `date.setMinutes(70)` will increment the hour by 1 and set the minutes to 10.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I am investigating ways we can test this. Currently it does not look like Jest lets us mock the timezone between tests. I manually verified in multiple 30/45 minute timezones and the fix does appear to work.