### PR TITLE
fix(overlays): focus is not moved if active element is in overlay

### DIFF
--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -430,7 +430,13 @@ export const present = async (
     focusPreviousElementOnDismiss(overlay.el);
   }
 
-  if (overlay.keyboardClose) {
+  /**
+   * If the focused element is already
+   * inside the overlay component then
+   * focus should not be moved from that
+   * to the overlay container.
+   */
+  if (overlay.keyboardClose && !!document.activeElement && !overlay.el.contains(document.activeElement)) {
     overlay.el.focus();
   }
 };

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -436,7 +436,7 @@ export const present = async (
    * focus should not be moved from that
    * to the overlay container.
    */
-  if (overlay.keyboardClose && !!document.activeElement && !overlay.el.contains(document.activeElement)) {
+  if (overlay.keyboardClose && document.activeElement !== null && !overlay.el.contains(document.activeElement)) {
     overlay.el.focus();
   }
 };

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -436,7 +436,7 @@ export const present = async (
    * focus should not be moved from that
    * to the overlay container.
    */
-  if (overlay.keyboardClose && document.activeElement !== null && !overlay.el.contains(document.activeElement)) {
+  if (overlay.keyboardClose && (document.activeElement === null || !overlay.el.contains(document.activeElement))) {
     overlay.el.focus();
   }
 };

--- a/core/src/utils/test/overlays/overlays.e2e.ts
+++ b/core/src/utils/test/overlays/overlays.e2e.ts
@@ -1,0 +1,27 @@
+import { expect } from '@playwright/test';
+import { test } from '@utils/test/playwright';
+
+test.describe('overlays: focus', () => {
+  test('should not focus the overlay container if element inside of overlay is focused', async ({ page }) => {
+    await page.setContent(`
+      <ion-button id="open-modal">Show Modal</ion-button>
+      <ion-modal trigger="open-modal">
+        <ion-content>
+          <ion-input autofocus="true"></ion-input>
+        </ion-content>
+      </ion-modal>
+    `)
+
+    const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+    const button = page.locator('ion-button');
+    const input = page.locator('ion-input');
+
+    await button.click();
+    await input.evaluate((el: HTMLIonInputElement) => el.setFocus());
+
+    await ionModalDidPresent.next();
+    await page.waitForChanges();
+
+    expect(page.locator('ion-input input')).toBeFocused();
+  });
+});

--- a/core/src/utils/test/overlays/overlays.e2e.ts
+++ b/core/src/utils/test/overlays/overlays.e2e.ts
@@ -2,7 +2,9 @@ import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('overlays: focus', () => {
-  test('should not focus the overlay container if element inside of overlay is focused', async ({ page }) => {
+  test('should not focus the overlay container if element inside of overlay is focused', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.metadata.rtl === true, 'RTL tests are not needed as layout is not checked');
+
     await page.setContent(`
       <ion-button id="open-modal">Show Modal</ion-button>
       <ion-modal trigger="open-modal">

--- a/core/src/utils/test/overlays/overlays.e2e.ts
+++ b/core/src/utils/test/overlays/overlays.e2e.ts
@@ -10,7 +10,7 @@ test.describe('overlays: focus', () => {
           <ion-input autofocus="true"></ion-input>
         </ion-content>
       </ion-modal>
-    `)
+    `);
 
     const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
     const button = page.locator('ion-button');


### PR DESCRIPTION
⚠️  Give co-author credit to [MarkChrisLevy](https://github.com/MarkChrisLevy) prior to merge

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/24127 resolves https://github.com/ionic-team/ionic-framework/issues/24820


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Opening an overlay no longer focuses the overlay container if the currently focused element is already inside of the overlay.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
