### PR TITLE
feat(tabs): scroll to top of view when pressing tab button

### DIFF
--- a/core/src/utils/config.ts
+++ b/core/src/utils/config.ts
@@ -33,6 +33,12 @@ export interface IonicConfig {
   statusTap?: boolean;
 
   /**
+   * Whenever clicking the active tab should cause the scroll to top in an application.
+   * Defaults to `false`.
+   */
+  tabTap?: boolean;
+
+  /**
    * Overrides the default icon in all `<ion-back-button>` components.
    */
   backButtonIcon?: string;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: [#22558](https://github.com/ionic-team/ionic-framework/issues/22558)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- pressing tab button will scroll to top if page is root
- added global config `tabTap` which is default `false`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
