### PR TITLE
fix(datetime): header renders correct date

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -2112,11 +2112,11 @@ export class Datetime implements ComponentInterface {
       return;
     }
 
-    const { activeParts, titleSelectedDatesFormatter } = this;
+    const { activeParts, multiple, titleSelectedDatesFormatter } = this;
     const isArray = Array.isArray(activeParts);
 
     let headerText: string;
-    if (isArray && activeParts.length !== 1) {
+    if (multiple && isArray && activeParts.length !== 1) {
       headerText = `${activeParts.length} days`; // default/fallback for multiple selection
       if (titleSelectedDatesFormatter !== undefined) {
         try {

--- a/core/src/components/datetime/test/multiple/datetime.e2e.ts
+++ b/core/src/components/datetime/test/multiple/datetime.e2e.ts
@@ -206,7 +206,7 @@ test.describe('datetime: multiple date selection (functionality)', () => {
           }
         }
       </script>
-    `)
+    `);
     await page.waitForSelector(`.datetime-ready`);
     const datetime = page.locator('ion-datetime');
     const header = datetime.locator('.datetime-selected-date');

--- a/core/src/components/datetime/test/multiple/datetime.e2e.ts
+++ b/core/src/components/datetime/test/multiple/datetime.e2e.ts
@@ -189,4 +189,28 @@ test.describe('datetime: multiple date selection (functionality)', () => {
     await juneButtons.nth(0).click();
     await expect(header).toHaveText('Selected: 0');
   });
+
+  test('header text should render default date when multiple="false"', async ({ page }) => {
+    await page.setContent(`
+      <ion-datetime locale="en-US" show-default-title="true"></ion-datetime>
+
+      <script>
+        const mockToday = '2022-10-10T16:22';
+        Date = class extends Date {
+          constructor(...args) {
+            if (args.length === 0) {
+              super(mockToday)
+            } else {
+              super(...args);
+            }
+          }
+        }
+      </script>
+    `)
+    await page.waitForSelector(`.datetime-ready`);
+    const datetime = page.locator('ion-datetime');
+    const header = datetime.locator('.datetime-selected-date');
+
+    await expect(header).toHaveText('Mon, Oct 10');
+  });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/26116

The title formatter logic only checked if `activeParts` was an array, not if `multiple="true"`. As a result, when the `activeParts` variable was refactored to an array in https://github.com/ionic-team/ionic-framework/commit/0aee328b4b84d5668752e5ae0792334d0173c2bb, "0 days" started showing on single-select datetimes with no value.

This does not impact `ion-datetime-button` as that component checked for `multiple="true"`.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The title formatter for multiple date selection only renders when `multiple="true"`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
