### PR TITLE
test(playwright): wait for events to be ready before proceeding

### DIFF
--- a/core/src/utils/test/playwright/playwright-page.ts
+++ b/core/src/utils/test/playwright/playwright-page.ts
@@ -43,7 +43,7 @@ export const test = base.extend<CustomFixtures>({
     page.spyOnEvent = (eventName: string) => spyOnEvent(page, eventName);
 
     // Custom event behavior
-    initPageEvents(page);
+    await initPageEvents(page);
 
     await use(page);
   },


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

I am seeing intermittent test failures here: https://github.com/ionic-team/ionic-framework/runs/6277771155?check_suite_focus=true

I can reproduce the issue locally. However, the tests still failed even when removing the body of my test. I dug deeper and received this error:

```
1) [firefox] › src/components/modal/test/card-refresher/modal.e2e.ts:6:8 › card modal - with refresher › it should not swipe to close on the content due to the presence of the refresher 

    page.exposeFunction: Target closed

        at initPageEvents (/Users/liamdebeasi/Ionic/ionic/core/src/utils/test/playwright/page/event-spy.ts:72:14)
        at Object.page [as fn] (/Users/liamdebeasi/Ionic/ionic/core/src/utils/test/playwright/playwright-page.ts:46:5)

    attachment #1: trace (application/zip) ---------------------------------------------------------
    test-results/src-components-modal-test-card-refresher-modal-23a41-he-content-due-to-the-presence-of-the-refresher-firefox1-repeat73/trace.zip
    Usage:

        npx playwright show-trace test-results/src-components-modal-test-card-refresher-modal-23a41-he-content-due-to-the-presence-of-the-refresher-firefox1-repeat73/trace.zip
```

It appears that `page.exposeFunction` resolving after the test is torn down can cause the test to fail.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- I added an `await` to ensure that `exposeFunction` resolves before proceeding with the test.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
