### PR TITLE
fix(item,card): aria-label is reflected to the inner button

### DIFF
--- a/core/src/components/card/card.tsx
+++ b/core/src/components/card/card.tsx
@@ -1,9 +1,11 @@
 import type { ComponentInterface } from '@stencil/core';
-import { Component, Host, Prop, h } from '@stencil/core';
+import { Element, Component, Host, Prop, h } from '@stencil/core';
 
 import { getIonMode } from '../../global/ionic-global';
 import type { AnimationBuilder, Color, Mode, RouterDirection } from '../../interface';
 import type { AnchorInterface, ButtonInterface } from '../../utils/element-interface';
+import type { Attributes } from '../../utils/helpers';
+import { inheritAriaAttributes } from '../../utils/helpers';
 import { createColorClasses, openURL } from '../../utils/theme';
 
 /**
@@ -20,6 +22,9 @@ import { createColorClasses, openURL } from '../../utils/theme';
   shadow: true,
 })
 export class Card implements ComponentInterface, AnchorInterface, ButtonInterface {
+  private inheritedAttributes: Attributes = {};
+
+  @Element() el!: HTMLElement;
   /**
    * The color to use from your application's color palette.
    * Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`.
@@ -81,6 +86,10 @@ export class Card implements ComponentInterface, AnchorInterface, ButtonInterfac
    */
   @Prop() target: string | undefined;
 
+  componentWillLoad() {
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
+  }
+
   private isClickable(): boolean {
     return this.href !== undefined || this.button;
   }
@@ -91,11 +100,12 @@ export class Card implements ComponentInterface, AnchorInterface, ButtonInterfac
     if (!clickable) {
       return [<slot></slot>];
     }
-    const { href, routerAnimation, routerDirection } = this;
+    const { href, routerAnimation, routerDirection, inheritedAttributes } = this;
     const TagType = clickable ? (href === undefined ? 'button' : 'a') : ('div' as any);
+    const ariaLabel = inheritedAttributes['aria-label'];
     const attrs =
       TagType === 'button'
-        ? { type: this.type }
+        ? { type: this.type, ariaLabel }
         : {
             download: this.download,
             href: this.href,

--- a/core/src/components/card/test/aria.spec.ts
+++ b/core/src/components/card/test/aria.spec.ts
@@ -1,0 +1,17 @@
+import { newSpecPage } from '@stencil/core/testing';
+
+import { Card } from '../card';
+
+describe('card: button', () => {
+  it('should reflect aria-label to button', async () => {
+    const page = await newSpecPage({
+      components: [Card],
+      html: `<ion-card button="true" aria-label="Test"></ion-card>`,
+    });
+
+    const button = page.body.querySelector('ion-card')!.shadowRoot!.querySelector('button')!;
+    const ariaLabel = button.getAttribute('ariaLabel');
+
+    expect(ariaLabel).toEqual('Test');
+  });
+});

--- a/core/src/components/card/test/basic/index.html
+++ b/core/src/components/card/test/basic/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Card - Basic</title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
+    <link href="../../../../../css/ionic.bundle.css" rel="stylesheet" />
+    <link href="../../../../../scripts/testing/styles.css" rel="stylesheet" />
+    <script src="../../../../../scripts/testing/scripts.js"></script>
+    <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+    <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Card - Basic</ion-title>
+        </ion-toolbar>
+      </ion-header>
+
+      <ion-content class="ion-padding">
+        <ion-card>
+          <ion-card-header>
+            <ion-card-subtitle>Card Subtitle</ion-card-subtitle>
+            <ion-card-title>Card Title</ion-card-title>
+          </ion-card-header>
+
+          <ion-card-content>
+            Keep close to Nature's heart... and break clear away, once in awhile, and climb a mountain or spend a week
+            in the woods. Wash your spirit clean.
+          </ion-card-content>
+        </ion-card>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/core/src/components/item/item.tsx
+++ b/core/src/components/item/item.tsx
@@ -5,7 +5,8 @@ import { chevronForward } from 'ionicons/icons';
 import { getIonMode } from '../../global/ionic-global';
 import type { AnimationBuilder, Color, CssClassMap, RouterDirection, StyleEventDetail } from '../../interface';
 import type { AnchorInterface, ButtonInterface } from '../../utils/element-interface';
-import { raf } from '../../utils/helpers';
+import type { Attributes } from '../../utils/helpers';
+import { inheritAriaAttributes, raf } from '../../utils/helpers';
 import { printIonError } from '../../utils/logging';
 import { createColorClasses, hostContext, openURL } from '../../utils/theme';
 import type { InputChangeEventDetail } from '../input/input-interface';
@@ -38,6 +39,7 @@ export class Item implements ComponentInterface, AnchorInterface, ButtonInterfac
   private labelColorStyles = {};
   private itemStyles = new Map<string, CssClassMap>();
   private clickListener?: (ev: Event) => void;
+  private inheritedAttributes: Attributes = {};
 
   @Element() el!: HTMLIonItemElement;
 
@@ -226,6 +228,7 @@ export class Item implements ComponentInterface, AnchorInterface, ButtonInterfac
 
   componentDidLoad() {
     raf(() => {
+      this.inheritedAttributes = inheritAriaAttributes(this.el);
       this.setMultipleInputs();
       this.focusable = this.isFocusable();
     });
@@ -359,15 +362,17 @@ export class Item implements ComponentInterface, AnchorInterface, ButtonInterfac
       target,
       routerAnimation,
       routerDirection,
+      inheritedAttributes,
     } = this;
     const childStyles = {} as any;
     const mode = getIonMode(this);
     const clickable = this.isClickable();
     const canActivate = this.canActivate();
     const TagType = clickable ? (href === undefined ? 'button' : 'a') : ('div' as any);
+    const ariaLabel = inheritedAttributes['aria-label'];
     const attrs =
       TagType === 'button'
-        ? { type: this.type }
+        ? { type: this.type, ariaLabel }
         : {
             download,
             href,
@@ -390,6 +395,7 @@ export class Item implements ComponentInterface, AnchorInterface, ButtonInterfac
     const ariaDisabled = disabled || childStyles['item-interactive-disabled'] ? 'true' : null;
     const fillValue = fill || 'none';
     const inList = hostContext('ion-list', this.el);
+
     return (
       <Host
         aria-disabled={ariaDisabled}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`aria-label` is not reflected to the focusable element (button) when using `ion-item` or `ion-card`.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #25885


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- If an `aria-label` is set on an `ion-card` using `button`, it will be reflected to the inner button.
- If an `aria-label` is set on an `ion-item` using `button`, it will be reflected to the inner button.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Opted against writing a spec test for `ion-item`, since it is rendered x2 on load, causing issues with the spec test.

Created a basic card template, since no example exists currently for quick preview/manipulation. 