### PR TITLE
test(range): wait for events to emit

### DIFF
--- a/core/src/components/range/test/basic/range.e2e.ts
+++ b/core/src/components/range/test/basic/range.e2e.ts
@@ -21,6 +21,9 @@ test.describe('range: basic', () => {
     await dragElementBy(rangeEl, page, testInfo.project.metadata.rtl ? -300 : 300, 0);
     await page.waitForChanges();
 
+    await rangeStart.next();
+    await rangeEnd.next();
+
     /**
      * dragElementBy defaults to starting the drag from the middle of the el,
      * so the start value should jump to 50 despite the range defaulting to 20.
@@ -33,6 +36,9 @@ test.describe('range: basic', () => {
      */
     await dragElementBy(rangeEl, page, 0, 0);
     await page.waitForChanges();
+
+    await rangeStart.next();
+    await rangeEnd.next();
 
     expect(rangeStart).toHaveReceivedEventDetail({ value: 50 });
     expect(rangeEnd).toHaveReceivedEventDetail({ value: 50 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: https://github.com/ionic-team/ionic-framework/actions/runs/3244264729/jobs/5320265358

The range event test was not waiting for the event to be received before checking the event payload, leading to some flaky tests.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Range tests now wait for start/end events to have been received.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
