### PR TITLE
fix(overlays): dismiss on keydown to avoid chrome for windows and firefox bug

### DIFF
--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -307,7 +307,7 @@ const connectListeners = (doc: Document) => {
     });
 
     // handle ESC to close overlay
-    doc.addEventListener('keyup', (ev) => {
+    doc.addEventListener('keydown', (ev) => {
       if (ev.key === 'Escape') {
         const lastOverlay = getOverlay(doc);
         if (lastOverlay?.backdropDismiss) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/25802

It looks like when dismissing an `alert` dialog with the Escape key, Firefox will dispatch a `keyup` event. This causes overlays in Ionic to also dismiss. Other browsers do not emit `keyup` when dismissing an `alert` with the Escape key.

This impacts Firefox (all platforms) and Chrome for Windows. Using `keydown` avoids this bug and better aligns our overlays with what the browser and native platforms do. For example, the native alert dialog dismisses on `keydown`. Additionally, when using a keyboard on iOS/iPadOS it is possible to dismiss certain overlays on keydown by pressing Escape/Ctrl+[.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Listen on `keydown` to dismiss overlays instead of `keyup`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


**Breaking Change**

Overlays will now be dismissed during the `keydown` phase of pressing Escape instead of `keyup`. Developers listening for the `keydown` event should listen on `keyup` instead.