### PR TITLE
fix(accordion-group): do not adjust incorrect values

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -62,7 +62,9 @@ This section details the desktop browser, JavaScript framework, and mobile platf
 
 <h4 id="version-7x-accordion-group">Accordion Group</h4>
 
-`ionChange` is no longer emitted when the `value` of `ion-accordion-group` is modified externally. `ionChange` is only emitted from user committed changes, such as clicking or tapping the accordion header.
+-`ionChange` is no longer emitted when the `value` of `ion-accordion-group` is modified externally. `ionChange` is only emitted from user committed changes, such as clicking or tapping the accordion header.
+
+- Accordion Group no longer automatically adjusts the `value` property when passed an array and `multiple="false"`. Developers should update their apps to ensure they are using the API correctly.
 
 <h4 id="version-7x-checkbox">Checkbox</h4>
 

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -73,7 +73,7 @@ export namespace Components {
          */
         "requestAccordionToggle": (accordionValue: string | undefined, accordionExpand: boolean) => Promise<void>;
         /**
-          * The value of the accordion group.
+          * The value of the accordion group. This controls which accordions are expanded. This should be an array of strings only when `multiple="true"`
          */
         "value"?: string | string[] | null;
     }
@@ -3814,7 +3814,7 @@ declare namespace LocalJSX {
          */
         "readonly"?: boolean;
         /**
-          * The value of the accordion group.
+          * The value of the accordion group. This controls which accordions are expanded. This should be an array of strings only when `multiple="true"`
          */
         "value"?: string | string[] | null;
     }

