### PR TITLE
feat(toggle): ionChange will only emit from user committed changes

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -24,6 +24,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
   - [Segment](#version-7x-segment)
   - [Slides](#version-7x-slides)
   - [Textarea](#version-7x-textarea)
+  - [Toggle](#version-7x-toggle)
   - [Virtual Scroll](#version-7x-virtual-scroll)
 - [JavaScript Frameworks](#version-7x-javascript-frameworks)
   - [React](#version-7x-react)
@@ -139,6 +140,10 @@ Developers using these components will need to migrate to using Swiper.js direct
 - The `debounce` property has been updated to control the timing in milliseconds to delay the event emission of the `ionInput` event after each keystroke. Previously it would delay the event emission of `ionChange`.
 
 - `ionInput` dispatches an event detail of `null` when the textarea is cleared as a result of `clear-on-edit="true"`.
+
+<h4 id="version-7x-toggle">Toggle</h4>
+
+- `ionChange` is no longer emitted when the `checked` property of `ion-toggle` is modified externally. `ionChange` is only emitted from user committed changes, such as clicking the toggle to set it on or off.
 
 <h4 id="version-7x-virtual-scroll">Virtual Scroll</h4>
 

--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -1909,7 +1909,8 @@ export class IonTitle {
 import type { ToggleChangeEventDetail as IToggleToggleChangeEventDetail } from '@ionic/core';
 export declare interface IonToggle extends Components.IonToggle {
   /**
-   * Emitted when the value property has changed. 
+   * Emitted when the user switches the toggle on or off. Does not emit
+when programmatically changing the value of the `checked` property. 
    */
   ionChange: EventEmitter<CustomEvent<IToggleToggleChangeEventDetail>>;
   /**

--- a/angular/test/base/e2e/src/inputs.spec.ts
+++ b/angular/test/base/e2e/src/inputs.spec.ts
@@ -39,7 +39,7 @@ describe('Inputs', () => {
     cy.get('#reset-button').click();
 
     cy.get('ion-checkbox#first-checkbox').click();
-    cy.get('ion-toggle').invoke('prop', 'checked', true);
+    cy.get('ion-toggle').click();
 
     cy.get('ion-input').eq(0).type('hola');
     cy.get('ion-input input').eq(0).blur();

--- a/angular/test/base/e2e/src/inputs.spec.ts
+++ b/angular/test/base/e2e/src/inputs.spec.ts
@@ -39,7 +39,7 @@ describe('Inputs', () => {
     cy.get('#reset-button').click();
 
     cy.get('ion-checkbox#first-checkbox').click();
-    cy.get('ion-toggle').click();
+    cy.get('ion-toggle').first().click();
 
     cy.get('ion-input').eq(0).type('hola');
     cy.get('ion-input input').eq(0).blur();

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -6725,7 +6725,7 @@ declare namespace LocalJSX {
          */
         "onIonBlur"?: (event: IonToggleCustomEvent<void>) => void;
         /**
-          * Emitted when the value property has changed.
+          * Emitted when the user switches the toggle on or off. Does not emit when programmatically changing the value of the `checked` property.
          */
         "onIonChange"?: (event: IonToggleCustomEvent<ToggleChangeEventDetail>) => void;
         /**

--- a/core/src/components/toggle/test/basic/toggle.e2e.ts
+++ b/core/src/components/toggle/test/basic/toggle.e2e.ts
@@ -52,14 +52,14 @@ test.describe('toggle: basic', () => {
     });
   });
 
-  test('should fire change event if checked prop is changed directly', async ({ page }) => {
+  test('should not fire change event if checked prop is changed directly', async ({ page }) => {
     const toggle = page.locator('#orange');
     const ionChange = await page.spyOnEvent('ionChange');
 
     await toggle.evaluate((el: HTMLIonToggleElement) => (el.checked = true));
     await page.waitForChanges();
 
-    expect(ionChange).toHaveReceivedEvent();
+    expect(ionChange).toHaveReceivedEventTimes(0);
   });
 
   test('should pass properties down to hidden input', async ({ page }) => {

--- a/core/src/components/toggle/toggle.tsx
+++ b/core/src/components/toggle/toggle.tsx
@@ -70,7 +70,8 @@ export class Toggle implements ComponentInterface {
   @Prop() enableOnOffLabels: boolean | undefined = undefined;
 
   /**
-   * Emitted when the value property has changed.
+   * Emitted when the user switches the toggle on or off. Does not emit
+   * when programmatically changing the value of the `checked` property.
    */
   @Event() ionChange!: EventEmitter<ToggleChangeEventDetail>;
 
@@ -90,20 +91,24 @@ export class Toggle implements ComponentInterface {
    */
   @Event() ionStyle!: EventEmitter<StyleEventDetail>;
 
-  @Watch('checked')
-  checkedChanged(isChecked: boolean) {
-    this.ionChange.emit({
-      checked: isChecked,
-      value: this.value,
-    });
-  }
-
   @Watch('disabled')
   disabledChanged() {
     this.emitStyle();
     if (this.gesture) {
       this.gesture.enable(!this.disabled);
     }
+  }
+
+  private toggleChecked() {
+    const { checked, value } = this;
+
+    const isNowChecked = !checked;
+    this.checked = isNowChecked;
+
+    this.ionChange.emit({
+      checked: isNowChecked,
+      value: value,
+    });
   }
 
   async connectedCallback() {
@@ -146,7 +151,7 @@ export class Toggle implements ComponentInterface {
 
   private onMove(detail: GestureDetail) {
     if (shouldToggle(isRTL(this.el), this.checked, detail.deltaX, -10)) {
-      this.checked = !this.checked;
+      this.toggleChecked();
       hapticSelection();
     }
   }
@@ -172,7 +177,7 @@ export class Toggle implements ComponentInterface {
     ev.preventDefault();
 
     if (this.lastDrag + 300 < Date.now()) {
-      this.checked = !this.checked;
+      this.toggleChecked();
     }
   };
 

--- a/core/src/components/toggle/toggle.tsx
+++ b/core/src/components/toggle/toggle.tsx
@@ -107,7 +107,7 @@ export class Toggle implements ComponentInterface {
 
     this.ionChange.emit({
       checked: isNowChecked,
-      value: value,
+      value,
     });
   }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`ion-toggle` will emit an `ionChange` event if the value of the `checked` property is changed programmatically.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

`ionChange` is now only emitted from the user clicking or dragging the handle to toggle it.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
