### PR TITLE
test(range): disable gesture test

### DIFF
--- a/core/src/components/range/test/range-events.e2e.ts
+++ b/core/src/components/range/test/range-events.e2e.ts
@@ -1,0 +1,133 @@
+import { expect } from '@playwright/test';
+import { test } from '@utils/test/playwright';
+
+test.describe('range: events:', () => {
+  test.beforeEach(({ skip }) => {
+    skip.rtl();
+    skip.mode('md');
+  });
+
+  test.describe(' ionChange', () => {
+    test('should not emit if the value is set programmatically', async ({ page }) => {
+      await page.setContent(`<ion-range></ion-range>`);
+
+      const range = page.locator('ion-range');
+      const ionChangeSpy = await page.spyOnEvent('ionChange');
+
+      await range.evaluate((el: HTMLIonRangeElement) => {
+        el.value = 50;
+      });
+
+      await page.waitForChanges();
+
+      expect(ionChangeSpy).toHaveReceivedEventTimes(0);
+
+      // Update the value again to make sure it doesn't emit a second time
+      await range.evaluate((el: HTMLIonRangeElement) => {
+        el.value = 60;
+      });
+
+      await page.waitForChanges();
+
+      expect(ionChangeSpy).toHaveReceivedEventTimes(0);
+    });
+
+    // TODO(FW-2873)
+    test.skip('should emit when the knob is released', async ({ page }) => {
+      await page.setContent(`<ion-range></ion-range>`);
+
+      const rangeHandle = page.locator('ion-range .range-knob-handle');
+      const ionChangeSpy = await page.spyOnEvent('ionChange');
+
+      const boundingBox = await rangeHandle.boundingBox();
+
+      await rangeHandle.hover();
+      await page.mouse.down();
+      await page.mouse.move(boundingBox!.x + 100, boundingBox!.y);
+
+      await page.mouse.up();
+
+      await ionChangeSpy.next();
+
+      expect(ionChangeSpy).toHaveReceivedEventTimes(1);
+    });
+
+    test('should emit when the knob is moved with the keyboard', async ({ page }) => {
+      await page.setContent(`<ion-range value="50"></ion-range>`);
+
+      const rangeHandle = page.locator('ion-range .range-knob-handle');
+      const ionChangeSpy = await page.spyOnEvent('ionChange');
+
+      await rangeHandle.click();
+
+      await page.keyboard.press('ArrowLeft');
+      await ionChangeSpy.next();
+
+      expect(ionChangeSpy).toHaveReceivedEventDetail({ value: 49 });
+
+      await page.keyboard.press('ArrowRight');
+      await ionChangeSpy.next();
+
+      expect(ionChangeSpy).toHaveReceivedEventDetail({ value: 50 });
+
+      await page.keyboard.press('ArrowUp');
+      await ionChangeSpy.next();
+
+      expect(ionChangeSpy).toHaveReceivedEventDetail({ value: 51 });
+
+      await page.keyboard.press('ArrowDown');
+      await ionChangeSpy.next();
+
+      expect(ionChangeSpy).toHaveReceivedEventDetail({ value: 50 });
+    });
+  });
+
+  test.describe('ionInput', () => {
+    // TODO(FW-2873) Enable this test when touch events/gestures are better supported in Playwright
+    test.skip('should emit when the knob is dragged', async ({ page }) => {
+      await page.setContent(`<ion-range></ion-range>`);
+
+      const rangeHandle = page.locator('ion-range .range-knob-handle');
+      const ionInputSpy = await page.spyOnEvent('ionInput');
+
+      const boundingBox = await rangeHandle.boundingBox();
+
+      await rangeHandle.hover();
+      await page.mouse.down();
+      await page.mouse.move(boundingBox!.x + 100, boundingBox!.y);
+
+      await ionInputSpy.next();
+
+      expect(ionInputSpy).toHaveReceivedEvent();
+    });
+
+    test('should emit when the knob is moved with the keyboard', async ({ page }) => {
+      await page.setContent(`<ion-range value="50"></ion-range>`);
+
+      const rangeHandle = page.locator('ion-range .range-knob-handle');
+      const ionInputSpy = await page.spyOnEvent('ionInput');
+
+      await rangeHandle.click();
+
+      await page.keyboard.press('ArrowLeft');
+      await ionInputSpy.next();
+
+      expect(ionInputSpy).toHaveReceivedEventDetail({ value: 49 });
+
+      await page.keyboard.press('ArrowRight');
+      await ionInputSpy.next();
+
+      expect(ionInputSpy).toHaveReceivedEventDetail({ value: 50 });
+
+      await page.keyboard.press('ArrowUp');
+      await ionInputSpy.next();
+
+      expect(ionInputSpy).toHaveReceivedEventDetail({ value: 51 });
+
+      await page.keyboard.press('ArrowDown');
+      await ionInputSpy.next();
+
+      expect(ionInputSpy).toHaveReceivedEventDetail({ value: 50 });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
I missed a range gesture test in my last PR. This test is still flaky

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Disabled the remaining range gesture test and added a TODO

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
