### PR TITLE
feat(checkbox): ionChange fires on user interaction

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -14,6 +14,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
 
 - [Browser and Platform Support](#version-7x-browser-platform-support)
 - [Components](#version-7x-components)
+  - [Checkbox](#version-7x-checkbox)
   - [Overlays](#version-7x-overlays)
   - [Range](#version-7x-range)
   - [Slides](#version-7x-slides)
@@ -49,6 +50,10 @@ This section details the desktop browser, JavaScript framework, and mobile platf
 | Android  | 5.1+ with Chromium 79+ |
 
 <h2 id="version-7x-components">Components</h2>
+
+<h4 id="version-7x-checkbox">Checkbox</h4>
+
+`ionChange` is no longer emitted when the `checked` property of `ion-checkbox` is modified externally. `ionChange` is only emitted from user committed changes, such as clicking or tapping the checkbox.
 
 <h4 id="version-7x-overlays">Overlays</h4>
 

--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -385,7 +385,10 @@ export class IonCardTitle {
 import type { CheckboxChangeEventDetail as ICheckboxCheckboxChangeEventDetail } from '@ionic/core';
 export declare interface IonCheckbox extends Components.IonCheckbox {
   /**
-   * Emitted when the checked property has changed. 
+   * Emitted when the checked property has changed
+as a result of a user action such as a click.
+This event will not emit when programmatically
+setting the checked property. 
    */
   ionChange: EventEmitter<CustomEvent<ICheckboxCheckboxChangeEventDetail>>;
   /**

--- a/angular/test/base/e2e/src/inputs.spec.ts
+++ b/angular/test/base/e2e/src/inputs.spec.ts
@@ -38,7 +38,7 @@ describe('Inputs', () => {
   it('change values should update angular', () => {
     cy.get('#reset-button').click();
 
-    cy.get('ion-checkbox').invoke('prop', 'checked', true);
+    cy.get('ion-checkbox#first-checkbox').click();
     cy.get('ion-toggle').invoke('prop', 'checked', true);
 
     cy.get('ion-input').eq(0).type('hola');

--- a/angular/test/base/src/app/inputs/inputs.component.html
+++ b/angular/test/base/src/app/inputs/inputs.component.html
@@ -75,7 +75,7 @@
 
     <ion-item>
       <ion-label>Checkbox</ion-label>
-      <ion-checkbox [(ngModel)]="checkbox" slot="start"></ion-checkbox>
+      <ion-checkbox [(ngModel)]="checkbox" slot="start" id="first-checkbox"></ion-checkbox>
       <ion-note slot="end" id="checkbox-note">{{checkbox}}</ion-note>
     </ion-item>
 

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -4307,7 +4307,7 @@ declare namespace LocalJSX {
          */
         "onIonBlur"?: (event: IonCheckboxCustomEvent<void>) => void;
         /**
-          * Emitted when the checked property has changed.
+          * Emitted when the checked property has changed as a result of a user action such as a click. This event will not emit when programmatically setting the checked property.
          */
         "onIonChange"?: (event: IonCheckboxCustomEvent<CheckboxChangeEventDetail>) => void;
         /**

--- a/core/src/components/checkbox/checkbox.tsx
+++ b/core/src/components/checkbox/checkbox.tsx
@@ -63,7 +63,10 @@ export class Checkbox implements ComponentInterface {
   @Prop() value: any | null = 'on';
 
   /**
-   * Emitted when the checked property has changed.
+   * Emitted when the checked property has changed
+   * as a result of a user action such as a click.
+   * This event will not emit when programmatically
+   * setting the checked property.
    */
   @Event() ionChange!: EventEmitter<CheckboxChangeEventDetail>;
 
@@ -88,11 +91,7 @@ export class Checkbox implements ComponentInterface {
   }
 
   @Watch('checked')
-  checkedChanged(isChecked: boolean) {
-    this.ionChange.emit({
-      checked: isChecked,
-      value: this.value,
-    });
+  checkedChanged() {
     this.emitStyle();
   }
 
@@ -114,11 +113,25 @@ export class Checkbox implements ComponentInterface {
     }
   }
 
+  /**
+   * Sets the checked property and emits
+   * the ionChange event. Use this to update the
+   * checked state in response to user-generated
+   * actions such as a click.
+   */
+  private setChecked = (state: boolean) => {
+    const isChecked = (this.checked = state);
+    this.ionChange.emit({
+      checked: isChecked,
+      value: this.value,
+    });
+  };
+
   private onClick = (ev: any) => {
     ev.preventDefault();
 
     this.setFocus();
-    this.checked = !this.checked;
+    this.setChecked(!this.checked);
     this.indeterminate = false;
   };
 

--- a/core/src/components/checkbox/checkbox.tsx
+++ b/core/src/components/checkbox/checkbox.tsx
@@ -127,7 +127,7 @@ export class Checkbox implements ComponentInterface {
     });
   };
 
-  private onClick = (ev: any) => {
+  private toggleChecked = (ev: any) => {
     ev.preventDefault();
 
     this.setFocus();
@@ -166,7 +166,6 @@ export class Checkbox implements ComponentInterface {
 
     return (
       <Host
-        onClick={this.onClick}
         aria-labelledby={label ? labelId : null}
         aria-checked={`${checked}`}
         aria-hidden={disabled ? 'true' : null}
@@ -189,6 +188,7 @@ export class Checkbox implements ComponentInterface {
           aria-checked={`${checked}`}
           disabled={disabled}
           id={inputId}
+          onChange={this.toggleChecked}
           onFocus={() => this.onFocus()}
           onBlur={() => this.onBlur()}
           ref={(focusEl) => (this.focusEl = focusEl)}

--- a/core/src/components/checkbox/test/basic/checkbox.e2e.ts
+++ b/core/src/components/checkbox/test/basic/checkbox.e2e.ts
@@ -10,3 +10,52 @@ test.describe('checkbox: basic', () => {
     expect(await page.screenshot()).toMatchSnapshot(`checkbox-basic-${page.getSnapshotSettings()}.png`);
   });
 });
+
+test.describe.only('checkbox: ionChange', () => {
+  test.beforeEach(({ skip }) => {
+    skip.rtl();
+  });
+  test('should fire ionChange when interacting with checkbox', async ({ page }) => {
+    await page.setContent(`
+      <ion-checkbox value="my-checkbox"></ion-checkbox>
+    `);
+
+    const ionChange = await page.spyOnEvent('ionChange');
+    const checkbox = page.locator('ion-checkbox');
+
+    await checkbox.click();
+    await expect(ionChange).toHaveReceivedEventDetail({ value: 'my-checkbox', checked: true });
+
+    await checkbox.click();
+    await expect(ionChange).toHaveReceivedEventDetail({ value: 'my-checkbox', checked: false });
+  });
+
+  test('should fire ionChange when interacting with checkbox in item', async ({ page }) => {
+    await page.setContent(`
+      <ion-item>
+        <ion-checkbox value="my-checkbox"></ion-checkbox>
+      </ion-item>
+    `);
+
+    const ionChange = await page.spyOnEvent('ionChange');
+    const item = page.locator('ion-item');
+
+    await item.click();
+    await expect(ionChange).toHaveReceivedEventDetail({ value: 'my-checkbox', checked: true });
+
+    await item.click();
+    await expect(ionChange).toHaveReceivedEventDetail({ value: 'my-checkbox', checked: false });
+  });
+
+  test('should not fire when programmatically setting a value', async ({ page }) => {
+    await page.setContent(`
+      <ion-checkbox value="my-checkbox"></ion-checkbox>
+    `);
+
+    const ionChange = await page.spyOnEvent('ionChange');
+    const checkbox = page.locator('ion-checkbox');
+
+    await checkbox.evaluate((el: HTMLIonCheckboxElement) => (el.checked = true));
+    await expect(ionChange).not.toHaveReceivedEvent();
+  });
+});

--- a/core/src/components/checkbox/test/basic/checkbox.e2e.ts
+++ b/core/src/components/checkbox/test/basic/checkbox.e2e.ts
@@ -11,7 +11,7 @@ test.describe('checkbox: basic', () => {
   });
 });
 
-test.describe.only('checkbox: ionChange', () => {
+test.describe('checkbox: ionChange', () => {
   test.beforeEach(({ skip }) => {
     skip.rtl();
   });

--- a/core/src/components/datetime/test/color/datetime.e2e.ts
+++ b/core/src/components/datetime/test/color/datetime.e2e.ts
@@ -6,10 +6,9 @@ test.describe('datetime: color', () => {
     await page.goto('/src/components/datetime/test/color');
 
     const colorSelect = page.locator('ion-select');
-    const darkModeToggle = page.locator('ion-checkbox');
     const datetime = page.locator('ion-datetime');
 
-    await darkModeToggle.evaluate((el: HTMLIonCheckboxElement) => (el.checked = true));
+    await page.evaluate(() => document.body.classList.toggle('dark'));
     await page.waitForChanges();
 
     expect(await datetime.first().screenshot()).toMatchSnapshot(
@@ -19,7 +18,7 @@ test.describe('datetime: color', () => {
       `datetime-color-custom-dark-${page.getSnapshotSettings()}.png`
     );
 
-    await darkModeToggle.evaluate((el: HTMLIonCheckboxElement) => (el.checked = false));
+    await page.evaluate(() => document.body.classList.toggle('dark'));
     await colorSelect.evaluate((el: HTMLIonSelectElement) => (el.value = 'danger'));
     await page.waitForChanges();
 
@@ -30,7 +29,7 @@ test.describe('datetime: color', () => {
       `datetime-color-custom-light-color-${page.getSnapshotSettings()}.png`
     );
 
-    await darkModeToggle.evaluate((el: HTMLIonCheckboxElement) => (el.checked = true));
+    await page.evaluate(() => document.body.classList.toggle('dark'));
     await page.waitForChanges();
 
     expect(await datetime.first().screenshot()).toMatchSnapshot(


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: N/A internal ticket

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `ion-checkbox` now emits `ionChange` whenever the native `change` event fires on `<input type="checkbox" />`.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

`ionChange` is no longer emitted when the `checked` property of `ion-checkbox` is modified externally. `ionChange` is only emitted from user committed changes, such as clicking or tapping the checkbox.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
