### PR TITLE
fix(vue): lifecycles now fire on tabs pages

### DIFF
--- a/packages/vue/src/components/IonRouterOutlet.ts
+++ b/packages/vue/src/components/IonRouterOutlet.ts
@@ -88,19 +88,20 @@ export const IonRouterOutlet = /*@__PURE__*/ defineComponent({
        * all of the keys in the params object, we check the url path to
        * see if they are different after ensuring we are in a parameterized route.
        */
-      if (currentMatchedRouteRef === undefined) { return; }
+      if (currentMatchedRouteRef !== undefined) {
+        const matchedDifferentRoutes = currentMatchedRouteRef !== previousMatchedRouteRef;
+        const matchedDifferentParameterRoutes = (
+          currentRoute.matched[currentRoute.matched.length - 1] === currentMatchedRouteRef &&
+          currentRoute.path !== previousMatchedPath
+        );
 
-      const matchedDifferentRoutes = currentMatchedRouteRef !== previousMatchedRouteRef;
-      const matchedDifferentParameterRoutes = (
-        currentRoute.matched[currentRoute.matched.length - 1] === currentMatchedRouteRef &&
-        currentRoute.path !== previousMatchedPath
-      );
-
-      if (matchedDifferentRoutes || matchedDifferentParameterRoutes) {
-        setupViewItem(matchedRouteRef);
-        previousMatchedRouteRef = currentMatchedRouteRef;
-        previousMatchedPath = currentRoute.path;
+        if (matchedDifferentRoutes || matchedDifferentParameterRoutes) {
+          setupViewItem(matchedRouteRef);
+        }
       }
+
+      previousMatchedRouteRef = currentMatchedRouteRef;
+      previousMatchedPath = currentRoute.path;
     });
 
     const canStart = () => {
@@ -274,13 +275,13 @@ See https://ionicframework.com/docs/vue/navigation#ionpage for more information.
        * return early for swipe to go back when
        * going from a non-tabs page to a tabs page.
        */
-      if (isViewVisible(enteringEl) && leavingViewItem !== undefined && !isViewVisible(leavingViewItem.ionPageElement)) {
+      if (isViewVisible(enteringEl) && leavingViewItem?.ionPageElement !== undefined && !isViewVisible(leavingViewItem.ionPageElement)) {
         return;
       }
 
       fireLifecycle(enteringViewItem.vueComponent, enteringViewItem.vueComponentRef, LIFECYCLE_WILL_ENTER);
 
-      if (leavingViewItem && enteringViewItem !== leavingViewItem) {
+      if (leavingViewItem?.ionPageElement && enteringViewItem !== leavingViewItem) {
         let animationBuilder = routerAnimation;
         const leavingEl = leavingViewItem.ionPageElement;
 

--- a/packages/vue/test-app/tests/unit/lifecycle.spec.ts
+++ b/packages/vue/test-app/tests/unit/lifecycle.spec.ts
@@ -128,6 +128,14 @@ describe('Lifecycle Events', () => {
       ionViewDidLeave: jest.fn(),
     }
 
+    const NonTabPage = {
+      ...BasePage,
+      ionViewWillEnter: jest.fn(),
+      ionViewDidEnter: jest.fn(),
+      ionViewWillLeave: jest.fn(),
+      ionViewDidLeave: jest.fn(),
+    }
+
 
     const router = createRouter({
       history: createWebHistory(process.env.BASE_URL),
@@ -135,7 +143,7 @@ describe('Lifecycle Events', () => {
         { path: '/', component: TabsPage, children: [
           { path: 'tab1', component: Tab1Page }
         ]},
-        { path: '/non-tab', component: BasePage }
+        { path: '/non-tab', component: NonTabPage }
       ]
     });
 
@@ -155,6 +163,9 @@ describe('Lifecycle Events', () => {
     expect(Tab1Page.ionViewWillEnter).toHaveBeenCalled();
     expect(Tab1Page.ionViewDidEnter).toHaveBeenCalled();
 
+    expect(NonTabPage.ionViewWillEnter).not.toHaveBeenCalled();
+    expect(NonTabPage.ionViewDidEnter).not.toHaveBeenCalled();
+
     // Navigate out of tabs
     router.push('/non-tab');
     jest.resetAllMocks();
@@ -168,6 +179,9 @@ describe('Lifecycle Events', () => {
     //expect(Tab1Page.ionViewWillLeave).toHaveBeenCalled();
     //expect(Tab1Page.ionViewDidLeave).toHaveBeenCalled();
 
+    expect(NonTabPage.ionViewWillEnter).toHaveBeenCalled();
+    expect(NonTabPage.ionViewDidEnter).toHaveBeenCalled();
+
     // Go back
     router.back();
     jest.resetAllMocks();
@@ -179,6 +193,9 @@ describe('Lifecycle Events', () => {
     expect(Tab1Page.ionViewWillEnter).toHaveBeenCalled();
     expect(Tab1Page.ionViewDidEnter).toHaveBeenCalled();
 
+    expect(NonTabPage.ionViewWillLeave).toHaveBeenCalled();
+    expect(NonTabPage.ionViewDidLeave).toHaveBeenCalled();
+
     // Navigate out of tabs again
     router.push('/non-tab');
     jest.resetAllMocks();
@@ -186,6 +203,9 @@ describe('Lifecycle Events', () => {
 
     expect(TabsPage.ionViewWillLeave).toHaveBeenCalled();
     expect(TabsPage.ionViewDidLeave).toHaveBeenCalled();
+
+    expect(NonTabPage.ionViewWillEnter).toHaveBeenCalled();
+    expect(NonTabPage.ionViewDidEnter).toHaveBeenCalled();
 
     // Go back again
     router.back();
@@ -195,7 +215,7 @@ describe('Lifecycle Events', () => {
     expect(TabsPage.ionViewWillEnter).toHaveBeenCalled();
     expect(TabsPage.ionViewDidEnter).toHaveBeenCalled();
 
-    expect(Tab1Page.ionViewWillEnter).toHaveBeenCalled();
-    expect(Tab1Page.ionViewDidEnter).toHaveBeenCalled();
+    expect(NonTabPage.ionViewWillLeave).toHaveBeenCalled();
+    expect(NonTabPage.ionViewDidLeave).toHaveBeenCalled();
   })
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/25784

When navigating to an inner tabs page (Tab1), the `currentMatchedRouteRef` is the route definition for the Tab1 page and `previousMatchedRouteRef` is `undefined`.  We then set `previousMatchedRouteRef` to  `currentMatchedRouteRef` so that we can have a reference to the last route that this outlet matched next time the `currentMatchedRouteRef` changes.

 When navigating away from the tabs context, `currentMatchedRouteRef` becomes `undefined` but `previousMatchedRouteRef` stays at Tab1. Since `currentMatchedRouteRef` is undefined, we return early and do not update `previousMatchedRouteRef`. This means that when we navigate back to Tabs1, both `currentMatchedRouteRef` and `previousMatchedRouteRef` match Tab1. As a result, we do not call `setupViewItem` and the inner Tab1 page does not fire lifecycle hooks.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- We now clear out `previousMatchedRouteRef` when navigating away from a page.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
