### PR TITLE
Sync feature 7 12 8 2

### DIFF
--- a/.github/workflows/stencil-eval.yml
+++ b/.github/workflows/stencil-eval.yml
@@ -47,13 +47,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/workflows/actions/test-core-spec
 
-  test-core-e2e:
-    needs: [build-core]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/workflows/actions/test-core-e2e
-
   test-core-screenshot:
     strategy:
       # This ensures that all screenshot shard

--- a/core/playwright.config.ts
+++ b/core/playwright.config.ts
@@ -85,7 +85,10 @@ const config: PlaywrightTestConfig = {
   },
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  /* Fail fast on CI */
+  maxFailures: process.env.CI ? 1 : 0,
+  /* Flaky test should be either addressed or disabled until we can address them */
+  retries: 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/core/src/components/datetime/test/basic/datetime.e2e.ts
+++ b/core/src/components/datetime/test/basic/datetime.e2e.ts
@@ -300,9 +300,12 @@ test.describe('datetime: visibility', () => {
 
     await datetime.evaluate((el: HTMLIonDatetimeElement) => el.style.setProperty('display', 'none'));
     await expect(datetime).toBeHidden();
+    await expect(datetime).not.toHaveClass(/datetime-ready/);
 
     await datetime.evaluate((el: HTMLIonDatetimeElement) => el.style.removeProperty('display'));
     await expect(datetime).toBeVisible();
+
+    await page.waitForSelector('.datetime-ready');
 
     // month/year interface should be reset
     await expect(monthYearInterface).toBeHidden();

--- a/core/src/components/datetime/test/presentation/datetime.e2e.ts
+++ b/core/src/components/datetime/test/presentation/datetime.e2e.ts
@@ -159,9 +159,10 @@ class TimePickerFixture {
   }
 
   async goto() {
-    await this.page.goto(`/src/components/datetime/test/presentation`);
-    await this.page.locator('select').selectOption('time');
-    await this.page.waitForSelector('.datetime-presentation-time');
+    await this.page.setContent(`
+      <ion-datetime presentation="time" value="2022-03-10T13:00:00"></ion-datetime>
+    `);
+    await this.page.waitForSelector('.datetime-ready');
     this.timePicker = this.page.locator('ion-datetime');
   }
 

--- a/core/src/components/item-sliding/test/basic/item-sliding.e2e.ts
+++ b/core/src/components/item-sliding/test/basic/item-sliding.e2e.ts
@@ -40,7 +40,8 @@ test.describe('item-sliding: basic', () => {
     expect(await item.screenshot()).toMatchSnapshot(`item-sliding-gesture-${page.getSnapshotSettings()}.png`);
   });
 
-  test('should not scroll when the item-sliding is swiped', async ({ page, skip }) => {
+  // TODO FW-3006
+  test.skip('should not scroll when the item-sliding is swiped', async ({ page, skip }) => {
     skip.browser('webkit', 'mouse.wheel is not available in WebKit');
     skip.rtl();
 

--- a/core/src/components/item-sliding/test/scroll-target/item-sliding.e2e.ts
+++ b/core/src/components/item-sliding/test/scroll-target/item-sliding.e2e.ts
@@ -2,7 +2,8 @@ import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('item-sliding: scroll-target', () => {
-  test('should not scroll when the item-sliding is swiped in custom scroll target', async ({ page, skip }) => {
+  // TODO FW-3006
+  test.skip('should not scroll when the item-sliding is swiped in custom scroll target', async ({ page, skip }) => {
     skip.browser('webkit', 'mouse.wheel is not available in WebKit');
     skip.rtl();
 

--- a/core/src/components/modal/gestures/utils.ts
+++ b/core/src/components/modal/gestures/utils.ts
@@ -1,6 +1,5 @@
-import { GESTURE } from '@utils/overlays';
-
 import type { Animation } from '../../../interface';
+import { GESTURE } from '../../../utils/overlays';
 
 export const handleCanDismiss = async (el: HTMLIonModalElement, animation: Animation) => {
   /**

--- a/core/src/components/picker-column-internal/test/disabled/picker-column-internal.e2e.ts
+++ b/core/src/components/picker-column-internal/test/disabled/picker-column-internal.e2e.ts
@@ -60,7 +60,7 @@ test.describe('picker-column-internal: disabled', () => {
     `);
 
     const disabledItem = page.locator('ion-picker-column-internal .picker-item.picker-item-disabled');
-    expect(disabledItem).not.toBeEnabled();
+    await expect(disabledItem).not.toBeEnabled();
   });
   test('disabled picker item should not be considered active', async ({ page }) => {
     await page.setContent(`
@@ -79,7 +79,7 @@ test.describe('picker-column-internal: disabled', () => {
     `);
 
     const disabledItem = page.locator('ion-picker-column-internal .picker-item[data-value="b"]');
-    expect(disabledItem).not.toHaveClass(/picker-item-active/);
+    await expect(disabledItem).not.toHaveClass(/picker-item-active/);
   });
   test('setting the value to a disabled item should not cause that item to be active', async ({ page }) => {
     await page.setContent(`
@@ -103,8 +103,8 @@ test.describe('picker-column-internal: disabled', () => {
     await page.waitForChanges();
 
     const disabledItem = page.locator('ion-picker-column-internal .picker-item[data-value="b"]');
-    expect(disabledItem).toHaveClass(/picker-item-disabled/);
-    expect(disabledItem).not.toHaveClass(/picker-item-active/);
+    await expect(disabledItem).toHaveClass(/picker-item-disabled/);
+    await expect(disabledItem).not.toHaveClass(/picker-item-active/);
   });
   test('defaulting the value to a disabled item should not cause that item to be active', async ({ page }) => {
     await page.setContent(`
@@ -124,7 +124,7 @@ test.describe('picker-column-internal: disabled', () => {
     `);
 
     const disabledItem = page.locator('ion-picker-column-internal .picker-item[data-value="b"]');
-    expect(disabledItem).toHaveClass(/picker-item-disabled/);
-    expect(disabledItem).not.toHaveClass(/picker-item-active/);
+    await expect(disabledItem).toHaveClass(/picker-item-disabled/);
+    await expect(disabledItem).not.toHaveClass(/picker-item-active/);
   });
 });

--- a/core/src/utils/tap-click/test/tap-click.e2e.ts
+++ b/core/src/utils/tap-click/test/tap-click.e2e.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('tap click utility', () => {
@@ -14,8 +15,9 @@ test.describe('tap click utility', () => {
     if (box) {
       await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
       await page.mouse.down();
+      await page.waitForChanges();
     }
 
-    await page.waitForSelector('button.ion-activated');
+    await expect(button).toHaveClass(/ion-activated/);
   });
 });

--- a/core/src/utils/test/overlays/overlays.e2e.ts
+++ b/core/src/utils/test/overlays/overlays.e2e.ts
@@ -113,22 +113,26 @@ test.describe('overlays: focus', () => {
       <ion-button id="open-modal">Show Modal</ion-button>
       <ion-modal trigger="open-modal">
         <ion-content>
-          <ion-input autofocus="true"></ion-input>
+          <input />
         </ion-content>
       </ion-modal>
     `);
 
     const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+    const ionModalWillPresent = await page.spyOnEvent('ionModalWillPresent');
     const button = page.locator('ion-button');
-    const input = page.locator('ion-input');
+    const input = page.locator('input');
 
     await button.click();
-    await input.evaluate((el: HTMLIonInputElement) => el.setFocus());
+
+    await ionModalWillPresent.next();
+
+    await input.evaluate((el: HTMLInputElement) => el.focus());
 
     await ionModalDidPresent.next();
     await page.waitForChanges();
 
-    await expect(page.locator('ion-input input')).toBeFocused();
+    await expect(input).toBeFocused();
   });
 
   test('should not select a hidden focusable element', async ({ page, browserName }) => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
