### PR TITLE
fix(modal, popover): do not dismiss when ionDismiss is emitted

### DIFF
--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -723,13 +723,6 @@ export class Modal implements ComponentInterface, OverlayInterface {
     this.dismiss(undefined, BACKDROP);
   };
 
-  private onDismiss = (ev: UIEvent) => {
-    ev.stopPropagation();
-    ev.preventDefault();
-
-    this.dismiss();
-  };
-
   private onLifecycle = (modalEvent: CustomEvent) => {
     const el = this.usersElement;
     const name = LIFECYCLE_MAP[modalEvent.type];
@@ -770,7 +763,6 @@ export class Modal implements ComponentInterface, OverlayInterface {
         }}
         id={modalId}
         onIonBackdropTap={this.onBackdropTap}
-        onIonDismiss={this.onDismiss}
         onIonModalDidPresent={this.onLifecycle}
         onIonModalWillPresent={this.onLifecycle}
         onIonModalWillDismiss={this.onLifecycle}

--- a/core/src/components/popover/popover.tsx
+++ b/core/src/components/popover/popover.tsx
@@ -521,13 +521,6 @@ export class Popover implements ComponentInterface, PopoverInterface {
     return eventMethod(this.el, 'ionPopoverWillDismiss');
   }
 
-  private onDismiss = (ev: UIEvent) => {
-    ev.stopPropagation();
-    ev.preventDefault();
-
-    this.dismiss();
-  };
-
   private onBackdropTap = () => {
     this.dismiss(undefined, BACKDROP);
   };
@@ -613,7 +606,6 @@ export class Popover implements ComponentInterface, PopoverInterface {
         onIonPopoverWillPresent={onLifecycle}
         onIonPopoverWillDismiss={onLifecycle}
         onIonPopoverDidDismiss={onLifecycle}
-        onIonDismiss={this.onDismiss}
         onIonBackdropTap={this.onBackdropTap}
       >
         {!parentPopover && <ion-backdrop tappable={this.backdropDismiss} visible={this.showBackdrop} part="backdrop" />}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/25124

Modal and popover listen for a generic `ionDismiss` event. This was added years ago, but the event itself has not been used for a long time: https://github.com/ionic-team/ionic-framework/blob/bd5b67304d365594ba3a0ead33dacba9b5a584e4/packages/ionic/src/modal/modal.tsx#L32

`ionDismiss` appears to have been added as a testing API during the early development of Ionic v4: https://github.com/ionic-team/ionic-framework/blob/bd5b67304d365594ba3a0ead33dacba9b5a584e4/packages/ionic/src/core-hn/comments-page.tsx#L12

Perhaps it was indeed meant to be a public API, but it was never documented. We also have alternative means of dismissing a modal now, so I am not sure this code is even needed.

With the introduction of `ionDismiss` with `ion-select`, modals and popovers that contain a select are now dismissing when the `ionDismiss` event is emitted from `ion-select`.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `ionDismiss` is no longer listened for in a modal or popover.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
