### PR TITLE
fix(picker-column-internal): tabbing between columns works

### DIFF
--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -306,8 +306,19 @@ export class PickerColumnInternal implements ComponentInterface {
         <div class="picker-item picker-item-empty">&nbsp;</div>
         <div class="picker-item picker-item-empty">&nbsp;</div>
         {items.map((item, index) => {
+          {
+            /*
+            Users should be able to tab
+            between multiple columns. As a result,
+            we set tabindex here so that tabbing switches
+            between columns instead of buttons. Users
+            can still use arrow keys on the keyboard to
+            navigate the column up and down.
+          */
+          }
           return (
             <button
+              tabindex="-1"
               class={{
                 'picker-item': true,
                 'picker-item-disabled': item.disabled || false,

--- a/core/src/components/picker-internal/test/basic/picker-internal.e2e.ts
+++ b/core/src/components/picker-internal/test/basic/picker-internal.e2e.ts
@@ -12,6 +12,65 @@ test.describe('picker-internal', () => {
     );
   });
 
+  test.describe('picker-internal: focus', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.setContent(`
+        <ion-picker-internal>
+          <ion-picker-column-internal value="full-stack" id="first"></ion-picker-column-internal>
+          <ion-picker-column-internal value="onion" id="second"></ion-picker-column-internal>
+        </ion-picker-internal>
+
+        <script>
+          const columns = document.querySelectorAll('ion-picker-column-internal');
+          columns[0].items = [
+            { text: 'Minified', value: 'minified' },
+            { text: 'Responsive', value: 'responsive' },
+            { text: 'Full Stack', value: 'full-stack' },
+            { text: 'Mobile First', value: 'mobile-first' },
+            { text: 'Serverless', value: 'serverless' },
+          ]
+
+          columns[1].items = [
+            { text: 'Tomato', value: 'tomato' },
+            { text: 'Avocado', value: 'avocado' },
+            { text: 'Onion', value: 'onion' },
+            { text: 'Potato', value: 'potato' },
+            { text: 'Artichoke', value: 'artichoke' },
+          ];
+        </script>
+      `);
+    });
+
+    test('tabbing should correctly move focus between columns', async ({ page }) => {
+      const firstColumn = page.locator('ion-picker-column-internal#first');
+      const secondColumn = page.locator('ion-picker-column-internal#second');
+
+      // Focus first column
+      await page.keyboard.press('Tab');
+      expect(firstColumn).toBeFocused();
+
+      await page.waitForChanges();
+
+      // Focus second column
+      await page.keyboard.press('Tab');
+      expect(secondColumn).toBeFocused();
+    });
+
+    test('tabbing should correctly move focus back', async ({ page }) => {
+      const firstColumn = page.locator('ion-picker-column-internal#first');
+      const secondColumn = page.locator('ion-picker-column-internal#second');
+
+      await secondColumn.focus();
+      expect(secondColumn).toBeFocused();
+
+      await page.waitForChanges();
+
+      // Focus first column
+      await page.keyboard.press('Shift+Tab');
+      expect(firstColumn).toBeFocused();
+    });
+  });
+
   test.describe('within overlay:', () => {
     // TODO (FW-1397): Remove this test.skip when the issue is fixed.
     test.skip(true, 'Mobile Safari and Chrome on Linux renders the selected option incorrectly');


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->

Sean noted in https://github.com/ionic-team/ionic-framework/pull/25389#issuecomment-1154653491 that tabbing between columns broke as a result of our usage of `<button>` for each picker item in picker column internal.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- This PR removes each `<button>` from keyboard tabbing via `tabindex="-1"`. This causes tabbing the focus between columns. Users can still use the arrow keys to select items up/down within a column (this is the behavior that existed prior to the `<button>` change).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
