### PR TITLE
chore(ci): always bootstrap packages

### DIFF
--- a/.github/workflows/actions/publish-npm/action.yml
+++ b/.github/workflows/actions/publish-npm/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
     - name: Update Version
-      run: lerna version ${{ inputs.version }} --yes --no-changelog --no-push --no-git-tag-version
+      run: lerna version ${{ inputs.version }} --yes --exact --no-changelog --no-push --no-git-tag-version
       shell: bash
       working-directory: ${{ inputs.working-directory }}
     - name: Run Build

--- a/.github/workflows/actions/publish-npm/action.yml
+++ b/.github/workflows/actions/publish-npm/action.yml
@@ -21,7 +21,7 @@ runs:
       with:
         node-version: 16.x
     - name: Install Dependencies
-      run: lerna bootstrap --scope ${{ inputs.scope }} --ignore-scripts -- --legacy-peer-deps
+      run: lerna bootstrap --include-dependencies --scope ${{ inputs.scope }} --ignore-scripts -- --legacy-peer-deps
       shell: bash
       working-directory: ${{ inputs.working-directory }}
     - name: Update Version

--- a/.github/workflows/actions/publish-npm/action.yml
+++ b/.github/workflows/actions/publish-npm/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
     - name: Update Version
-      run: npm version ${{ inputs.version }}
+      run: lerna version ${{ inputs.version }} --yes --no-changelog --no-push --no-git-tag-version
       shell: bash
       working-directory: ${{ inputs.working-directory }}
     - name: Run Build
@@ -39,6 +39,6 @@ runs:
       env:
         NPM_TOKEN: ${{ inputs.token }}
     - name: Publish to NPM
-      run: npm publish ${{ inputs.folder }} --tag ${{ inputs.tag }}  --git-tag-version false
+      run: npm publish ${{ inputs.folder }} --tag ${{ inputs.tag }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/release-ionic.yml
+++ b/.github/workflows/release-ionic.yml
@@ -140,6 +140,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Restore @ionic/core built cache
+      uses: ./.github/workflows/actions/download-archive
+      with:
+        name: ionic-core
+        path: ./core
+        filename: CoreBuild.zip
     - name: Restore @ionic/angular built cache
       uses: ./.github/workflows/actions/download-archive
       with:
@@ -160,6 +166,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Restore @ionic/core built cache
+      uses: ./.github/workflows/actions/download-archive
+      with:
+        name: ionic-core
+        path: ./core
+        filename: CoreBuild.zip
     - name: Restore @ionic/react built cache
       uses: ./.github/workflows/actions/download-archive
       with:
@@ -179,6 +191,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Restore @ionic/core built cache
+      uses: ./.github/workflows/actions/download-archive
+      with:
+        name: ionic-core
+        path: ./core
+        filename: CoreBuild.zip
     - name: Restore @ionic/vue built cache
       uses: ./.github/workflows/actions/download-archive
       with:


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->

## Dependency Packages Not Symlinked
Using `--scope` causes other dependency packages to not be symlinked. For example, using `--scope @ionic/angular` will cause `@ionic/core` to not be symlinked in the angular package. As a result, framework packages do not necessarily build with the latest API information available to them.

This does not impact the contents of releases, but it does impact the ability to release a package if it tries to get a newer API from an older version of Ionic Core. I discovered this while trying to release a dev build of Ionic 7 where Angular tried to use a new interface that was not available in older versions of Ionic: https://github.com/ionic-team/ionic-framework/actions/runs/3527294227

## Dependency Package Versions Not Changed
`lerna version` made sure that versions for dependencies were also bumped. So if `@ionic/angular` was bumped to `7.0.0-foo` then its dependency of `@ionic/core` was also bumped to `7.0.0-foo`. `npm version` does not do that for us.

Additionally, dependency packages use `^` which means that developers on older versions of Ionic could potentially get newer dependency versions.

**Example**

`@ionic/angular`: `6.3.8`

In `@ionic/angular`'s package.json, it has a dependency of `@ionic/core: ^6.3.8`

When Ionic Angular and Ionic Core 6.3.9 come out, if developers still on `@ionic/angular@6.3.8` do a fresh install of their node modules, they will receive `@ionic/angular@6.3.8` but with `@ionic/core@6.3.9`.

This means that installing dev builds for a framework did not also install the dev build for @ionic/core.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- All packages are now symlinked by adding `--include-dependencies` to `lerna bootstrap`
- Other framework packages also restore the `core` build as they pull from @ionic/core.
- Removed `npm version` in favor of `lerna version` so dependency versions are updated.
- The dependency versions are now updated exactly instead of using `^`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
