### PR TITLE
test(input): reduce masking test flakiness

### DIFF
--- a/core/src/components/input/test/masking/input.e2e.ts
+++ b/core/src/components/input/test/masking/input.e2e.ts
@@ -15,11 +15,11 @@ test.describe('input: masking', () => {
     await input.click();
 
     // Playwright types this in one character at a time.
-    await page.keyboard.type('S p a c e s');
+    await page.keyboard.type('A B C', { delay: 100 });
     await ionInput.next();
 
     // ionInput is called for each character.
-    await expect(ionInput).toHaveReceivedEventTimes(11);
-    await expect(input).toHaveJSProperty('value', 'Spaces');
+    await expect(ionInput).toHaveReceivedEventTimes(5);
+    await expect(input).toHaveJSProperty('value', 'ABC');
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
The test is flaky again when trying to sync `feature-7.0`: https://github.com/ionic-team/ionic-framework/actions/runs/3160231835/jobs/5144478692

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- I added some delays to typing each character to help reduce flakiness. Playwright calls this out as a way of simulating a user typing: https://playwright.dev/docs/api/class-keyboard#keyboard-type

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
