### PR TITLE
chore(many): replace `any` types and add tech debt tickets

### DIFF
--- a/angular/src/app-initialize.ts
+++ b/angular/src/app-initialize.ts
@@ -6,6 +6,8 @@ import { Config } from './providers/config';
 import { IonicWindow } from './types/interfaces';
 import { raf } from './util/util';
 
+// TODO(FW-2827): types
+
 export const appInitialize = (config: Config, doc: Document, zone: NgZone) => {
   return (): any => {
     const win: IonicWindow | undefined = doc.defaultView as any;

--- a/angular/src/directives/angular-component-lib/utils.ts
+++ b/angular/src/directives/angular-component-lib/utils.ts
@@ -2,6 +2,8 @@
 /* tslint:disable */
 import { fromEvent } from 'rxjs';
 
+// TODO(FW-2827): types
+
 export const proxyInputs = (Cmp: any, inputs: string[]) => {
   const Prototype = Cmp.prototype;
   inputs.forEach(item => {

--- a/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
@@ -18,13 +18,13 @@ export class BooleanValueAccessorDirective extends ValueAccessor {
     super(injector, el);
   }
 
-  writeValue(value: any): void {
+  writeValue(value: boolean): void {
     this.el.nativeElement.checked = this.lastValue = value == null ? false : value;
     setIonicClasses(this.el);
   }
 
   @HostListener('ionChange', ['$event.target'])
-  _handleIonChange(el: any): void {
+  _handleIonChange(el: HTMLInputElement): void {
     this.handleChangeEvent(el, el.checked);
   }
 }

--- a/angular/src/directives/control-value-accessors/radio-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/radio-value-accessor.ts
@@ -20,7 +20,7 @@ export class RadioValueAccessorDirective extends ValueAccessor {
   }
 
   @HostListener('ionSelect', ['$event.target'])
-  _handleIonSelect(el: any): void {
+  _handleIonSelect(el: HTMLInputElement): void {
     this.handleChangeEvent(el, el.checked);
   }
 }

--- a/angular/src/directives/control-value-accessors/select-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/select-value-accessor.ts
@@ -20,7 +20,7 @@ export class SelectValueAccessorDirective extends ValueAccessor {
   }
 
   @HostListener('ionChange', ['$event.target'])
-  _handleChangeEvent(el: any): void {
+  _handleChangeEvent(el: HTMLInputElement): void {
     this.handleChangeEvent(el, el.value);
   }
 }

--- a/angular/src/directives/control-value-accessors/text-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/text-value-accessor.ts
@@ -20,7 +20,7 @@ export class TextValueAccessorDirective extends ValueAccessor {
   }
 
   @HostListener('ionChange', ['$event.target'])
-  _handleInputEvent(el: any): void {
+  _handleInputEvent(el: HTMLInputElement): void {
     this.handleChangeEvent(el, el.value);
   }
 }

--- a/angular/src/directives/control-value-accessors/value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/value-accessor.ts
@@ -4,6 +4,8 @@ import { Subscription } from 'rxjs';
 
 import { raf } from '../../util/util';
 
+// TODO(FW-2827): types
+
 @Directive()
 export class ValueAccessor implements ControlValueAccessor, AfterViewInit, OnDestroy {
   private onChange: (value: any) => void = () => {

--- a/angular/src/directives/navigation/ion-router-outlet.ts
+++ b/angular/src/directives/navigation/ion-router-outlet.ts
@@ -30,6 +30,8 @@ import { isComponentFactoryResolver } from '../../util/util';
 import { StackController } from './stack-controller';
 import { RouteView, getUrl } from './stack-utils';
 
+// TODO(FW-2827): types
+
 @Directive({
   selector: 'ion-router-outlet',
   exportAs: 'outlet',

--- a/angular/src/directives/navigation/stack-controller.ts
+++ b/angular/src/directives/navigation/stack-controller.ts
@@ -17,6 +17,8 @@ import {
   toSegments,
 } from './stack-utils';
 
+// TODO(FW-2827): types
+
 export class StackController {
   private views: RouteView[] = [];
   private runningTask?: Promise<any>;

--- a/angular/src/directives/navigation/stack-utils.ts
+++ b/angular/src/directives/navigation/stack-utils.ts
@@ -86,6 +86,7 @@ export interface StackEvent {
   tabSwitch: boolean;
 }
 
+// TODO(FW-2827): types
 export interface RouteView {
   id: number;
   url: string;

--- a/angular/src/directives/overlays/modal.ts
+++ b/angular/src/directives/overlays/modal.ts
@@ -108,6 +108,7 @@ export declare interface IonModal extends Components.IonModal {
   ],
 })
 export class IonModal {
+  // TODO(FW-2827): type
   @ContentChild(TemplateRef, { static: false }) template: TemplateRef<any>;
 
   isCmpOpen: boolean = false;

--- a/angular/src/directives/overlays/popover.ts
+++ b/angular/src/directives/overlays/popover.ts
@@ -99,6 +99,7 @@ export declare interface IonPopover extends Components.IonPopover {
   ],
 })
 export class IonPopover {
+  // TODO(FW-2827): type
   @ContentChild(TemplateRef, { static: false }) template: TemplateRef<any>;
 
   isCmpOpen: boolean = false;

--- a/angular/src/providers/angular-delegate.ts
+++ b/angular/src/providers/angular-delegate.ts
@@ -21,6 +21,8 @@ import { EnvironmentInjector } from '../di/r3_injector';
 import { NavParams } from '../directives/navigation/nav-params';
 import { isComponentFactoryResolver } from '../util/util';
 
+// TODO(FW-2827): types
+
 @Injectable()
 export class AngularDelegate {
   constructor(private zone: NgZone, private appRef: ApplicationRef) {}

--- a/angular/src/providers/platform.ts
+++ b/angular/src/providers/platform.ts
@@ -3,6 +3,8 @@ import { NgZone, Inject, Injectable } from '@angular/core';
 import { BackButtonEventDetail, KeyboardEventDetail, Platforms, getPlatforms, isPlatform } from '@ionic/core';
 import { Subscription, Subject } from 'rxjs';
 
+// TODO(FW-2827): types
+
 export interface BackButtonEmitter extends Subject<BackButtonEventDetail> {
   subscribeWithPriority(
     priority: number,

--- a/angular/src/schematics/utils/config.ts
+++ b/angular/src/schematics/utils/config.ts
@@ -4,6 +4,8 @@ import { parse } from 'jsonc-parser';
 
 const CONFIG_PATH = 'angular.json';
 
+// TODO(FW-2827): types
+
 export function readConfig(host: Tree): any {
   const sourceText = host.read(CONFIG_PATH)?.toString('utf-8');
   return JSON.parse(sourceText);

--- a/angular/src/types/interfaces.ts
+++ b/angular/src/types/interfaces.ts
@@ -1,5 +1,5 @@
 export interface IonicGlobal {
-  config?: any;
+  config?: any; // TODO(FW-2827): type
   asyncQueue?: boolean;
 }
 

--- a/angular/src/util/overlay.ts
+++ b/angular/src/util/overlay.ts
@@ -1,3 +1,5 @@
+// TODO(FW-2827): types
+
 interface ControllerShape<Opts, HTMLElm> {
   create(options: Opts): Promise<HTMLElm>;
   dismiss(data?: any, role?: string, id?: string): Promise<boolean>;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
