### PR TITLE
fix(input, textarea): padding is now added to content so inputs scroll above keyboard

### DIFF
--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -9,7 +9,8 @@ export const enableScrollAssist = (
   inputEl: HTMLInputElement | HTMLTextAreaElement,
   contentEl: HTMLElement | null,
   footerEl: HTMLIonFooterElement | null,
-  keyboardHeight: number
+  keyboardHeight: number,
+  enableScrollPadding: boolean
 ) => {
   /**
    * When the input is about to receive

--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -25,6 +25,7 @@ export const enableScrollAssist = (
    * 2. The native keyboard resize mode is either "none"
    * (keyboard overlays webview) or undefined (resize
    * information unavailable)
+   * Resize info is available on Capacitor 4+
    */
   const addScrollPadding =
     enableScrollPadding && (keyboardResize === undefined || keyboardResize.mode === KeyboardResize.None);

--- a/core/src/utils/input-shims/hacks/scroll-padding.ts
+++ b/core/src/utils/input-shims/hacks/scroll-padding.ts
@@ -55,7 +55,7 @@ export const setClearScrollPaddingListener = (
     if (contentEl) {
       setScrollPadding(contentEl, 0, doneCallback);
     }
-  }
+  };
 
   inputEl.addEventListener('focusout', clearScrollPadding, { once: true });
-}
+};

--- a/core/src/utils/input-shims/hacks/scroll-padding.ts
+++ b/core/src/utils/input-shims/hacks/scroll-padding.ts
@@ -1,51 +1,61 @@
-import { findClosestIonContent } from '../../content';
-
 const PADDING_TIMER_KEY = '$ionPaddingTimer';
 
