### PR TITLE
chore(ci): fix update screenshot action to account for existing screenshot

### DIFF
--- a/.github/workflows/actions/test-core-screenshot/action.yml
+++ b/.github/workflows/actions/test-core-screenshot/action.yml
@@ -41,10 +41,41 @@ runs:
       shell: bash
       working-directory: ./core
     - name: Test and Update
+      id: test-and-update
       if: inputs.update == 'true'
-      run: npx playwright test --shard=${{ inputs.shard }}/${{ inputs.totalShards }} --update-snapshots
+      # Keep track of the files that were
+      # changed so they can be correctly restored
+      # in the combine step.
+      # To do this, we move only the changed files
+      # to a separate directory, while preserving the
+      # directory structure of the source.
+      # When, we create and archive of these results
+      # so that the combine step can simply
+      # unzip and move the changed files into place.
+      # We have extra logic added so that job runners
+      # that do not have any new screenshots do not create
+      # an unnecessary .zip.
+      # Note that we need to unzip directory to be "core"
+      # which is why we not using the upload-archive
+      # composite step here.
+      run: |
+        npx playwright test --shard=${{ inputs.shard }}/${{ inputs.totalShards }} --update-snapshots
+        git add src/\*.png --force
+        mkdir updated-screenshots
+        cd ../ && rsync -R --progress $(git diff --name-only --cached) core/updated-screenshots
+        if [ -d core/updated-screenshots/core ]; then
+          echo "::set-output name=hasUpdatedScreenshots::$(echo 'true')"
+          cd core/updated-screenshots
+          zip -q -r ../../UpdatedScreenshots-${{ inputs.shard }}-${{ inputs.totalShards }}.zip core
+        fi
       shell: bash
       working-directory: ./core
+    - name: Archive Updated Screenshots
+      if: inputs.update == 'true' && steps.test-and-update.outputs.hasUpdatedScreenshots == 'true'
+      uses: actions/upload-artifact@v2
+      with:
+        name: updated-screenshots-${{ inputs.shard }}-${{ inputs.totalShards }}
+        path: UpdatedScreenshots-${{ inputs.shard }}-${{ inputs.totalShards }}.zip
     - name: Archive Test Results
       # The always() ensures that this step
       # runs even if the previous step fails.
@@ -57,4 +88,4 @@ runs:
       with:
         name: test-results-${{ inputs.shard }}-${{ inputs.totalShards }}
         output: core/TestResults-${{ inputs.shard }}-${{ inputs.totalShards }}.zip
-        paths: core/playwright-report core/src
+        paths: core/playwright-report

--- a/.github/workflows/actions/update-reference-screenshots/action.yml
+++ b/.github/workflows/actions/update-reference-screenshots/action.yml
@@ -1,91 +1,41 @@
-name: 'Test Core Screenshot'
-description: 'Test Core Screenshot'
-inputs:
-  shard:
-    description: 'Playwright Test Shard (ex: 2)'
-  totalShards:
-    description: 'Playwright total number of test shards (ex: 4)'
-  update:
-    description: 'Whether or not to update the reference snapshots'
+name: 'Update Reference Screenshots'
+description: 'Update Reference Screenshots'
+
+on:
+  workflow_dispatch:
+
 runs:
   using: 'composite'
   steps:
     - uses: actions/setup-node@v1
       with:
         node-version: 15.x
-
-    - name: Cache Core Node Modules
-      uses: actions/cache@v2
-      env:
-        cache-name: core-node-modules
+    - uses: actions/download-artifact@v2
       with:
-        path: ./core/node_modules
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./core/package-lock.json') }}-v2
-    - uses: ./.github/workflows/actions/download-archive
-      with:
-        name: ionic-core
-        path: ./core
-        filename: CoreBuild.zip
-    - uses: ./.github/workflows/actions/download-archive
-      with:
-        name: ionic-core-src
-        path: ./core
-        filename: CoreSrc.zip
-    - name: Install Playwright Dependencies
-      run: npx playwright install && npx playwright install-deps
-      shell: bash
-      working-directory: ./core
-    - name: Test
-      if: inputs.update != 'true'
-      run: npx playwright test --shard=${{ inputs.shard }}/${{ inputs.totalShards }}
-      shell: bash
-      working-directory: ./core
-    - name: Test and Update
-      id: test-and-update
-      if: inputs.update == 'true'
-      # Keep track of the files that were
-      # changed so they can be correctly restored
-      # in the combine step.
-      # To do this, we move only the changed files
-      # to a separate directory, while preserving the
-      # directory structure of the source.
-      # When, we create and archive of these results
-      # so that the combine step can simply
-      # unzip and move the changed files into place.
-      # We have extra logic added so that job runners
-      # that do not have any new screenshots do not create
-      # an unnecessary .zip.
-      # Note that we need to unzip directory to be "core"
-      # which is why we not using the upload-archive
-      # composite step here.
+        path: ./artifacts
+    - name: Extract Archives
+      # This finds all .zip files in the ./artifacts
+      # directory, including nested directories.
+      # It then unzips every .zip to the root directory
       run: |
