### PR TITLE
fix(vue): adding class to IonPage no longer hides component

### DIFF
--- a/packages/vue/src/components/IonPage.ts
+++ b/packages/vue/src/components/IonPage.ts
@@ -9,7 +9,7 @@ export const IonPage = /*@__PURE__*/ defineComponent({
   mounted() {
     this.$props.registerIonPage(this.$refs.ionPage);
   },
-  setup(props, { attrs, slots }) {
+  setup(_, { attrs, slots }) {
     return () => {
       return h(
         'div',

--- a/packages/vue/src/components/IonPage.ts
+++ b/packages/vue/src/components/IonPage.ts
@@ -3,7 +3,6 @@ import { h, defineComponent } from 'vue';
 export const IonPage = /*@__PURE__*/ defineComponent({
   name: 'IonPage',
   props: {
-    isInOutlet: { type: Boolean, default: false },
     registerIonPage: { type: Function, default: () => {} }
   },
   mounted() {

--- a/packages/vue/src/components/IonPage.ts
+++ b/packages/vue/src/components/IonPage.ts
@@ -10,14 +10,12 @@ export const IonPage = /*@__PURE__*/ defineComponent({
     this.$props.registerIonPage(this.$refs.ionPage);
   },
   setup(props, { attrs, slots }) {
-    const hidePageClass = (props.isInOutlet) ? 'ion-page-invisible' : '';
     return () => {
-      const existingClasses = attrs.class ?? '';
       return h(
         'div',
         {
           ...attrs,
-          ['class']: `ion-page ${hidePageClass} ${existingClasses}`,
+          ['class']: 'ion-page',
           ref: 'ionPage'
         },
         slots.default && slots.default()

--- a/packages/vue/src/components/IonRouterOutlet.ts
+++ b/packages/vue/src/components/IonRouterOutlet.ts
@@ -427,6 +427,11 @@ See https://ionicframework.com/docs/vue/navigation#ionpage for more information.
        * as a result of a navigation change.
        */
       if (viewItem.registerCallback) {
+        /**
+         * Page should be hidden initially
+         * to avoid flickering.
+         */
+        ionPageEl.classList.add('ion-page-invisible');
         viewItem.registerCallback();
 
       /**

--- a/packages/vue/src/components/IonRouterOutlet.ts
+++ b/packages/vue/src/components/IonRouterOutlet.ts
@@ -466,7 +466,6 @@ See https://ionicframework.com/docs/vue/navigation#ionpage for more information.
         let props = {
           ref: c.vueComponentRef,
           key: c.pathname,
-          isInOutlet: true,
           registerIonPage: (ionPageEl: HTMLElement) => registerIonPage(c, ionPageEl)
         }
 

--- a/packages/vue/test-app/tests/unit/page.spec.ts
+++ b/packages/vue/test-app/tests/unit/page.spec.ts
@@ -62,4 +62,25 @@ describe('IonPage', () => {
     expect(cmp.classes('ion-page')).toBe(true);
     expect(cmp.classes('custom-class')).toBe(true);
   });
+  it('should not re-add ion-page-invisible when setting the class', async () => {
+    const Page1 = {
+      template: `<ion-page :is-in-outlet="true" :class="{ 'custom-class': addClass }"></ion-page>`,
+      name: 'Page1',
+      components: { IonPage },
+      data() {
+        return {
+          addClass: false
+        }
+      }
+    };
+
+    const wrapper = mount(Page1);
+
+    expect(wrapper.classes('custom-class')).toBe(false);
+
+    await wrapper.setData({ addClass: true });
+
+    expect(wrapper.classes('custom-class')).toBe(true);
+    expect(wrapper.classes('ion-page-invisible')).toBe(false);
+  });
 })

--- a/packages/vue/test-app/tests/unit/page.spec.ts
+++ b/packages/vue/test-app/tests/unit/page.spec.ts
@@ -64,7 +64,7 @@ describe('IonPage', () => {
   });
   it('should not re-add ion-page-invisible when setting the class', async () => {
     const Page1 = {
-      template: `<ion-page :is-in-outlet="true" :class="{ 'custom-class': addClass }"></ion-page>`,
+      template: `<ion-page :class="{ 'custom-class': addClass }"></ion-page>`,
       name: 'Page1',
       components: { IonPage },
       data() {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: Internal ticket

Dynamically adding a class to `IonPage` causes the component to re-render. This means that `IonPage` components used inside of `IonRouterOutlet` would get the `.ion-page-invisible` class re-added, even if it was removed: https://github.com/ionic-team/ionic-framework/blob/main/packages/vue/src/components/IonPage.ts#L13

This resulted in the `IonPage` component hiding when a custom class is added. Also, the custom class showed up twice because we re-added it in `existingClasses`: https://github.com/ionic-team/ionic-framework/blob/main/packages/vue/src/components/IonPage.ts#L20


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed `existingClasses`, so the custom class only shows up once.
- Tweaked how we set `ion-page-invisible`. This class is now added in `IonRouterOutlet` (as it is only needed when using routing) when the `IonPage` component is mounted initially.
- The private `isInOutlet` property on `IonPage` was used to determine when to add `ion-page-invisible`. As this class  is now added by `IonRouterOutlet`, the `isInOutlet` property is no longer needed and has been removed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