-export const enableScrollPadding = (keyboardHeight: number) => {
-  const doc = document;
-
-  const onFocusin = (ev: any) => {
-    setScrollPadding(ev.target, keyboardHeight);
-  };
-  const onFocusout = (ev: any) => {
-    setScrollPadding(ev.target, 0);
-  };
-
-  doc.addEventListener('focusin', onFocusin);
-  doc.addEventListener('focusout', onFocusout);
-
-  return () => {
-    doc.removeEventListener('focusin', onFocusin);
-    doc.removeEventListener('focusout', onFocusout);
-  };
-};
-
-const setScrollPadding = (input: HTMLElement, keyboardHeight: number) => {
-  if (input.tagName !== 'INPUT') {
-    return;
-  }
-  if (input.parentElement && input.parentElement.tagName === 'ION-INPUT') {
-    return;
-  }
-  if (input.parentElement?.parentElement?.tagName === 'ION-SEARCHBAR') {
-    return;
-  }
-
-  const el = findClosestIonContent(input);
-  if (el === null) {
-    return;
-  }
-  const timer = (el as any)[PADDING_TIMER_KEY];
+/**
+ * Scroll padding adds additional padding to the bottom
+ * of ion-content so that there is enough scroll space
+ * for an input to be scrolled above the keyboard. This
+ * is needed in environments where the webview does not
+ * resize when the keyboard opens.
+ *
+ * Example: If an input at the bottom of ion-content is
+ * focused, there is no additional scrolling space below
+ * it, so the input cannot be scrolled above the keyboard.
+ * Scroll padding fixes this by adding padding equal to the
+ * height of the keyboard to the bottom of the content.
+ *
+ * Common environments where this is needed:
+ * - Mobile Safari: The keyboard overlays the content
+ * - Capacitor/Cordova on iOS: The keyboard overlays the content
+ * when the KeyboardResize mode is set to 'none'.
+ */
+export const setScrollPadding = (contentEl: HTMLElement, paddingAmount: number, clearCallback?: () => void) => {
+  const timer = (contentEl as any)[PADDING_TIMER_KEY];
   if (timer) {
     clearTimeout(timer);
   }
 
-  if (keyboardHeight > 0) {
-    el.style.setProperty('--keyboard-offset', `${keyboardHeight}px`);
+  if (paddingAmount > 0) {
+    contentEl.style.setProperty('--keyboard-offset', `${paddingAmount}px`);
   } else {
-    (el as any)[PADDING_TIMER_KEY] = setTimeout(() => {
-      el.style.setProperty('--keyboard-offset', '0px');
+    (contentEl as any)[PADDING_TIMER_KEY] = setTimeout(() => {
+      contentEl.style.setProperty('--keyboard-offset', '0px');
+      if (clearCallback) {
+        clearCallback();
+      }
     }, 120);
   }
 };
+
+/**
+ * When an input is about to be focused,
+ * set a timeout to clear any scroll padding
+ * on the content. Note: The clearing
+ * is done on a timeout so that if users
+ * are moving focus from one input to the next
+ * then re-adding scroll padding to the new
+ * input with cancel the timeout to clear the
+ * scroll padding.
+ */
+export const setClearScrollPaddingListener = (
+  inputEl: HTMLInputElement | HTMLTextAreaElement,
+  contentEl: HTMLElement | null,
+  doneCallback: () => void
+) => {
+  const clearScrollPadding = () => {
+    if (contentEl) {
+      setScrollPadding(contentEl, 0, doneCallback);
+    }
+  }
+
+  inputEl.addEventListener('focusout', clearScrollPadding, { once: true });
+}

--- a/core/src/utils/input-shims/hacks/test/index.html
+++ b/core/src/utils/input-shims/hacks/test/index.html
@@ -88,6 +88,24 @@
             keyboardHeight: 250,
           },
         };
+
+        const params = new URLSearchParams(window.location.href.split('?')[1]);
+        const resizeMode = params.get('resizeMode');
+
+        if (resizeMode) {
+          window.Capacitor = {
+            isPluginAvailable: (plugin) => plugin === 'Keyboard',
+            Plugins: {
+              Keyboard: {
+                getResizeMode: () => {
+                  return Promise.resolve({
+                    mode: resizeMode,
+                  });
+                },
+              },
+            },
+          };
+        }
       </script>
     </ion-app>
   </body>

--- a/core/src/utils/input-shims/hacks/test/scroll-assist.e2e.ts
+++ b/core/src/utils/input-shims/hacks/test/scroll-assist.e2e.ts
@@ -72,4 +72,22 @@ test.describe('scroll-assist', () => {
     await expect(await getScrollPosition(content)).not.toBe(0);
     await expect(content).not.toHaveCSS('--keyboard-offset', '0px');
   });
+
+  test('should keep scroll padding even when switching between inputs', async ({ page }) => {
+    const input = page.locator('#input-outside-viewport');
+    const textarea = page.locator('#textarea-outside-viewport');
+    const content = page.locator('ion-content');
+
+    await input.click({ force: true });
+    await page.waitForChanges();
+    await expect(input.locator('input:not(.cloned-input)')).toBeFocused();
+
+    await expect(content).not.toHaveCSS('--keyboard-offset', '0px');
+
+    await textarea.click({ force: true });
+    await page.waitForChanges();
+    await expect(textarea.locator('textarea:not(.cloned-input)')).toBeFocused();
+
+    await expect(content).not.toHaveCSS('--keyboard-offset', '0px');
+  });
 });

--- a/core/src/utils/input-shims/hacks/test/scroll-assist.e2e.ts
+++ b/core/src/utils/input-shims/hacks/test/scroll-assist.e2e.ts
@@ -9,15 +9,15 @@ test.describe('scroll-assist', () => {
 
       return scrollEl.scrollTop;
     });
