### PR TITLE
fix(dependencies): latest patch is installed

### DIFF
--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.3.2",
       "license": "MIT",
       "dependencies": {
-        "@ionic/core": "^6.3.2",
+        "@ionic/core": "6.3.2",
         "jsonc-parser": "^3.0.0",
         "tslib": "^2.0.0"
       },

--- a/angular/package.json
+++ b/angular/package.json
@@ -45,7 +45,7 @@
     "validate": "npm i && npm run lint && npm run test && npm run build"
   },
   "dependencies": {
-    "@ionic/core": "^6.3.2",
+    "@ionic/core": "6.3.2",
     "jsonc-parser": "^3.0.0",
     "tslib": "^2.0.0"
   },

--- a/packages/react-router/package-lock.json
+++ b/packages/react-router/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.3.2",
       "license": "MIT",
       "dependencies": {
-        "@ionic/react": "^6.3.2",
+        "@ionic/react": "6.3.2",
         "tslib": "*"
       },
       "devDependencies": {

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -37,7 +37,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@ionic/react": "^6.3.2",
+    "@ionic/react": "6.3.2",
     "tslib": "*"
   },
   "peerDependencies": {

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.3.2",
       "license": "MIT",
       "dependencies": {
-        "@ionic/core": "^6.3.2",
+        "@ionic/core": "6.3.2",
         "ionicons": "^6.0.2",
         "tslib": "*"
       },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,7 @@
     "css/"
   ],
   "dependencies": {
-    "@ionic/core": "^6.3.2",
+    "@ionic/core": "6.3.2",
     "ionicons": "^6.0.2",
     "tslib": "*"
   },

--- a/packages/vue-router/package-lock.json
+++ b/packages/vue-router/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.3.2",
       "license": "MIT",
       "dependencies": {
-        "@ionic/vue": "^6.3.2"
+        "@ionic/vue": "6.3.2"
       },
       "devDependencies": {
         "@types/jest": "^28.1.1",

--- a/packages/vue-router/package.json
+++ b/packages/vue-router/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/ionic-team/ionic#readme",
   "dependencies": {
-    "@ionic/vue": "^6.3.2"
+    "@ionic/vue": "6.3.2"
   },
   "devDependencies": {
     "@types/jest": "^28.1.1",

--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.3.2",
       "license": "MIT",
       "dependencies": {
-        "@ionic/core": "^6.3.2",
+        "@ionic/core": "6.3.2",
         "ionicons": "^6.0.2"
       },
       "devDependencies": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -61,7 +61,7 @@
     "vue-router": "^4.0.16"
   },
   "dependencies": {
-    "@ionic/core": "^6.3.2",
+    "@ionic/core": "6.3.2",
     "ionicons": "^6.0.2"
   },
   "vetur": {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Dependency update


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/26137

Packages that depend on other Ionic packages currently use `^` which tells package managers to install the latest minor version of the package. This means that when downgrading a package, it is possible to still get the latest version of a dependency.

Example:

**package.json** for `@ionic/angular`:

```
"version": "6.3.0"
"dependencies": {
  "@ionic/core": "^6.3.0"
}
```

When Ionic 6.3.1 is released, the `package.json` is updated to:

```
"version": "6.3.1"
"dependencies": {
  "@ionic/core": "^6.3.1"
}
```

The problem is if developers wanted to downgrade to `@ionic/angular@6.3.0.`, package managers would still install `@ionic/core@6.3.1` since `^6.3.0` allows for that.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The exact version of Ionic is now installed.
- Note: I skipped `@ionic/angular-server` because `@ionic/angular` is listed as a peer dependency. Updating the version triggers https://github.com/npm/cli/issues/4819. I could change the peerDep to a regular dep, but I am unsure if this would cause any issues in developer applications.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