-        npx playwright test --shard=${{ inputs.shard }}/${{ inputs.totalShards }} --update-snapshots
+        find . -type f -name 'UpdatedScreenshots-*.zip' -exec unzip -q -o -d ../ {} \;
+      shell: bash
+      working-directory: ./artifacts
+    - name: Push Screenshots
+      # Configure user as Ionitron
+      # and push only the changed .png snapshots
+      # to the remote branch.
+      # Screenshots are in .gitignore
+      # to prevent local screenshots from getting
+      # pushed to Git. As a result, we need --force
+      # here so that CI generated screenshots can
+      # get added to git. Screenshot ground truths
+      # should only be added via this CI process.
+      run: |
+        git config user.name ionitron
+        git config user.email hi@ionicframework.com
         git add src/\*.png --force
-        mkdir updated-screenshots
-        cd ../ && rsync -R --progress $(git diff --name-only --cached) core/updated-screenshots
-        if [ -d core/updated-screenshots/core ]; then
-          echo "::set-output name=hasUpdatedScreenshots::$(echo 'true')"
-          cd core/updated-screenshots
-          zip -q -r ../../UpdatedScreenshots-${{ inputs.shard }}-${{ inputs.totalShards }}.zip core
-        fi
+        git commit -m "chore(): add updated snapshots"
+        git push
       shell: bash
       working-directory: ./core
-    - name: Archive Updated Screenshots
-      if: inputs.update == 'true' && steps.test-and-update.outputs.hasUpdatedScreenshots == 'true'
-      uses: actions/upload-artifact@v2
-      with:
-        name: updated-screenshots-${{ inputs.shard }}-${{ inputs.totalShards }}
-        path: UpdatedScreenshots-${{ inputs.shard }}-${{ inputs.totalShards }}.zip
-    - name: Archive Test Results
-      # The always() ensures that this step
-      # runs even if the previous step fails.
-      # We want the test results to be archived
-      # even if the test fails in the previous
-      # step, otherwise there would be no way
-      # to debug these tests.
-      if: always()
-      uses: ./.github/workflows/actions/upload-archive
-      with:
-        name: test-results-${{ inputs.shard }}-${{ inputs.totalShards }}
-        output: core/TestResults-${{ inputs.shard }}-${{ inputs.totalShards }}.zip
-        paths: core/playwright-report

--- a/.github/workflows/actions/update-reference-screenshots/action.yml
+++ b/.github/workflows/actions/update-reference-screenshots/action.yml
@@ -1,41 +1,91 @@
-name: 'Update Reference Screenshots'
-description: 'Update Reference Screenshots'
-
-on:
-  workflow_dispatch:
-
+name: 'Test Core Screenshot'
+description: 'Test Core Screenshot'
+inputs:
+  shard:
+    description: 'Playwright Test Shard (ex: 2)'
+  totalShards:
+    description: 'Playwright total number of test shards (ex: 4)'
+  update:
+    description: 'Whether or not to update the reference snapshots'
 runs:
   using: 'composite'
   steps:
     - uses: actions/setup-node@v1
       with:
         node-version: 15.x
-    - uses: actions/download-artifact@v2
+
+    - name: Cache Core Node Modules
+      uses: actions/cache@v2
+      env:
+        cache-name: core-node-modules
       with:
