### PR TITLE
test(range): fix flaky start/end event test

### DIFF
--- a/core/src/components/range/test/basic/e2e.ts
+++ b/core/src/components/range/test/basic/e2e.ts
@@ -29,6 +29,7 @@ test('range: start/end events', async () => {
   const rangeEl = await page.$('#basic');
 
   await dragElementBy(rangeEl, page, 300, 0);
+  await page.waitForChanges();
 
   /**
    * dragElementBy defaults to starting the drag from the middle of the el,
@@ -41,6 +42,7 @@ test('range: start/end events', async () => {
    * Verify both events fire if range is clicked without dragging.
    */
   await dragElementBy(rangeEl, page, 0, 0);
+  await page.waitForChanges();
 
   expect(rangeStart).toHaveReceivedEventDetail({ value: 50 });
   expect(rangeEnd).toHaveReceivedEventDetail({ value: 50 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The `ion-range` test for the `ionKnobMoveStart` and `ionKnobMoveEnd` events fails sometimes.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Test should now pass consistently.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

There's technically a possibility it could still fail, but I ran the updated test dozens of times via CI with no issues, so it seems good to me now.