### PR TITLE
fix(modal): backdrop animation when backdropBreakpoint is 1

### DIFF
--- a/core/src/components/modal/utils.spec.ts
+++ b/core/src/components/modal/utils.spec.ts
@@ -1,7 +1,6 @@
 import { getBackdropValueForSheet } from './utils';
 
 describe('getBackdropValueForSheet()', () => {
-
   it('should return a valid integer when backdropBreakpoint is 1', () => {
     /**
      * Issue: https://github.com/ionic-team/ionic-framework/issues/25402
@@ -11,5 +10,4 @@ describe('getBackdropValueForSheet()', () => {
     expect(getBackdropValueForSheet(5, backdropBreakpoint)).toBe(4);
     expect(getBackdropValueForSheet(10, backdropBreakpoint)).toBe(9);
   });
-
 });

--- a/core/src/components/modal/utils.spec.ts
+++ b/core/src/components/modal/utils.spec.ts
@@ -1,0 +1,15 @@
+import { getBackdropValueForSheet } from './utils';
+
+describe('getBackdropValueForSheet()', () => {
+
+  it('should return a valid integer when backdropBreakpoint is 1', () => {
+    /**
+     * Issue: https://github.com/ionic-team/ionic-framework/issues/25402
+     */
+    const backdropBreakpoint = 1;
+    expect(getBackdropValueForSheet(1, backdropBreakpoint)).toBe(0);
+    expect(getBackdropValueForSheet(5, backdropBreakpoint)).toBe(4);
+    expect(getBackdropValueForSheet(10, backdropBreakpoint)).toBe(9);
+  });
+
+});

--- a/core/src/components/modal/utils.ts
+++ b/core/src/components/modal/utils.ts
@@ -24,7 +24,7 @@ export const getBackdropValueForSheet = (x: number, backdropBreakpoint: number) 
    * This is simplified from:
    * m = (1 - 0) / (maxBreakpoint - backdropBreakpoint)
    */
-  const slope = 1 / (1 - backdropBreakpoint);
+  const slope = Math.min(1 / (1 - backdropBreakpoint), 1);
 
   /**
    * From here, compute b which is

--- a/core/src/components/modal/utils.ts
+++ b/core/src/components/modal/utils.ts
@@ -23,6 +23,9 @@ export const getBackdropValueForSheet = (x: number, backdropBreakpoint: number) 
    *
    * This is simplified from:
    * m = (1 - 0) / (maxBreakpoint - backdropBreakpoint)
+   *
+   * We prevent the slope from being greater than 1, since with a backdropBreakpoint
+   * value of 1, the slope would evaluate to Infinity.
    */
   const slope = Math.min(1 / (1 - backdropBreakpoint), 1);
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When the `backdropBreakpoint` on a sheet modal is `1`, the calculation for the opacity keyframe animation will return an invalid result (`NaN`). This is due to the calculation evaluating to `x * Infinity + -Infinity`.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #25402


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Prevent the `slope` calculation from returning a value larger than `1`
- Backdrop animation does not flicker solid black when using `backdropBreakpoint` of `1` on a sheet modal and performing a dismiss swipe gesture

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `6.1.9-dev.11654617845.1b4d9725` ✅