### PR TITLE
fix(react): inline overlays display contents consistently

### DIFF
--- a/packages/react/src/components/createInlineOverlayComponent.tsx
+++ b/packages/react/src/components/createInlineOverlayComponent.tsx
@@ -144,6 +144,7 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
                 {
                   id: 'ion-react-wrapper',
                   ref: this.wrapperRef,
+                  className: 'ion-delegate-host',
                   style: {
                     display: 'flex',
                     flexDirection: 'column',

--- a/packages/react/test-app/tests/e2e/specs/overlay-components/KeepContentsMounted.cy.ts
+++ b/packages/react/test-app/tests/e2e/specs/overlay-components/KeepContentsMounted.cy.ts
@@ -27,6 +27,25 @@ describe('keepContentsMounted', () => {
 
       cy.get('ion-modal ion-content').should('exist');
     });
+
+    it('should display contents consistently on re-open', () => {
+      // https://github.com/ionic-team/ionic-framework/issues/26253
+      cy.visit('/keep-contents-mounted');
+
+      cy.get('#open-modal').click();
+
+      cy.get('ion-modal ion-content').should('exist');
+
+      cy.get('ion-modal ion-button').click();
+
+      cy.get('ion-modal')
+        .should('not.be.visible')
+        .should('have.class', 'overlay-hidden');
+
+      cy.get('#open-modal').click();
+
+      cy.get('ion-modal ion-button').should('be.visible');
+    })
   })
   describe('popover', () => {
     it('should not mount component if false', () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Presenting an inline overlay multiple times in React will hide the overlay contents on the second+ open.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #26253


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds the `ion-delegate-host` class to the React wrapper, so the additional element is not created
- Inline overlay contents are consistently displayed when presenting

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Testing these changes:
- Run the React test-app
- Visit the Keep Contents Mounted test suite
- Present a modal
- Observe: Contents load/display
- Dismiss modal
- Present modal again
- Observe: Contents should load/display consistently


Dev-build: `6.3.6-dev.11668017847.1d5c7dbd`
