### PR TITLE
fix(reorder-group): synchronize reordering with style update

### DIFF
--- a/core/src/components/reorder-group/reorder-group.tsx
+++ b/core/src/components/reorder-group/reorder-group.tsx
@@ -226,13 +226,16 @@ export class ReorderGroup implements ComponentInterface {
         this.el.insertBefore(selectedItemEl, ref);
       }
 
-      if (Array.isArray(listOrReorder)) {
-        listOrReorder = reorderArray(listOrReorder, fromIndex, toIndex);
-      }
+      // setTimeout forces the style update to synchronize with the reordering.
+      setTimeout(() => {
+        if (Array.isArray(listOrReorder)) {
+          listOrReorder = reorderArray(listOrReorder, fromIndex, toIndex);
+        }
 
-      for (let i = 0; i < len; i++) {
-        children[i].style['transform'] = '';
-      }
+        for (let i = 0; i < len; i++) {
+          children[i].style['transform'] = '';
+        }
+      });
 
       selectedItemEl.style.transition = '';
       selectedItemEl.classList.remove(ITEM_REORDER_SELECTED);


### PR DESCRIPTION
closes #21182

- [X] Bugfix

## What is the current behavior?

In the function completeSync(), in the reorder-group component:

When used in Firefox, the most recently set value of the translateY css property is applied to the selectedItemEl variable and rendered visually before the cleared transform property is rendered. This creates the appearance of a "double" animation as the element jumps out of place and slides to its final location.

Issue URL:  https://github.com/ionic-team/ionic-framework/issues/21182

## What is the new behavior?

The reorder operation and the update to the style property are moved to the next turn of the event loop by setTimeout (with default of 0 delay), which causes Firefox to render them in the expected way (no jumping of the selected element).

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
