### PR TITLE
ci(release): purge JSDelivr cache on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Purge JSDelivr Cache
         run: | 
           curl -X POST \
-            http://purge.jsdelivr.net/ \
+            https://purge.jsdelivr.net/ \
             -H 'cache-control: no-cache' \
             -H 'content-type: application/json' \
             -d '{

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,4 +61,21 @@ jobs:
           git add .
           git commit -m "chore(): update package lock files"
           git push
+      # Purge the JSDeliver CDN cache so
+      # component playgrounds always load
+      # the latest version of Ionic.
+      - name: Purge JSDelivr Cache
+        run: | 
+          curl -X POST \
+            http://purge.jsdelivr.net/ \
+            -H 'cache-control: no-cache' \
+            -H 'content-type: application/json' \
+            -d '{
+          "path": [
+            "/npm/@ionic/core@6/dist/ionic/ionic.esm.js",
+            "/npm/@ionic/core@latest/dist/ionic/ionic.esm.js",
+            "/npm/@ionic/core@6/css/ionic.bundle.css,
+            "/npm/@ionic/core@latest/css/ionic.bundle.css
+          ]}'
+
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

JSDeliver caches resources for ~7 days: https://github.com/jsdelivr/jsdelivr#caching. This means that for up to 7 days after a release, the component playgrounds load an outdated version of Ionic. This is problematic with feature releases where the playgrounds for the new features will not work as an old version of Ionic is loaded.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- On successful release, a request will be made to JSDeliver to purge the JS and CSS files for the `6` and `latest` tags for Ionic Core.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