-  }
+  };
   test.beforeEach(async ({ page, skip }) => {
     skip.rtl();
     skip.mode('md', 'Scroll utils are only needed on iOS mode');
     skip.browser('firefox');
-    skip.browser('chromium')
+    skip.browser('chromium');
 
     await page.goto('/src/utils/input-shims/hacks/test');
-  })
+  });
   test('should not activate when input is above the keyboard', async ({ page }) => {
     const input = page.locator('#input-above-keyboard');
     const content = page.locator('ion-content');

--- a/core/src/utils/input-shims/hacks/test/scroll-assist.e2e.ts
+++ b/core/src/utils/input-shims/hacks/test/scroll-assist.e2e.ts
@@ -57,4 +57,19 @@ test.describe('scroll-assist', () => {
 
     await expect(await getScrollPosition(content)).not.toBe(0);
   });
+
+  test('should add scroll padding for an input at the bottom of the scroll container', async ({ page }) => {
+    const input = page.locator('#input-outside-viewport');
+    const content = page.locator('ion-content');
+
+    await expect(await getScrollPosition(content)).toBe(0);
+    await expect(content).toHaveCSS('--keyboard-offset', '0px');
+
+    await input.click({ force: true });
+    await page.waitForChanges();
+    await expect(input.locator('input:not(.cloned-input)')).toBeFocused();
+
+    await expect(await getScrollPosition(content)).not.toBe(0);
+    await expect(content).not.toHaveCSS('--keyboard-offset', '0px');
+  });
 });

--- a/core/src/utils/input-shims/hacks/test/scroll-assist.e2e.ts
+++ b/core/src/utils/input-shims/hacks/test/scroll-assist.e2e.ts
@@ -1,93 +1,178 @@
 import { expect } from '@playwright/test';
 import type { Locator } from '@playwright/test';
+import { KeyboardResize } from '@utils/native/keyboard';
+import type { E2EPage } from '@utils/test/playwright';
 import { test } from '@utils/test/playwright';
 
