### PR TITLE
test(ci): do not store Ionic Core source as artifact

### DIFF
--- a/.github/workflows/actions/build-core-stencil-eval/action.yml
+++ b/.github/workflows/actions/build-core-stencil-eval/action.yml
@@ -43,8 +43,3 @@ runs:
         name: ionic-core
         output: core/CoreBuild.zip
         paths: core/dist core/components core/css core/hydrate core/loader core/src/components.d.ts
-    - uses: ./.github/workflows/actions/upload-archive
-      with:
-        name: ionic-core-src
-        output: core/CoreSrc.zip
-        paths: core/src

--- a/.github/workflows/actions/build-core/action.yml
+++ b/.github/workflows/actions/build-core/action.yml
@@ -23,8 +23,3 @@ runs:
         name: ionic-core
         output: core/CoreBuild.zip
         paths: core/dist core/components core/css core/hydrate core/loader core/src/components.d.ts
-    - uses: ./.github/workflows/actions/upload-archive
-      with:
-        name: ionic-core-src
-        output: core/CoreSrc.zip
-        paths: core/src

--- a/.github/workflows/actions/test-core-screenshot/action.yml
+++ b/.github/workflows/actions/test-core-screenshot/action.yml
@@ -18,11 +18,6 @@ runs:
         name: ionic-core
         path: ./core
         filename: CoreBuild.zip
-    - uses: ./.github/workflows/actions/download-archive
-      with:
-        name: ionic-core-src
-        path: ./core
-        filename: CoreSrc.zip
     - name: Install Playwright Dependencies
       run: npm install && npx playwright install && npx playwright install-deps
       shell: bash


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
The `@ionic/core` source (including all screenshots) are being stored as a build artifact even though it is not needed anywhere. The e2e tests consume it, but they don't need to because they already clone the core repo.

This slows the build step down and delays any other tests from running.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- the core build step no longer stores the source code as an artifact
- the e2e tests no longer download the source code artifact

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
