### PR TITLE
fix(datetime): add dev warnings when setting out of bounds value

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -11,6 +11,7 @@ import { isRTL } from '../../utils/rtl';
 import { createColorClasses } from '../../utils/theme';
 import type { PickerColumnItem } from '../picker-column-internal/picker-column-internal-interfaces';
 
+import { isAfter, isBefore, isSameDay } from './utils/comparison';
 import {
   generateMonths,
   generateTime,
@@ -326,6 +327,10 @@ export class Datetime implements ComponentInterface {
        */
       const valueDateParts = parseDate(this.value);
       if (valueDateParts) {
+        if (isBefore(valueDateParts, this.minParts) || isAfter(valueDateParts, this.maxParts)) {
+          printIonWarning('The value passed to ion-datetime is earlier than the min or later than the max.');
+        }
+
         const { month, day, year, hour, minute } = valueDateParts;
         const ampm = hour >= 12 ? 'pm' : 'am';
 
@@ -1084,7 +1089,13 @@ export class Datetime implements ComponentInterface {
   private processValue = (value?: string | null) => {
     this.highlightActiveParts = !!value;
     const valueToProcess = parseDate(value || getToday());
-    const { month, day, year, hour, minute, tzOffset } = clampDate(valueToProcess, this.minParts, this.maxParts);
+    const clampedDate = clampDate(valueToProcess, this.minParts, this.maxParts);
+
+    if (!isSameDay(valueToProcess, clampedDate)) {
+      printIonWarning('The value passed to ion-datetime is earlier than the min or later than the max.');
+    }
+
+    const { month, day, year, hour, minute, tzOffset } = clampedDate;
 
     this.setWorkingParts({
       month,

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -11,7 +11,7 @@ import { isRTL } from '../../utils/rtl';
 import { createColorClasses } from '../../utils/theme';
 import type { PickerColumnItem } from '../picker-column-internal/picker-column-internal-interfaces';
 
-import { isAfter, isBefore, isSameDay } from './utils/comparison';
+import { warnIfValueOutOfBounds } from './utils/comparison';
 import {
   generateMonths,
   generateTime,
@@ -327,9 +327,7 @@ export class Datetime implements ComponentInterface {
        */
       const valueDateParts = parseDate(this.value);
       if (valueDateParts) {
-        if (isBefore(valueDateParts, this.minParts) || isAfter(valueDateParts, this.maxParts)) {
-          printIonWarning('The value passed to ion-datetime is earlier than the min or later than the max.');
-        }
+        warnIfValueOutOfBounds(valueDateParts, this.minParts, this.maxParts);
 
         const { month, day, year, hour, minute } = valueDateParts;
         const ampm = hour >= 12 ? 'pm' : 'am';
@@ -1089,13 +1087,11 @@ export class Datetime implements ComponentInterface {
   private processValue = (value?: string | null) => {
     this.highlightActiveParts = !!value;
     const valueToProcess = parseDate(value || getToday());
-    const clampedDate = clampDate(valueToProcess, this.minParts, this.maxParts);
 
-    if (!isSameDay(valueToProcess, clampedDate)) {
-      printIonWarning('The value passed to ion-datetime is earlier than the min or later than the max.');
-    }
+    const { minParts, maxParts } = this;
+    warnIfValueOutOfBounds(valueToProcess, minParts, maxParts);
 
-    const { month, day, year, hour, minute, tzOffset } = clampedDate;
+    const { month, day, year, hour, minute, tzOffset } = clampDate(valueToProcess, minParts, maxParts);
 
     this.setWorkingParts({
       month,

--- a/core/src/components/datetime/test/minmax/datetime.e2e.ts
+++ b/core/src/components/datetime/test/minmax/datetime.e2e.ts
@@ -109,7 +109,7 @@ test.describe('datetime: minmax', () => {
     });
   });
 
-  test.only('setting value outside bounds should show in-bounds month', async ({ page }) => {
+  test('setting value outside bounds should show in-bounds month', async ({ page }) => {
     await page.setContent(`
       <ion-datetime min="2021-06-01" max="2021-06-30" value="2021-05-01"></ion-datetime>
     `);

--- a/core/src/components/datetime/test/minmax/datetime.e2e.ts
+++ b/core/src/components/datetime/test/minmax/datetime.e2e.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test';
+import type { E2EPage } from '@utils/test/playwright';
 import { test } from '@utils/test/playwright';
 
 test.describe('datetime: minmax', () => {
@@ -109,14 +110,28 @@ test.describe('datetime: minmax', () => {
     });
   });
 
-  test('setting value outside bounds should show in-bounds month', async ({ page }) => {
-    await page.setContent(`
-      <ion-datetime min="2021-06-01" max="2021-06-30" value="2021-05-01"></ion-datetime>
-    `);
+  test.describe('setting value outside bounds should show in-bounds month', () => {
+    const testDisplayedMonth = async (page: E2EPage, content: string) => {
+      await page.setContent(content);
+      await page.waitForSelector('.datetime-ready');
 
-    await page.waitForSelector('.datetime-ready');
+      const calendarMonthYear = page.locator('ion-datetime .calendar-month-year');
+      expect(calendarMonthYear).toHaveText('June 2021');
+    };
 
-    const calendarMonthYear = page.locator('ion-datetime .calendar-month-year');
-    expect(calendarMonthYear).toHaveText('June 2021');
+    test('when min is defined', async ({ page }) => {
+      await testDisplayedMonth(page, `<ion-datetime min="2021-06-01" value="2021-05-01"></ion-datetime>`);
+    });
+
+    test('when max is defined', async ({ page }) => {
+      await testDisplayedMonth(page, `<ion-datetime max="2021-06-30" value="2021-07-01"></ion-datetime>`);
+    });
+
+    test('when both min and max are defined', async ({ page }) => {
+      await testDisplayedMonth(
+        page,
+        `<ion-datetime min="2021-06-01" max="2021-06-30" value="2021-05-01"></ion-datetime>`
+      );
+    });
   });
 });

--- a/core/src/components/datetime/test/minmax/datetime.e2e.ts
+++ b/core/src/components/datetime/test/minmax/datetime.e2e.ts
@@ -47,6 +47,7 @@ test.describe('datetime: minmax', () => {
     expect(nextButton).toBeDisabled();
     expect(prevButton).toBeEnabled();
   });
+
   test('datetime: minmax months disabled', async ({ page }) => {
     await page.goto('/src/components/datetime/test/minmax');
     const calendarMonths = page.locator('ion-datetime#inside .calendar-month');
@@ -67,6 +68,7 @@ test.describe('datetime: minmax', () => {
     expect(navButtons.nth(0)).toHaveAttribute('disabled', '');
     expect(navButtons.nth(1)).toHaveAttribute('disabled', '');
   });
+
   test('datetime: min including day should not disable month', async ({ page }) => {
     await page.goto('/src/components/datetime/test/minmax');
     await page.waitForSelector('.datetime-ready');
@@ -77,6 +79,7 @@ test.describe('datetime: minmax', () => {
     expect(calendarMonths.nth(1)).not.toHaveClass(/calendar-month-disabled/);
     expect(calendarMonths.nth(2)).not.toHaveClass(/calendar-month-disabled/);
   });
+
   test.describe('when the datetime does not have a value', () => {
     test('all time values should be available for selection', async ({ page }) => {
       /**
@@ -104,5 +107,16 @@ test.describe('datetime: minmax', () => {
       expect(await hours.count()).toBe(12);
       expect(await minutes.count()).toBe(60);
     });
+  });
+
+  test.only('setting value outside bounds should show in-bounds month', async ({ page }) => {
+    await page.setContent(`
+      <ion-datetime min="2021-06-01" max="2021-06-30" value="2021-05-01"></ion-datetime>
+    `);
+
+    await page.waitForSelector('.datetime-ready');
+
+    const calendarMonthYear = page.locator('ion-datetime .calendar-month-year');
+    expect(calendarMonthYear).toHaveText('June 2021');
   });
 });

--- a/core/src/components/datetime/utils/comparison.ts
+++ b/core/src/components/datetime/utils/comparison.ts
@@ -1,3 +1,5 @@
+import { printIonWarning } from '@utils/logging';
+
 import type { DatetimeParts } from '../datetime-interface';
 
 /**
@@ -35,4 +37,15 @@ export const isAfter = (baseParts: DatetimeParts, compareParts: DatetimeParts) =
       baseParts.day &&
       baseParts.day > compareParts.day!)
   );
+};
+
+export const warnIfValueOutOfBounds = (value: DatetimeParts, min: DatetimeParts, max: DatetimeParts) => {
+  if((min && isBefore(value, min)) || (max && isAfter(value, max))) {
+    printIonWarning(
+      "The value provided to ion-datetime is out of bounds.\n\n" +
+      `Min: ${JSON.stringify(min)}\n` +
+      `Max: ${JSON.stringify(max)}\n` +
+      `Value: ${JSON.stringify(value)}`
+    );
+  }
 };

--- a/core/src/components/datetime/utils/comparison.ts
+++ b/core/src/components/datetime/utils/comparison.ts
@@ -40,12 +40,12 @@ export const isAfter = (baseParts: DatetimeParts, compareParts: DatetimeParts) =
 };
 
 export const warnIfValueOutOfBounds = (value: DatetimeParts, min: DatetimeParts, max: DatetimeParts) => {
-  if((min && isBefore(value, min)) || (max && isAfter(value, max))) {
+  if ((min && isBefore(value, min)) || (max && isAfter(value, max))) {
     printIonWarning(
-      "The value provided to ion-datetime is out of bounds.\n\n" +
-      `Min: ${JSON.stringify(min)}\n` +
-      `Max: ${JSON.stringify(max)}\n` +
-      `Value: ${JSON.stringify(value)}`
+      'The value provided to ion-datetime is out of bounds.\n\n' +
+        `Min: ${JSON.stringify(min)}\n` +
+        `Max: ${JSON.stringify(max)}\n` +
+        `Value: ${JSON.stringify(value)}`
     );
   }
 };


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Originally, assigning a `value` to `ion-datetime` that's sufficiently earlier than the `min` or later than the `max` would lead to a disabled month being displayed, and the user being unable to navigate in either direction. This was mostly resolved here https://github.com/ionic-team/ionic-framework/pull/25351 since both assigning a value and leaving it to the default go through the `processValue` function. The dev experience just needs some polish.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: https://github.com/ionic-team/ionic-framework/issues/24881


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Console warnings for out-of-bounds values are now printed when either assigning an initial `value`, or updating it programmatically.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Tests for console warnings have been flaky in the past, so I didn't include one. I did add a test to ensure an in-bounds month is displayed, though, since the existing tests only cover datetimes with no initial value.