### PR TITLE
fix(fab-button): aria attributes are inherited

### DIFF
--- a/core/src/components/fab-button/fab-button.tsx
+++ b/core/src/components/fab-button/fab-button.tsx
@@ -5,6 +5,8 @@ import { close } from 'ionicons/icons';
 import { getIonMode } from '../../global/ionic-global';
 import type { AnimationBuilder, Color, RouterDirection } from '../../interface';
 import type { AnchorInterface, ButtonInterface } from '../../utils/element-interface';
+import { inheritAriaAttributes } from '../../utils/helpers';
+import type { Attributes } from '../../utils/helpers';
 import { createColorClasses, hostContext, openURL } from '../../utils/theme';
 
 /**
@@ -23,6 +25,7 @@ import { createColorClasses, hostContext, openURL } from '../../utils/theme';
 })
 export class FabButton implements ComponentInterface, AnchorInterface, ButtonInterface {
   private fab: HTMLIonFabElement | null = null;
+  private inheritedAttributes: Attributes = {};
 
   @Element() el!: HTMLElement;
 
@@ -142,8 +145,12 @@ export class FabButton implements ComponentInterface, AnchorInterface, ButtonInt
     fab.toggle();
   };
 
+  componentWillLoad() {
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
+  }
+
   render() {
-    const { el, disabled, color, href, activated, show, translucent, size } = this;
+    const { el, disabled, color, href, activated, show, translucent, size, inheritedAttributes } = this;
     const inList = hostContext('ion-fab-list', el);
     const mode = getIonMode(this);
     const TagType = href === undefined ? 'button' : ('a' as any);
@@ -182,6 +189,7 @@ export class FabButton implements ComponentInterface, AnchorInterface, ButtonInt
           onFocus={this.onFocus}
           onBlur={this.onBlur}
           onClick={(ev: Event) => openURL(href, ev, this.routerDirection, this.routerAnimation)}
+          {...inheritedAttributes}
         >
           <ion-icon icon={this.closeIcon} part="close-icon" class="close-icon" lazy={false}></ion-icon>
           <span class="button-inner">

--- a/core/src/components/fab-button/test/fab-button.spec.ts
+++ b/core/src/components/fab-button/test/fab-button.spec.ts
@@ -1,0 +1,19 @@
+import { newSpecPage } from '@stencil/core/testing';
+
+import { FabButton } from '../fab-button';
+
+describe('should inherit aria attributes to inner <button>', () => {
+  it('should ', async () => {
+    const page = await newSpecPage({
+      components: [FabButton],
+      html: `
+        <ion-fab-button aria-label="Hello World">My Button</ion-fab-button>
+      `,
+    });
+
+    const fabButton = page.body.querySelector('ion-fab-button');
+    const root = fabButton.shadowRoot;
+    const nativeButton = root.querySelector('button');
+    expect(nativeButton.getAttribute('aria-label')).toEqual('Hello World');
+  });
+});

--- a/core/src/components/fab-button/test/fab-button.spec.ts
+++ b/core/src/components/fab-button/test/fab-button.spec.ts
@@ -2,8 +2,8 @@ import { newSpecPage } from '@stencil/core/testing';
 
 import { FabButton } from '../fab-button';
 
-describe('should inherit aria attributes to inner <button>', () => {
-  it('should ', async () => {
+describe('fab-button: aria attributes', () => {
+  it('should inherit aria attributes to inner <button>', async () => {
     const page = await newSpecPage({
       components: [FabButton],
       html: `


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/25633


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Aria attributes are now inherited to the native `<button>` element inside of `ion-fab-button`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
