### PR TITLE
fix(picker-column-internal): switching off an input mode column preserves scroll

### DIFF
--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -264,6 +264,7 @@ export class PickerColumnInternal implements ComponentInterface {
 
         timeout = setTimeout(() => {
           this.isScrolling = false;
+          hapticSelectionEnd();
 
           /**
            * Certain tasks (such as those that
@@ -293,7 +294,6 @@ export class PickerColumnInternal implements ComponentInterface {
 
           if (selectedItem.value !== this.value) {
             this.setValue(selectedItem.value);
-            hapticSelectionEnd();
           }
         }, 250);
       });

--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -24,7 +24,8 @@ import type { PickerColumnItem } from './picker-column-internal-interfaces';
 })
 export class PickerColumnInternal implements ComponentInterface {
   private destroyScrollListener?: () => void;
-  private hapticsStarted = false;
+  private isScrolling = false;
+  private scrollEndCallback?: () => void;
   private isColumnVisible = false;
 
   @State() isActive = false;
@@ -187,11 +188,30 @@ export class PickerColumnInternal implements ComponentInterface {
     const isColumnActive = inputModeColumn === undefined || inputModeColumn === this.el;
 
     if (!useInputMode || !isColumnActive) {
-      this.isActive = false;
+      this.setInputModeActive(false);
       return;
     }
 
-    this.isActive = true;
+    this.setInputModeActive(true);
+  };
+
+  /**
+   * Setting isActive will cause a re-render.
+   * As a result, we do not want to cause the
+   * re-render mid scroll as this will cause
+   * the picker column to jump back to
+   * whatever value was selected at the
+   * start of the scroll interaction.
+   */
+  private setInputModeActive = (state: boolean) => {
+    if (this.isScrolling) {
+      this.scrollEndCallback = () => {
+        this.isActive = state;
+      };
+      return;
+    }
+
+    this.isActive = state;
   };
 
   /**
@@ -213,9 +233,9 @@ export class PickerColumnInternal implements ComponentInterface {
           timeout = undefined;
         }
 
-        if (!this.hapticsStarted) {
+        if (!this.isScrolling) {
           hapticSelectionStart();
-          this.hapticsStarted = true;
+          this.isScrolling = true;
         }
 
         /**
@@ -260,7 +280,19 @@ export class PickerColumnInternal implements ComponentInterface {
           if (selectedItem.value !== this.value) {
             this.setValue(selectedItem.value);
             hapticSelectionEnd();
-            this.hapticsStarted = false;
+            this.isScrolling = false;
+
+            /**
+             * Certain tasks (such as those that
+             * cause re-renders) should only be done
+             * once scrolling has finished, otherwise
+             * flickering may occur.
+             */
+            const { scrollEndCallback } = this;
+            if (scrollEndCallback) {
+              scrollEndCallback();
+              this.scrollEndCallback = undefined;
+            }
           }
         }, 250);
       });

--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -263,6 +263,20 @@ export class PickerColumnInternal implements ComponentInterface {
         activeElement.classList.add(PICKER_COL_ACTIVE);
 
         timeout = setTimeout(() => {
+          this.isScrolling = false;
+
+          /**
+           * Certain tasks (such as those that
+           * cause re-renders) should only be done
+           * once scrolling has finished, otherwise
+           * flickering may occur.
+           */
+          const { scrollEndCallback } = this;
+          if (scrollEndCallback) {
+            scrollEndCallback();
+            this.scrollEndCallback = undefined;
+          }
+
           const dataIndex = activeElement.getAttribute('data-index');
 
           /**
@@ -280,19 +294,6 @@ export class PickerColumnInternal implements ComponentInterface {
           if (selectedItem.value !== this.value) {
             this.setValue(selectedItem.value);
             hapticSelectionEnd();
-            this.isScrolling = false;
-
-            /**
-             * Certain tasks (such as those that
-             * cause re-renders) should only be done
-             * once scrolling has finished, otherwise
-             * flickering may occur.
-             */
-            const { scrollEndCallback } = this;
-            if (scrollEndCallback) {
-              scrollEndCallback();
-              this.scrollEndCallback = undefined;
-            }
           }
         }, 250);
       });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Sean reported an issue where quickly blurring a picker column with `numericInput="true"` causes the scroll position to get reset back to whatever it was at when the scroll gesture started. This was because we updated `this.isActive` mid-scroll. `isActive` is a state variable which causes a re-render whenever its value changes. This resulted in a re-render happening mid scroll.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updated the internal logic to only update `isActive` once scrolling is done.
- If no scrolling is happening then `isActive` will be set right away

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

| `main` | branch |
| ------- | ------- |
| <video src="https://user-images.githubusercontent.com/2721089/173629744-b4b35d0c-cbf3-459f-aa65-1c82a491dd3a.mov"></video> | <video src="https://user-images.githubusercontent.com/2721089/173629771-e1486971-ffa6-4ab7-bcc2-0e7cf7b3d120.mov"></video> |

Note: Capturing an automated test for this is difficult on CI because of how quick the focus change needs to happen. I recommend testing manually at http://localhost:3333/src/components/picker-internal/test/basic on the numeric input pickers.