### PR TITLE
fix(label): text contents will repaint on change

### DIFF
--- a/core/src/components/label/label.ios.scss
+++ b/core/src/components/label/label.ios.scss
@@ -1,5 +1,5 @@
-@import './label';
-@import './label.ios.vars';
+@import "./label";
+@import "./label.ios.vars";
 
 // iOS Label
 // --------------------------------------------------

--- a/core/src/components/label/label.ios.scss
+++ b/core/src/components/label/label.ios.scss
@@ -1,5 +1,5 @@
-@import "./label";
-@import "./label.ios.vars";
+@import './label';
+@import './label.ios.vars';
 
 // iOS Label
 // --------------------------------------------------
@@ -10,7 +10,6 @@
 
   line-height: $label-ios-text-wrap-line-height;
 }
-
 
 // iOS Stacked & Floating Labels
 // --------------------------------------------------
@@ -23,14 +22,14 @@
 
 :host(.label-floating) {
   @include margin(null, null, 0, null);
-  @include transform(translate3d(0, 29px, 0));
+  @include transform(translate(0, 29px));
   @include transform-origin(start, top);
 
   transition: transform 150ms ease-in-out;
 }
 
 :host-context(.item-textarea).label-floating {
-  @include transform(translate3d(0, 28px, 0));
+  @include transform(translate(0, 28px));
 }
 
 :host-context(.item-has-focus).label-stacked,
@@ -41,7 +40,7 @@
 :host-context(.item-has-focus).label-floating,
 :host-context(.item-has-placeholder:not(.item-input)).label-floating,
 :host-context(.item-has-value).label-floating {
-  @include transform(translate3d(0, 0, 0), scale(.82));
+  @include transform(scale(0.82));
 }
 
 // iOS Typography
@@ -74,7 +73,12 @@
 }
 
 ::slotted(*) p {
-  @include margin($item-ios-paragraph-margin-top, $item-ios-paragraph-margin-end, $item-ios-paragraph-margin-bottom, $item-ios-paragraph-margin-start);
+  @include margin(
+    $item-ios-paragraph-margin-top,
+    $item-ios-paragraph-margin-end,
+    $item-ios-paragraph-margin-bottom,
+    $item-ios-paragraph-margin-start
+  );
 
   font-size: $item-ios-paragraph-font-size;
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

In Mobile Safari, when conditionally rendering an `ion-item` next to another `ion-item` with a floating `ion-label` and dynamic text, the text node will not repaint correctly within the same frame.

For example: (Pseudo code)
```html
<ion-button (click)="update()">Update</ion-button>

<ion-item *ngIf="shouldRender">
  <ion-label position="floating">Text</ion-label>
  <ion-input></ion-input>
</ion-item>
<ion-item>
  <ion-label position="floating">{{ dynamicText }}</ion-label>
  <ion-input></ion-input>
</ion-item>
```

```ts
shouldRender = true;
dynamicText = 'Initial';

update() {
  this.shouldRender = false;
  this.dynamicText = 'Updated';
}
```

In this sample, the `dynamicText` value will remain its initially set value ("Initial"), even after clicking the button to update its state. This will occur until the input/label is interacted with, causing a repaint of the layer.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: Internal (Enterprise)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removes the `transform3d` rules on floating labels, which causes this painting issue to occur in Mobile Safari.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `6.1.9-dev.11654203961.1dc8c64c`

Reproduction app: https://github.com/sean-perkins/webkit-label-transform-paint (note: Issue is only present on _Mobile_ Safari).

In the reproduction app, after selecting the button, you would expect the "ZIP" input label to render with "Post Code".
