### PR TITLE
refactor(datetime): remove ios 13 calendar day fix

### DIFF
--- a/core/src/components/datetime/datetime.scss
+++ b/core/src/components/datetime/datetime.scss
@@ -364,22 +364,8 @@ ion-picker-column-internal {
 
   position: absolute;
 
-  /**
-   * Explicit position values are required here
-   * as pseudo element positioning is incorrect
-   * in older implementations of css grid.
-   *
-   * TODO: FW-1720: Remove top/left styles when deprecating iOS 13 support
-   */
-  /* stylelint-disable-next-line property-disallowed-list */
-  top: 50%;
-  /* stylelint-disable-next-line property-disallowed-list */
-  left: 50%;
-
   width: 32px;
   height: 32px;
-
-  transform: translate(-50%, -50%);
 
   content: " ";
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: N/A This code was added to account for a pre-iOS 14 bug where pseudo elements in CSS grid were not positioned correctly.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The pre-iOS 14 fix has been removed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
