### PR TITLE
feat(toggle): add `onOffLabelsEnabled` property to IonicConfig

### DIFF
--- a/core/src/components/toggle/test/toggle.spec.ts
+++ b/core/src/components/toggle/test/toggle.spec.ts
@@ -1,0 +1,43 @@
+import { newSpecPage } from '@stencil/core/testing';
+
+import { config } from '../../../global/config';
+import { Toggle } from '../toggle';
+
+describe('toggle', () => {
+  beforeEach(() => {
+    config.reset({});
+  });
+
+  const newToggle = async (): Promise<Toggle> => {
+    const { rootInstance } = await newSpecPage({
+      components: [Toggle],
+      html: `<ion-toggle></ion-toggle>`,
+    });
+    return rootInstance;
+  };
+
+  describe('enableOnOffLabels', () => {
+    it('set custom attribute on the instance, override config', async () => {
+      const t = await newToggle();
+      t.enableOnOffLabels = false;
+      config.reset({
+        onOffLabelsEnabled: true,
+      });
+      expect(t.onOffLabelsEnabled).toBe(false);
+    });
+
+    it('set custom attribute in the config', async () => {
+      config.reset({
+        onOffLabelsEnabled: true,
+      });
+      const t = await newToggle();
+      expect(t.onOffLabelsEnabled).toBe(true);
+    });
+
+    it('set custom icon on the instance', async () => {
+      const t = await newToggle();
+      t.enableOnOffLabels = true;
+      expect(t.onOffLabelsEnabled).toBe(true);
+    });
+  });
+});

--- a/core/src/components/toggle/toggle.tsx
+++ b/core/src/components/toggle/toggle.tsx
@@ -2,6 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Prop, State, Watch, h } from '@stencil/core';
 import { checkmarkOutline, removeOutline, ellipseOutline } from 'ionicons/icons';
 
+import { config } from '../../global/config';
 import { getIonMode } from '../../global/ionic-global';
 import type { Color, Gesture, GestureDetail, Mode, StyleEventDetail, ToggleChangeEventDetail } from '../../interface';
 import { getAriaLabel, renderHiddenInput } from '../../utils/helpers';
@@ -131,6 +132,12 @@ export class Toggle implements ComponentInterface {
     this.emitStyle();
   }
 
+  get onOffLabelsEnabled(): boolean {
+    const { enableOnOffLabels } = this;
+
+    return enableOnOffLabels !== undefined ? enableOnOffLabels : config.get('onOffLabelsEnabled');
+  }
+
   private emitStyle() {
     this.ionStyle.emit({
       'interactive-disabled': this.disabled,
@@ -206,7 +213,7 @@ export class Toggle implements ComponentInterface {
   }
 
   render() {
-    const { activated, color, checked, disabled, el, inputId, name, enableOnOffLabels } = this;
+    const { activated, color, checked, disabled, el, inputId, name, onOffLabelsEnabled } = this;
     const mode = getIonMode(this);
     const { label, labelId, labelText } = getAriaLabel(el, inputId);
     const value = this.getValue();
@@ -233,11 +240,11 @@ export class Toggle implements ComponentInterface {
           {/* The iOS on/off labels are rendered outside of .toggle-icon-wrapper,
            since the wrapper is translated when the handle is interacted with and
            this would move the on/off labels outside of the view box */}
-          {enableOnOffLabels &&
+          {onOffLabelsEnabled &&
             mode === 'ios' && [this.renderOnOffSwitchLabels(mode, true), this.renderOnOffSwitchLabels(mode, false)]}
           <div class="toggle-icon-wrapper">
             <div class="toggle-inner" part="handle">
-              {enableOnOffLabels && mode === 'md' && this.renderOnOffSwitchLabels(mode, checked)}
+              {onOffLabelsEnabled && mode === 'md' && this.renderOnOffSwitchLabels(mode, checked)}
             </div>
           </div>
         </div>

--- a/core/src/utils/config.ts
+++ b/core/src/utils/config.ts
@@ -59,6 +59,11 @@ export interface IonicConfig {
   menuType?: string;
 
   /**
+   * Overrides the default enableOnOffLabels in all `<ion-toggle>` components.
+   */
+  onOffLabelsEnabled?: boolean;
+
+  /**
    * Overrides the default spinner in all `<ion-spinner>` components.
    * By default the spinner type is chosen based in the mode (ios or md).
    */


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Atm there is no way of configuring the `enableOnOffLabels` property of the `<ion-toggle>` globally


<!-- Issues are required for both bug fixes and features. -->
Issue URL: closes #26082 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- New property `onOffLabelsEnabled` added to Ionic's global config

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
