### PR TITLE
fix(popover): inline popover positioning with fit-content or auto width

### DIFF
--- a/angular/src/directives/overlays/popover.ts
+++ b/angular/src/directives/overlays/popover.ts
@@ -108,7 +108,7 @@ export class IonPopover {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     this.el = r.nativeElement;
 
-    this.el.addEventListener('willPresent', () => {
+    this.el.addEventListener('ionMount', () => {
       this.isCmpOpen = true;
       c.detectChanges();
     });

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -5908,7 +5908,7 @@ declare namespace LocalJSX {
          */
         "onDidPresent"?: (event: IonPopoverCustomEvent<void>) => void;
         /**
-          * Emitted before the popover has presented, but after the component has been mounted in the DOM.
+          * Emitted before the popover has presented, but after the component has been mounted in the DOM. This event exists for ion-popover to resolve an issue with the popover and the lazy build, that the transition is unable to get the correct dimensions of the popover with auto sizing. This is not required for other overlays, since the existing overlay transitions are not effected by auto sizing content.
          */
         "onIonMount"?: (event: IonPopoverCustomEvent<void>) => void;
         /**

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -5908,6 +5908,10 @@ declare namespace LocalJSX {
          */
         "onDidPresent"?: (event: IonPopoverCustomEvent<void>) => void;
         /**
+          * Emitted before the popover has presented, but after the component has been mounted in the DOM.
+         */
+        "onIonMount"?: (event: IonPopoverCustomEvent<void>) => void;
+        /**
           * Emitted after the popover has dismissed.
          */
         "onIonPopoverDidDismiss"?: (event: IonPopoverCustomEvent<OverlayEventDetail>) => void;

--- a/core/src/components/popover/popover.tsx
+++ b/core/src/components/popover/popover.tsx
@@ -318,6 +318,12 @@ export class Popover implements ComponentInterface, PopoverInterface {
   /**
    * Emitted before the popover has presented, but after the component
    * has been mounted in the DOM.
+   * This event exists for ion-popover to resolve an issue with the
+   * popover and the lazy build, that the transition is unable to get
+   * the correct dimensions of the popover with auto sizing.
+   * This is not required for other overlays, since the existing
+   * overlay transitions are not effected by auto sizing content.
+   *
    * @internal
    */
   @Event() ionMount!: EventEmitter<void>;
@@ -453,9 +459,12 @@ export class Popover implements ComponentInterface, PopoverInterface {
     this.usersElement = await attachComponent(delegate, this.el, this.component, ['popover-viewport'], data, inline);
     await deepReady(this.usersElement);
 
-    this.ionMount.emit();
-
+    // TODO: FW-2773: Apply this to only the lazy build.
     if (inline === true) {
+      /**
+       * ionMount only needs to be emitted if the popover is inline.
+       */
+      this.ionMount.emit();
       /**
        * Wait one raf before presenting the popover.
        * This allows the lazy build enough time to

--- a/core/src/components/popover/popover.tsx
+++ b/core/src/components/popover/popover.tsx
@@ -453,8 +453,9 @@ export class Popover implements ComponentInterface, PopoverInterface {
     this.usersElement = await attachComponent(delegate, this.el, this.component, ['popover-viewport'], data, inline);
     await deepReady(this.usersElement);
 
+    this.ionMount.emit();
+
     if (inline === true) {
-      this.ionMount.emit();
       /**
        * Wait one raf before presenting the popover.
        * This allows the lazy build enough time to

--- a/core/src/components/popover/popover.tsx
+++ b/core/src/components/popover/popover.tsx
@@ -459,6 +459,11 @@ export class Popover implements ComponentInterface, PopoverInterface {
     this.usersElement = await attachComponent(delegate, this.el, this.component, ['popover-viewport'], data, inline);
     await deepReady(this.usersElement);
 
+    if (!this.keyboardEvents) {
+      this.configureKeyboardInteraction();
+    }
+    this.configureDismissInteraction();
+
     // TODO: FW-2773: Apply this to only the lazy build.
     if (inline === true) {
       /**
@@ -472,11 +477,6 @@ export class Popover implements ComponentInterface, PopoverInterface {
        */
       await waitOneFrame();
     }
-
-    if (!this.keyboardEvents) {
-      this.configureKeyboardInteraction();
-    }
-    this.configureDismissInteraction();
 
     this.currentTransition = present(this, 'popoverEnter', iosEnterAnimation, mdEnterAnimation, {
       event: event || this.event,

--- a/core/src/components/popover/utils.ts
+++ b/core/src/components/popover/utils.ts
@@ -928,3 +928,7 @@ export const shouldShowArrow = (side: PositionSide, didAdjustBounds = false, ev?
 
   return true;
 };
+
+export const waitOneFrame = () => {
+  return new Promise<void>((resolve) => raf(() => resolve()));
+};


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Inline popovers with a width of `auto` or `fit-content` are incorrectly positioned when the popover is presented. 

This bug would apply to _any_ enter animation for overlays that relies on the dimensions of the content inside of the overlay, to position the overlay during the transition.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #24716


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Inline popovers with a width of `auto` or `fit-content` are positioned correctly when presented.
- `AnimationBuilder` can be resolved asynchronously, to handle animations that require additional async operations

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
