### PR TITLE
fix(vue): generate web-types for components

### DIFF
--- a/packages/vue/scripts/build-web-types.js
+++ b/packages/vue/scripts/build-web-types.js
@@ -1,16 +1,39 @@
-const fs = require("fs")
-const docs = require("@ionic/core/dist/docs.json")
-const { pascalCase } = require('change-case')
+const fs = require("fs");
+const docs = require("@ionic/core/dist/docs.json");
+const { pascalCase } = require("change-case");
 
-const components = []
+const components = [];
 
-for (const component of docs.components) {
-  if (!component.usage.vue) continue
-  const attributes = []
-  const slots = []
-  const events = []
-  const componentName = pascalCase(component.tag)
-  const docUrl = "https://ionicframework.com/docs/api/" + component.tag.substr(4)
+/**
+ * The list of tag names to ignore generating web types for.
+ */
+const excludeComponents = [
+  "ion-app",
+  "ion-icon",
+  "ion-nav",
+  "ion-nav-link",
+  "ion-tabs",
+  "ion-tab-bar",
+  "ion-router",
+  "ion-route-redirect",
+  "ion-router-link",
+  "ion-router-outlet",
+];
+
+/**
+ * The filtered set of components to generate web types for.
+ */
+const filteredComponents = docs.components.filter(
+  (c) => !excludeComponents.includes(c.tag)
+);
+
+for (const component of filteredComponents) {
+  const attributes = [];
+  const slots = [];
+  const events = [];
+  const componentName = pascalCase(component.tag);
+  const docUrl =
+    "https://ionicframework.com/docs/api/" + component.tag.substr(4);
 
   for (const prop of component.props || []) {
     attributes.push({
@@ -20,9 +43,9 @@ for (const component of docs.components) {
       default: prop.default,
       value: {
         kind: "expression",
-        type: prop.type
-      }
-    })
+        type: prop.type,
+      },
+    });
   }
 
   for (const event of component.events || []) {
@@ -33,18 +56,20 @@ for (const component of docs.components) {
     events.push({
       name: eventName,
       description: event.docs,
-      arguments: [{
-        name: "detail",
-        type: event.detail
-      }]
-    })
+      arguments: [
+        {
+          name: "detail",
+          type: event.detail,
+        },
+      ],
+    });
   }
 
   for (const slot of component.slots || []) {
     slots.push({
       name: slot.name === "" ? "default" : slot.name,
-      description: slot.docs
-    })
+      description: slot.docs,
+    });
   }
 
   components.push({
@@ -52,13 +77,17 @@ for (const component of docs.components) {
     "doc-url": docUrl,
     description: component.docs,
     source: {
-      module: "@ionic/core/" + component.filePath.replace("./src/", "dist/types/").replace(".tsx", ".d.ts"),
-      symbol: componentName.substr(3)
+      module:
+        "@ionic/core/" +
+        component.filePath
+          .replace("./src/", "dist/types/")
+          .replace(".tsx", ".d.ts"),
+      symbol: componentName.substr(3),
     },
     attributes,
     slots,
-    events
-  })
+    events,
+  });
 }
 
 const webTypes = {
@@ -70,9 +99,9 @@ const webTypes = {
     html: {
       "types-syntax": "typescript",
       "description-markup": "markdown",
-      tags: components
-    }
-  }
-}
+      tags: components,
+    },
+  },
+};
 
-fs.writeFileSync("dist/web-types.json", JSON.stringify(webTypes, null, 2))
+fs.writeFileSync("dist/web-types.json", JSON.stringify(webTypes, null, 2));

--- a/packages/vue/scripts/build-web-types.js
+++ b/packages/vue/scripts/build-web-types.js
@@ -12,8 +12,6 @@ const excludeComponents = [
   "ion-icon",
   "ion-nav",
   "ion-nav-link",
-  "ion-tabs",
-  "ion-tab-bar",
   "ion-router",
   "ion-route-redirect",
   "ion-router-link",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When moving the docs and usage examples out of the `ionic-framework` repository to `ionic-docs`, the script that generates web-types for Vue broke. It no longer had the `.usage.vue` property in the generated `docs.json`, resulting in no component types being generated.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #26198


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Web-types are generated for all components, unless manually excluded in the `excludeComponents` array (within the script file for now)
  - Excluded components are loosely based on the components that did not generate web-types in 5.6.x


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
