### PR TITLE
fix(react): loading layout is correct with no message

### DIFF
--- a/packages/react/src/hooks/useIonLoading.tsx
+++ b/packages/react/src/hooks/useIonLoading.tsx
@@ -18,7 +18,7 @@ export function useIonLoading(): UseIonLoadingResult {
 
   const present = useCallback(
     (
-      messageOrOptions: string | (LoadingOptions & HookOverlayOptions) = '',
+      messageOrOptions?: string | (LoadingOptions & HookOverlayOptions),
       duration?: number,
       spinner?: SpinnerTypes
     ) => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/26219

Loading only renders the message content when `message !== undefined`. Since `useIonLoading` defaulted the message to `''`, the message content was always being rendered causing extra spacing to be added.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `useIonLoading` now defaults the `message` property to `undefined`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
