### PR TITLE
fix(datetime): account for previous years with preferWheel

### DIFF
--- a/core/src/components/datetime/test/prefer-wheel/datetime.e2e.ts
+++ b/core/src/components/datetime/test/prefer-wheel/datetime.e2e.ts
@@ -198,6 +198,23 @@ test.describe('datetime: prefer wheel', () => {
 
       expect(dateValues).toHaveText(['2月1日(火)', '2月2日(水)', '2月3日(木)']);
     });
+    test('should respect min and max bounds even across years', async ({ page }) => {
+      await page.setContent(`
+        <ion-datetime
+          presentation="date-time"
+          prefer-wheel="true"
+          value="2022-02-01"
+          min="2021-12-01"
+          max="2023-01-01"
+        ></ion-datetime>
+      `);
+
+      await page.waitForSelector('.datetime-ready');
+
+      const dateValues = page.locator('.date-column .picker-item:not(.picker-item-empty)');
+
+      expect(await dateValues.count()).toBe(427);
+    });
   });
   test.describe('datetime: time-date wheel rendering', () => {
     test('should not have visual regressions', async ({ page }) => {
@@ -285,6 +302,23 @@ test.describe('datetime: prefer wheel', () => {
       const dateValues = page.locator('.date-column .picker-item:not(.picker-item-empty)');
 
       expect(dateValues).toHaveText(['2月1日(火)', '2月2日(水)', '2月3日(木)']);
+    });
+    test('should respect min and max bounds even across years', async ({ page }) => {
+      await page.setContent(`
+        <ion-datetime
+          presentation="time-date"
+          prefer-wheel="true"
+          value="2022-02-01"
+          min="2021-12-01"
+          max="2023-01-01"
+        ></ion-datetime>
+      `);
+
+      await page.waitForSelector('.datetime-ready');
+
+      const dateValues = page.locator('.date-column .picker-item:not(.picker-item-empty)');
+
+      expect(await dateValues.count()).toBe(427);
     });
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: Internal ticket

As noted in https://github.com/ionic-team/ionic-framework/pull/25432/files#diff-2096901ec14aa009bc4a017f56dd504533b6e1c2fb939717be4fe18f331f7a9fR457, `preferWheel` with `date-time` or `time-date` does not show last/next years dates. The problem is functions like `getMonthColumnData` was built to only work within a single year. With the exception of the date+time wheel picker, all datetime variants work within a single year at a time. Since the date+time wheel picker does not, this issue occurred.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Instead of `getMonthColumnData`, I added a `getAllMonthsInRange` function which takes a starting DatetimeParts and an ending DatetimeParts and generates an array of all month parts in that range.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
