### PR TITLE
fix(datetime): day periods render correctly based on min/max

### DIFF
--- a/core/src/components/datetime/test/data.spec.ts
+++ b/core/src/components/datetime/test/data.spec.ts
@@ -205,6 +205,36 @@ describe('generateTime()', () => {
     expect(minutes).toStrictEqual([10, 15, 20]);
   });
 
+  it('should allow both am/pm when min is am and max is pm', () => {
+    // https://github.com/ionic-team/ionic-framework/issues/26216
+    const today = {
+      day: 22,
+      month: 5,
+      year: 2021,
+      hour: 5,
+      minute: 43,
+    };
+    const min = {
+      day: 22,
+      month: 5,
+      year: 2021,
+      hour: 11,
+      minute: 14,
+    };
+    const max = {
+      day: 22,
+      month: 5,
+      year: 2021,
+      hour: 12,
+      minute: 14,
+    };
+
+    const { am, pm } = generateTime(today, 'h12', min, max);
+
+    expect(am).toBe(true);
+    expect(pm).toBe(true);
+  });
+
   describe('hourCycle is 23', () => {
     it('should return hours in 24 hour format', () => {
       const refValue = {

--- a/core/src/components/datetime/utils/data.ts
+++ b/core/src/components/datetime/utils/data.ts
@@ -221,7 +221,7 @@ export const generateTime = (
           const convertedHour = refParts.ampm === 'pm' ? (hour + 12) % 24 : hour;
           return (use24Hour ? hour : convertedHour) <= maxParts.hour!;
         });
-        isPMAllowed = maxParts.hour >= 13;
+        isPMAllowed = maxParts.hour >= 12;
       }
       if (maxParts.minute !== undefined && refParts.hour === maxParts.hour) {
         // The available minutes should only be filtered when the hour is the same as the max hour.
@@ -533,7 +533,7 @@ export const getTimeColumnsData = (
   minParts?: DatetimeParts,
   maxParts?: DatetimeParts,
   allowedHourValues?: number[],
-  allowedMinuteVaues?: number[]
+  allowedMinuteValues?: number[]
 ): { [key: string]: PickerColumnItem[] } => {
   const use24Hour = is24Hour(locale, hourCycle);
   const { hours, minutes, am, pm } = generateTime(
@@ -542,7 +542,7 @@ export const getTimeColumnsData = (
     minParts,
     maxParts,
     allowedHourValues,
-    allowedMinuteVaues
+    allowedMinuteValues
   );
 
   const hoursItems = hours.map((hour) => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When the `min` was for 11am and the `max` was for 12pm, the "pm" day period option was not available for selection. 


<!-- Issues are required for both bug fixes and features. -->
Issue URL: https://github.com/ionic-team/ionic-framework/issues/26216


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Day periods render correctly based on min/max

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `6.3.5-dev.11667857244.18413739`
