### PR TITLE
DO NOT MERGE Fw 2521

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1714,10 +1714,11 @@ export class Datetime implements ComponentInterface {
     }
 
     const valueIsDefined = this.value !== null && this.value !== undefined;
+    const activePart = this.getDefaultPart();
 
     const { hoursData, minutesData, dayPeriodData } = getTimeColumnsData(
       this.locale,
-      this.workingParts,
+      activePart,
       this.hourCycle,
       valueIsDefined ? this.minParts : undefined,
       valueIsDefined ? this.maxParts : undefined,

--- a/core/src/components/datetime/test/minmax/datetime.e2e.ts
+++ b/core/src/components/datetime/test/minmax/datetime.e2e.ts
@@ -235,7 +235,10 @@ test.describe('datetime: minmax', () => {
     await expect(hourPickerItems).toHaveText(['12', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11']);
   });
 
-  test('time values should be filtered based on active day even when changing working parts', async ({ page, skip }) => {
+  test('time values should be filtered based on active day even when changing working parts', async ({
+    page,
+    skip,
+  }) => {
     skip.rtl();
 
     await page.setContent(`
@@ -258,7 +261,6 @@ test.describe('datetime: minmax', () => {
     await page.click('button#bind');
 
     const ionPopoverDidPresent = await page.spyOnEvent('ionPopoverDidPresent');
-    const ionPopoverDidDismiss = await page.spyOnEvent('ionPopoverDidDismiss');
     const datetimeMonthDidChange = await page.spyOnEvent('datetimeMonthDidChange');
 
     // Go to the next month
@@ -282,5 +284,5 @@ test.describe('datetime: minmax', () => {
     // Ensure the number of hours and minutes are correct
     expect(await hours.count()).toBe(3);
     expect(await minutes.count()).toBe(45);
-  })
+  });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: Internal ticket

The allowed hour/minute values were always generated based on the working parts. This means that the moment you changed months via the next/prev buttons, you could select any time value. As a result, changing the month and selecting an invalid time value would cause the datetime picker to visually reset to the previous month.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Time values are now generated based on what the user has selected (or the fallback part of "today").

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
