### PR TITLE
fix(datetime): wheel picker is easier to use with screen readers

### DIFF
--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -397,7 +397,7 @@ export class PickerColumnInternal implements ComponentInterface {
   get activeItem() {
     const { value, items } = this;
 
-    return items.find(item => item.value === value && !item.disabled);
+    return items.find((item) => item.value === value && !item.disabled);
   }
 
   render() {

--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -394,12 +394,30 @@ export class PickerColumnInternal implements ComponentInterface {
     ) as HTMLElement | null;
   }
 
+  get activeItem() {
+    const { value, items } = this;
+
+    return items.find(item => item.value === value && !item.disabled);
+  }
+
   render() {
-    const { items, color, isActive, numericInput } = this;
+    const { items, color, isActive, numericInput, activeItem } = this;
     const mode = getIonMode(this);
 
     return (
       <Host
+        /*
+          Spin button allows users to swipe
+          between picker columns and then drag
+          to select items within a single column.
+          valuetext is required because valuenow does
+          not always reflect the intended value of the
+          spinbutton. Developers must also provide either
+          aria-label or aria-labelledby on the host.
+        */
+        role="spinbutton"
+        aria-valuenow={activeItem?.value}
+        aria-valuetext={activeItem?.text}
         tabindex={0}
         class={createColorClasses(color, {
           [mode]: true,

--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -159,7 +159,7 @@ export class PickerColumnInternal implements ComponentInterface {
         const oldActive = getElementRoot(this.el).querySelector(`.${PICKER_COL_ACTIVE}`);
         oldActive?.classList.remove(PICKER_COL_ACTIVE);
         this.scrollActiveItemIntoView();
-        this.activeItem?.classList.add(PICKER_COL_ACTIVE);
+        this.activeItemEl?.classList.add(PICKER_COL_ACTIVE);
 
         this.initializeScrollListener();
       } else {
@@ -180,10 +180,10 @@ export class PickerColumnInternal implements ComponentInterface {
   }
 
   componentDidRender() {
-    const { activeItem, items, isColumnVisible, value } = this;
+    const { activeItemEl, items, isColumnVisible, value } = this;
 
     if (isColumnVisible) {
-      if (activeItem) {
+      if (activeItemEl) {
         this.scrollActiveItemIntoView();
       } else if (items[0]?.value !== value) {
         /**
@@ -201,7 +201,7 @@ export class PickerColumnInternal implements ComponentInterface {
   /** @internal  */
   @Method()
   async scrollActiveItemIntoView() {
-    const activeEl = this.activeItem;
+    const activeEl = this.activeItemEl;
 
     if (activeEl) {
       this.centerPickerItemInView(activeEl, false);
@@ -296,7 +296,7 @@ export class PickerColumnInternal implements ComponentInterface {
     const { el } = this;
 
     let timeout: any;
-    let activeEl: HTMLElement | null = this.activeItem;
+    let activeEl: HTMLElement | null = this.activeItemEl;
 
     const scrollCallback = () => {
       raf(() => {
@@ -388,7 +388,7 @@ export class PickerColumnInternal implements ComponentInterface {
     });
   };
 
-  get activeItem() {
+  get activeItemEl() {
     return getElementRoot(this.el).querySelector(
       `.picker-item[data-value="${this.value}"]:not([disabled])`
     ) as HTMLElement | null;

--- a/core/src/components/picker-internal/test/a11y/index.html
+++ b/core/src/components/picker-internal/test/a11y/index.html
@@ -16,7 +16,7 @@
         <h1>Picker - a11y</h1>
 
         <ion-picker-internal>
-          <ion-picker-column-internal color="tertiary" value="3"></ion-picker-column-internal>
+          <ion-picker-column-internal color="tertiary" value="3" aria-label="Select Item"></ion-picker-column-internal>
         </ion-picker-internal>
       </ion-content>
 

--- a/core/src/components/picker-internal/test/a11y/index.html
+++ b/core/src/components/picker-internal/test/a11y/index.html
@@ -29,7 +29,7 @@
           { text: 'Fourth', value: '4' },
           { text: 'Fifth', value: '5' },
           { text: 'Sixth', value: '6' },
-          { text: 'Seventh', value: '7' },
+          { text: 'Seventh', value: '7', disabled: true },
         ];
       </script>
     </ion-app>

--- a/core/src/components/picker-internal/test/a11y/picker-internal.e2e.ts
+++ b/core/src/components/picker-internal/test/a11y/picker-internal.e2e.ts
@@ -10,4 +10,27 @@ test.describe('picker-internal: a11y', () => {
 
     expect(results.violations).toEqual([]);
   });
+  test('should set the aria-valuenow and aria-valuetext attributes', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.metadata.rtl === true, 'This does not test LTR vs RTL layouts.');
+    test.skip(testInfo.project.metadata.mode === 'md', 'This does not have mode specific logic.');
+
+    await page.goto(`/src/components/picker-internal/test/a11y`);
+
+    const column = page.locator('ion-picker-column-internal');
+    await expect(column).toHaveAttribute('aria-valuenow', '3');
+    await expect(column).toHaveAttribute('aria-valuetext', 'Third');
+
+    await column.evaluate((el: HTMLIonPickerColumnInternalElement) => (el.value = '6'));
+    await page.waitForChanges();
+
+    await expect(column).toHaveAttribute('aria-valuenow', '6');
+    await expect(column).toHaveAttribute('aria-valuetext', 'Sixth');
+
+    await column.evaluate((el: HTMLIonPickerColumnInternalElement) => (el.value = '7'));
+    await page.waitForChanges();
+
+    // Item 7 is disabled, so the picker will reset to the first item
+    await expect(column).toHaveAttribute('aria-valuenow', '1');
+    await expect(column).toHaveAttribute('aria-valuetext', 'First');
+  });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/25221

Currently, swiping left/right with a screen reader enabled moves users between buttons within a single picker column. This makes it very difficult to move between columns because users need to swipe through all buttons in a column before proceeding to the next one.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds the "role="spinbutton"` on the picker column. This makes it so that swiping moves between columns instead of moving between buttons within a single column. Users can then double tap to scroll a wheel up or down to select a new value.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


| `main` | branch |
| ------- | ------- |
| <video src="https://user-images.githubusercontent.com/2721089/183687336-cca6767b-9b63-4efe-b18b-395965ea15ea.mp4"></video> | <video src="https://user-images.githubusercontent.com/2721089/183687387-b1d69f25-2d76-47e2-b814-b82a5970436a.mp4"></video> |


