### PR TITLE
test(angular): add timeouts to tabs navigation extras test

### DIFF
--- a/angular/test/test-app/cypress/support/commands.js
+++ b/angular/test/test-app/cypress/support/commands.js
@@ -25,7 +25,7 @@
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
 Cypress.Commands.add('ionSwipeToGoBack', (complete = false, selector = 'ion-router-outlet') => {
-  const increment = (complete) ? 60 : 25;
+  const increment = complete ? 60 : 25;
   cy.get(selector)
     .first()
     .trigger('mousedown', 0, 275, { which: 1, force: true })
@@ -37,18 +37,16 @@ Cypress.Commands.add('ionSwipeToGoBack', (complete = false, selector = 'ion-rout
     .wait(50)
     .trigger('mousemove', increment * 4, 275, { which: 1, force: true })
     .wait(50)
-    .trigger('mouseup', increment * 4, 275, { which: 1, force: true })
+    .trigger('mouseup', increment * 4, 275, { which: 1, force: true });
   cy.wait(150);
-})
+});
 
 Cypress.Commands.add('testStack', (selector, expected) => {
   cy.document().then((doc) => {
-    const children = Array.from(
-      doc.querySelector(selector).children
-    ).map(el => el.tagName.toLowerCase());
+    const children = Array.from(doc.querySelector(selector).children).map((el) => el.tagName.toLowerCase());
     expect(children).to.deep.equal(expected);
-  })
-})
+  });
+});
 
 Cypress.Commands.add('testLifeCycle', (selector, expected) => {
   cy.get(`${selector} #ngOnInit`).invoke('text').should('equal', '1');
@@ -56,24 +54,26 @@ Cypress.Commands.add('testLifeCycle', (selector, expected) => {
   cy.get(`${selector} #ionViewDidEnter`).invoke('text').should('equal', expected.ionViewDidEnter.toString());
   cy.get(`${selector} #ionViewWillLeave`).invoke('text').should('equal', expected.ionViewWillLeave.toString());
   cy.get(`${selector} #ionViewDidLeave`).invoke('text').should('equal', expected.ionViewDidLeave.toString());
-})
+});
 
 Cypress.Commands.add('ionPageVisible', (selector) => {
   cy.get(selector)
     .should('have.class', 'ion-page')
     .should('not.have.class', 'ion-page-hidden')
     .should('not.have.class', 'ion-page-invisible')
-    .should('have.length', 1)
-})
+    .should('have.length', 1);
+});
 
 Cypress.Commands.add('ionPageHidden', (selector) => {
-  cy.get(selector)
-    .should('have.class', 'ion-page')
-    .should('have.class', 'ion-page-hidden')
-    .should('have.length', 1)
-})
+  cy.get(selector).should('have.class', 'ion-page').should('have.class', 'ion-page-hidden').should('have.length', 1);
+});
 
 Cypress.Commands.add('ionPageDoesNotExist', (selector) => {
-  cy.get(selector)
-    .should('not.exist')
+  cy.get(selector).should('not.exist');
+});
+
+Cypress.Commands.add('ionTabClick', (tabText) => {
+  // TODO: Figure out how to get rid of wait. It's a workaround for flakiness in CI.
+  cy.wait(250);
+  cy.contains('ion-tab-button', tabText).click({ force: true });
 });

--- a/angular/test/test-app/cypress/support/index.d.ts
+++ b/angular/test/test-app/cypress/support/index.d.ts
@@ -63,6 +63,11 @@ declare namespace Cypress {
      * ```
      */
     ionPageDoesNotExist(selector: string): Chainable<any>
+
+    /**
+     * Clicks on a tab button with the given text.
+     */
+    ionTabClick(tabText: string): Chainable<any>;
   }
 }
 

--- a/angular/test/test-app/e2e/src/tabs.spec.ts
+++ b/angular/test/test-app/e2e/src/tabs.spec.ts
@@ -230,13 +230,13 @@ describe('Tabs', () => {
       tab.find('#goto-next').click();
       testTabTitle('Tab 1 - Page 2 (2)');
 
-      cy.get('#tab-button-contact').click();
+      cy.wait(300).get('#tab-button-contact').click();
       testTabTitle('Tab 2 - Page 1');
 
-      cy.get('#tab-button-account').click();
+      cy.wait(300).get('#tab-button-account').click();
       testTabTitle('Tab 1 - Page 2 (2)');
 
-      cy.get('#tab-button-account').click();
+      cy.wait(300).get('#tab-button-account').click();
       testTabTitle('Tab 1 - Page 1');
 
       testUrlContains(rootUrl);

--- a/angular/test/test-app/e2e/src/tabs.spec.ts
+++ b/angular/test/test-app/e2e/src/tabs.spec.ts
@@ -230,13 +230,13 @@ describe('Tabs', () => {
       tab.find('#goto-next').click();
       testTabTitle('Tab 1 - Page 2 (2)');
 
-      cy.wait(300).get('#tab-button-contact').click();
+      cy.ionTabClick('Tab Two');
       testTabTitle('Tab 2 - Page 1');
 
-      cy.wait(300).get('#tab-button-account').click();
+      cy.ionTabClick('Tab One');
       testTabTitle('Tab 1 - Page 2 (2)');
 
-      cy.wait(300).get('#tab-button-account').click();
+      cy.ionTabClick('Tab One');
       testTabTitle('Tab 1 - Page 1');
 
       testUrlContains(rootUrl);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The Angular e2e test for tabs will occasionally fail (not reproducible on local). 

<!-- Issues are required for both bug fixes and features. -->
Issue URL: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Introduces a timeout delay for the click events to offset what I believe to be the issue in Cypress.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

If the test continues to break after this change, we can revert this commit. 

Tested on 3 CI runs and it did not fail once. 
