### PR TITLE
test(modal): remove redundant header swipe test

### DIFF
--- a/core/src/components/modal/test/card-scroll-target/modal.e2e.ts
+++ b/core/src/components/modal/test/card-scroll-target/modal.e2e.ts
@@ -8,18 +8,6 @@ test.describe('card modal - scroll target', () => {
     await page.goto('/src/components/modal/test/card-scroll-target');
   });
   test.describe('card modal: swipe to close', () => {
-    test('it should swipe to close when swiped on the header', async ({ page }) => {
-      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
-      const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
-
-      await page.click('#card');
-      await ionModalDidPresent.next();
-
-      const header = await page.locator('ion-modal ion-header');
-      await dragElementBy(header, page, 0, 500);
-
-      await ionModalDidDismiss.next();
-    });
     test('it should swipe to close when swiped on the content', async ({ page }) => {
       const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
       const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The purpose of the `card-scroll-target` tests is to verify that swiping on the custom content scroll target works as intended. Swiping on the header is not needed as the regular `card` tests already check for this.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed the redundant swiping on the header test for the custom scroll target

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
