### PR TITLE
fix(input): highlight color does not apply to text

### DIFF
--- a/core/src/components/input/input.scss
+++ b/core/src/components/input/input.scss
@@ -331,11 +331,6 @@
   --border-color: var(--highlight-color);
 }
 
-:host(.ion-touched.ion-valid) label,
-:host(.ion-touched.ion-invalid) label {
-  color: var(--highlight-color);
-}
-
 // Input Hint Text
 // ----------------------------------------------------------------
 

--- a/core/src/components/input/test/a11y/input.e2e.ts
+++ b/core/src/components/input/test/a11y/input.e2e.ts
@@ -5,7 +5,6 @@ import { test } from '@utils/test/playwright';
 test.describe('input: a11y', () => {
   test.beforeEach(async ({ skip }) => {
     skip.rtl();
-    skip.mode('md');
   });
 
   test('should not have accessibility violations', async ({ page }) => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
When testing the new input changes in an app I notices that the form validation colors were applying to the visible label text:

![image](https://user-images.githubusercontent.com/2721089/203568921-f8c0725a-2c1a-444f-9a43-25a8d19b41b1.png)

This likely happened when I made the switch to using a `<label>` to wrap the entire container instead of just using it on the label text. The Playwright diff threshold was likely too high to catch this small of a change.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

![image](https://user-images.githubusercontent.com/2721089/203573504-77c46adf-6e90-4ca1-b719-3a1faec8b2db.png)


- The form validation color no longer applies to the input text color.
- I changed the a11y tests to run for both ios and md mode as per https://github.com/ionic-team/ionic-framework/pull/26348#discussion_r1030499934

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
