### PR TITLE
fix(datetime): switching presentation closes month/year picker

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1027,6 +1027,13 @@ export class Datetime implements ComponentInterface {
     this.destroyInteractionListeners();
 
     this.initializeListeners();
+
+    /**
+     * The month/year picker from the date interface
+     * should be closed as it is not available in non-date
+     * interfaces.
+     */
+    this.showMonthAndYear = false;
   }
 
   private processValue = (value?: string | null) => {

--- a/core/src/components/datetime/test/presentation/datetime.e2e.ts
+++ b/core/src/components/datetime/test/presentation/datetime.e2e.ts
@@ -83,6 +83,27 @@ test.describe('datetime: presentation', () => {
 
     expect(ionChangeSpy.length).toBe(1);
   });
+
+  test.only('switching presentation should close month/year picker', async ({ page }, testInfo) => {
+    await test.skip(testInfo.project.metadata.rtl === true, 'This feature does not have RTL specific behaviors.');
+
+    await page.setContent(`
+      <ion-datetime presentation="date"></ion-datetime>
+    `)
+
+    await page.waitForSelector('.datetime-ready');
+
+    const datetime = page.locator('ion-datetime');
+    const monthYearButton = page.locator('ion-datetime .calendar-month-year');
+    await monthYearButton.click();
+
+    await expect(datetime).toHaveClass(/show-month-and-year/);
+
+    await datetime.evaluate((el: HTMLIonDatetimeElement) => el.presentation = 'time');
+    await page.waitForChanges();
+
+    await expect(datetime).not.toHaveClass(/show-month-and-year/);
+  })
 });
 
 test.describe('datetime: presentation: time', () => {

--- a/core/src/components/datetime/test/presentation/datetime.e2e.ts
+++ b/core/src/components/datetime/test/presentation/datetime.e2e.ts
@@ -84,7 +84,7 @@ test.describe('datetime: presentation', () => {
     expect(ionChangeSpy.length).toBe(1);
   });
 
-  test.only('switching presentation should close month/year picker', async ({ page }, testInfo) => {
+  test('switching presentation should close month/year picker', async ({ page }, testInfo) => {
     await test.skip(testInfo.project.metadata.rtl === true, 'This feature does not have RTL specific behaviors.');
 
     await page.setContent(`

--- a/core/src/components/datetime/test/presentation/datetime.e2e.ts
+++ b/core/src/components/datetime/test/presentation/datetime.e2e.ts
@@ -89,7 +89,7 @@ test.describe('datetime: presentation', () => {
 
     await page.setContent(`
       <ion-datetime presentation="date"></ion-datetime>
-    `)
+    `);
 
     await page.waitForSelector('.datetime-ready');
 
@@ -99,11 +99,11 @@ test.describe('datetime: presentation', () => {
 
     await expect(datetime).toHaveClass(/show-month-and-year/);
 
-    await datetime.evaluate((el: HTMLIonDatetimeElement) => el.presentation = 'time');
+    await datetime.evaluate((el: HTMLIonDatetimeElement) => (el.presentation = 'time'));
     await page.waitForChanges();
 
     await expect(datetime).not.toHaveClass(/show-month-and-year/);
-  })
+  });
 });
 
 test.describe('datetime: presentation: time', () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
While testing https://github.com/ionic-team/ionic-framework/pull/25655 I noticed that opening the month/year picker, dismissing the overlay, then opening the time picker caused the time picker to not show up. The reason was that the month/year picker, which is not available in time interfaces, was still considered "open". As a result, a blank datetime component was shown.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Switching between presentation modes now closes the month/year picker.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
