### PR TITLE
fix(datetime): display time in user's timezone after selection

### DIFF
--- a/core/src/components/datetime/test/format.spec.ts
+++ b/core/src/components/datetime/test/format.spec.ts
@@ -5,6 +5,7 @@ import {
   addTimePadding,
   getMonthAndYear,
   getLocalizedDayPeriod,
+  getLocalizedTime,
 } from '../utils/format';
 
 describe('generateDayAriaLabel()', () => {
@@ -97,5 +98,61 @@ describe('getLocalizedDayPeriod', () => {
 
   it('should return PM when the date is in the afternoon', () => {
     expect(getLocalizedDayPeriod('en-US', 'pm'));
+  });
+});
+
+describe('getLocalizedTime', () => {
+  describe('with a timezone offset', () => {
+    it('should ignore the offset and localize the time to PM', () => {
+      const datetimeParts = {
+        day: 1,
+        month: 1,
+        year: 2022,
+        hour: 13,
+        minute: 40,
+        tzOffset: -240,
+      };
+
+      expect(getLocalizedTime('en-US', datetimeParts, false)).toEqual('1:40 PM');
+    });
+
+    it('should ignore the offset and localize the time to AM', () => {
+      const datetimeParts = {
+        day: 1,
+        month: 1,
+        year: 2022,
+        hour: 9,
+        minute: 40,
+        tzOffset: -240,
+      };
+
+      expect(getLocalizedTime('en-US', datetimeParts, false)).toEqual('9:40 AM');
+    });
+  });
+
+  it('should localize the time to PM', () => {
+    const datetimeParts = {
+      day: 1,
+      month: 1,
+      year: 2022,
+      hour: 13,
+      minute: 40,
+      tzOffset: 0,
+    };
+
+    expect(getLocalizedTime('en-US', datetimeParts, false)).toEqual('1:40 PM');
+  });
+
+  it('should localize the time to AM', () => {
+    const datetimeParts = {
+      day: 1,
+      month: 1,
+      year: 2022,
+      hour: 9,
+      minute: 40,
+      tzOffset: 0,
+    };
+
+    expect(getLocalizedTime('en-US', datetimeParts, false)).toEqual('9:40 AM');
   });
 });

--- a/core/src/components/datetime/utils/format.ts
+++ b/core/src/components/datetime/utils/format.ts
@@ -20,7 +20,14 @@ export const getLocalizedTime = (locale: string, refParts: DatetimeParts, use24H
     minute: 'numeric',
     timeZone: 'UTC',
     hour12: !use24Hour,
-  }).format(removeDateTzOffset(new Date(convertDataToISO(refParts))));
+  }).format(
+    new Date(
+      convertDataToISO({
+        ...refParts,
+        tzOffset: undefined,
+      })
+    )
+  );
 };
 
 /**

--- a/core/src/components/datetime/utils/format.ts
+++ b/core/src/components/datetime/utils/format.ts
@@ -24,6 +24,7 @@ export const getLocalizedTime = (locale: string, refParts: DatetimeParts, use24H
     new Date(
       convertDataToISO({
         ...refParts,
+        // TODO: FW-1831 will remove the need to manually set the tzOffset to undefined
         tzOffset: undefined,
       })
     )

--- a/core/src/components/datetime/utils/format.ts
+++ b/core/src/components/datetime/utils/format.ts
@@ -20,7 +20,7 @@ export const getLocalizedTime = (locale: string, refParts: DatetimeParts, use24H
     minute: 'numeric',
     timeZone: 'UTC',
     hour12: !use24Hour,
-  }).format(new Date(convertDataToISO(refParts)));
+  }).format(removeDateTzOffset(new Date(convertDataToISO(refParts))));
 };
 
 /**

--- a/core/src/components/datetime/utils/parse.ts
+++ b/core/src/components/datetime/utils/parse.ts
@@ -104,8 +104,6 @@ export function parseDate(val: string | string[] | undefined | null): DatetimePa
       // + or -
       tzOffset *= -1;
     }
-  } else {
-    tzOffset = new Date().getTimezoneOffset() * -1;
   }
 
   // can also get second and millisecond from parse[6] and parse[7] if needed

--- a/core/src/components/datetime/utils/parse.ts
+++ b/core/src/components/datetime/utils/parse.ts
@@ -104,6 +104,8 @@ export function parseDate(val: string | string[] | undefined | null): DatetimePa
       // + or -
       tzOffset *= -1;
     }
+  } else {
+    tzOffset = new Date().getTimezoneOffset() * -1;
   }
 
   // can also get second and millisecond from parse[6] and parse[7] if needed


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When datetime is rendered initially, the time is formatted with a `tzOffset` of `0`. When the time is manipulated in the time overlay/picker, the `tzOffset` is applied (to the users timezone, i.e. `-240`) and incorrectly formats the displayed time.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #25693


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removes the `tzOffset` when localizing the time for display


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `6.2.1-dev.11659121131.15481a1f` ✅
