### PR TITLE
feat(accordion): ionChange will only emit from user committed changes

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -14,6 +14,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
 
 - [Browser and Platform Support](#version-7x-browser-platform-support)
 - [Components](#version-7x-components)
+  - [Accordion Group](#version-7x-accordion-group)
   - [Overlays](#version-7x-overlays)
   - [Range](#version-7x-range)
   - [Slides](#version-7x-slides)
@@ -49,6 +50,10 @@ This section details the desktop browser, JavaScript framework, and mobile platf
 | Android  | 5.1+ with Chromium 79+ |
 
 <h2 id="version-7x-components">Components</h2>
+
+<h4 id="version-7x-accordion-group">Accordion Group</h4>
+
+`ionChange` will no longer be emitted when the `value` of `ion-accordion-group` is modified externally. `ionChange` will only be emitted from user committed changes, such as clicking or tapping the accordion header.
 
 <h4 id="version-7x-overlays">Overlays</h4>
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -53,7 +53,7 @@ This section details the desktop browser, JavaScript framework, and mobile platf
 
 <h4 id="version-7x-accordion-group">Accordion Group</h4>
 
-`ionChange` will no longer be emitted when the `value` of `ion-accordion-group` is modified externally. `ionChange` will only be emitted from user committed changes, such as clicking or tapping the accordion header.
+`ionChange` is no longer emitted when the `value` of `ion-accordion-group` is modified externally. `ionChange` is only emitted from user committed changes, such as clicking or tapping the accordion header.
 
 <h4 id="version-7x-overlays">Overlays</h4>
 

--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -31,7 +31,10 @@ export class IonAccordion {
 import type { AccordionGroupChangeEventDetail as IAccordionGroupAccordionGroupChangeEventDetail } from '@ionic/core';
 export declare interface IonAccordionGroup extends Components.IonAccordionGroup {
   /**
-   * Emitted when the value property has changed. 
+   * Emitted when the value property has changed
+as a result of a user action such as a click.
+This event will not emit when programmatically setting
+the value property. 
    */
   ionChange: EventEmitter<CustomEvent<IAccordionGroupAccordionGroupChangeEventDetail>>;
 

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -68,6 +68,9 @@ export namespace Components {
           * If `true`, the accordion group cannot be interacted with, but does not alter the opacity.
          */
         "readonly": boolean;
+        /**
+          * This method is used to ensure that the value of ion-accordion-group is being set in a valid way. This method should only be called in response to a user generated action.
+         */
         "requestAccordionToggle": (accordionValue: string | undefined, accordionExpand: boolean) => Promise<void>;
         /**
           * The value of the accordion group.

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -3807,9 +3807,13 @@ declare namespace LocalJSX {
          */
         "multiple"?: boolean;
         /**
-          * Emitted when the value property has changed.
+          * Emitted when the value property has changed as a result of a user action such as a click. This event will not emit when programmatically setting the value property.
          */
         "onIonChange"?: (event: IonAccordionGroupCustomEvent<AccordionGroupChangeEventDetail>) => void;
+        /**
+          * Emitted when the value property has changed.
+         */
+        "onIonValueChange"?: (event: IonAccordionGroupCustomEvent<AccordionGroupChangeEventDetail>) => void;
         /**
           * If `true`, the accordion group cannot be interacted with, but does not alter the opacity.
          */

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -3811,7 +3811,7 @@ declare namespace LocalJSX {
          */
         "onIonChange"?: (event: IonAccordionGroupCustomEvent<AccordionGroupChangeEventDetail>) => void;
         /**
-          * Emitted when the value property has changed.
+          * Emitted when the value property has changed. This is used to ensure that ion-accordion can respond to any value property changes.
          */
         "onIonValueChange"?: (event: IonAccordionGroupCustomEvent<AccordionGroupChangeEventDetail>) => void;
         /**

--- a/core/src/components/accordion-group/accordion-group.tsx
+++ b/core/src/components/accordion-group/accordion-group.tsx
@@ -64,6 +64,8 @@ export class AccordionGroup implements ComponentInterface {
 
   /**
    * Emitted when the value property has changed.
+   * This is used to ensure that ion-accordion can respond
+   * to any value property changes.
    * @internal
    */
   @Event() ionValueChange!: EventEmitter<AccordionGroupChangeEventDetail>;

--- a/core/src/components/accordion-group/accordion-group.tsx
+++ b/core/src/components/accordion-group/accordion-group.tsx
@@ -169,6 +169,10 @@ export class AccordionGroup implements ComponentInterface {
   }
 
   /**
+   * This method is used to ensure that the value
+   * of ion-accordion-group is being set in a valid
+   * way. This method should only be called in
+   * response to a user generated action.
    * @internal
    */
   @Method()

--- a/core/src/components/accordion-group/accordion-group.tsx
+++ b/core/src/components/accordion-group/accordion-group.tsx
@@ -55,9 +55,18 @@ export class AccordionGroup implements ComponentInterface {
   @Prop() expand: 'compact' | 'inset' = 'compact';
 
   /**
-   * Emitted when the value property has changed.
+   * Emitted when the value property has changed
+   * as a result of a user action such as a click.
+   * This event will not emit when programmatically setting
+   * the value property.
    */
   @Event() ionChange!: EventEmitter<AccordionGroupChangeEventDetail>;
+
+  /**
+   * Emitted when the value property has changed.
+   * @internal
+   */
+  @Event() ionValueChange!: EventEmitter<AccordionGroupChangeEventDetail>;
 
   @Watch('value')
   valueChanged() {
@@ -74,6 +83,12 @@ export class AccordionGroup implements ComponentInterface {
     if (!multiple && Array.isArray(value)) {
       this.setValue(value[0]);
     }
+
+    /**
+     * Do not use `value` here as that will be
+     * not account for the adjustment we make above.
+     */
+    this.ionValueChange.emit({ value: this.value });
   }
 
   @Watch('disabled')

--- a/core/src/components/accordion-group/accordion-group.tsx
+++ b/core/src/components/accordion-group/accordion-group.tsx
@@ -68,11 +68,11 @@ export class AccordionGroup implements ComponentInterface {
      * let multiple accordions be open
      * at once, but user passes an array
      * just grab the first value.
+     * This should emit ionChange because
+     * we are updating the value internally.
      */
     if (!multiple && Array.isArray(value)) {
-      this.value = value[0];
-    } else {
-      this.ionChange.emit({ value: this.value });
+      this.setValue(value[0]);
     }
   }
 
@@ -156,6 +156,19 @@ export class AccordionGroup implements ComponentInterface {
   }
 
   /**
+   * Sets the value property and emits ionChange.
+   * This should only be called when the user interacts
+   * with the accordion and not for any update
+   * to the value property. The exception is when
+   * the app sets the value of a single-select
+   * accordion group to an array.
+   */
+  private setValue(accordionValue: string | string[] | null | undefined) {
+    const value = (this.value = accordionValue);
+    this.ionChange.emit({ value });
+  }
+
+  /**
    * @internal
    */
   @Method()
@@ -177,10 +190,10 @@ export class AccordionGroup implements ComponentInterface {
         const processedValue = Array.isArray(groupValue) ? groupValue : [groupValue];
         const valueExists = processedValue.find((v) => v === accordionValue);
         if (valueExists === undefined && accordionValue !== undefined) {
-          this.value = [...processedValue, accordionValue];
+          this.setValue([...processedValue, accordionValue]);
         }
       } else {
-        this.value = accordionValue;
+        this.setValue(accordionValue);
       }
     } else {
       /**
@@ -190,9 +203,9 @@ export class AccordionGroup implements ComponentInterface {
       if (multiple) {
         const groupValue = value || [];
         const processedValue = Array.isArray(groupValue) ? groupValue : [groupValue];
-        this.value = processedValue.filter((v) => v !== accordionValue);
+        this.setValue(processedValue.filter((v) => v !== accordionValue));
       } else {
-        this.value = undefined;
+        this.setValue(undefined);
       }
     }
   }

--- a/core/src/components/accordion/accordion.tsx
+++ b/core/src/components/accordion/accordion.tsx
@@ -85,14 +85,14 @@ export class Accordion implements ComponentInterface {
     const accordionGroupEl = (this.accordionGroupEl = this.el?.closest('ion-accordion-group'));
     if (accordionGroupEl) {
       this.updateState(true);
-      addEventListener(accordionGroupEl, 'ionChange', this.updateListener);
+      addEventListener(accordionGroupEl, 'ionValueChange', this.updateListener);
     }
   }
 
   disconnectedCallback() {
     const accordionGroupEl = this.accordionGroupEl;
     if (accordionGroupEl) {
-      removeEventListener(accordionGroupEl, 'ionChange', this.updateListener);
+      removeEventListener(accordionGroupEl, 'ionValueChange', this.updateListener);
     }
   }
 

--- a/core/src/components/accordion/test/basic/accordion.e2e.ts
+++ b/core/src/components/accordion/test/basic/accordion.e2e.ts
@@ -11,10 +11,10 @@ test.describe('accordion: basic', () => {
   });
 });
 
-test.describe.only('accordion: ionChange', () => {
+test.describe('accordion: ionChange', () => {
   test.beforeEach(({ skip }) => {
     skip.rtl();
-  })
+  });
   test('should fire ionChange when interacting with accordions', async ({ page }) => {
     await page.setContent(`
       <ion-accordion-group value="second">
@@ -71,7 +71,7 @@ test.describe.only('accordion: ionChange', () => {
     const ionChange = await page.spyOnEvent('ionChange');
     const accordionGroup = page.locator('ion-accordion-group');
 
-    await accordionGroup.evaluate((el: HTMLIonAccordionGroupElement) => el.value = 'second');
+    await accordionGroup.evaluate((el: HTMLIonAccordionGroupElement) => (el.value = 'second'));
     await expect(ionChange).not.toHaveReceivedEvent();
   });
 
@@ -97,7 +97,7 @@ test.describe.only('accordion: ionChange', () => {
     const ionChange = await page.spyOnEvent('ionChange');
     const accordionGroup = page.locator('ion-accordion-group');
 
-    await accordionGroup.evaluate((el: HTMLIonAccordionGroupElement) => el.value = ['second', 'third']);
+    await accordionGroup.evaluate((el: HTMLIonAccordionGroupElement) => (el.value = ['second', 'third']));
     await expect(ionChange).toHaveReceivedEventDetail({ value: 'second' });
   });
-})
+});

--- a/core/src/components/accordion/test/basic/accordion.e2e.ts
+++ b/core/src/components/accordion/test/basic/accordion.e2e.ts
@@ -10,3 +10,94 @@ test.describe('accordion: basic', () => {
     expect(await page.screenshot()).toMatchSnapshot(`accordion-basic-${page.getSnapshotSettings()}.png`);
   });
 });
+
+test.describe.only('accordion: ionChange', () => {
+  test.beforeEach(({ skip }) => {
+    skip.rtl();
+  })
+  test('should fire ionChange when interacting with accordions', async ({ page }) => {
+    await page.setContent(`
+      <ion-accordion-group value="second">
+        <ion-accordion value="first">
+          <button slot="header">Header</button>
+          <div slot="content">First Content</div>
+        </ion-accordion>
+        <ion-accordion value="second">
+          <button slot="header">Header</button>
+          <div slot="content">Second Content</div>
+        </ion-accordion>
+        <ion-accordion value="third">
+          <button slot="header">Header</button>
+          <div slot="content">Third Content</div>
+        </ion-accordion>
+      </ion-accordion-group>
+    `);
+
+    const ionChange = await page.spyOnEvent('ionChange');
+    const accordionHeaders = page.locator('button[slot="header"]');
+
+    await accordionHeaders.nth(0).click();
+    await expect(ionChange).toHaveReceivedEventDetail({ value: 'first' });
+
+    await accordionHeaders.nth(1).click();
+    await expect(ionChange).toHaveReceivedEventDetail({ value: 'second' });
+
+    await accordionHeaders.nth(1).click();
+    await expect(ionChange).toHaveReceivedEventDetail({ value: undefined });
+
+    await accordionHeaders.nth(2).click();
+    await expect(ionChange).toHaveReceivedEventDetail({ value: 'third' });
+  });
+
+  test('should not fire when programmatically setting a valid value', async ({ page }) => {
+    await page.setContent(`
+      <ion-accordion-group>
+        <ion-accordion value="first">
+          <button slot="header">Header</button>
+          <div slot="content">First Content</div>
+        </ion-accordion>
+        <ion-accordion value="second">
+          <button slot="header">Header</button>
+          <div slot="content">Second Content</div>
+        </ion-accordion>
+        <ion-accordion value="third">
+          <button slot="header">Header</button>
+          <div slot="content">Third Content</div>
+        </ion-accordion>
+      </ion-accordion-group>
+
+    `);
+
+    const ionChange = await page.spyOnEvent('ionChange');
+    const accordionGroup = page.locator('ion-accordion-group');
+
+    await accordionGroup.evaluate((el: HTMLIonAccordionGroupElement) => el.value = 'second');
+    await expect(ionChange).not.toHaveReceivedEvent();
+  });
+
+  test('should fire ionChange setting array of values on a single selection accordion', async ({ page }) => {
+    await page.setContent(`
+      <ion-accordion-group>
+        <ion-accordion value="first">
+          <button slot="header">Header</button>
+          <div slot="content">First Content</div>
+        </ion-accordion>
+        <ion-accordion value="second">
+          <button slot="header">Header</button>
+          <div slot="content">Second Content</div>
+        </ion-accordion>
+        <ion-accordion value="third">
+          <button slot="header">Header</button>
+          <div slot="content">Third Content</div>
+        </ion-accordion>
+      </ion-accordion-group>
+
+    `);
+
+    const ionChange = await page.spyOnEvent('ionChange');
+    const accordionGroup = page.locator('ion-accordion-group');
+
+    await accordionGroup.evaluate((el: HTMLIonAccordionGroupElement) => el.value = ['second', 'third']);
+    await expect(ionChange).toHaveReceivedEventDetail({ value: 'second' });
+  });
+})

--- a/packages/vue/src/proxies.ts
+++ b/packages/vue/src/proxies.ts
@@ -92,7 +92,8 @@ export const IonAccordionGroup = /*@__PURE__*/ defineContainer<JSX.IonAccordionG
   'disabled',
   'readonly',
   'expand',
-  'ionChange'
+  'ionChange',
+  'ionValueChange'
 ],
 'value', 'v-ion-change', 'ionChange');
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: N/A Internal ticket


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `ionChange` will now fire as a result of user-generated actions only.
- The one exception is when an app passes an array of values to a single-select accordion. When that happens, we set the `value` to be the first item in the array and re-emit `ionChange`.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

`ionChange` will no longer be emitted when the `value` of `ion-accordion-group` is modified externally. `ionChange` will only be emitted from user committed changes, such as clicking or tapping the accordion header.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
