### PR TITLE
chore(forms): add revision legacy form detection

### DIFF
--- a/core/src/utils/forms/form-controller.ts
+++ b/core/src/utils/forms/form-controller.ts
@@ -18,8 +18,7 @@ export const createLegacyFormController = (el: AllowedFormElements): LegacyFormC
    * can check to see if the component has slotted text
    * in the light DOM.
    */
-  const hasLabelProp =
-    (controlEl as any).label !== undefined || (controlEl.shadowRoot !== null && controlEl.textContent !== '');
+  const hasLabelProp = (controlEl as any).label !== undefined || hasLabelSlot(controlEl);
   const hasAriaLabelAttribute = controlEl.hasAttribute('aria-label');
 
   /**
@@ -38,3 +37,33 @@ export const createLegacyFormController = (el: AllowedFormElements): LegacyFormC
 export type LegacyFormController = {
   hasLegacyControl: () => boolean;
 };
+
+const hasLabelSlot = (controlEl: HTMLElement) => {
+  const root = controlEl.shadowRoot;
+  if (root === null) {
+    return false;
+  }
+
+  /**
+   * Components that have a named label slot
+   * also have other slots, so we need to query for
+   * anything that is explicitly passed to slot="label"
+   */
+  if (NAMED_LABEL_SLOT_COMPONENTS.includes(controlEl.tagName) && controlEl.querySelector('[slot="label"]') !== null) {
+    return true;
+  }
+
+  /**
+   * Components that have an unnamed slot for the label
+   * have no other slots, so we can check the textContent
+   * of the element.
+   */
+  if (UNNAMED_LABEL_SLOT_COMPONENTS.includes(controlEl.tagName) && controlEl.textContent !== '') {
+    return true;
+  }
+
+  return false;
+};
+
+const NAMED_LABEL_SLOT_COMPONENTS: string[] = [];
+const UNNAMED_LABEL_SLOT_COMPONENTS = ['ION-TOGGLE'];


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Sean recommended that I pull our the recent form controller changes since the changes are currently in other feature branches: https://github.com/ionic-team/ionic-framework/pull/26470#discussion_r1046570708


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updates the form controller to account for elements with named  and unnamed label slots.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
