### PR TITLE
docs(modal, popover): add docs for explaining isOpen behavior

### DIFF
--- a/core/src/components/modal/readme.md
+++ b/core/src/components/modal/readme.md
@@ -12,6 +12,14 @@ There are two ways to use `ion-modal`: inline or via the `modalController`. Each
 
 When using `ion-modal` with Angular, React, or Vue, the component you pass in will be destroyed when the modal is dismissed. As this functionality is provided by the JavaScript framework, using `ion-modal` without a JavaScript framework will not destroy the component you passed in. If this is a needed functionality, we recommend using the `modalController` instead.
 
+### Using isOpen
+
+When using inline modals, developers have access to the `isOpen` property which allows them to control the state of the modal through the state of their application. This is helpful for opening a modal after a state change without needing to explicitly call the `present` method on `ion-modal`.
+
+ Note that `isOpen` uses a one way data binding. This means that a reactive variable that sets `isOpen` to `true` will not be automatically set to `false` when the modal dismisses. Developers need to listen for the `ionModalDidDismiss` or `didDismiss` events and set the reactive variable to `false` themselves.
+ 
+ The reason for this is it prevents the internals of `ion-modal` from being tightly coupled with the state of the application. With a one way data binding, the modal only needs to concern itself with the boolean value that the reactive variable provides. With a two way data binding, the modal needs to concern itself with both the boolean value as well as the existence of the reactive variable itself. This can lead to non-deterministic behaviors and make applications harder to debug.
+
 ### Angular 
 
 Since the component you passed in needs to be created when the modal is presented and destroyed when the modal is dismissed, we are unable to project the content using `<ng-content>` internally. Instead, we use `<ng-container>` which expects an `<ng-template>` to be passed in. As a result, when passing in your component you will need to wrap it in an `<ng-template>`:

--- a/core/src/components/popover/readme.md
+++ b/core/src/components/popover/readme.md
@@ -10,6 +10,14 @@ There are two ways to use `ion-popover`: inline or via the `popoverController`. 
 
 When using `ion-popover` with Angular, React, or Vue, the component you pass in will be destroyed when the popover is dismissed. As this functionality is provided by the JavaScript framework, using `ion-popover` without a JavaScript framework will not destroy the component you passed in. If this is a needed functionality, we recommend using the `popoverController` instead.
 
+### Using isOpen
+
+When using inline popovers, developers have access to the `isOpen` property which allows them to control the state of the popover through the state of their application. This is helpful for opening a popover after a state change without needing to explicitly call the `present` method on `ion-popover`.
+
+ Note that `isOpen` uses a one way data binding. This means that a reactive variable that sets `isOpen` to `true` will not be automatically set to `false` when the popover dismisses. Developers need to listen for the `ionPopoverDidDismiss` or `didDismiss` events and set the reactive variable to `false` themselves.
+ 
+ The reason for this is it prevents the internals of `ion-popover` from being tightly coupled with the state of the application. With a one way data binding, the popover only needs to concern itself with the boolean value that the reactive variable provides. With a two way data binding, the popover needs to concern itself with both the boolean value as well as the existence of the reactive variable itself. This can lead to non-deterministic behaviors and make applications harder to debug.
+
 ### Angular 
 
 Since the component you passed in needs to be created when the popover is presented and destroyed when the popover is dismissed, we are unable to project the content using `<ng-content>` internally. Instead, we use `<ng-container>` which expects an `<ng-template>` to be passed in. As a result, when passing in your component you will need to wrap it in an `<ng-template>`:


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The isOpen one way data binding behavior is not clear in the docs. It is also not clear why the one way data binding exists.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updated the modal and popover docs to highlight the intended behavior of `isOpen` and why it behaves that way.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
