### PR TITLE
fix(select): avoid duplicate dialogs and backdrops when clicking

### DIFF
--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -188,8 +188,8 @@ export class Select implements ComponentInterface {
     if (this.disabled || this.isExpanded) {
       return undefined;
     }
-    const overlay = (this.overlay = await this.createOverlay(event));
     this.isExpanded = true;
+    const overlay = (this.overlay = await this.createOverlay(event));
     overlay.onDidDismiss().then(() => {
       this.overlay = undefined;
       this.isExpanded = false;

--- a/core/src/components/select/test/basic/select.e2e.ts
+++ b/core/src/components/select/test/basic/select.e2e.ts
@@ -1,29 +1,21 @@
-
 import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('select: basic', () => {
-
   test('should not open multiple alert windows when clicked multiple times', async ({ page }) => {
-
     test.info().annotations.push({
       type: 'issue',
-      description: 'https://github.com/ionic-team/ionic-framework/issues/25126'
+      description: 'https://github.com/ionic-team/ionic-framework/issues/25126',
     });
 
     await page.goto(`/src/components/select/test/basic`);
 
     const genderSelect = page.locator('#gender');
 
-    await Promise.all([
-      genderSelect.click(),
-      genderSelect.click(),
-      genderSelect.click()
-    ]);
+    await Promise.all([genderSelect.click(), genderSelect.click(), genderSelect.click()]);
 
     const alerts = await page.$$('ion-alert');
 
     expect(alerts.length).toBe(1);
   });
-
 });

--- a/core/src/components/select/test/basic/select.e2e.ts
+++ b/core/src/components/select/test/basic/select.e2e.ts
@@ -8,11 +8,21 @@ test.describe('select: basic', () => {
       description: 'https://github.com/ionic-team/ionic-framework/issues/25126',
     });
 
-    await page.goto(`/src/components/select/test/basic`);
+    await page.goto('/src/components/select/test/basic');
 
-    const genderSelect = page.locator('#gender');
+    const select = page.locator('#gender');
 
-    await Promise.all([genderSelect.click(), genderSelect.click(), genderSelect.click()]);
+    await select.evaluate((el: HTMLSelectElement) => {
+      /*
+       * Playwright's click() method attempts to scroll to the handle
+       * to perform the action. That is problematic when the overlay
+       * is already visible. We manually click() the element instead
+       * to avoid flaky tests.
+       */
+      el.click();
+      el.click();
+      el.click();
+    });
 
     const alerts = await page.$$('ion-alert');
 

--- a/core/src/components/select/test/basic/select.e2e.ts
+++ b/core/src/components/select/test/basic/select.e2e.ts
@@ -1,0 +1,29 @@
+
+import { expect } from '@playwright/test';
+import { test } from '@utils/test/playwright';
+
+test.describe('select: basic', () => {
+
+  test('should not open multiple alert windows when clicked multiple times', async ({ page }) => {
+
+    test.info().annotations.push({
+      type: 'issue',
+      description: 'https://github.com/ionic-team/ionic-framework/issues/25126'
+    });
+
+    await page.goto(`/src/components/select/test/basic`);
+
+    const genderSelect = page.locator('#gender');
+
+    await Promise.all([
+      genderSelect.click(),
+      genderSelect.click(),
+      genderSelect.click()
+    ]);
+
+    const alerts = await page.$$('ion-alert');
+
+    expect(alerts.length).toBe(1);
+  });
+
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Rapidly clicking an `ion-select` can produce multiple `ion-alert` and backdrops. This is because the internal state flag is only set after the overlay is created (before presenting). You can produce this reliably by manually calling `.click()` multiple times on the same element reference.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #25126


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Sets the flag prior to the overlay being created, this prevents multiple alert/backdrops from being presented.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `6.1.3-dev.11650650446.100eff34` 🟨
