### PR TITLE
test(modal): remove redundant test

### DIFF
--- a/core/src/components/modal/test/sheet/modal.e2e.ts
+++ b/core/src/components/modal/test/sheet/modal.e2e.ts
@@ -52,25 +52,6 @@ test.describe('sheet modal: backdrop', () => {
     await input.click();
     expect(input).toBeFocused();
   });
-  test('input outside sheet modal should not be focusable when backdrop is active', async ({ page }) => {
-    const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
-
-    await page.click('#backdrop-active');
-
-    await ionModalDidPresent.next();
-
-    const input = await page.locator('#root-input input');
-
-    /**
-     * Input is behind the active backdrop
-     * so users will click the backdrop first
-     * before getting the input. Using force
-     * allows us to test focus trapping even
-     * when the backdrop is enabled.
-     */
-    await input.click({ force: true });
-    expect(input).not.toBeFocused();
-  })
 });
 
 test.describe('sheet modal: setting the breakpoint', () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


The test itself was flaky, but I realized that the test is made redundant by `should dismiss the sheet modal when clicking the active backdrop` in the same file. Clicking the backdrop when it is active should dismiss the sheet. When the backdrop is presented, you are never going to be able to click the input with a pointer as the backdrop will receive the click event first.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
