### PR TITLE
fix(datetime): highlights now show above content in modal

### DIFF
--- a/core/src/components/picker-internal/picker-internal.scss
+++ b/core/src/components/picker-internal/picker-internal.scss
@@ -36,6 +36,8 @@
 
   width: 100%;
 
+  transform: translateZ(0);
+
   /**
    * This is needed for WebKit
    * otherwise the fade will appear

--- a/core/src/components/picker-internal/picker-internal.scss
+++ b/core/src/components/picker-internal/picker-internal.scss
@@ -36,13 +36,13 @@
 
   width: 100%;
 
+  /**
+   * The transform and z-index
+   * are needed for WebKit otherwise
+   * the fade will appear underneath the picker.
+   */
   transform: translateZ(0);
 
-  /**
-   * This is needed for WebKit
-   * otherwise the fade will appear
-   * underneath the picker.
-   */
   z-index: 1;
 
   pointer-events: none;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/25755

Safari has some rendering quirks with layers/compositing when using accelerated animations. As a result, the iOS modal animation was causing the picker internal's highlights to not be promoted to their own layers.

Causing a repaint was usually enough to "fix" the issue.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Highlights are now promoted to their own layers

Note: I could not capture this in a Playwright screenshot. (I am assuming that somewhere in the screenshot flow, a repaint happens "fixing" the issue)

| `main` | branch |
| ------- | ------- |
| ![Screen Shot 2022-08-12 at 9 48 32 AM](https://user-images.githubusercontent.com/2721089/184367113-313a8c0f-1be3-4904-b6fd-2a9fb1d6aa4c.png) | ![image](https://user-images.githubusercontent.com/2721089/184367073-8aafc343-7698-4d59-8028-dea196b0c2f4.png) |

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
