### PR TITLE
test(range): disable gesture test

### DIFF
--- a/core/src/components/range/test/range-events.e2e.ts
+++ b/core/src/components/range/test/range-events.e2e.ts
@@ -82,7 +82,8 @@ test.describe('range: events:', () => {
   });
 
   test.describe('ionInput', () => {
-    test('should emit when the knob is dragged', async ({ page }) => {
+    // TODO(FW-2873) Enable this test when touch events/gestures are better supported in Playwright
+    test.skip('should emit when the knob is dragged', async ({ page }) => {
       await page.setContent(`<ion-range></ion-range>`);
 
       const rangeHandle = page.locator('ion-range .range-knob-handle');


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
The gesture-based range tests are very flaky: https://github.com/ionic-team/ionic-framework/actions/runs/3518210747/jobs/5897125963#step:11:1158

At the moment we do not have a good solution for gestures in Playwright: https://github.com/microsoft/playwright/issues/2903

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Disabled the dragging test for ion-range

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
