### PR TITLE
fix(refresher): quickly swiping down no longer causes duplicate refresh

### DIFF
--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -337,6 +337,8 @@ export class Refresher implements ComponentInterface {
         this.state !== RefresherState.Completing &&
         this.scrollEl!.scrollTop === 0,
       onStart: (ev: GestureDetail) => {
+        this.progress = 0;
+
         ev.data = { animation: undefined, didStart: false, cancelled: false };
       },
       onMove: (ev: GestureDetail) => {
@@ -372,10 +374,10 @@ export class Refresher implements ComponentInterface {
           return;
         }
 
+        this.gesture!.enable(false);
+
         writeTask(() => this.scrollEl!.style.removeProperty('--overflow'));
         if (this.progress <= 0.4) {
-          this.gesture!.enable(false);
-
           ev.data.animation.progressEnd(0, this.progress, 500).onFinish(() => {
             this.animations.forEach((ani) => ani.destroy());
             this.animations = [];
@@ -394,6 +396,7 @@ export class Refresher implements ComponentInterface {
           await snapBackAnimation.play();
           this.beginRefresh();
           ev.data.animation.destroy();
+          this.gesture!.enable(true);
         });
       },
     });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/25418

See https://github.com/ionic-team/ionic-framework/issues/25418#issuecomment-1156532270 for explanation of why this happens


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Reset `this.progress` to `0` in the `onStart` callback. This is the same as what the non-native refreshers do.
- This uncovered another issue where quickly swiping to complete caused an error because we were not disabling the gesture correctly. I changed this to always disable the gesture in `onEnd` and then have each animation re-enable the gesture (the snapback animations)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Note: This fix cannot be tested reliably on CI because it requires swiping quickly which cannot be guaranteed on CI.
