### PR TITLE
fix(datetime): selecting today with multiple date select now works

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1929,7 +1929,7 @@ export class Datetime implements ComponentInterface {
                         day,
                         year,
                       },
-                      isActive
+                      isActive && highlightActiveParts
                     );
                   } else {
                     this.setActiveParts({


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Sean noted that https://github.com/ionic-team/ionic-framework/actions/runs/2776107067 was failing due to an unrelated test. Upon further investigation it was determined that selecting today's date with `multiple="true"` does not work on the first click. 

When we call `setActiveParts` on clicking the day button, we pass in `isActive`. Presumably this was done to ensure that we can toggle dates: https://github.com/ionic-team/ionic-framework/blob/61e4ffe47f73034808b65ee37342f540ee5a6a97/core/src/components/datetime/datetime.tsx#L1932. Unfortunately,`isActive` doesn’t necessarily mean the date is selected. It means it is either selected or highlighted as “today’s date”.

Future work should clean this up so it is easier to reason about.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- We now pass in `isActive && highlightActiveParts` to differentiate between a today's date that is selected vs today's date that just has the outline.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
