### PR TITLE
feat(loading): isOpen presents and dismisses loading overlay

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -693,6 +693,7 @@ ion-loading,prop,cssClass,string | string[] | undefined,undefined,false,false
 ion-loading,prop,duration,number,0,false,false
 ion-loading,prop,enterAnimation,((baseEl: any, opts?: any) => Animation) | undefined,undefined,false,false
 ion-loading,prop,htmlAttributes,undefined | { [key: string]: any; },undefined,false,false
+ion-loading,prop,isOpen,boolean,false,false,false
 ion-loading,prop,keyboardClose,boolean,true,false,false
 ion-loading,prop,leaveAnimation,((baseEl: any, opts?: any) => Animation) | undefined,undefined,false,false
 ion-loading,prop,message,IonicSafeString | string | undefined,undefined,false,false

--- a/core/api.txt
+++ b/core/api.txt
@@ -705,10 +705,14 @@ ion-loading,method,dismiss,dismiss(data?: any, role?: string) => Promise<boolean
 ion-loading,method,onDidDismiss,onDidDismiss<T = any>() => Promise<OverlayEventDetail<T>>
 ion-loading,method,onWillDismiss,onWillDismiss<T = any>() => Promise<OverlayEventDetail<T>>
 ion-loading,method,present,present() => Promise<void>
+ion-loading,event,didDismiss,OverlayEventDetail<any>,true
+ion-loading,event,didPresent,void,true
 ion-loading,event,ionLoadingDidDismiss,OverlayEventDetail<any>,true
 ion-loading,event,ionLoadingDidPresent,void,true
 ion-loading,event,ionLoadingWillDismiss,OverlayEventDetail<any>,true
 ion-loading,event,ionLoadingWillPresent,void,true
