### PR TITLE
fix(modal): set default aria-label

### DIFF
--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -18,7 +18,8 @@ import type {
 } from '../../interface';
 import { findIonContent, printIonContentErrorMsg } from '../../utils/content';
 import { CoreDelegate, attachComponent, detachComponent } from '../../utils/framework-delegate';
-import { raf } from '../../utils/helpers';
+import { raf, inheritAttributes } from '../../utils/helpers';
+import type { Attributes } from '../../utils/helpers';
 import { KEYBOARD_DID_OPEN } from '../../utils/keyboard/keyboard';
 import { printIonWarning } from '../../utils/logging';
 import { BACKDROP, activeAnimations, dismiss, eventMethod, prepareOverlay, present } from '../../utils/overlays';
@@ -66,6 +67,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
   private sortedBreakpoints?: number[];
   private keyboardOpenCallback?: () => void;
   private moveSheetToBreakpoint?: (options: MoveSheetToBreakpointOptions) => Promise<void>;
+  private inheritedAttributes: Attributes = {};
 
   private inline = false;
   private workingDelegate?: FrameworkDelegate;
@@ -334,7 +336,9 @@ export class Modal implements ComponentInterface, OverlayInterface {
   }
 
   componentWillLoad() {
-    const { breakpoints, initialBreakpoint, swipeToClose } = this;
+    const { breakpoints, initialBreakpoint, swipeToClose, el } = this;
+
+    this.inheritedAttributes = inheritAttributes(el, ['aria-label']);
 
     /**
      * If user has custom ID set then we should
@@ -855,7 +859,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
   };
 
   render() {
-    const { handle, isSheetModal, presentingElement, htmlAttributes, handleBehavior } = this;
+    const { handle, isSheetModal, presentingElement, htmlAttributes, handleBehavior, inheritedAttributes } = this;
 
     const showHandle = handle !== false && isSheetModal;
     const mode = getIonMode(this);
@@ -865,10 +869,13 @@ export class Modal implements ComponentInterface, OverlayInterface {
 
     return (
       <Host
-        no-router
+        role="dialog"
         aria-modal="true"
-        tabindex="-1"
+        aria-label="modal"
         {...(htmlAttributes as any)}
+        {...inheritedAttributes}
+        no-router
+        tabindex="-1"
         style={{
           zIndex: `${20000 + this.overlayIndex}`,
         }}
@@ -896,7 +903,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
 
         {mode === 'ios' && <div class="modal-shadow"></div>}
 
-        <div role="dialog" class="modal-wrapper ion-overlay-wrapper" part="content" ref={(el) => (this.wrapperEl = el)}>
+        <div class="modal-wrapper ion-overlay-wrapper" part="content" ref={(el) => (this.wrapperEl = el)}>
           {showHandle && (
             <button
               class="modal-handle"

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -871,11 +871,11 @@ export class Modal implements ComponentInterface, OverlayInterface {
       <Host
         role="dialog"
         aria-modal="true"
+        tabindex="-1"
         aria-label="modal"
         {...(htmlAttributes as any)}
         {...inheritedAttributes}
         no-router
-        tabindex="-1"
         style={{
           zIndex: `${20000 + this.overlayIndex}`,
         }}

--- a/core/src/components/modal/test/a11y/index.html
+++ b/core/src/components/modal/test/a11y/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Modal - a11y</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
+    <link href="../../../../../css/ionic.bundle.css" rel="stylesheet" />
+    <link href="../../../../../scripts/testing/styles.css" rel="stylesheet" />
+    <script src="../../../../../scripts/testing/scripts.js"></script>
+    <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+  </head>
+
+  <body>
+    <main>
+      <h1>Modal - a11y</h1>
+
+      <button id="open-modal">Open Modal</button>
+      <ion-modal trigger="open-modal">My content</ion-modal>
+    </main>
+  </body>
+</html>

--- a/core/src/components/modal/test/a11y/modal.e2e.ts
+++ b/core/src/components/modal/test/a11y/modal.e2e.ts
@@ -1,0 +1,38 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect } from '@playwright/test';
+import { test } from '@utils/test/playwright';
+
+test.describe('modal: a11y', () => {
+  test.beforeEach(async ({ page, skip }) => {
+    skip.rtl();
+    skip.mode('md');
+    await page.goto(`/src/components/modal/test/a11y`);
+  });
+
+  test('should not have accessibility violations', async ({ page }) => {
+    const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+    const button = page.locator('#open-modal');
+
+    await button.click();
+    await ionModalDidPresent.next();
+
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test('should set default aria attributes', async ({ page }) => {
+    const modal = page.locator('ion-modal');
+
+    await expect(modal).toHaveAttribute('aria-label', 'modal');
+    await expect(modal).toHaveAttribute('aria-modal', 'true');
+    await expect(modal).toHaveAttribute('role', 'dialog');
+  });
+
+  test('should allow for custom aria attributes', async ({ page }) => {
+    await page.setContent(`
+      <ion-modal aria-label="my custom label">My content</ion-modal>
+    `);
+    const modal = page.locator('ion-modal');
+    await expect(modal).toHaveAttribute('aria-label', 'my custom label');
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/23108

Dialog elements require an `aria-label` which `ion-modal` did not have. Additionally, the `role="dialog"` was set on an inner element while `aria-modal="true"` was set on the host. This caused an issue with voiceover for macOS where the modal was announced as a "group" instead of a "dialog"


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Moves `role="dialog"` from `.modal-wrapper` to the Host.
- Adds a default `aria-label`.

There's probably an argument to be made that all of these attributes should be encapsulated inside of the shadow DOM on `.modal-wrapper` (same goes for the other overlays), but I think that should go through a design process first. This PR focuses on resolving the basic issues with modal.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
