### PR TITLE
fix(input): clearOnEdit clears input when user initially types

### DIFF
--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -28,20 +28,19 @@ import { createColorClasses } from '../../utils/theme';
 export class Input implements ComponentInterface {
   private nativeInput?: HTMLInputElement;
   private inputId = `ion-input-${inputIds++}`;
-  private didBlurAfterEdit = false;
   private inheritedAttributes: Attributes = {};
   private isComposing = false;
   /**
-   * If `true`, the user cleared the input by pressing the clear icon,
-   * within the session of the input being focused.
+   * `true` if the input was cleared as a result of the user typing
+   * with `clearOnEdit` enabled.
    *
-   * This property is reset to `false` when the input is blurred.
+   * Resets when the input loses focus.
    */
-  private inputCleared = false;
+  private didInputClearOnEdit = false;
   /**
    * The value of the input when the input is focused.
    */
-  private focusedValue: string | number | null | undefined;
+  private focusedValue?: string | number | null;
 
   @State() hasFocus = false;
 
@@ -346,6 +345,8 @@ export class Input implements ComponentInterface {
     const { value } = this;
     // Checks for both null and undefined values
     const newValue = value == null ? value : value.toString();
+    // Emitting a value change should update the internal state for tracking the focused value
+    this.focusedValue = newValue;
     this.ionChange.emit({ value: newValue });
   }
 
@@ -383,20 +384,17 @@ export class Input implements ComponentInterface {
 
   private onBlur = (ev: FocusEvent) => {
     this.hasFocus = false;
-    this.focusChanged();
     this.emitStyle();
 
-    if (this.inputCleared) {
-      if (this.focusedValue !== this.value) {
-        /**
-         * Emits the `ionChange` event when the input value
-         * is different than the value when the input was focused.
-         */
-        this.emitValueChange();
-      }
-      this.focusedValue = undefined;
-      this.inputCleared = false;
+    if (this.focusedValue !== this.value) {
+      /**
+       * Emits the `ionChange` event when the input value
+       * is different than the value when the input was focused.
+       */
+      this.emitValueChange();
     }
+
+    this.didInputClearOnEdit = false;
 
     this.ionBlur.emit(ev);
   };
@@ -404,25 +402,29 @@ export class Input implements ComponentInterface {
   private onFocus = (ev: FocusEvent) => {
     this.hasFocus = true;
     this.focusedValue = this.value;
-    this.focusChanged();
     this.emitStyle();
 
     this.ionFocus.emit(ev);
   };
 
   private onKeydown = (ev: KeyboardEvent) => {
-    if (this.shouldClearOnEdit()) {
-      // Did the input value change after it was blurred and edited?
-      // Do not clear if user is hitting Enter to submit form
-      if (this.didBlurAfterEdit && this.hasValue() && ev.key !== 'Enter') {
-        // Clear the input
-        this.clearTextInput();
-      }
-
-      // Reset the flag
-      this.didBlurAfterEdit = false;
-    }
+    this.checkClearOnEdit(ev);
   };
+
+  private checkClearOnEdit(ev: KeyboardEvent) {
+    if (!this.shouldClearOnEdit()) {
+      return;
+    }
+    /**
+     * Clear the input if the control has not been previously cleared during focus.
+     * Do not clear if the user hitting enter to submit a form.
+     */
+    if (!this.didInputClearOnEdit && this.hasValue() && ev.key !== 'Enter') {
+      this.value = '';
+      this.didInputClearOnEdit = true;
+    }
+    this.ionInput.emit(ev);
+  }
 
   private onCompositionStart = () => {
     this.isComposing = true;
@@ -432,36 +434,16 @@ export class Input implements ComponentInterface {
     this.isComposing = false;
   };
 
-  private clearTextInput = (ev?: Event) => {
+  private onClearButtonClick = (ev?: Event) => {
     if (this.clearInput && !this.readonly && !this.disabled && ev) {
       ev.preventDefault();
       ev.stopPropagation();
-
       // Attempt to focus input again after pressing clear button
       this.setFocus();
     }
-
     this.value = '';
-    this.inputCleared = true;
-
     this.ionInput.emit(ev);
-
-    /**
-     * This is needed for clearOnEdit
-     * Otherwise the value will not be cleared
-     * if user is inside the input
-     */
-    if (this.nativeInput) {
-      this.nativeInput.value = '';
-    }
   };
-
-  private focusChanged() {
-    // If clearOnEdit is enabled and the input blurred but has a value, set a flag
-    if (!this.hasFocus && this.shouldClearOnEdit() && this.hasValue()) {
-      this.didBlurAfterEdit = true;
-    }
-  }
 
   private hasValue(): boolean {
     return this.getValue().length > 0;
@@ -532,7 +514,7 @@ export class Input implements ComponentInterface {
                */
               ev.preventDefault();
             }}
-            onClick={this.clearTextInput}
+            onClick={this.onClearButtonClick}
           />
         )}
       </Host>

--- a/core/src/components/input/test/basic/input.e2e.ts
+++ b/core/src/components/input/test/basic/input.e2e.ts
@@ -201,3 +201,31 @@ test.describe('input: clear button', () => {
     await expect(nativeInput).toBeFocused();
   });
 });
+
+test.describe('input: clearOnEdit', () => {
+  test('should clear the input on first keystroke of input being focused', async ({ page }) => {
+    await page.setContent(`<ion-input value="some value" clear-on-edit="true"></ion-input>`);
+
+    const input = page.locator('ion-input');
+
+    await input.click();
+    await input.type('h');
+
+    expect(await input.evaluate((el: HTMLIonInputElement) => el.value)).toBe('h');
+
+    await input.type('ello world');
+
+    expect(await input.evaluate((el: HTMLIonInputElement) => el.value)).toBe('hello world');
+  });
+
+  test('should not clear the input when pressing Enter', async ({ page }) => {
+    await page.setContent(`<ion-input value="some value" clear-on-edit="true"></ion-input>`);
+
+    const input = page.locator('ion-input');
+
+    await input.click();
+    await page.keyboard.press('Enter');
+
+    expect(await input.evaluate((el: HTMLIonInputElement) => el.value)).toBe('some value');
+  });
+});

--- a/core/src/components/input/test/input-events.e2e.ts
+++ b/core/src/components/input/test/input-events.e2e.ts
@@ -64,15 +64,28 @@ test.describe('input: events: ionChange', () => {
 });
 
 test.describe('input: events: ionInput', () => {
-  test.describe('should emit', () => {
-    test('when the input is cleared', async ({ page }) => {
-      await page.setContent(`<ion-input value="some value" clear-input="true"></ion-input>`);
+  test('should emit when the input is cleared', async ({ page }) => {
+    await page.setContent(`<ion-input value="some value" clear-input="true"></ion-input>`);
 
-      const ionInputSpy = await page.spyOnEvent('ionInput');
+    const ionInputSpy = await page.spyOnEvent('ionInput');
 
-      await page.click('ion-input .input-clear-icon');
+    await page.click('ion-input .input-clear-icon');
 
-      expect(ionInputSpy).toHaveReceivedEventDetail({ isTrusted: true });
-    });
+    expect(ionInputSpy).toHaveReceivedEventDetail({ isTrusted: true });
+  });
+
+  test('should emit when the input is cleared from the keyboard', async ({ page }) => {
+    await page.setContent(`<ion-input value="some value" clear-on-edit="true"></ion-input>`);
+
+    const input = page.locator('ion-input');
+    const ionInputSpy = await page.spyOnEvent('ionInput');
+
+    await input.click();
+    await page.keyboard.press('Backspace');
+
+    expect(await input.evaluate((el: HTMLIonInputElement) => el.value)).toBe('');
+
+    expect(ionInputSpy).toHaveReceivedEventTimes(1);
+    expect(ionInputSpy).toHaveReceivedEventDetail({ isTrusted: true });
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The `ion-input` field does not initially clear when `clearOnEdit` is enabled, with a default value, when the control is first focused and modified. 

`ionInput` can emit an detail of `undefined`.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: Internal


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `ion-input` with `clearOnEdit` enabled will clear the input when the control receives focus and is modified
  - It will not clear if the user presses "Enter" to submit a form.
  - It will not clear for subsequent input while the control has focus (e.g. does not clear on each keypress).
 - `ionInput` correctly emits the parent event as the detail.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
