### PR TITLE
chore(popover): ionMount is only emitted for lazy build

### DIFF
--- a/core/src/components/popover/popover.tsx
+++ b/core/src/components/popover/popover.tsx
@@ -457,19 +457,24 @@ export class Popover implements ComponentInterface, PopoverInterface {
     };
 
     const { inline, delegate } = this.getDelegate(true);
+    const lazyBuild = hasLazyBuild(el);
     this.usersElement = await attachComponent(delegate, el, this.component, ['popover-viewport'], data, inline);
-    hasLazyBuild(el) && (await deepReady(this.usersElement));
+    lazyBuild && (await deepReady(this.usersElement));
 
     if (!this.keyboardEvents) {
       this.configureKeyboardInteraction();
     }
     this.configureDismissInteraction();
 
-    // TODO: FW-2773: Apply this to only the lazy build.
-    /**
-     * ionMount only needs to be emitted if the popover is inline.
-     */
-    this.ionMount.emit();
+    if (lazyBuild) {
+      /**
+       * We only want to emit `ionMount` for the lazy build,
+       * since it is only needed for mounting the overlay
+       * to the DOM before the transition has started and
+       * the popover position is calculated.
+       */
+      this.ionMount.emit();
+    }
     /**
      * Wait one raf before presenting the popover.
      * This allows the lazy build enough time to


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Refactor, but changes the functional behavior to only emit for the lazy build. 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`ionMount` is emitted for CE build and lazy build.


<!-- Issues are required for both bug fixes and features. -->
Issue URL: Internal


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `ionMount` is only emitted for the lazy build (is only needed in Angular due to the conditionally mounting the overlay content with Angular templates).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
