### PR TITLE
test(angular): tabs sibling page test is no longer flaky

### DIFF
--- a/angular/test/base/e2e/src/tabs.spec.ts
+++ b/angular/test/base/e2e/src/tabs.spec.ts
@@ -406,8 +406,6 @@ describe('Tabs', () => {
 function testTabTitle(title) {
   const tab = getSelectedTab();
 
-  console.log(tab)
-
   // Find is used to get a direct descendant instead of get
   tab.find('ion-title').should('have.text', title);
   return getSelectedTab();

--- a/angular/test/base/e2e/src/tabs.spec.ts
+++ b/angular/test/base/e2e/src/tabs.spec.ts
@@ -115,6 +115,16 @@ describe('Tabs', () => {
       ]);
 
       cy.get('#tab-button-account').click();
+
+      /**
+       * Wait for the leaving view to
+       * be unmounted otherwise testTabTitle
+       * may get the leaving view before it
+       * is unmounted.
+       */
+      cy.ionPageVisible('app-tabs-tab1');
+      cy.ionPageDoesNotExist('app-tabs-tab1-nested');
+
       testTabTitle('Tab 1 - Page 1');
       cy.testStack('ion-tabs ion-router-outlet', [
         'app-tabs-tab1',
@@ -280,33 +290,33 @@ describe('Tabs', () => {
   describe('entry url - /', () => {
     it('should pop to the root outlet from the tabs outlet', () => {
       cy.visit('/');
-  
+
       cy.get('ion-title').should('contain.text', 'Test App');
-  
+
       cy.get('ion-item').contains('Tabs test').click();
-  
+
       cy.get('ion-title').should('contain.text', 'Tab 1 - Page 1');
-  
+
       cy.get('#goto-tab1-page2').click();
-  
+
       cy.get('ion-title').should('contain.text', 'Tab 1 - Page 2 (1)');
-  
+
       cy.get('#goto-global').click();
-  
+
       cy.get('ion-title').should('contain.text', 'Global Page');
-  
+
       cy.get('#goto-prev-pop').click();
-  
+
       cy.get('ion-title').should('contain.text', 'Tab 1 - Page 2 (1)');
-  
+
       cy.get('#goto-prev').click();
-  
+
       cy.get('ion-title').should('contain.text', 'Tab 1 - Page 1');
-  
+
       cy.get('#goto-previous-page').click();
-  
+
       cy.get('ion-title').should('contain.text', 'Test App');
-  
+
     });
   });
 
@@ -395,6 +405,8 @@ describe('Tabs', () => {
 
 function testTabTitle(title) {
   const tab = getSelectedTab();
+
+  console.log(tab)
 
   // Find is used to get a direct descendant instead of get
   tab.find('ion-title').should('have.text', title);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: N/A The Angular E2E `should navigate deep then go home` test is flaky. The reason is that we try to check the active page title immediately after popping nested tabs pages off the stack: https://github.com/ionic-team/ionic-framework/blob/725b13fa60775dc9f9c3491cb545c70a5a9162eb/angular/test/base/e2e/src/tabs.spec.ts#L117-L118

Sometimes Cypress is able to get the active page title before the nested pages have been removed from the DOM. As a result, the title is later checked on a page that has since been unmounted, causing Cypress to throw the following error:

```
CypressError: Timed out retrying after 4000ms: `cy.should()` failed because this element is detached from the DOM.
```


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The test waits for the leaving pages to not exist in the DOM before querying the active page.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