--- a/core/src/components/accordion-group/accordion-group.tsx
+++ b/core/src/components/accordion-group/accordion-group.tsx
@@ -80,7 +80,7 @@ export class AccordionGroup implements ComponentInterface {
     if (!multiple && Array.isArray(value)) {
       printIonWarning(
         `ion-accordion-group was passed an array of values, but multiple="false". This is incorrect usage and may result in unexpected behaviors. To dismiss this warning, pass a string to the "value" property when multiple="false".
-  Value Passed: ${value}`,
+  Value Passed: [${value.map(v => `'${v}'`).join(', ')}]`,
         this.el
       );
     }

--- a/core/src/components/accordion-group/accordion-group.tsx
+++ b/core/src/components/accordion-group/accordion-group.tsx
@@ -3,6 +3,7 @@ import { Component, Element, Event, Host, Listen, Method, Prop, Watch, h } from 
 
 import { getIonMode } from '../../global/ionic-global';
 import type { AccordionGroupChangeEventDetail } from '../../interface';
+import { printIonWarning } from '../../utils/logging';
 
 /**
  * @virtualProp {"ios" | "md"} mode - The mode determines which platform styles to use.
@@ -32,7 +33,9 @@ export class AccordionGroup implements ComponentInterface {
   @Prop() multiple?: boolean;
 
   /**
-   * The value of the accordion group.
+   * The value of the accordion group. This controls which
+   * accordions are expanded.
+   * This should be an array of strings only when `multiple="true"`
    */
   @Prop({ mutable: true }) value?: string | string[] | null;
 
@@ -74,16 +77,12 @@ export class AccordionGroup implements ComponentInterface {
   valueChanged() {
     const { value, multiple } = this;
 
-    /**
-     * If accordion group does not
-     * let multiple accordions be open
-     * at once, but user passes an array
-     * just grab the first value.
-     * This should emit ionChange because
-     * we are updating the value internally.
-     */
     if (!multiple && Array.isArray(value)) {
-      this.setValue(value[0]);
+      printIonWarning(
+        `ion-accordion-group was passed an array of values, but multiple="false". This is incorrect usage and may result in unexpected behaviors. To dismiss this warning, pass a string to the "value" property when multiple="false".
+  Value Passed: ${value}`,
+        this.el
+      );
     }
 
     /**

--- a/core/src/components/accordion-group/accordion-group.tsx
+++ b/core/src/components/accordion-group/accordion-group.tsx
@@ -78,9 +78,19 @@ export class AccordionGroup implements ComponentInterface {
     const { value, multiple } = this;
 
     if (!multiple && Array.isArray(value)) {
+      /**
+       * We do some processing on the `value` array so
+       * that it looks more like an array when logged to
+       * the console.
+       * Example given ['a', 'b']
+       * Default toString() behavior: a,b
+       * Custom behavior: ['a', 'b']
+       */
       printIonWarning(
         `ion-accordion-group was passed an array of values, but multiple="false". This is incorrect usage and may result in unexpected behaviors. To dismiss this warning, pass a string to the "value" property when multiple="false".
-  Value Passed: [${value.map(v => `'${v}'`).join(', ')}]`,
+
+  Value Passed: [${value.map((v) => `'${v}'`).join(', ')}]
+`,
         this.el
       );
     }

--- a/core/src/components/accordion/test/accordion.spec.ts
+++ b/core/src/components/accordion/test/accordion.spec.ts
@@ -40,42 +40,6 @@ it('should open correct accordions', async () => {
   expect(accordions[2].classList.contains('accordion-collapsed')).toEqual(true);
 });
 
-it('should not open more than one accordion when multiple="false"', async () => {
-  const page = await newSpecPage({
-    components: [Item, Accordion, AccordionGroup],
-    html: `
-      <ion-accordion-group animated="false">
-        <ion-accordion value="first">
-          <ion-item slot="header">Label</ion-item>
-          <div slot="content">Content</div>
-        </ion-accordion>
-        <ion-accordion value="second">
-          <ion-item slot="header">Label</ion-item>
-          <div slot="content">Content</div>
-        </ion-accordion>
-        <ion-accordion value="third">
-          <ion-item slot="header">Label</ion-item>
-          <div slot="content">Content</div>
-        </ion-accordion>
-      </ion-accordion-group>
-    `,
-  });
-
-  const accordionGroup = page.body.querySelector('ion-accordion-group');
-  const accordions = accordionGroup.querySelectorAll('ion-accordion');
-
-  accordions.forEach((accordion) => {
-    expect(accordion.classList.contains('accordion-collapsed')).toEqual(true);
-  });
-
-  accordionGroup.value = ['first', 'second'];
-  await page.waitForChanges();
-
-  expect(accordions[0].classList.contains('accordion-collapsed')).toEqual(false);
-  expect(accordions[1].classList.contains('accordion-collapsed')).toEqual(true);
-  expect(accordions[2].classList.contains('accordion-collapsed')).toEqual(true);
-});
-
 it('should open more than one accordion when multiple="true"', async () => {
   const page = await newSpecPage({
     components: [Item, Accordion, AccordionGroup],

--- a/core/src/components/accordion/test/basic/accordion.e2e.ts
+++ b/core/src/components/accordion/test/basic/accordion.e2e.ts
@@ -74,30 +74,4 @@ test.describe('accordion: ionChange', () => {
     await accordionGroup.evaluate((el: HTMLIonAccordionGroupElement) => (el.value = 'second'));
     await expect(ionChange).not.toHaveReceivedEvent();
   });
-
-  test('should fire ionChange setting array of values on a single selection accordion', async ({ page }) => {
-    await page.setContent(`
-      <ion-accordion-group>
-        <ion-accordion value="first">
-          <button slot="header">Header</button>
-          <div slot="content">First Content</div>
-        </ion-accordion>
-        <ion-accordion value="second">
-          <button slot="header">Header</button>
-          <div slot="content">Second Content</div>
-        </ion-accordion>
-        <ion-accordion value="third">
-          <button slot="header">Header</button>
-          <div slot="content">Third Content</div>
-        </ion-accordion>
-      </ion-accordion-group>
-
-    `);
-
-    const ionChange = await page.spyOnEvent('ionChange');
-    const accordionGroup = page.locator('ion-accordion-group');
-
-    await accordionGroup.evaluate((el: HTMLIonAccordionGroupElement) => (el.value = ['second', 'third']));
-    await expect(ionChange).toHaveReceivedEventDetail({ value: 'second' });
-  });
 });


### PR DESCRIPTION
⚠️ Be sure to set commit message to the breaking change note when merging 


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: N/A

As per our `ionChange` revision requirements, components should avoid updating `value` internally unless by a user-committed action.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Accordion group no longer updates the `value` property internally when passed an incorrect value. It will now log a warning message to the console.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
