### PR TITLE
fix(datetime): emit ionChange for non-calendar picker presentation

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -442,12 +442,13 @@ export class Datetime implements ComponentInterface {
   @Method()
   async confirm(closeOverlay = false) {
     /**
-     * If highlightActiveParts is false, this means the datetime was inited
-     * without a value, and the user hasn't selected one yet. We shouldn't
-     * update the value in this case, since otherwise it would be mysteriously
-     * set to today.
+     * We only update the value if the presentation is not a calendar picker,
+     * or if `highlightActiveParts` is true; indicating that the user
+     * has selected a date from the calendar picker.
+     *
+     * Otherwise "today" would accidentally be set as the value.
      */
-    if (this.highlightActiveParts) {
+    if (this.highlightActiveParts || !this.isCalendarPicker) {
       /**
        * Prevent convertDataToISO from doing any
        * kind of transformation based on timezone
@@ -521,6 +522,10 @@ export class Datetime implements ComponentInterface {
 
     this.confirm();
   };
+
+  private get isCalendarPicker() {
+    return this.presentation === 'date' || this.presentation === 'date-time' || this.presentation === 'time-date';
+  }
 
   /**
    * Stencil sometimes sets calendarBodyRef to null on rerender, even though

--- a/core/src/components/datetime/test/presentation/datetime.e2e.ts
+++ b/core/src/components/datetime/test/presentation/datetime.e2e.ts
@@ -83,7 +83,6 @@ test.describe('datetime: presentation', () => {
 
     expect(ionChangeSpy.length).toBe(1);
   });
-
 });
 
 test.describe('datetime: presentation: time', () => {

--- a/core/src/components/datetime/test/presentation/datetime.e2e.ts
+++ b/core/src/components/datetime/test/presentation/datetime.e2e.ts
@@ -27,6 +27,63 @@ test.describe('datetime: presentation', () => {
       );
     }
   });
+
+  test('presentation: time: should emit ionChange', async ({ page }) => {
+    await page.goto(`/src/components/datetime/test/presentation`);
+
+    const ionChangeSpy = await page.spyOnEvent('ionChange');
+    await page.locator('select').selectOption('time');
+    await page.waitForChanges();
+
+    await page.locator('text=12 >> nth=0').click();
+
+    await ionChangeSpy.next();
+
+    expect(ionChangeSpy.length).toBe(1);
+  });
+
+  test('presentation: month-year: should emit ionChange', async ({ page }) => {
+    await page.goto(`/src/components/datetime/test/presentation`);
+
+    const ionChangeSpy = await page.spyOnEvent('ionChange');
+    await page.locator('select').selectOption('month-year');
+    await page.waitForChanges();
+
+    await page.locator('text=April').click();
+
+    await ionChangeSpy.next();
+
+    expect(ionChangeSpy.length).toBe(1);
+  });
+
+  test('presentation: month: should emit ionChange', async ({ page }) => {
+    await page.goto(`/src/components/datetime/test/presentation`);
+
+    const ionChangeSpy = await page.spyOnEvent('ionChange');
+    await page.locator('select').selectOption('month');
+    await page.waitForChanges();
+
+    await page.locator('text=April').click();
+
+    await ionChangeSpy.next();
+
+    expect(ionChangeSpy.length).toBe(1);
+  });
+
+  test('presentation: year: should emit ionChange', async ({ page }) => {
+    await page.goto(`/src/components/datetime/test/presentation`);
+
+    const ionChangeSpy = await page.spyOnEvent('ionChange');
+    await page.locator('select').selectOption('year');
+    await page.waitForChanges();
+
+    await page.locator('text=2021').click();
+
+    await ionChangeSpy.next();
+
+    expect(ionChangeSpy.length).toBe(1);
+  });
+
 });
 
 test.describe('datetime: presentation: time', () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When the `presentation` is not a calendar picker (`time`, `month-year`, `month` or `year`), selecting a value does not emit `ionChange`, unless the datetime was initialized with a default value. 

This is due to this PR change: #25338

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #25375


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The new value for the datetime will only be set if the check for a calendar picker with a new date selection is `true` or if the presentation of the datetime is of `time`, `month`, `year` or `month-year`. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `6.1.8-dev.11654024993.1c2aa477` 🟨
