### PR TITLE
test(alert): wait for alert to open

### DIFF
--- a/core/src/components/alert/test/a11y/alert.e2e.ts
+++ b/core/src/components/alert/test/a11y/alert.e2e.ts
@@ -35,8 +35,12 @@ test.describe('alert: a11y', () => {
   });
 
   test('should not have accessibility violations when header and message are defined', async ({ page }) => {
+    const didPresent = await page.spyOnEvent('ionAlertDidPresent');
+
     const button = page.locator('#bothHeaders');
+
     await button.click();
+    await didPresent.next();
 
     const results = await new AxeBuilder({ page }).analyze();
     expect(results.violations).toEqual([]);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: https://github.com/ionic-team/ionic-framework/actions/runs/3085123989/jobs/4988091184

The Axe test for `ion-alert` does not wait for the alert to be presented before running the Axe checks: https://github.com/ionic-team/ionic-framework/blob/55ebd6cdf39c01b401e876b76e755bfa04db8f65/core/src/components/alert/test/a11y/alert.e2e.ts#L39

This can lead to Axe running before the alert is fully presented/rendered.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Test now waits for the `ionAlertDidPresent` event before running the Axe check.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
