### PR TITLE
fix(alert): add default aria-label

### DIFF
--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -584,12 +584,14 @@ export class Alert implements ComponentInterface, OverlayInterface {
     const subHdrId = `alert-${overlayIndex}-sub-hdr`;
     const msgId = `alert-${overlayIndex}-msg`;
     const role = this.inputs.length > 0 || this.buttons.length > 0 ? 'alertdialog' : 'alert';
+    const defaultAriaLabel = header || subHeader || 'Alert';
 
     return (
       <Host
         role={role}
         aria-modal="true"
         tabindex="-1"
+        aria-label={defaultAriaLabel}
         {...(htmlAttributes as any)}
         style={{
           zIndex: `${20000 + overlayIndex}`,

--- a/core/src/components/alert/test/a11y/alert.e2e.ts
+++ b/core/src/components/alert/test/a11y/alert.e2e.ts
@@ -1,0 +1,43 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect } from '@playwright/test';
+import type { E2EPage } from '@utils/test/playwright';
+import { test } from '@utils/test/playwright';
+
+const testAriaLabel = async (page: E2EPage, buttonID: string, expectedAriaLabel: string) => {
+  const button = page.locator(`#${buttonID}`);
+  await button.click();
+
+  const alert = page.locator('ion-alert');
+  await expect(alert).toHaveAttribute('aria-label', expectedAriaLabel);
+};
+
+test.describe('alert: a11y', () => {
+  test.beforeEach(async ({ page, skip }) => {
+    skip.rtl();
+    await page.goto(`/src/components/alert/test/a11y`);
+  });
+
+  test('should not have accessibility violations', async ({ page }) => {
+    const button = page.locator('#customHeader');
+    await button.click();
+
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test('should have fallback aria-label when no header or subheader is specified', async ({ page }) => {
+    await testAriaLabel(page, 'noHeader', 'Alert');
+  });
+
+  test('should inherit aria-label from header', async ({ page }) => {
+    await testAriaLabel(page, 'customHeader', 'Header');
+  });
+
+  test('should inherit aria-label from subheader if no header is specified', async ({ page }) => {
+    await testAriaLabel(page, 'subHeaderOnly', 'Subtitle');
+  });
+
+  test('should allow for manually specifying aria-label', async ({ page }) => {
+    await testAriaLabel(page, 'customAriaLabel', 'Custom alert');
+  });
+});

--- a/core/src/components/alert/test/a11y/index.html
+++ b/core/src/components/alert/test/a11y/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Alert - A11y</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
+    <link href="../../../../../css/ionic.bundle.css" rel="stylesheet" />
+    <link href="../../../../../scripts/testing/styles.css" rel="stylesheet" />
+    <script src="../../../../../scripts/testing/scripts.js"></script>
+    <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+    <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+  </head>
+  <script type="module">
+    import { alertController } from '../../../../dist/ionic/index.esm.js';
+    window.alertController = alertController;
+  </script>
+
+  <body>
+    <main class="ion-padding">
+      <h1>Alert - A11y</h1>
+
+      <ion-button id="noHeader" expand="block" onclick="presentNoHeader()">Alert With No Header</ion-button>
+      <ion-button id="customHeader" expand="block" onclick="presentCustomHeader()">Alert With Custom Header</ion-button>
+      <ion-button id="subHeaderOnly" expand="block" onclick="presentSubHeaderOnly()"
+        >Alert With Subheader Only</ion-button
+      >
+      <ion-button id="customAriaLabel" expand="block" onclick="presentCustomAriaLabel()"
+        >Alert With Custom Aria Label</ion-button
+      >
+    </main>
+
+    <script>
+      async function openAlert(opts) {
+        const alert = await alertController.create(opts);
+        await alert.present();
+      }
+
+      function presentNoHeader() {
+        openAlert({
+          message: 'This is an alert message.',
+          buttons: ['OK'],
+        });
+      }
+
+      function presentCustomHeader() {
+        openAlert({
+          header: 'Header',
+          subHeader: 'Subtitle',
+          message: 'This is an alert message.',
+          buttons: ['OK'],
+        });
+      }
+
+      function presentSubHeaderOnly() {
+        openAlert({
+          subHeader: 'Subtitle',
+          message: 'This is an alert message.',
+          buttons: ['OK'],
+        });
+      }
+
+      function presentCustomAriaLabel() {
+        openAlert({
+          header: 'Header',
+          subHeader: 'Subtitle',
+          message: 'This is an alert message with a custom aria-label.',
+          buttons: ['OK'],
+          htmlAttributes: {
+            'aria-label': 'Custom alert',
+          },
+        });
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Accessibility-related fix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`ion-alert` throws Axe accessibility violations by default due to not having an `aria-label`.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: N/A (internal ticket)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Default aria-label added, pulling from the alert's `header` (or `subHeader` if no header is defined) and falling back to simply `'Alert'` if needed. Devs can already define a custom aria-label using the `htmlAttributes` property when presenting the alert.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
