### PR TITLE
fix(vue): go back to correct view with memory history

### DIFF
--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -120,7 +120,12 @@ export const createIonRouter = (opts: IonicVueRouterOptions, router: Router) => 
              * will go back in a linear fashion.
              */
             prevInfo.pathname === routeInfo.pushedByRoute &&
-            routeInfo.tab === '' && prevInfo.tab === ''
+
+            /**
+             * Tab info can be undefined or '' (empty string)
+             * both are false-y values, so we can just use !.
+             */
+            !routeInfo.tab && !prevInfo.tab
           )
         ) {
           router.back();

--- a/packages/vue/test-app/tests/unit/memory.spec.ts
+++ b/packages/vue/test-app/tests/unit/memory.spec.ts
@@ -71,6 +71,6 @@ describe('createMemoryHistory', () => {
     await pageTwoButton.trigger('click');
     await waitForRouter();
 
-    expect(push).toHaveBeenCalledTimes(1);
+    expect(push).toHaveBeenCalledTimes(2);
   });
 })

--- a/packages/vue/test-app/tests/unit/memory.spec.ts
+++ b/packages/vue/test-app/tests/unit/memory.spec.ts
@@ -1,0 +1,76 @@
+import { mount } from '@vue/test-utils';
+import { createRouter, createMemoryHistory } from '@ionic/vue-router';
+import {
+  IonContent,
+  IonHeader,
+  IonToolbar,
+  IonBackButton,
+  IonicVue,
+  IonApp,
+  IonRouterOutlet,
+  IonPage,
+} from '@ionic/vue';
+import { waitForRouter } from './utils';
+
+const App = {
+  components: { IonApp, IonRouterOutlet },
+  template: '<ion-app><ion-router-outlet /></ion-app>',
+}
+
+describe('createMemoryHistory', () => {
+  beforeAll(() => {
+    (HTMLElement.prototype as HTMLIonRouterOutletElement).commit = jest.fn();
+  });
+  it('should not error when going back with memory router', async () => {
+    const PageTemplate = {
+      template: `
+        <ion-page>
+          <ion-header>
+            <ion-toolbar>
+              <ion-back-button></ion-back-button>
+            </ion-toolbar>
+          </ion-header>
+          <ion-content></ion-content>
+        </ion-page>
+      `,
+      components: { IonPage, IonContent, IonHeader, IonToolbar, IonBackButton }
+    }
+
+    const router = createRouter({
+      history: createMemoryHistory(process.env.BASE_URL),
+      routes: [
+        { path: '/', component: PageTemplate },
+        { path: '/page2', component: PageTemplate },
+        { path: '/page3', component: PageTemplate }
+      ]
+    });
+    const push = jest.spyOn(router, 'back')
+
+    router.push('/');
+    await router.isReady();
+    const wrapper = mount(App, {
+      global: {
+        plugins: [router, IonicVue]
+      }
+    });
+
+    router.push('/page2');
+    await waitForRouter();
+
+    router.push('/page3');
+    await waitForRouter();
+
+
+    const backButtons = wrapper.findAllComponents(IonBackButton);
+    const pageTwoButton = backButtons[1];
+    const pageThreeButton = backButtons[2];
+
+    await pageThreeButton.trigger('click');
+    await waitForRouter();
+
+    await pageTwoButton.trigger('click');
+    await waitForRouter();
+
+    expect(push).toHaveBeenCalledTimes(1);
+  });
+})


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/25705

The current check did not account for tab values that are `undefined` initially.  As a result, the code was getting pushed into a block that should be only run when in tabs. We should clean this up in the future and converge on either `''` or `undefined`, but for now we can account for both with a false-y check.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Ionic Vue Router correctly checks to see if a page is/is not in tabs.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
