### PR TITLE
fix(modal): sheet modal dismisses correctly

### DIFF
--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -708,7 +708,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
 
     this.currentTransition = dismiss(this, data, role, 'modalLeave', iosLeaveAnimation, mdLeaveAnimation, {
       presentingEl: this.presentingElement,
-      currentBreakpoint: this.currentBreakpoint !== undefined || this.initialBreakpoint,
+      currentBreakpoint: this.currentBreakpoint ?? this.initialBreakpoint,
       backdropBreakpoint: this.backdropBreakpoint,
     });
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/26108

The sheet modal dismiss behavior changed as a result of our strict-boolean-expressions refactor: https://github.com/ionic-team/ionic-framework/commit/ae6aa0cb8e158783c09adc2f64e607505be55a28#diff-fe05ef73704648b399bf1ae571ca7b507d02accd5a42ce8081bc9fd778c81ba9R707

In particular, this line changed: https://github.com/ionic-team/ionic-framework/blob/bbd6c9ae6cb69eca1847524cd17b19db27b7f8d2/core/src/components/modal/modal.tsx#L711

When currentBreakpoint was defined, the expression evaluated to `true` which got interpreted as the number `1`. As a result, the sheet modal jumped up to breakpoint `1` on dismiss.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The code was changed to used the nullish coalescing operator (??) as we likely wanted to fallback to `this.initialBreakpoint` when `this.currentBreakpoint` is `undefined`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
