### PR TITLE
fix(nav): exclude nav from custom dialog

### DIFF
--- a/core/src/css/core.scss
+++ b/core/src/css/core.scss
@@ -170,7 +170,7 @@ html.ios ion-modal.modal-card .ion-page {
  * These changes allow certain dimension values
  * such as fit-content to work correctly.
  */
-ion-modal .ion-page {
+ion-modal .ion-page:not(ion-nav .ion-page) {
   position: relative;
 
   contain: layout style;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves #25688, resolves #25677

The issue was caused by this commit: https://github.com/ionic-team/ionic-framework/commit/a6f3ae67ab91ab95408ad425156167edc3570978

We targeted `ion-modal .ion-page` but did not consider that `.ion-page` is also used inside of `ion-nav`. As a result, this changed the styles for pages in `ion-nav` and broke page transitions.

We also considered just doing `ion-modal .ion-page`, but there is an existing issue where multiple `.ion-page` elements can be appended on subsequent modal presentations. The fix for that will take some time, so we opted to exclude `ion-nav` from the `.ion-page` changes for now.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- pages in ion-nav are now excluded from the custom dialog changes.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
