### PR TITLE
fix(react): can assign ref to IonNav

### DIFF
--- a/packages/react/src/components/navigation/IonNav.tsx
+++ b/packages/react/src/components/navigation/IonNav.tsx
@@ -4,13 +4,18 @@ import React, { useState } from 'react';
 
 import { ReactDelegate } from '../../framework-delegate';
 import { createReactComponent } from '../react-component-lib';
+import { createForwardRef } from '../utils';
 
 const IonNavInner = createReactComponent<
   JSX.IonNav & { delegate: FrameworkDelegate },
   HTMLIonNavElement
 >('ion-nav', undefined, undefined, defineCustomElement);
 
-export const IonNav: React.FC<JSX.IonNav> = ({ children, ...restOfProps }) => {
+type IonNavProps = JSX.IonNav & {
+  forwardedRef?: React.ForwardedRef<HTMLIonNavElement>;
+};
+
+const IonNavInternal: React.FC<IonNavProps> = ({ children, forwardedRef, ...restOfProps }) => {
   const [views, setViews] = useState<React.ReactElement[]>([]);
 
   /**
@@ -23,8 +28,10 @@ export const IonNav: React.FC<JSX.IonNav> = ({ children, ...restOfProps }) => {
   const delegate = ReactDelegate(addView, removeView);
 
   return (
-    <IonNavInner delegate={delegate} {...restOfProps}>
+    <IonNavInner delegate={delegate} ref={forwardedRef} {...restOfProps}>
       {views}
     </IonNavInner>
   );
 };
+
+export const IonNav = createForwardRef<IonNavProps, HTMLIonNavElement>(IonNavInternal, 'IonNav');

--- a/packages/react/test-app/cypress/integration/navigation/IonNav.spec.ts
+++ b/packages/react/test-app/cypress/integration/navigation/IonNav.spec.ts
@@ -7,6 +7,10 @@ describe('IonNav', () => {
     cy.get('ion-nav').contains('Page one content');
   });
 
+  it('should have a ref defined', () => {
+    cy.get('#navRef').should('have.text', 'Nav ref is defined: true');
+  });
+
   it('should push a page', () => {
     cy.get('ion-button').contains('Go to Page Two').click();
     cy.get('#pageTwoContent').should('be.visible');

--- a/packages/react/test-app/src/pages/navigation/NavComponent.tsx
+++ b/packages/react/test-app/src/pages/navigation/NavComponent.tsx
@@ -11,7 +11,7 @@ import {
   IonBackButton,
   IonPage,
 } from '@ionic/react';
-import React from 'react';
+import React, { useRef } from 'react';
 
 const PageOne = (props: { someString: string; someNumber: number; someBoolean: boolean }) => {
   return (
@@ -80,9 +80,11 @@ const PageThree = () => {
 };
 
 const NavComponent: React.FC = () => {
+  const ref = useRef<any>();
   return (
     <IonPage>
       <IonNav
+        ref={ref}
         root={PageOne}
         rootParams={{
           someString: 'Hello',

--- a/packages/react/test-app/src/pages/navigation/NavComponent.tsx
+++ b/packages/react/test-app/src/pages/navigation/NavComponent.tsx
@@ -13,7 +13,15 @@ import {
 } from '@ionic/react';
 import React, { useRef } from 'react';
 
-const PageOne = (props: { someString: string; someNumber: number; someBoolean: boolean }) => {
+const PageOne = ({
+  nav,
+  ...restOfProps
+}: {
+  someString: string;
+  someNumber: number;
+  someBoolean: boolean;
+  nav: React.MutableRefObject<HTMLIonNavElement>;
+}) => {
   return (
     <>
       <IonHeader>
@@ -26,7 +34,8 @@ const PageOne = (props: { someString: string; someNumber: number; someBoolean: b
       </IonHeader>
       <IonContent id="pageOneContent">
         <IonLabel>Page one content</IonLabel>
-        <div id="pageOneProps">{JSON.stringify(props)}</div>
+        <div id="pageOneProps">{JSON.stringify(restOfProps)}</div>
+        <div id="navRef">Nav ref is defined: {nav.current !== null ? 'true' : 'false'}</div>
         <IonNavLink
           routerDirection="forward"
           component={PageTwo}
@@ -90,6 +99,7 @@ const NavComponent: React.FC = () => {
           someString: 'Hello',
           someNumber: 3,
           someBoolean: true,
+          nav: ref,
         }}
       />
     </IonPage>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Developers cannot assign a `ref` to `IonNav` in React.


<!-- Issues are required for both bug fixes and features. -->
Issue URL: #25652


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Developers can assign a `ref` to `IonNav` in React.
- Uses a forwarded ref for the React component

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