+ion-loading,event,willDismiss,OverlayEventDetail<any>,true
+ion-loading,event,willPresent,void,true
 ion-loading,css-prop,--backdrop-opacity
 ion-loading,css-prop,--background
 ion-loading,css-prop,--height

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -1377,6 +1377,7 @@ export namespace Components {
           * Additional classes to apply for custom CSS. If multiple classes are provided they should be separated by spaces.
          */
         "cssClass"?: string | string[];
+        "delegate"?: FrameworkDelegate;
         /**
           * Dismiss the loading overlay after it has been presented.
           * @param data Any data to emit in the dismiss events.
@@ -1391,10 +1392,15 @@ export namespace Components {
           * Animation to use when the loading indicator is presented.
          */
         "enterAnimation"?: AnimationBuilder;
+        "hasController": boolean;
         /**
           * Additional attributes to pass to the loader.
          */
         "htmlAttributes"?: LoadingAttributes;
+        /**
+          * If `true`, the loading indicator will open. If `false`, the loading indicator will close. Use this if you need finer grained control over presentation, otherwise just use the loadingController or the `trigger` property. Note: `isOpen` will not automatically be set back to `false` when the loading indicator dismisses. You will need to do that in your code.
+         */
+        "isOpen": boolean;
         /**
           * If `true`, the keyboard will be automatically dismissed when the overlay is presented.
          */
@@ -5163,6 +5169,7 @@ declare namespace LocalJSX {
           * Additional classes to apply for custom CSS. If multiple classes are provided they should be separated by spaces.
          */
         "cssClass"?: string | string[];
+        "delegate"?: FrameworkDelegate;
         /**
           * Number of milliseconds to wait before dismissing the loading indicator.
          */
@@ -5171,10 +5178,15 @@ declare namespace LocalJSX {
           * Animation to use when the loading indicator is presented.
          */
         "enterAnimation"?: AnimationBuilder;
+        "hasController"?: boolean;
         /**
           * Additional attributes to pass to the loader.
          */
         "htmlAttributes"?: LoadingAttributes;
+        /**
+          * If `true`, the loading indicator will open. If `false`, the loading indicator will close. Use this if you need finer grained control over presentation, otherwise just use the loadingController or the `trigger` property. Note: `isOpen` will not automatically be set back to `false` when the loading indicator dismisses. You will need to do that in your code.
+         */
+        "isOpen"?: boolean;
         /**
           * If `true`, the keyboard will be automatically dismissed when the overlay is presented.
          */

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -5204,6 +5204,14 @@ declare namespace LocalJSX {
          */
         "mode"?: "ios" | "md";
         /**
+          * Emitted after the loading indicator has dismissed. Shorthand for ionLoadingDidDismiss.
+         */
+        "onDidDismiss"?: (event: IonLoadingCustomEvent<OverlayEventDetail>) => void;
+        /**
+          * Emitted after the loading indicator has presented. Shorthand for ionLoadingWillDismiss.
+         */
+        "onDidPresent"?: (event: IonLoadingCustomEvent<void>) => void;
+        /**
           * Emitted after the loading has dismissed.
          */
         "onIonLoadingDidDismiss"?: (event: IonLoadingCustomEvent<OverlayEventDetail>) => void;
@@ -5219,6 +5227,14 @@ declare namespace LocalJSX {
           * Emitted before the loading has presented.
          */
         "onIonLoadingWillPresent"?: (event: IonLoadingCustomEvent<void>) => void;
+        /**
+          * Emitted before the loading indicator has dismissed. Shorthand for ionLoadingWillDismiss.
+         */
+        "onWillDismiss"?: (event: IonLoadingCustomEvent<OverlayEventDetail>) => void;
+        /**
+          * Emitted before the loading indicator has presented. Shorthand for ionLoadingWillPresent.
+         */
+        "onWillPresent"?: (event: IonLoadingCustomEvent<void>) => void;
         "overlayIndex": number;
         /**
           * If `true`, a backdrop will be displayed behind the loading indicator.

--- a/core/src/components/loading/loading.tsx
+++ b/core/src/components/loading/loading.tsx
@@ -11,7 +11,6 @@ import type {
   OverlayInterface,
   SpinnerTypes,
 } from '../../interface';
-import { detachComponent } from '../../utils/framework-delegate';
 import { raf } from '../../utils/helpers';
 import {
   BACKDROP,
@@ -24,7 +23,6 @@ import {
 import type { IonicSafeString } from '../../utils/sanitization';
 import { sanitizeDOMString } from '../../utils/sanitization';
 import { getClassMap } from '../../utils/theme';
-import { deepReady } from '../../utils/transition';
 
 import { iosEnterAnimation } from './animations/ios.enter';
 import { iosLeaveAnimation } from './animations/ios.leave';
@@ -46,8 +44,6 @@ export class Loading implements ComponentInterface, OverlayInterface {
   private readonly delegateController = createDelegateController(this);
   private durationTimeout: any;
   private currentTransition?: Promise<any>;
-  // Reference to the user's provided loading content
-  private usersElement?: HTMLElement;
 
   presented = false;
   lastFocus?: HTMLElement;
@@ -228,8 +224,7 @@ export class Loading implements ComponentInterface, OverlayInterface {
     const { delegate } = this.delegateController.getDelegate(true);
 
     if (delegate) {
-      this.usersElement = await delegate.attachViewToDom(this.el, undefined);
-      await deepReady(this.usersElement);
+      await delegate.attachViewToDom(this.el, undefined);
     }
 
     this.currentTransition = present(this, 'loadingEnter', iosEnterAnimation, mdEnterAnimation);
@@ -264,7 +259,10 @@ export class Loading implements ComponentInterface, OverlayInterface {
     if (dismissed) {
       const { delegate } = this.delegateController.getDelegate();
       if (delegate) {
-        await detachComponent(delegate, this.usersElement);
+        const { el } = this;
+        if (el) {
+          delegate.removeViewFromDom(el.parentElement, el);
+        }
       }
     }
 

--- a/core/src/components/loading/loading.tsx
+++ b/core/src/components/loading/loading.tsx
@@ -227,7 +227,7 @@ export class Loading implements ComponentInterface, OverlayInterface {
       await deepReady(this.usersElement);
     }
 
-    this.currentTransition = present(this, 'loadingEnter', iosEnterAnimation, mdEnterAnimation, undefined);
+    this.currentTransition = present(this, 'loadingEnter', iosEnterAnimation, mdEnterAnimation);
 
     await this.currentTransition;
 
@@ -258,7 +258,9 @@ export class Loading implements ComponentInterface, OverlayInterface {
 
     if (dismissed) {
       const { delegate } = this.getDelegate();
-      await detachComponent(delegate, this.usersElement);
+      if (delegate) {
+        await detachComponent(delegate, this.usersElement);
+      }
     }
 
     return dismissed;

--- a/core/src/components/loading/loading.tsx
+++ b/core/src/components/loading/loading.tsx
@@ -221,11 +221,7 @@ export class Loading implements ComponentInterface, OverlayInterface {
       await this.currentTransition;
     }
 
-    const { delegate } = this.delegateController.getDelegate(true);
-
-    if (delegate) {
-      await delegate.attachViewToDom(this.el, undefined);
-    }
+    await this.delegateController.attachViewToDom();
 
     this.currentTransition = present(this, 'loadingEnter', iosEnterAnimation, mdEnterAnimation);
 
@@ -257,13 +253,7 @@ export class Loading implements ComponentInterface, OverlayInterface {
     const dismissed = await this.currentTransition;
 
     if (dismissed) {
-      const { delegate } = this.delegateController.getDelegate();
-      if (delegate) {
-        const { el } = this;
-        if (el) {
-          delegate.removeViewFromDom(el.parentElement, el);
-        }
-      }
+      this.delegateController.removeViewFromDom();
     }
 
     return dismissed;

--- a/core/src/components/loading/loading.tsx
+++ b/core/src/components/loading/loading.tsx
@@ -158,6 +158,30 @@ export class Loading implements ComponentInterface, OverlayInterface {
    */
   @Event({ eventName: 'ionLoadingDidDismiss' }) didDismiss!: EventEmitter<OverlayEventDetail>;
 
+  /**
+   * Emitted after the loading indicator has presented.
+   * Shorthand for ionLoadingWillDismiss.
+   */
+  @Event({ eventName: 'didPresent' }) didPresentShorthand!: EventEmitter<void>;
+
+  /**
+   * Emitted before the loading indicator has presented.
+   * Shorthand for ionLoadingWillPresent.
+   */
+  @Event({ eventName: 'willPresent' }) willPresentShorthand!: EventEmitter<void>;
+
+  /**
+   * Emitted before the loading indicator has dismissed.
+   * Shorthand for ionLoadingWillDismiss.
+   */
+  @Event({ eventName: 'willDismiss' }) willDismissShorthand!: EventEmitter<OverlayEventDetail>;
+
+  /**
+   * Emitted after the loading indicator has dismissed.
+   * Shorthand for ionLoadingDidDismiss.
+   */
+  @Event({ eventName: 'didDismiss' }) didDismissShorthand!: EventEmitter<OverlayEventDetail>;
+
   connectedCallback() {
     prepareOverlay(this.el);
   }

--- a/core/src/components/loading/loading.tsx
+++ b/core/src/components/loading/loading.tsx
@@ -11,7 +11,7 @@ import type {
   OverlayInterface,
   SpinnerTypes,
 } from '../../interface';
-import { attachComponent, CoreDelegate, detachComponent } from '../../utils/framework-delegate';
+import { CoreDelegate, detachComponent } from '../../utils/framework-delegate';
 import { raf } from '../../utils/helpers';
 import { BACKDROP, dismiss, eventMethod, prepareOverlay, present } from '../../utils/overlays';
 import type { IonicSafeString } from '../../utils/sanitization';
@@ -196,10 +196,12 @@ export class Loading implements ComponentInterface, OverlayInterface {
       await this.currentTransition;
     }
 
-    const { inline, delegate } = this.getDelegate(true);
-    this.usersElement = await attachComponent(delegate, this.el, undefined, undefined, undefined, inline);
+    const { delegate } = this.getDelegate(true);
 
-    await deepReady(this.usersElement);
+    if (delegate) {
+      this.usersElement = await delegate.attachViewToDom(this.el, undefined);
+      await deepReady(this.usersElement);
+    }
 
     this.currentTransition = present(this, 'loadingEnter', iosEnterAnimation, mdEnterAnimation, undefined);
 

--- a/core/src/components/loading/test/isOpen/index.html
+++ b/core/src/components/loading/test/isOpen/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Loading - isOpen</title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
+    <link href="../../../../../css/ionic.bundle.css" rel="stylesheet" />
+    <link href="../../../../../scripts/testing/styles.css" rel="stylesheet" />
+    <script src="../../../../../scripts/testing/scripts.js"></script>
+    <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+    <style>
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        grid-row-gap: 20px;
+        grid-column-gap: 20px;
+
+        padding: 200px;
+      }
+
+      .grid-item {
+        margin: 0 auto;
+      }
+
+      h2 {
+        font-size: 12px;
+        font-weight: normal;
+
+        color: #6f7378;
+
+        margin-top: 10px;
+        margin-left: 5px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Loading - isOpen</ion-title>
+        </ion-toolbar>
+      </ion-header>
+
+      <ion-content class="ion-padding">
+        <div class="grid">
+          <div class="grid-item">
+            <h2>Default</h2>
+            <ion-button id="default" onclick="openLoading()">Open Loading</ion-button>
+          </div>
+          <div class="grid-item">
+            <h2>Open, then close after 500ms</h2>
+            <ion-button id="timeout" onclick="openLoading(500)">Open Loading</ion-button>
+          </div>
+        </div>
+
+        <ion-loading message="Hello world"></ion-loading>
+      </ion-content>
+    </ion-app>
+
+    <script>
+      const loading = document.querySelector('ion-loading');
+
+      const openLoading = (timeout) => {
+        loading.isOpen = true;
+
+        if (timeout) {
+          setTimeout(() => {
+            loading.isOpen = false;
+          }, timeout);
+        }
+      };
+
+      loading.addEventListener('ionLoadingDidDismiss', () => {
+        loading.isOpen = false;
+      });
+    </script>
+  </body>
+</html>

--- a/core/src/components/loading/test/isOpen/index.html
+++ b/core/src/components/loading/test/isOpen/index.html
@@ -17,8 +17,6 @@
         grid-template-columns: repeat(2, 1fr);
         grid-row-gap: 20px;
         grid-column-gap: 20px;
-
-        padding: 200px;
       }
 
       .grid-item {

--- a/core/src/components/loading/test/isOpen/loading.e2e.ts
+++ b/core/src/components/loading/test/isOpen/loading.e2e.ts
@@ -1,0 +1,29 @@
+import { test } from '@utils/test/playwright';
+
+test.describe('loading: isOpen', () => {
+  test.beforeEach(async ({ page, skip }) => {
+    skip.rtl('isOpen does not behave differently in RTL');
+    await page.goto('/src/components/loading/test/isOpen');
+  });
+
+  test('should open the loading indicator', async ({ page }) => {
+    const ionLoadingDidPresent = await page.spyOnEvent('ionLoadingDidPresent');
+    await page.click('#default');
+
+    await ionLoadingDidPresent.next();
+    await page.waitForSelector('ion-loading', { state: 'visible' });
+  });
+
+  test('should open the loading indicator then close after a timeout', async ({ page }) => {
+    const ionLoadingDidPresent = await page.spyOnEvent('ionLoadingDidPresent');
+    const ionLoadingDidDismiss = await page.spyOnEvent('ionLoadingDidDismiss');
+    await page.click('#timeout');
+
+    await ionLoadingDidPresent.next();
+    await page.waitForSelector('ion-loading', { state: 'visible' });
+
+    await ionLoadingDidDismiss.next();
+
+    await page.waitForSelector('ion-loading', { state: 'hidden' });
+  });
+});

--- a/core/src/components/loading/test/isOpen/loading.e2e.ts
+++ b/core/src/components/loading/test/isOpen/loading.e2e.ts
@@ -3,6 +3,7 @@ import { test } from '@utils/test/playwright';
 test.describe('loading: isOpen', () => {
   test.beforeEach(async ({ page, skip }) => {
     skip.rtl('isOpen does not behave differently in RTL');
+    skip.mode('md', 'isOpen does not behave differently in MD');
     await page.goto('/src/components/loading/test/isOpen');
   });
 

--- a/core/src/utils/framework-delegate.ts
+++ b/core/src/utils/framework-delegate.ts
@@ -53,6 +53,8 @@ export const CoreDelegate = () => {
     userComponentProps: any = {},
     cssClasses: string[] = []
   ) => {
+    const hasUserDefinedComponent = userComponent !== undefined;
+
     BaseComponent = parentElement;
     /**
      * If passing in a component via the `component` props
@@ -86,7 +88,7 @@ export const CoreDelegate = () => {
       BaseComponent.appendChild(el);
 
       await new Promise((resolve) => componentOnReady(el, resolve));
-    } else if (BaseComponent.children.length > 0 && cssClasses.length > 0) {
+    } else if (hasUserDefinedComponent && BaseComponent.children.length > 0) {
       // If there is no component, then we need to create a new parent
       // element to apply the css classes to.
       const el = BaseComponent.ownerDocument?.createElement('div');

--- a/core/src/utils/framework-delegate.ts
+++ b/core/src/utils/framework-delegate.ts
@@ -86,7 +86,7 @@ export const CoreDelegate = () => {
       BaseComponent.appendChild(el);
 
       await new Promise((resolve) => componentOnReady(el, resolve));
-    } else if (BaseComponent.children.length > 0) {
+    } else if (BaseComponent.children.length > 0 && cssClasses.length > 0) {
       // If there is no component, then we need to create a new parent
       // element to apply the css classes to.
       const el = BaseComponent.ownerDocument?.createElement('div');

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -626,9 +626,9 @@ export const BACKDROP = 'backdrop';
  * @param ref The component class instance.
  */
 export const createDelegateController = (ref: {
-  el: HTMLElement,
-  hasController: boolean,
-  delegate?: FrameworkDelegate
+  el: HTMLElement;
+  hasController: boolean;
+  delegate?: FrameworkDelegate;
 }) => {
   let inline = false;
   let workingDelegate: FrameworkDelegate | undefined;

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -619,15 +619,19 @@ export const BACKDROP = 'backdrop';
  * Creates a delegate controller.
  *
  * Requires that the component has the following properties:
- * - `delegate?: FrameworkDelegate`
  * - `el: HTMLElement`
  * - `hasController: boolean`
+ * - `delegate?: FrameworkDelegate`
  *
  * @param ref The component class instance.
  */
-export const createDelegateController = (ref: any) => {
+export const createDelegateController = (ref: {
+  el: HTMLElement,
+  hasController: boolean,
+  delegate?: FrameworkDelegate
+}) => {
   let inline = false;
-  let workingDelegate: FrameworkDelegate;
+  let workingDelegate: FrameworkDelegate | undefined;
 
   const coreDelegate: FrameworkDelegate = CoreDelegate();
 

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -636,7 +636,7 @@ export const createDelegateController = (ref: {
   const coreDelegate: FrameworkDelegate = CoreDelegate();
 
   /**
-   *  * Determines whether or not an overlay is being used
+   * Determines whether or not an overlay is being used
    * inline or via a controller/JS and returns the correct delegate.
    * By default, subsequent calls to getDelegate will use
    * a cached version of the delegate.
@@ -675,10 +675,14 @@ export const createDelegateController = (ref: {
    * @param component The component to optionally construct and append to the element.
    */
   const attachViewToDom = async (component?: any) => {
-    const { delegate } = getDelegate(true);
+    const { delegate, inline } = getDelegate(true);
     if (delegate) {
-      await delegate.attachViewToDom(ref.el, component);
+      return await delegate.attachViewToDom(ref.el, component);
     }
+    if (!inline && typeof component !== 'string' && !(component instanceof HTMLElement)) {
+      throw new Error('framework delegate is missing');
+    }
+    return null;
   };
 
   /**

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -663,6 +663,7 @@ export const createDelegateController = (ref: {
      * correct place.
      */
     const parentEl = el.parentNode as HTMLElement | null;
+
     inline = parentEl !== null && !hasController;
     workingDelegate = inline ? delegate || coreDelegate : delegate;
 
@@ -675,11 +676,12 @@ export const createDelegateController = (ref: {
    * @param component The component to optionally construct and append to the element.
    */
   const attachViewToDom = async (component?: any) => {
-    const { delegate, inline } = getDelegate(true);
+    const { delegate } = getDelegate(true);
     if (delegate) {
       return await delegate.attachViewToDom(ref.el, component);
     }
-    if (!inline && typeof component !== 'string' && !(component instanceof HTMLElement)) {
+    const { hasController } = ref;
+    if (hasController && component !== undefined) {
       throw new Error('framework delegate is missing');
     }
     return null;

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -669,7 +669,30 @@ export const createDelegateController = (ref: {
     return { inline, delegate: workingDelegate };
   };
 
+  /**
+   * Attaches a component in the DOM. Teleports the component
+   * to the root of the app.
+   * @param component The component to optionally construct and append to the element.
+   */
+  const attachViewToDom = async (component?: any) => {
+    const { delegate } = getDelegate(true);
+    if (delegate) {
+      await delegate.attachViewToDom(ref.el, component);
+    }
+  };
+
+  /**
+   * Moves a component back to its original location in the DOM.
+   */
+  const removeViewFromDom = () => {
+    const { delegate } = getDelegate();
+    if (delegate && ref.el) {
+      delegate.removeViewFromDom(ref.el.parentElement, ref.el);
+    }
+  };
+
   return {
-    getDelegate,
+    attachViewToDom,
+    removeViewFromDom,
   };
 };

--- a/packages/react/src/components/IonLoading.tsx
+++ b/packages/react/src/components/IonLoading.tsx
@@ -1,9 +1,9 @@
-import { LoadingOptions, loadingController } from '@ionic/core/components';
+import { JSX } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-loading.js';
 
-import { createControllerComponent } from './createControllerComponent';
+import { createInlineOverlayComponent } from './createInlineOverlayComponent';
 
-export const IonLoading = /*@__PURE__*/ createControllerComponent<
-  LoadingOptions,
+export const IonLoading = /*@__PURE__*/ createInlineOverlayComponent<
+  JSX.IonLoading,
   HTMLIonLoadingElement
->('ion-loading', loadingController, defineCustomElement);
+>('ion-loading', defineCustomElement);

--- a/packages/react/test-app/tests/e2e/specs/overlay-components/IonLoading.cy.ts
+++ b/packages/react/test-app/tests/e2e/specs/overlay-components/IonLoading.cy.ts
@@ -9,7 +9,7 @@ describe('IonLoading', () => {
     cy.get('ion-loading').contains('Loading');
 
     //loading goes away after 1s
-    cy.get('ion-loading').should('not.exist');
+    cy.get('ion-loading').should('not.be.visible');
   });
 
   it('display loading and call dismiss to close it', () => {
@@ -17,7 +17,7 @@ describe('IonLoading', () => {
     cy.get('ion-button').contains('Show Loading, hide after 250 ms').click();
     cy.get('ion-loading').contains('Loading');
 
-    //verify loading is gone
-    cy.get('ion-loading').should('not.exist');
+    //verify loading is hidden
+    cy.get('ion-loading').should('not.be.visible');
   });
 });

--- a/packages/vue/src/components/Overlays.ts
+++ b/packages/vue/src/components/Overlays.ts
@@ -23,7 +23,7 @@ export const IonActionSheet = /*@__PURE__*/ defineOverlayContainer<JSX.IonAction
     
 export const IonAlert = /*@__PURE__*/ defineOverlayContainer<JSX.IonAlert>('ion-alert', defineIonAlertCustomElement, ['animated', 'backdropDismiss', 'buttons', 'cssClass', 'enterAnimation', 'header', 'htmlAttributes', 'inputs', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'subHeader', 'translucent'], alertController);
     
-export const IonLoading = /*@__PURE__*/ defineOverlayContainer<JSX.IonLoading>('ion-loading', defineIonLoadingCustomElement, ['animated', 'backdropDismiss', 'cssClass', 'duration', 'enterAnimation', 'htmlAttributes', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'showBackdrop', 'spinner', 'translucent'], loadingController);
+export const IonLoading = /*@__PURE__*/ defineOverlayContainer<JSX.IonLoading>('ion-loading', defineIonLoadingCustomElement, ['animated', 'backdropDismiss', 'cssClass', 'duration', 'enterAnimation', 'htmlAttributes', 'isOpen', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'showBackdrop', 'spinner', 'translucent'], loadingController);
     
 export const IonPicker = /*@__PURE__*/ defineOverlayContainer<JSX.IonPicker>('ion-picker', defineIonPickerCustomElement, ['animated', 'backdropDismiss', 'buttons', 'columns', 'cssClass', 'duration', 'enterAnimation', 'htmlAttributes', 'keyboardClose', 'leaveAnimation', 'mode', 'showBackdrop'], pickerController);
     


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`ion-loading` cannot be used inline. 

<!-- Issues are required for both bug fixes and features. -->
Issue URL: Internal


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `ion-loading` supports `isOpen` property to present and dismiss the loading indicator
- Framework delegate will skip cloning element to a parent when there are no CSS classes to append to the parent 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
