### PR TITLE
fix(overlays): focus trapping no longer includes hidden elements

### DIFF
--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -83,7 +83,7 @@ export const createOverlay = <T extends HTMLIonOverlayElement>(
 };
 
 const focusableQueryString =
-  '[tabindex]:not([tabindex^="-"]), input:not([type=hidden]):not([tabindex^="-"]), textarea:not([tabindex^="-"]), button:not([tabindex^="-"]), select:not([tabindex^="-"]), .ion-focusable:not([tabindex^="-"])';
+  '[tabindex]:not([tabindex^="-"]), input:not([type=hidden]):not([tabindex^="-"]), textarea:not([tabindex^="-"]), button:not([tabindex^="-"]), select:not([tabindex^="-"]), .ion-focusable:not([tabindex^="-"]):not([hidden])';
 
 export const focusFirstDescendant = (ref: Element, overlay: HTMLIonOverlayElement) => {
   let firstInput = ref.querySelector(focusableQueryString) as HTMLElement | null;

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -87,7 +87,7 @@ export const createOverlay = <T extends HTMLIonOverlayElement>(
  * are eligible to receive focus. We select
  * interactive elements that meet the following
  * criteria:
- * 1. Element does not have tabindex="-1"
+ * 1. Element does not have a negative tabindex
  * 2. Element does not have [hidden]
  */
 const focusableQueryString =

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -82,6 +82,14 @@ export const createOverlay = <T extends HTMLIonOverlayElement>(
   return Promise.resolve() as any;
 };
 
+/**
+ * This query string selects elements that
+ * are eligible to receive focus. We select
+ * interactive elements that meet the following
+ * criteria:
+ * 1. Element does not have tabindex="-1"
+ * 2. Element does not have [hidden]
+ */
 const focusableQueryString =
   '[tabindex]:not([tabindex^="-"]):not([hidden]), input:not([type=hidden]):not([tabindex^="-"]):not([hidden]), textarea:not([tabindex^="-"]):not([hidden]), button:not([tabindex^="-"]):not([hidden]), select:not([tabindex^="-"]):not([hidden]), .ion-focusable:not([tabindex^="-"]):not([hidden])';
 

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -83,7 +83,7 @@ export const createOverlay = <T extends HTMLIonOverlayElement>(
 };
 
 const focusableQueryString =
-  '[tabindex]:not([tabindex^="-"]), input:not([type=hidden]):not([tabindex^="-"]), textarea:not([tabindex^="-"]), button:not([tabindex^="-"]), select:not([tabindex^="-"]), .ion-focusable:not([tabindex^="-"]):not([hidden])';
+  '[tabindex]:not([tabindex^="-"]):not([hidden]), input:not([type=hidden]):not([tabindex^="-"]):not([hidden]), textarea:not([tabindex^="-"]):not([hidden]), button:not([tabindex^="-"]):not([hidden]), select:not([tabindex^="-"]):not([hidden]), .ion-focusable:not([tabindex^="-"]):not([hidden])';
 
 export const focusFirstDescendant = (ref: Element, overlay: HTMLIonOverlayElement) => {
   let firstInput = ref.querySelector(focusableQueryString) as HTMLElement | null;

--- a/core/src/utils/test/overlays/overlays.e2e.ts
+++ b/core/src/utils/test/overlays/overlays.e2e.ts
@@ -28,7 +28,7 @@ test.describe('overlays: focus', () => {
     await expect(page.locator('ion-input input')).toBeFocused();
   });
 
-  test.only('should not select a hidden focusable element', async ({ page, browserName }) => {
+  test('should not select a hidden focusable element', async ({ page, browserName }) => {
     await page.setContent(`
       <ion-button id="open-modal">Show Modal</ion-button>
       <ion-modal trigger="open-modal">
@@ -41,7 +41,6 @@ test.describe('overlays: focus', () => {
 
     const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
     const presentButton = page.locator('ion-button#open-modal');
-    const hiddenButton = page.locator('ion-button#hidden');
     const visibleButton = page.locator('ion-button#visible');
     const tabKey = browserName === 'webkit' ? 'Alt+Tab' : 'Tab';
 

--- a/core/src/utils/test/overlays/overlays.e2e.ts
+++ b/core/src/utils/test/overlays/overlays.e2e.ts
@@ -4,7 +4,7 @@ import { test } from '@utils/test/playwright';
 test.describe('overlays: focus', () => {
   test.beforeEach(({ skip }) => {
     skip.rtl();
-  })
+  });
   test('should not focus the overlay container if element inside of overlay is focused', async ({ page }) => {
     await page.setContent(`
       <ion-button id="open-modal">Show Modal</ion-button>
@@ -52,5 +52,5 @@ test.describe('overlays: focus', () => {
 
     await page.keyboard.press(tabKey);
     await expect(visibleButton).toBeFocused();
-  })
+  });
 });

--- a/core/src/utils/test/overlays/overlays.e2e.ts
+++ b/core/src/utils/test/overlays/overlays.e2e.ts
@@ -2,9 +2,10 @@ import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('overlays: focus', () => {
-  test('should not focus the overlay container if element inside of overlay is focused', async ({ page, skip }) => {
+  test.beforeEach(({ skip }) => {
     skip.rtl();
-
+  })
+  test('should not focus the overlay container if element inside of overlay is focused', async ({ page }) => {
     await page.setContent(`
       <ion-button id="open-modal">Show Modal</ion-button>
       <ion-modal trigger="open-modal">
@@ -26,4 +27,31 @@ test.describe('overlays: focus', () => {
 
     await expect(page.locator('ion-input input')).toBeFocused();
   });
+
+  test.only('should not select a hidden focusable element', async ({ page, browserName }) => {
+    await page.setContent(`
+      <ion-button id="open-modal">Show Modal</ion-button>
+      <ion-modal trigger="open-modal">
+        <ion-content>
+          <ion-button hidden id="hidden">Hidden Button</ion-button>
+          <ion-button id="visible">Visible Button</ion-button>
+        </ion-content>
+      </ion-modal>
+    `);
+
+    const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+    const presentButton = page.locator('ion-button#open-modal');
+    const hiddenButton = page.locator('ion-button#hidden');
+    const visibleButton = page.locator('ion-button#visible');
+    const tabKey = browserName === 'webkit' ? 'Alt+Tab' : 'Tab';
+
+    await presentButton.click();
+    await ionModalDidPresent.next();
+
+    await page.keyboard.press(tabKey);
+    await expect(visibleButton).toBeFocused();
+
+    await page.keyboard.press(tabKey);
+    await expect(visibleButton).toBeFocused();
+  })
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: N/A internal ticket

When a hidden interactive if the first element, the focus trapping module tries to focus that element on tab. Since the element is hidden and not focusable, focus can escape from the overlay.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Focus trapping excludes elements hidden with the `hidden` attribute.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