-test.describe('scroll-assist', () => {
-  const getScrollPosition = async (contentEl: Locator) => {
-    return await contentEl.evaluate(async (el: HTMLIonContentElement) => {
-      const scrollEl = await el.getScrollElement();
+const getScrollPosition = async (contentEl: Locator) => {
+  return await contentEl.evaluate(async (el: HTMLIonContentElement) => {
+    const scrollEl = await el.getScrollElement();
 
-      return scrollEl.scrollTop;
-    });
-  };
+    return scrollEl.scrollTop;
+  });
+};
+
+test.describe('scroll-assist', () => {
+  let scrollAssistFixture: ScrollAssistFixture;
   test.beforeEach(async ({ page, skip }) => {
     skip.rtl();
     skip.mode('md', 'Scroll utils are only needed on iOS mode');
     skip.browser('firefox');
     skip.browser('chromium');
 
-    await page.goto('/src/utils/input-shims/hacks/test');
-  });
-  test('should not activate when input is above the keyboard', async ({ page }) => {
-    const input = page.locator('#input-above-keyboard');
-    const content = page.locator('ion-content');
-
-    await expect(await getScrollPosition(content)).toBe(0);
-
-    await input.click();
-    await expect(input.locator('input')).toBeFocused();
-    await page.waitForChanges();
-
-    await expect(await getScrollPosition(content)).toBe(0);
+    scrollAssistFixture = new ScrollAssistFixture(page);
   });
 
-  test('should activate when input is below the keyboard', async ({ page }) => {
-    const input = page.locator('#input-below-keyboard');
-    const content = page.locator('ion-content');
+  test.describe('scroll-assist: basic functionality', () => {
+    test.beforeEach(async () => {
+      await scrollAssistFixture.goto();
+    });
+    test('should not activate when input is above the keyboard', async () => {
+      await scrollAssistFixture.expectNotToHaveScrollAssist(
+        '#input-above-keyboard',
+        '#input-above-keyboard input:not(.cloned-input)'
+      );
+    });
 
-    await expect(await getScrollPosition(content)).toBe(0);
+    test('should activate when input is below the keyboard', async () => {
+      await scrollAssistFixture.expectToHaveScrollAssist(
+        '#input-below-keyboard',
+        '#input-below-keyboard input:not(.cloned-input)'
+      );
+    });
 
-    await input.click({ force: true });
-    await page.waitForChanges();
-    await expect(input.locator('input:not(.cloned-input)')).toBeFocused();
-
-    await expect(await getScrollPosition(content)).not.toBe(0);
+    test('should activate even when not explicitly tapping input', async () => {
+      await scrollAssistFixture.expectToHaveScrollAssist(
+        '#item-below-keyboard ion-label',
+        '#input-below-keyboard input:not(.cloned-input)'
+      );
+    });
   });
+  test.describe('scroll-assist: scroll-padding', () => {
+    test.describe('scroll-padding: browser/cordova', () => {
+      test.beforeEach(async () => {
+        await scrollAssistFixture.goto();
+      });
+      test('should add scroll padding for an input at the bottom of the scroll container', async () => {
+        await scrollAssistFixture.expectToHaveScrollPadding(
+          '#input-outside-viewport',
+          '#input-outside-viewport input:not(.cloned-input)'
+        );
+      });
 
-  test('should activate even when not explicitly tapping input', async ({ page }) => {
-    const label = page.locator('#item-below-keyboard ion-label');
-    const input = page.locator('#input-below-keyboard');
-    const content = page.locator('ion-content');
+      test('should keep scroll padding even when switching between inputs', async () => {
+        await scrollAssistFixture.expectToHaveScrollPadding(
+          '#input-outside-viewport',
+          '#input-outside-viewport input:not(.cloned-input)'
+        );
 
-    await expect(await getScrollPosition(content)).toBe(0);
+        await scrollAssistFixture.expectToHaveScrollPadding(
+          '#textarea-outside-viewport',
+          '#textarea-outside-viewport textarea:not(.cloned-input)'
+        );
+      });
+    });
+    test.describe('scroll-padding: webview resizing', () => {
+      test('should add scroll padding when webview resizing is "none"', async () => {
+        await scrollAssistFixture.goto(KeyboardResize.None);
 
-    await label.click({ force: true });
-    await page.waitForChanges();
-    await expect(input.locator('input:not(.cloned-input)')).toBeFocused();
+        await scrollAssistFixture.expectToHaveScrollPadding(
+          '#input-outside-viewport',
+          '#input-outside-viewport input:not(.cloned-input)'
+        );
+      });
+      test('should not add scroll padding when webview resizing is "body"', async () => {
+        await scrollAssistFixture.goto(KeyboardResize.Body);
 
-    await expect(await getScrollPosition(content)).not.toBe(0);
-  });
+        await scrollAssistFixture.expectNotToHaveScrollPadding(
+          '#input-outside-viewport',
+          '#input-outside-viewport input:not(.cloned-input)'
+        );
+      });
+      test('should not add scroll padding when webview resizing is "ionic"', async () => {
+        await scrollAssistFixture.goto(KeyboardResize.Ionic);
 
-  test('should add scroll padding for an input at the bottom of the scroll container', async ({ page }) => {
-    const input = page.locator('#input-outside-viewport');
-    const content = page.locator('ion-content');
+        await scrollAssistFixture.expectNotToHaveScrollPadding(
+          '#input-outside-viewport',
+          '#input-outside-viewport input:not(.cloned-input)'
+        );
+      });
+      test('should not add scroll padding when webview resizing is "native"', async () => {
+        await scrollAssistFixture.goto(KeyboardResize.Native);
 
-    await expect(await getScrollPosition(content)).toBe(0);
-    await expect(content).toHaveCSS('--keyboard-offset', '0px');
-
-    await input.click({ force: true });
-    await page.waitForChanges();
-    await expect(input.locator('input:not(.cloned-input)')).toBeFocused();
-
-    await expect(await getScrollPosition(content)).not.toBe(0);
-    await expect(content).not.toHaveCSS('--keyboard-offset', '0px');
-  });
-
-  test('should keep scroll padding even when switching between inputs', async ({ page }) => {
-    const input = page.locator('#input-outside-viewport');
-    const textarea = page.locator('#textarea-outside-viewport');
-    const content = page.locator('ion-content');
-
-    await input.click({ force: true });
-    await page.waitForChanges();
-    await expect(input.locator('input:not(.cloned-input)')).toBeFocused();
-
-    await expect(content).not.toHaveCSS('--keyboard-offset', '0px');
-
-    await textarea.click({ force: true });
-    await page.waitForChanges();
-    await expect(textarea.locator('textarea:not(.cloned-input)')).toBeFocused();
-
-    await expect(content).not.toHaveCSS('--keyboard-offset', '0px');
+        await scrollAssistFixture.expectNotToHaveScrollPadding(
+          '#input-outside-viewport',
+          '#input-outside-viewport input:not(.cloned-input)'
+        );
+      });
+    });
   });
 });
+
+class ScrollAssistFixture {
+  readonly page: E2EPage;
+  private content!: Locator;
+
+  constructor(page: E2EPage) {
+    this.page = page;
+  }
+
+  async goto(resizeMode?: KeyboardResize) {
+    let url = `/src/utils/input-shims/hacks/test`;
+    if (resizeMode !== undefined) {
+      url += `?resizeMode=${resizeMode}`;
+    }
+
+    await this.page.goto(url);
+
+    this.content = this.page.locator('ion-content');
+  }
+
+  private async focusInput(interactiveSelector: string, inputSelector: string) {
+    const { page } = this;
+    const interactive = page.locator(interactiveSelector);
+    const input = page.locator(inputSelector);
+
+    await interactive.click({ force: true });
+    await expect(input).toBeFocused();
+    await page.waitForChanges();
+  }
+
+  private getScrollPosition() {
+    const { content } = this;
+
+    return getScrollPosition(content);
+  }
+
+  async expectNotToHaveScrollAssist(interactiveSelector: string, inputSelector: string) {
+    await expect(await this.getScrollPosition()).toBe(0);
+
+    await this.focusInput(interactiveSelector, inputSelector);
+
+    await expect(await this.getScrollPosition()).toBe(0);
+  }
+
+  async expectToHaveScrollAssist(interactiveSelector: string, inputSelector: string) {
+    await expect(await this.getScrollPosition()).toBe(0);
+
+    await this.focusInput(interactiveSelector, inputSelector);
+
+    await expect(await this.getScrollPosition()).not.toBe(0);
+  }
+
+  async expectToHaveScrollPadding(interactiveSelector: string, inputSelector: string) {
+    const { content } = this;
+
+    await this.focusInput(interactiveSelector, inputSelector);
+
+    await expect(content).not.toHaveCSS('--keyboard-offset', '0px');
+  }
+
+  async expectNotToHaveScrollPadding(interactiveSelector: string, inputSelector: string) {
+    const { content } = this;
+
+    await this.focusInput(interactiveSelector, inputSelector);
+
+    await expect(content).toHaveCSS('--keyboard-offset', '0px');
+  }
+}

--- a/core/src/utils/input-shims/input-shims.ts
+++ b/core/src/utils/input-shims/input-shims.ts
@@ -5,11 +5,9 @@ import { componentOnReady } from '../helpers';
 import { enableHideCaretOnScroll } from './hacks/hide-caret';
 import { enableInputBlurring } from './hacks/input-blurring';
 import { enableScrollAssist } from './hacks/scroll-assist';
-import { enableScrollPadding } from './hacks/scroll-padding';
 
 const INPUT_BLURRING = true;
 const SCROLL_ASSIST = true;
-const SCROLL_PADDING = true;
 const HIDE_CARET = true;
 
 export const startInputShims = (config: Config) => {
@@ -55,7 +53,7 @@ export const startInputShims = (config: Config) => {
       scrollAssist &&
       !scrollAssistMap.has(componentEl)
     ) {
-      const rmFn = enableScrollAssist(componentEl, inputEl, scrollEl, footerEl, keyboardHeight);
+      const rmFn = enableScrollAssist(componentEl, inputEl, scrollEl, footerEl, keyboardHeight, scrollPadding);
       scrollAssistMap.set(componentEl, rmFn);
     }
   };
@@ -80,10 +78,6 @@ export const startInputShims = (config: Config) => {
 
   if (inputBlurring && INPUT_BLURRING) {
     enableInputBlurring();
-  }
-
-  if (scrollPadding && SCROLL_PADDING) {
-    enableScrollPadding(keyboardHeight);
   }
 
   // Input might be already loaded in the DOM before ion-device-hacks did.

--- a/core/src/utils/native/keyboard.ts
+++ b/core/src/utils/native/keyboard.ts
@@ -1,0 +1,26 @@
+import { win } from '../window';
+
+export interface KeyboardResizeOptions {
+  mode: KeyboardResize;
+}
+
+export enum KeyboardResize {
+  Body = 'body',
+  Ionic = 'ionic',
+  Native = 'native',
+  None = 'none',
+}
+
+export const Keyboard = {
+  getEngine() {
+    return (win as any)?.Capacitor?.isPluginAvailable('Keyboard') && (win as any)?.Capacitor.Plugins.Keyboard;
+  },
+  getResizeMode(): Promise<KeyboardResizeOptions | undefined> {
+    const engine = this.getEngine();
+    if (!engine || !engine.getResizeMode) {
+      return Promise.resolve(undefined);
+    }
+
+    return engine.getResizeMode();
+  },
+};

--- a/core/src/utils/test/playwright/page/utils/goto.ts
+++ b/core/src/utils/test/playwright/page/utils/goto.ts
@@ -22,7 +22,22 @@ export const goto = async (page: Page, url: string, options: any, testInfo: Test
   const formattedRtl = urlToParams.get('rtl') ?? rtl;
   const ionicTesting = urlToParams.get('ionic:_testing') ?? _testing;
 
-  const formattedUrl = `${splitUrl[0]}?ionic:_testing=${ionicTesting}&ionic:mode=${formattedMode}&rtl=${formattedRtl}`;
+  /**
+   * Pass through other custom query params
+   */
+  urlToParams.delete('ionic:mode');
+  urlToParams.delete('rtl');
+  urlToParams.delete('ionic:_testing');
+
+  /**
+   * Convert remaining query params to a string.
+   * Be sure to call decodeURIComponent to decode
+   * characters such as &.
+   */
+  const remainingQueryParams = decodeURIComponent(urlToParams.toString());
+  const remainingQueryParamsString = remainingQueryParams == '' ? '' : `&${remainingQueryParams}`;
+
+  const formattedUrl = `${splitUrl[0]}?ionic:_testing=${ionicTesting}&ionic:mode=${formattedMode}&rtl=${formattedRtl}${remainingQueryParamsString}`;
 
   testInfo.annotations.push({
     type: 'mode',


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/18532

There are a couple of issues:

1. Scroll padding was disabled for inputs. Environments where the keyboard overlays the webview typically have inputs that need more padding on the bottom in order to scroll into view.
2. Even when scroll padding was re-enabled there were race conditions due to the scroll padding and scroll assist utilities not being coordinated.
3. Scroll padding was being added in environments where it is not needed (i.e. when resizing the webview in Capacitor on iOS)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updates the test utils to allow for custom query parameters while not overriding the necessary ones for e2e testing to work
- Removes the standalone scroll padding listener in favor of one that is controlled by scroll assist. Scroll padding exists to enhance the scroll assist behavior, so I made these two utils coordinate better by having scroll assist trigger the padding. This also gets rid of the race condition issues.
- Added logic to check the resize mode. When resize mode is "none" in Capacitor or when it is unknown, scroll padding will be added. Scroll padding will be disabled in all other scenarios. The resize mode is unknown when running in a non Capacitor environment or when running the Cap Keyboard plugin older than v4.

There is likely some opportunities to improve the accuracy of how much scroll padding to add, but I am going to focus on just getting this working as that is more important.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

**Before and After example**

| `main` | branch |
| ------- | ------- |
| <video src="https://user-images.githubusercontent.com/2721089/187301056-73a2ede0-9cb5-4340-b666-4b5f208be2b0.mp4"></video> | <video src="https://user-images.githubusercontent.com/2721089/187301090-c7da2a48-378a-42d0-a03d-029846b74e12.mp4"></video> |

