### PR TITLE
fix(react): present controller overlays in React 18

### DIFF
--- a/packages/react/src/components/createControllerComponent.tsx
+++ b/packages/react/src/components/createControllerComponent.tsx
@@ -1,7 +1,12 @@
 import { OverlayEventDetail } from '@ionic/core/components';
 import React from 'react';
 
-import { attachProps, dashToPascalCase, defineCustomElement, setRef } from './react-component-lib/utils';
+import {
+  attachProps,
+  dashToPascalCase,
+  defineCustomElement,
+  setRef,
+} from './react-component-lib/utils';
 
 interface OverlayBase extends HTMLElement {
   present: () => Promise<void>;
@@ -39,7 +44,7 @@ export const createControllerComponent = <
 
   class Overlay extends React.Component<Props> {
     overlay?: OverlayType;
-    isUnmounted = false;
+    willUnmount = false;
 
     constructor(props: Props) {
       super(props);
@@ -51,6 +56,14 @@ export const createControllerComponent = <
     }
 
     async componentDidMount() {
+      /**
+       * Starting in React v18, strict mode will unmount and remount a component.
+       * See: https://reactjs.org/blog/2022/03/29/react-v18.html#new-strict-mode-behaviors
+       *
+       * We need to reset this flag when the component is re-mounted so that
+       * overlay.present() will be called and the overlay will display.
+       */
+      this.willUnmount = false;
       const { isOpen } = this.props;
       if (isOpen as boolean) {
         this.present();
@@ -58,7 +71,7 @@ export const createControllerComponent = <
     }
 
     componentWillUnmount() {
-      this.isUnmounted = true;
+      this.willUnmount = true;
       if (this.overlay) {
         this.overlay.dismiss();
       }
@@ -77,18 +90,17 @@ export const createControllerComponent = <
       if (this.props.onDidDismiss) {
         this.props.onDidDismiss(event);
       }
-      setRef(this.props.forwardedRef, null)
+      setRef(this.props.forwardedRef, null);
     }
 
     async present(prevProps?: Props) {
-      const {
-        isOpen,
-        onDidDismiss,
-        onDidPresent,
-        onWillDismiss,
-        onWillPresent,
-        ...cProps
-      } = this.props;
+      const { isOpen, onDidDismiss, onDidPresent, onWillDismiss, onWillPresent, ...cProps } =
+        this.props;
+
+      if (this.overlay) {
+        this.overlay.remove();
+      }
+
       this.overlay = await controller.create({
         ...(cProps as any),
       });
@@ -107,8 +119,8 @@ export const createControllerComponent = <
       );
       // Check isOpen again since the value could have changed during the async call to controller.create
       // It's also possible for the component to have become unmounted.
-      if (this.props.isOpen === true && this.isUnmounted === false) {
-        setRef(this.props.forwardedRef, this.overlay)
+      if (this.props.isOpen === true && this.willUnmount === false) {
+        setRef(this.props.forwardedRef, this.overlay);
         await this.overlay.present();
       }
     }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Starting in React 18, while in development mode, React will unmount and re-mount a component: https://reactjs.org/blog/2022/03/29/react-v18.html#new-strict-mode-behaviors. 🙃

This causes issues with internal logic within the `createControllerComponent` that will not present an overlay, if the component will be unmounted.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #25247


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Resets the flag for unmounting when the component is re-mounted.
- `IonLoading` will present when `isOpen` is set to `true`
- `IonAlert` will present when `isOpen` is set to `true`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `6.1.7-dev.11653598324.17fa560b` ✅
