### PR TITLE
chore(): add stronger typing to the tapclick utility

### DIFF
--- a/core/src/utils/tap-click.ts
+++ b/core/src/utils/tap-click.ts
@@ -172,10 +172,10 @@ const getActivatableTarget = (ev: UIEvent): any => {
      * objects other than Element can be targets too.
      * For example, AudioContext can be a target. In this
      * case, we know that the event is a UIEvent so we
-     * can assume that the path will contain either HTMLElement
+     * can assume that the path will contain either Element
      * or ShadowRoot.
      */
-    const path = ev.composedPath() as HTMLElement[] | ShadowRoot[];
+    const path = ev.composedPath() as Element[] | ShadowRoot[];
     for (let i = 0; i < path.length - 2; i++) {
       const el = path[i];
       if (!(el instanceof ShadowRoot) && el.classList.contains('ion-activatable')) {

--- a/core/src/utils/tap-click.ts
+++ b/core/src/utils/tap-click.ts
@@ -183,11 +183,6 @@ const getActivatableTarget = (ev: UIEvent): any => {
       }
     }
   } else {
-    /**
-     * EventTarget is not always Element.
-     * However, we know that the target will
-     * always be an Element in this scenario.
-     */
     return (ev.target as Element).closest('.ion-activatable');
   }
 };

--- a/core/src/utils/tap-click.ts
+++ b/core/src/utils/tap-click.ts
@@ -167,7 +167,6 @@ export const startTapClick = (config: Config) => {
 
 const getActivatableTarget = (ev: UIEvent): any => {
   if (ev.composedPath) {
-
     /**
      * composedPath returns EventTarget[]. However,
      * objects other than Element can be targets too.

--- a/core/src/utils/tap-click.ts
+++ b/core/src/utils/tap-click.ts
@@ -57,7 +57,7 @@ export const startTapClick = (config: Config) => {
     }
   };
 
-  const pointerDown = (ev: any) => {
+  const pointerDown = (ev: UIEvent) => {
     if (activatableEle || isScrolling()) {
       return;
     }
@@ -165,9 +165,18 @@ export const startTapClick = (config: Config) => {
   doc.addEventListener('contextmenu', onContextMenu, true);
 };
 
-const getActivatableTarget = (ev: any): any => {
+const getActivatableTarget = (ev: UIEvent): any => {
   if (ev.composedPath) {
-    const path = ev.composedPath() as HTMLElement[];
+
+    /**
+     * composedPath returns EventTarget[]. However,
+     * objects other than Element can be targets too.
+     * For example, AudioContext can be a target. In this
+     * case, we know that the event is a UIEvent so we
+     * can assume that the path will contain either HTMLElement
+     * or ShadowRoot.
+     */
+    const path = ev.composedPath() as HTMLElement[] | ShadowRoot[];
     for (let i = 0; i < path.length - 2; i++) {
       const el = path[i];
       if (!(el instanceof ShadowRoot) && el.classList.contains('ion-activatable')) {
@@ -175,7 +184,12 @@ const getActivatableTarget = (ev: any): any => {
       }
     }
   } else {
-    return ev.target.closest('.ion-activatable');
+    /**
+     * EventTarget is not always Element.
+     * However, we know that the target will
+     * always be an HTMLElement in this scenario.
+     */
+    return (ev.target as HTMLElement).closest('.ion-activatable');
   }
 };
 

--- a/core/src/utils/tap-click.ts
+++ b/core/src/utils/tap-click.ts
@@ -186,9 +186,9 @@ const getActivatableTarget = (ev: UIEvent): any => {
     /**
      * EventTarget is not always Element.
      * However, we know that the target will
-     * always be an HTMLElement in this scenario.
+     * always be an Element in this scenario.
      */
-    return (ev.target as HTMLElement).closest('.ion-activatable');
+    return (ev.target as Element).closest('.ion-activatable');
   }
 };
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: Internal ticket


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

According to https://developer.mozilla.org/en-US/docs/Web/API/EventTarget, EventTarget can be an element, document, window, AudioContext, etc. So just doing `ev.composedPath()` will lead to TypeScript errors.

For example, checking `el.classList` on an item in the path array does not work. This is because one of those items could be `Window` which does not have `classList`.

However, we know that the composedPath for tap click will only be comprised of Element/ShadowRoot so we can specify that. Note that I changed `HTMLElement` to `Element` to account for the possibility of SVG elements (ex: ion-icon). I don't think it will make any difference in how we build, but it's technically "more correct".


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
