### PR TITLE
fix(input): passive event listener for touch start events

### DIFF
--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -496,7 +496,7 @@ export class Input implements ComponentInterface {
             aria-label="reset"
             type="button"
             class="input-clear-icon"
-            onTouchStart={this.clearTextInput}
+            onPointerDown={this.clearTextInput}
             onMouseDown={this.clearTextInput}
             onKeyDown={this.clearTextOnEnter}
           />

--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -31,7 +31,7 @@ export const enableScrollAssist = (
       jsSetFocus(componentEl, inputEl, contentEl, footerEl, keyboardHeight);
     }
   };
-  componentEl.addEventListener('touchstart', touchStart, true);
+  componentEl.addEventListener('touchstart', touchStart, { capture: true, passive: true });
   componentEl.addEventListener('touchend', touchEnd, true);
 
   return () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When using an input with scroll assist or an input with a clear action, there is violations that are logged in the dev console:

> [Violation] Added non-passive event listener to a scroll-blocking 'touchstart' event.
Consider marking event handler as 'passive' to make the page more responsive.


<!-- Issues are required for both bug fixes and features. -->
Issue URL: #25599


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Refactors Input to use `onPointerDown` instead of `onTouchStart` (confirmed this does not regress the existing bug associated with using `onTouchStart`: #15319)
- Registers passive event listeners in the scroll assist util for `touchstart`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `6.1.14-dev.11657566839.18ed2481` ✅

Since the bug associated with this PR does not have functional problems, it is difficult to know the affected changes, if any. I confirmed that the clear action continues to work in browser and on device. I also confirmed the scroll assist does not appear to have regressed. The originally reporter also confirmed the dev-build.