-        path: ./artifacts
-    - name: Extract Archives
-      # This finds all .zip files in the ./artifacts
-      # directory, including nested directories.
-      # It then unzips every .zip to the root directory
-      run: |
-        find . -type f -name '*.zip' -exec unzip -q -o -d ../ -- '{}'  -x '*.zip' \;
-      shell: bash
-      working-directory: ./artifacts
-    - name: Push Screenshots
-      # Configure user as Ionitron
-      # and push only the changed .png snapshots
-      # to the remote branch.
-      # Screenshots are in .gitignore
-      # to prevent local screenshots from getting
-      # pushed to Git. As a result, we need --force
-      # here so that CI generated screenshots can
-      # get added to git. Screenshot ground truths
-      # should only be added via this CI process.
-      run: |
-        git config user.name ionitron
-        git config user.email hi@ionicframework.com
-        git add src/\*.png --force
-        git commit -m "chore(): add updated snapshots"
-        git push
+        path: ./core/node_modules
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./core/package-lock.json') }}-v2
+    - uses: ./.github/workflows/actions/download-archive
+      with:
+        name: ionic-core
+        path: ./core
+        filename: CoreBuild.zip
+    - uses: ./.github/workflows/actions/download-archive
+      with:
+        name: ionic-core-src
+        path: ./core
+        filename: CoreSrc.zip
+    - name: Install Playwright Dependencies
+      run: npx playwright install && npx playwright install-deps
       shell: bash
       working-directory: ./core
+    - name: Test
+      if: inputs.update != 'true'
+      run: npx playwright test --shard=${{ inputs.shard }}/${{ inputs.totalShards }}
+      shell: bash
+      working-directory: ./core
+    - name: Test and Update
+      id: test-and-update
+      if: inputs.update == 'true'
+      # Keep track of the files that were
+      # changed so they can be correctly restored
+      # in the combine step.
+      # To do this, we move only the changed files
+      # to a separate directory, while preserving the
+      # directory structure of the source.
+      # When, we create and archive of these results
+      # so that the combine step can simply
+      # unzip and move the changed files into place.
+      # We have extra logic added so that job runners
+      # that do not have any new screenshots do not create
+      # an unnecessary .zip.
+      # Note that we need to unzip directory to be "core"
+      # which is why we not using the upload-archive
+      # composite step here.
+      run: |
+        npx playwright test --shard=${{ inputs.shard }}/${{ inputs.totalShards }} --update-snapshots
+        git add src/\*.png --force
+        mkdir updated-screenshots
+        cd ../ && rsync -R --progress $(git diff --name-only --cached) core/updated-screenshots
+        if [ -d core/updated-screenshots/core ]; then
+          echo "::set-output name=hasUpdatedScreenshots::$(echo 'true')"
+          cd core/updated-screenshots
+          zip -q -r ../../UpdatedScreenshots-${{ inputs.shard }}-${{ inputs.totalShards }}.zip core
+        fi
+      shell: bash
+      working-directory: ./core
+    - name: Archive Updated Screenshots
+      if: inputs.update == 'true' && steps.test-and-update.outputs.hasUpdatedScreenshots == 'true'
+      uses: actions/upload-artifact@v2
+      with:
+        name: updated-screenshots-${{ inputs.shard }}-${{ inputs.totalShards }}
+        path: UpdatedScreenshots-${{ inputs.shard }}-${{ inputs.totalShards }}.zip
+    - name: Archive Test Results
+      # The always() ensures that this step
+      # runs even if the previous step fails.
+      # We want the test results to be archived
+      # even if the test fails in the previous
+      # step, otherwise there would be no way
+      # to debug these tests.
+      if: always()
+      uses: ./.github/workflows/actions/upload-archive
+      with:
+        name: test-results-${{ inputs.shard }}-${{ inputs.totalShards }}
+        output: core/TestResults-${{ inputs.shard }}-${{ inputs.totalShards }}.zip
+        paths: core/playwright-report


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

The update screenshots test had an issue where updating existing screenshots (as opposed to adding new screenshots) was not working as intended.

Given two test runner:

Runner A that updates Screenshot 1
Runner B that updates Screenshot 2

When the results from Runner A were added to the project, we got an updated Screenshot 1 and the old Screenshot 2.

When the results from Runner B were added to the project, we got an updated Screenshot 2 and an old Screenshot 1. The result is that the updated Screenshot 1 was overwritten by the old Screenshot 1 that got added from Runner B.

-------

This new approach ensures that only the changed screenshots per-runner are added to the archive. The directory structure is preserved, so unzipping and moving the screenshots should allow screenshots to be merged without any conflicts.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
