### PR TITLE
refactor(datetime): use key to preserve calendar body ref node

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -629,18 +629,8 @@ export class Datetime implements ComponentInterface {
     return presentation === 'date' || presentation === 'date-time' || presentation === 'time-date';
   }
 
-  /**
-   * Stencil sometimes sets calendarBodyRef to null on rerender, even though
-   * the element is present. Query for it manually as a fallback.
-   *
-   * TODO(FW-901) Remove when issue is resolved: https://github.com/ionic-team/stencil/issues/3253
-   */
-  private getCalendarBodyEl = () => {
-    return this.calendarBodyRef || this.el.shadowRoot?.querySelector('.calendar-body');
-  };
-
   private initializeKeyboardListeners = () => {
-    const calendarBodyRef = this.getCalendarBodyEl();
+    const calendarBodyRef = this.calendarBodyRef;
     if (!calendarBodyRef) {
       return;
     }
@@ -818,7 +808,7 @@ export class Datetime implements ComponentInterface {
   };
 
   private initializeCalendarListener = () => {
-    const calendarBodyRef = this.getCalendarBodyEl();
+    const calendarBodyRef = this.calendarBodyRef;
     if (!calendarBodyRef) {
       return;
     }
@@ -1241,7 +1231,7 @@ export class Datetime implements ComponentInterface {
   };
 
   private nextMonth = () => {
-    const calendarBodyRef = this.getCalendarBodyEl();
+    const calendarBodyRef = this.calendarBodyRef;
     if (!calendarBodyRef) {
       return;
     }
@@ -1261,7 +1251,7 @@ export class Datetime implements ComponentInterface {
   };
 
   private prevMonth = () => {
-    const calendarBodyRef = this.getCalendarBodyEl();
+    const calendarBodyRef = this.calendarBodyRef;
     if (!calendarBodyRef) {
       return;
     }
@@ -1980,7 +1970,7 @@ export class Datetime implements ComponentInterface {
   }
   private renderCalendarBody() {
     return (
-      <div class="calendar-body ion-focusable" ref={(el) => (this.calendarBodyRef = el)} tabindex="0">
+      <div class="calendar-body ion-focusable" ref={(el) => this.calendarBodyRef = el} tabindex="0">
         {generateMonths(this.workingParts).map(({ month, year }) => {
           return this.renderMonth(month, year);
         })}
@@ -1989,7 +1979,7 @@ export class Datetime implements ComponentInterface {
   }
   private renderCalendar(mode: Mode) {
     return (
-      <div class="datetime-calendar">
+      <div class="datetime-calendar" key="datetime-calendar">
         {this.renderCalendarHeader(mode)}
         {this.renderCalendarBody()}
       </div>

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1970,7 +1970,7 @@ export class Datetime implements ComponentInterface {
   }
   private renderCalendarBody() {
     return (
-      <div class="calendar-body ion-focusable" ref={(el) => this.calendarBodyRef = el} tabindex="0">
+      <div class="calendar-body ion-focusable" ref={(el) => (this.calendarBodyRef = el)} tabindex="0">
         {generateMonths(this.workingParts).map(({ month, year }) => {
           return this.renderMonth(month, year);
         })}


### PR DESCRIPTION
This fixes an issue with the Datetime component where in certain
circumstances a `ref` on an element rendered by the datetime component
would end up erroneously set to `null`, necessitating a yucky
`document.querySelector` based workaround.

The issue arises because of how Stencil's virtual DOM implementation
handles reconciling the children of old and new nodes, and in particular
how it deals with situations in which the order of children changes but
some of the nodes are conserved.

The way this was affecting the datetime component was that in certain
circumstances a method which returns a `<div>` with a `ref` would change
position in the children of another node. In particular, this can happen
if the `presentation` prop changes, causing the return value of the
`renderDatetime` function to change in turn. The salient changes to
the return value of _that_ function which would change look like
going from:

```ts
[
  this.renderCalendar(mode),
  this.renderTime()
]
```

to

```ts
[
  this.renderTime(),
  this.renderCalendar(mode)
]
```

`renderCalendar` in turn calls `renderCalendarBody` which returns the
`<div>` with the offending `ref` on it.

Anyhow, in reconciling these changed children when re-rendering the
component things can go wrong. Stencil's algorithm in this case does a
"best effort" at identifying nodes which should be kept between
re-renders, but it does not do an exhaustive check _unless nodes have a
key attr_. So, more or less, what was happening was that in cases where
the `<div>` with the `ref` on it was going to be included in the next
rendered output from the component Stencil would nonetheless remove the
'old' node and create a new identical one for the next render. Then
there is also a race condition where the new node would be created
before the old one is removed, causing the `ref` to be briefly set to
the new value (when the new VNode is created) and then reset to `null`
(when the old one was destroyed).

The fix is to set the `key` attribute on the `<div>` which is the
parent of the `<div>` with the `ref`. This allows Stencil to do an
exhaustive check when reconciling old and new children in order to
not needlessly throw away the old VDom node, and gets rid of the
behavior where the `ref` would end up set to `null` erroneously.
It's possible (but I think unlikely) that this change will result
in slightly less GC pressure, but I did no testing of that.

closes ionic-team/stencil#3253
FW-901

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

There is a bug in Stencil which this fixes (https://github.com/ionic-team/stencil/issues/3253).

Basically, there was an issue where switching the `presentation` prop on the Datetime component would erroneously set a `ref` stored on the component to `null`. This fixes that by setting a `key` attr on the relevant div so that Stencil's VDom child reconciliation / update algorithm can do a better job of finding nodes that are the same between renders. 

<!-- Issues are required for both bug fixes and features. -->
Issue #3523

## What is the new behavior?


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
