### PR TITLE
fix(datetime): month grid no longer loops on ios

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1111,7 +1111,7 @@ export class Datetime implements ComponentInterface {
    * so we need to re-init behavior with the new elements.
    */
   componentDidRender() {
-    const { presentation, prevPresentation, calendarBodyRef } = this;
+    const { presentation, prevPresentation, calendarBodyRef, minParts } = this;
 
     /**
      * TODO(FW-2165)
@@ -1124,7 +1124,7 @@ export class Datetime implements ComponentInterface {
      * changing again, thus changing the scroll position again and causing
      * an infinite loop.
      */
-    if (calendarBodyRef) {
+    if (calendarBodyRef && minParts !== undefined) {
       const workingMonth = calendarBodyRef.querySelector('.calendar-month:nth-of-type(1)');
       if (workingMonth) {
         calendarBodyRef.scrollLeft = workingMonth.clientWidth * (isRTL(this.el) ? -1 : 1);

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1111,7 +1111,25 @@ export class Datetime implements ComponentInterface {
    * so we need to re-init behavior with the new elements.
    */
   componentDidRender() {
-    const { presentation, prevPresentation } = this;
+    const { presentation, prevPresentation, calendarBodyRef } = this;
+
+    /**
+     * TODO(FW-2165)
+     * Remove this when https://bugs.webkit.org/show_bug.cgi?id=235960 is fixed.
+     * When using `min`, we add `scroll-snap-align: none`
+     * to the disabled month so that users cannot scroll to it.
+     * This triggers a bug in WebKit where the scroll position is reset.
+     * Since the month change logic is handled by a scroll listener,
+     * this causes the month to change leading to `scroll-snap-align`
+     * changing again, thus changing the scroll position again and causing
+     * an infinite loop.
+     */
+    if (calendarBodyRef) {
+      const workingMonth = calendarBodyRef.querySelector('.calendar-month:nth-of-type(1)');
+      if (workingMonth) {
+        calendarBodyRef.scrollLeft = workingMonth.clientWidth * (isRTL(this.el) ? -1 : 1);
+      }
+    }
 
     if (prevPresentation === null) {
       this.prevPresentation = presentation;

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1111,7 +1111,7 @@ export class Datetime implements ComponentInterface {
    * so we need to re-init behavior with the new elements.
    */
   componentDidRender() {
-    const { presentation, prevPresentation, calendarBodyRef, minParts } = this;
+    const { presentation, prevPresentation, calendarBodyRef, minParts, preferWheel } = this;
 
     /**
      * TODO(FW-2165)
@@ -1123,8 +1123,11 @@ export class Datetime implements ComponentInterface {
      * this causes the month to change leading to `scroll-snap-align`
      * changing again, thus changing the scroll position again and causing
      * an infinite loop.
+     * This issue only applies to the calendar grid, so we can disable
+     * it if the calendar grid is not being used.
      */
-    if (calendarBodyRef && minParts !== undefined) {
+    const hasCalendarGrid = !preferWheel && ['date-time', 'time-date', 'date'].includes(presentation);
+    if (minParts !== undefined && hasCalendarGrid && calendarBodyRef) {
       const workingMonth = calendarBodyRef.querySelector('.calendar-month:nth-of-type(1)');
       if (workingMonth) {
         calendarBodyRef.scrollLeft = workingMonth.clientWidth * (isRTL(this.el) ? -1 : 1);

--- a/core/src/components/datetime/test/minmax/datetime.e2e.ts
+++ b/core/src/components/datetime/test/minmax/datetime.e2e.ts
@@ -164,7 +164,7 @@ test.describe('datetime: minmax', () => {
 
     const buttons = page.locator('ion-datetime .calendar-next-prev ion-button');
     await buttons.nth(1).click();
-    await page.waitForChanges()
+    await page.waitForChanges();
 
     await datetimeMonthDidChange.next();
 
@@ -174,11 +174,11 @@ test.describe('datetime: minmax', () => {
      * for the bug ships in WebKit, this will be removed.
      */
     await page.evaluate(() => {
-      return new Promise(resolve => {
+      return new Promise((resolve) => {
         setTimeout(resolve, 500);
-      })
+      });
     });
 
     await expect(datetimeMonthDidChange).toHaveReceivedEventTimes(1);
-  })
+  });
 });

--- a/core/src/components/datetime/test/minmax/datetime.e2e.ts
+++ b/core/src/components/datetime/test/minmax/datetime.e2e.ts
@@ -134,4 +134,51 @@ test.describe('datetime: minmax', () => {
       );
     });
   });
+
+  // TODO(FW-2165)
+  test.only('should not loop infinitely in webkit', async ({ page, skip }) => {
+    test.info().annotations.push({
+      type: 'issue',
+      description: 'https://github.com/ionic-team/ionic-framework/issues/25752',
+    });
+
+    skip.browser('chromium');
+    skip.browser('firefox');
+
+    await page.setContent(`
+      <button id="bind">Bind datetimeMonthDidChange event</button>
+      <ion-datetime min="2022-04-15" value="2022-04-20" presentation="date" locale="en-US"></ion-datetime>
+
+      <script type="module">
+        import { InitMonthDidChangeEvent } from '/src/components/datetime/test/utils/month-did-change-event.js';
+        document.querySelector('#bind').addEventListener('click', function() {
+          InitMonthDidChangeEvent();
+        });
+      </script>
+    `);
+    await page.waitForSelector('.datetime-ready');
+
+    const datetimeMonthDidChange = await page.spyOnEvent('datetimeMonthDidChange');
+    const eventButton = page.locator('button#bind');
+    await eventButton.click();
+
+    const buttons = page.locator('ion-datetime .calendar-next-prev ion-button');
+    await buttons.nth(1).click();
+    await page.waitForChanges()
+
+    await datetimeMonthDidChange.next();
+
+    /**
+     * This is hacky, but its purpose is to make sure
+     * we are not triggering a WebKit bug. When the fix
+     * for the bug ships in WebKit, this will be removed.
+     */
+    await page.evaluate(() => {
+      return new Promise(resolve => {
+        setTimeout(resolve, 500);
+      })
+    });
+
+    await expect(datetimeMonthDidChange).toHaveReceivedEventTimes(1);
+  })
 });

--- a/core/src/components/datetime/test/minmax/datetime.e2e.ts
+++ b/core/src/components/datetime/test/minmax/datetime.e2e.ts
@@ -136,7 +136,7 @@ test.describe('datetime: minmax', () => {
   });
 
   // TODO(FW-2165)
-  test.only('should not loop infinitely in webkit', async ({ page, skip }) => {
+  test('should not loop infinitely in webkit', async ({ page, skip }) => {
     test.info().annotations.push({
       type: 'issue',
       description: 'https://github.com/ionic-team/ionic-framework/issues/25752',

--- a/core/src/utils/test/playwright/matchers/index.ts
+++ b/core/src/utils/test/playwright/matchers/index.ts
@@ -1,7 +1,9 @@
 import { toHaveReceivedEvent } from './toHaveReceivedEvent';
 import { toHaveReceivedEventDetail } from './toHaveReceivedEventDetail';
+import { toHaveReceivedEventTimes } from './toHaveReceivedEventTimes';
 
 export const matchers = {
   toHaveReceivedEvent,
   toHaveReceivedEventDetail,
+  toHaveReceivedEventTimes
 };

--- a/core/src/utils/test/playwright/matchers/index.ts
+++ b/core/src/utils/test/playwright/matchers/index.ts
@@ -5,5 +5,5 @@ import { toHaveReceivedEventTimes } from './toHaveReceivedEventTimes';
 export const matchers = {
   toHaveReceivedEvent,
   toHaveReceivedEventDetail,
-  toHaveReceivedEventTimes
+  toHaveReceivedEventTimes,
 };

--- a/core/src/utils/test/playwright/matchers/toHaveReceivedEventTimes.ts
+++ b/core/src/utils/test/playwright/matchers/toHaveReceivedEventTimes.ts
@@ -1,0 +1,32 @@
+import type { EventSpy } from '../page/event-spy';
+
+export function toHaveReceivedEventTimes(eventSpy: EventSpy, count: number) {
+  if (!eventSpy) {
+    return {
+      message: () => `toHaveReceivedEventTimes event spy is null`,
+      pass: false,
+    };
+  }
+
+  if (typeof (eventSpy as any).then === 'function') {
+    return {
+      message: () =>
+        `expected spy to have received event, but it was not resolved (did you forget an await operator?).`,
+      pass: false,
+    };
+  }
+
+  if (!eventSpy.eventName) {
+    return {
+      message: () => `toHaveReceivedEventTimes did not receive an event spy`,
+      pass: false,
+    };
+  }
+
+  const pass = eventSpy.length === count;
+
+  return {
+    message: () => `expected event "${eventSpy.eventName}" to have been called ${count} times, but it was called ${eventSpy.events.length} times`,
+    pass: pass,
+  };
+}

--- a/core/src/utils/test/playwright/matchers/toHaveReceivedEventTimes.ts
+++ b/core/src/utils/test/playwright/matchers/toHaveReceivedEventTimes.ts
@@ -26,7 +26,8 @@ export function toHaveReceivedEventTimes(eventSpy: EventSpy, count: number) {
   const pass = eventSpy.length === count;
 
   return {
-    message: () => `expected event "${eventSpy.eventName}" to have been called ${count} times, but it was called ${eventSpy.events.length} times`,
+    message: () =>
+      `expected event "${eventSpy.eventName}" to have been called ${count} times, but it was called ${eventSpy.events.length} times`,
     pass: pass,
   };
 }

--- a/core/src/utils/test/playwright/testExpect.d.ts
+++ b/core/src/utils/test/playwright/testExpect.d.ts
@@ -8,6 +8,11 @@ interface CustomMatchers<R = unknown> {
    * @param eventDetail The expected detail of the event.
    */
   toHaveReceivedEventDetail(eventDetail: any): R;
+
+  /**
+   * Will check how many times the event has been received.
+   */
+  toHaveReceivedEventTimes(count: number): R;
 }
 
 declare namespace PlaywrightTest {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/25752


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Scroll position is now corrected in `componentOnRender` when using `min`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
