### PR TITLE
fix(searchbar): keypress can activate clear button

### DIFF
--- a/core/src/components/searchbar/searchbar.tsx
+++ b/core/src/components/searchbar/searchbar.tsx
@@ -511,9 +511,6 @@ export class Searchbar implements ComponentInterface {
             autoComplete={this.autocomplete}
             autoCorrect={this.autocorrect}
             spellcheck={this.spellcheck}
-            onFocusout={() => {
-              console.log('focus out');
-            }}
           />
 
           {mode === 'md' && cancelButton}

--- a/core/src/components/searchbar/searchbar.tsx
+++ b/core/src/components/searchbar/searchbar.tsx
@@ -243,13 +243,8 @@ export class Searchbar implements ComponentInterface {
   /**
    * Clears the input field and triggers the control change.
    */
-  private onClearInput = (ev?: Event, shouldFocus?: boolean) => {
+  private onClearInput = (shouldFocus?: boolean) => {
     this.ionClear.emit();
-
-    if (ev) {
-      ev.preventDefault();
-      ev.stopPropagation();
-    }
 
     // setTimeout() fixes https://github.com/ionic-team/ionic/issues/7527
     // wait for 4 frames
@@ -516,6 +511,9 @@ export class Searchbar implements ComponentInterface {
             autoComplete={this.autocomplete}
             autoCorrect={this.autocorrect}
             spellcheck={this.spellcheck}
+            onFocusout={() => {
+              console.log('focus out');
+            }}
           />
 
           {mode === 'md' && cancelButton}
@@ -533,8 +531,15 @@ export class Searchbar implements ComponentInterface {
             type="button"
             no-blur
             class="searchbar-clear-button"
-            onMouseDown={(ev) => this.onClearInput(ev, true)}
-            onTouchStart={(ev) => this.onClearInput(ev, true)}
+            onPointerDown={(ev) => {
+              /**
+               * This prevents mobile browsers from
+               * blurring the input when the clear
+               * button is activated.
+               */
+              ev.preventDefault();
+            }}
+            onClick={() => this.onClearInput(true)}
           >
             <ion-icon
               aria-hidden="true"

--- a/core/src/components/searchbar/test/basic/searchbar.e2e.ts
+++ b/core/src/components/searchbar/test/basic/searchbar.e2e.ts
@@ -33,3 +33,47 @@ test.describe('searchbar: basic', () => {
     await expect(cancelButton).toHaveCount(0);
   });
 });
+
+test.describe('searchbar: clear button', () => {
+  test.beforeEach(({ skip }) => {
+    skip.rtl();
+  })
+  test('should clear the input when pressed', async ({ page }) => {
+    await page.setContent(`
+      <ion-searchbar value="abc" show-clear-button="always"></ion-searchbar>
+    `);
+
+    const searchbar = page.locator('ion-searchbar');
+    const clearButton = searchbar.locator('.searchbar-clear-button');
+
+    await expect(searchbar).toHaveJSProperty('value', 'abc');
+
+    await clearButton.click();
+    await page.waitForChanges();
+
+    await expect(searchbar).toHaveJSProperty('value', '');
+  })
+  /**
+   * Note: This only tests the desktop focus behavior.
+   * Mobile browsers have different restrictions around
+   * focusing inputs, so these platforms should always
+   * be tested when making changes to the focus behavior.
+   */
+  test('should keep the input focused when the clear button is pressed', async ({ page }) => {
+    await page.setContent(`
+      <ion-searchbar value="abc"></ion-searchbar>
+    `);
+
+    const searchbar = page.locator('ion-searchbar');
+    const nativeInput = searchbar.locator('input');
+    const clearButton = searchbar.locator('.searchbar-clear-button');
+
+    await searchbar.click();
+    await expect(nativeInput).toBeFocused();
+
+    await clearButton.click();
+    await page.waitForChanges();
+
+    await expect(nativeInput).toBeFocused();
+  })
+})


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
