### PR TITLE
fix(all): import path is now correct when using ionic in a stencil app

### DIFF
--- a/core/src/components/footer/footer.tsx
+++ b/core/src/components/footer/footer.tsx
@@ -1,8 +1,9 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, h } from '@stencil/core';
-import { findIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 
 import { getIonMode } from '../../global/ionic-global';
+import { findIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
+
 
 import { handleFooterFade } from './footer.utils';
 

--- a/core/src/components/footer/footer.tsx
+++ b/core/src/components/footer/footer.tsx
@@ -1,6 +1,6 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, h } from '@stencil/core';
-import { findIonContent, getScrollElement, printIonContentErrorMsg } from '@utils/content';
+import { findIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 
 import { getIonMode } from '../../global/ionic-global';
 

--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -1,6 +1,6 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, h, writeTask } from '@stencil/core';
-import { findIonContent, getScrollElement, printIonContentErrorMsg } from '@utils/content';
+import { findIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 
 import { getIonMode } from '../../global/ionic-global';
 import type { Attributes } from '../../utils/helpers';

--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -1,8 +1,8 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, h, writeTask } from '@stencil/core';
-import { findIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 
 import { getIonMode } from '../../global/ionic-global';
+import { findIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 import type { Attributes } from '../../utils/helpers';
 import { inheritAttributes } from '../../utils/helpers';
 import { hostContext } from '../../utils/theme';

--- a/core/src/components/infinite-scroll/infinite-scroll.tsx
+++ b/core/src/components/infinite-scroll/infinite-scroll.tsx
@@ -1,6 +1,6 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h, readTask, writeTask } from '@stencil/core';
-import { findClosestIonContent, getScrollElement, printIonContentErrorMsg } from '@utils/content';
+import { findClosestIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 
 import { getIonMode } from '../../global/ionic-global';
 

--- a/core/src/components/infinite-scroll/infinite-scroll.tsx
+++ b/core/src/components/infinite-scroll/infinite-scroll.tsx
@@ -1,8 +1,9 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h, readTask, writeTask } from '@stencil/core';
-import { findClosestIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 
 import { getIonMode } from '../../global/ionic-global';
+import { findClosestIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
+
 
 @Component({
   tag: 'ion-infinite-scroll',

--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -1,6 +1,6 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h, readTask, writeTask } from '@stencil/core';
-import { findClosestIonContent, getScrollElement, printIonContentErrorMsg } from '@utils/content';
+import { findClosestIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 
 import { getIonMode } from '../../global/ionic-global';
 import type { Animation, Gesture, GestureDetail, RefresherEventDetail } from '../../interface';

--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -1,10 +1,11 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h, readTask, writeTask } from '@stencil/core';
-import { findClosestIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
+
 
 import { getIonMode } from '../../global/ionic-global';
 import type { Animation, Gesture, GestureDetail, RefresherEventDetail } from '../../interface';
 import { getTimeGivenProgression } from '../../utils/animation/cubic-bezier';
+import { findClosestIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 import { clamp, getElementRoot, raf, transitionEndAsync } from '../../utils/helpers';
 import { hapticImpact } from '../../utils/native/haptic';
 

--- a/core/src/components/reorder-group/reorder-group.tsx
+++ b/core/src/components/reorder-group/reorder-group.tsx
@@ -1,6 +1,6 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h } from '@stencil/core';
-import { findClosestIonContent, getScrollElement } from '@utils/content';
+import { findClosestIonContent, getScrollElement } from '../../utils/content';
 
 import { getIonMode } from '../../global/ionic-global';
 import type { Gesture, GestureDetail, ItemReorderEventDetail } from '../../interface';

--- a/core/src/components/reorder-group/reorder-group.tsx
+++ b/core/src/components/reorder-group/reorder-group.tsx
@@ -1,9 +1,10 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h } from '@stencil/core';
-import { findClosestIonContent, getScrollElement } from '../../utils/content';
+
 
 import { getIonMode } from '../../global/ionic-global';
 import type { Gesture, GestureDetail, ItemReorderEventDetail } from '../../interface';
+import { findClosestIonContent, getScrollElement } from '../../utils/content';
 import { hapticSelectionChanged, hapticSelectionEnd, hapticSelectionStart } from '../../utils/native/haptic';
 
 const enum ReorderGroupState {

--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -1,5 +1,4 @@
 import { getScrollElement, scrollByPoint } from '../../content';
-
 import { pointerCoord, raf } from '../../helpers';
 
 import { isFocused, relocateInput } from './common';

--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -1,4 +1,4 @@
-import { getScrollElement, scrollByPoint } from '@utils/content';
+import { getScrollElement, scrollByPoint } from '../../content';
 
 import { pointerCoord, raf } from '../../helpers';
 

--- a/core/src/utils/input-shims/hacks/scroll-padding.ts
+++ b/core/src/utils/input-shims/hacks/scroll-padding.ts
@@ -1,4 +1,4 @@
-import { findClosestIonContent } from '@utils/content';
+import { findClosestIonContent } from '../../content';
 
 const PADDING_TIMER_KEY = '$ionPaddingTimer';
 

--- a/core/src/utils/input-shims/input-shims.ts
+++ b/core/src/utils/input-shims/input-shims.ts
@@ -1,6 +1,5 @@
-import { findClosestIonContent } from '../content';
-
 import type { Config } from '../../interface';
+import { findClosestIonContent } from '../content';
 import { componentOnReady } from '../helpers';
 
 import { enableHideCaretOnScroll } from './hacks/hide-caret';

--- a/core/src/utils/input-shims/input-shims.ts
+++ b/core/src/utils/input-shims/input-shims.ts
@@ -1,4 +1,4 @@
-import { findClosestIonContent } from '@utils/content';
+import { findClosestIonContent } from '../content';
 
 import type { Config } from '../../interface';
 import { componentOnReady } from '../helpers';

--- a/core/src/utils/status-tap.ts
+++ b/core/src/utils/status-tap.ts
@@ -1,5 +1,5 @@
 import { readTask, writeTask } from '@stencil/core';
-import { findClosestIonContent, scrollToTop } from '@utils/content';
+import { findClosestIonContent, scrollToTop } from './content';
 
 import { componentOnReady } from './helpers';
 

--- a/core/src/utils/status-tap.ts
+++ b/core/src/utils/status-tap.ts
@@ -1,6 +1,6 @@
 import { readTask, writeTask } from '@stencil/core';
-import { findClosestIonContent, scrollToTop } from './content';
 
+import { findClosestIonContent, scrollToTop } from './content';
 import { componentOnReady } from './helpers';
 
 export const startStatusTap = () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/25122

This appears to be a Stencil bug, but using a Stencil library with aliased paths inside of another Stencil library causes import errors. This does not happen in non-Stencil apps.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Imports are now correct in Stencil apps

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
