### PR TITLE
test(accordion): avoid scroll assist cloned input

### DIFF
--- a/core/src/components/accordion/test/a11y/accordion.e2e.ts
+++ b/core/src/components/accordion/test/a11y/accordion.e2e.ts
@@ -12,7 +12,7 @@ test.describe('accordion: a11y', () => {
     const personalInfoHeader = page.locator('ion-accordion:first-child > ion-item');
     const billingAddressHeader = page.locator('ion-accordion:nth-child(2) > ion-item');
     const shippingAddressHeader = page.locator('ion-accordion:nth-child(3) > ion-item');
-    const addressInput = page.locator('#address1 input');
+    const addressInput = page.locator('#address1 input:not(.cloned-input)');
 
     await page.keyboard.press(tabKey);
     await expect(personalInfoHeader).toBeFocused();


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: N/A

Accordion related tests were failing intermittently on Safari. Scroll assist adds a cloned input inside of `ion-input` as part of its adjustment work, and sometimes that would be in the DOM long enough for playwright to pick it up. This led to errors such as the following:
```
expect.toBeFocused: Error: strict mode violation: "#address1 input" resolved to 2 elements:
        1) <input type="text" placeholder="" autocorrect="off" aut…/> aka playwright.$("input[name="ion-input-11"] >> nth=0")
        2) <input type="text" tabindex="-1" placeholder="" autocor…/> aka playwright.$("input[name="ion-input-11"] >> nth=1")
```

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Avoid selecting the cloned input in tests

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
