### PR TITLE
chore(many): replace `any` types and add tech debt tickets

### DIFF
--- a/angular/src/app-initialize.ts
+++ b/angular/src/app-initialize.ts
@@ -6,6 +6,8 @@ import { Config } from './providers/config';
 import { IonicWindow } from './types/interfaces';
 import { raf } from './util/util';
 
+// TODO(FW-2827): types
+
 export const appInitialize = (config: Config, doc: Document, zone: NgZone) => {
   return (): any => {
     const win: IonicWindow | undefined = doc.defaultView as any;

--- a/angular/src/directives/angular-component-lib/utils.ts
+++ b/angular/src/directives/angular-component-lib/utils.ts
@@ -2,6 +2,8 @@
 /* tslint:disable */
 import { fromEvent } from 'rxjs';
 
+// TODO(FW-2827): types
+
 export const proxyInputs = (Cmp: any, inputs: string[]) => {
   const Prototype = Cmp.prototype;
   inputs.forEach(item => {

--- a/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
@@ -18,13 +18,13 @@ export class BooleanValueAccessorDirective extends ValueAccessor {
     super(injector, el);
   }
 
-  writeValue(value: any): void {
+  writeValue(value: boolean): void {
     this.el.nativeElement.checked = this.lastValue = value == null ? false : value;
     setIonicClasses(this.el);
   }
 
   @HostListener('ionChange', ['$event.target'])
-  _handleIonChange(el: any): void {
+  _handleIonChange(el: HTMLIonCheckboxElement | HTMLIonToggleElement): void {
     this.handleChangeEvent(el, el.checked);
   }
 }

--- a/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
@@ -24,7 +24,7 @@ export class BooleanValueAccessorDirective extends ValueAccessor {
   }
 
   @HostListener('ionChange', ['$event.target'])
-  _handleIonChange(el: HTMLIonCheckboxElement | HTMLIonToggleElement): void {
+  _handleIonChange(el: HTMLInputElement): void {
     this.handleChangeEvent(el, el.checked);
   }
 }

--- a/angular/src/directives/control-value-accessors/numeric-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/numeric-value-accessor.ts
@@ -19,7 +19,7 @@ export class NumericValueAccessorDirective extends ValueAccessor {
   }
 
   @HostListener('ionChange', ['$event.target'])
-  _handleIonChange(el: HTMLIonInputElement): void {
+  _handleIonChange(el: HTMLInputElement): void {
     this.handleChangeEvent(el, el.value);
   }
 

--- a/angular/src/directives/control-value-accessors/numeric-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/numeric-value-accessor.ts
@@ -19,7 +19,7 @@ export class NumericValueAccessorDirective extends ValueAccessor {
   }
 
   @HostListener('ionChange', ['$event.target'])
-  _handleIonChange(el: any): void {
+  _handleIonChange(el: HTMLIonInputElement): void {
     this.handleChangeEvent(el, el.value);
   }
 

--- a/angular/src/directives/control-value-accessors/radio-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/radio-value-accessor.ts
@@ -20,7 +20,7 @@ export class RadioValueAccessorDirective extends ValueAccessor {
   }
 
   @HostListener('ionSelect', ['$event.target'])
-  _handleIonSelect(el: any): void {
+  _handleIonSelect(el: HTMLInputElement): void {
     this.handleChangeEvent(el, el.checked);
   }
 }

--- a/angular/src/directives/control-value-accessors/select-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/select-value-accessor.ts
@@ -20,7 +20,7 @@ export class SelectValueAccessorDirective extends ValueAccessor {
   }
 
   @HostListener('ionChange', ['$event.target'])
-  _handleChangeEvent(el: any): void {
+  _handleChangeEvent(el: HTMLInputElement): void {
     this.handleChangeEvent(el, el.value);
   }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
