### PR TITLE
test(overlays): remove broken test

### DIFF
--- a/core/src/utils/test/overlays/overlays.e2e.ts
+++ b/core/src/utils/test/overlays/overlays.e2e.ts
@@ -108,33 +108,6 @@ test.describe('overlays: focus', () => {
   test.beforeEach(({ skip }) => {
     skip.rtl();
   });
-  test('should not focus the overlay container if element inside of overlay is focused', async ({ page }) => {
-    await page.setContent(`
-      <ion-button id="open-modal">Show Modal</ion-button>
-      <ion-modal trigger="open-modal">
-        <ion-content>
-          <input />
-        </ion-content>
-      </ion-modal>
-    `);
-
-    const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
-    const ionModalWillPresent = await page.spyOnEvent('ionModalWillPresent');
-    const button = page.locator('ion-button');
-    const input = page.locator('input');
-
-    await button.click();
-
-    await ionModalWillPresent.next();
-
-    await input.evaluate((el: HTMLInputElement) => el.focus());
-
-    await ionModalDidPresent.next();
-    await page.waitForChanges();
-
-    await expect(input).toBeFocused();
-  });
-
   test('should not select a hidden focusable element', async ({ page, browserName }) => {
     await page.setContent(`
       <style>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
The `focus()` method needs to run (and be rendered in the browser) before the modal is full presented otherwise the test will fail. This kind of precise timing test is not a good fit for CI.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed the overlay focus test
At the moment I'm not aware of a better way to check this, which is why I removed it instead of skipping it.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
