### PR TITLE
chore(eslint): add async playwright assert rule

### DIFF
--- a/core/.eslintrc.js
+++ b/core/.eslintrc.js
@@ -40,7 +40,14 @@ module.exports = {
         "allowAny": true
       }
     ],
-    "custom-rules/no-component-on-ready-method": "error",
-    "custom-rules/await-playwright-promise-assertion": "error"
-  }
+    "custom-rules/no-component-on-ready-method": "error"
+  },
+  "overrides": [
+    {
+      "files": ["*.e2e.ts"],
+      "rules": {
+        "custom-rules/await-playwright-promise-assertion": "error"
+      }
+    }
+  ]
 };

--- a/core/.eslintrc.js
+++ b/core/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
         "allowAny": true
       }
     ],
-    "custom-rules/no-component-on-ready-method": "error"
+    "custom-rules/no-component-on-ready-method": "error",
+    "custom-rules/await-playwright-promise-assertion": "error"
   }
 };

--- a/core/custom-rules/await-playwright-promise-assertion.js
+++ b/core/custom-rules/await-playwright-promise-assertion.js
@@ -29,7 +29,6 @@ module.exports = {
           ) {
             context.report({ node: node, messageId: 'awaitPlayewrightPromiseAssertion' });
           }
-
         }
       }
     }

--- a/core/custom-rules/await-playwright-promise-assertion.js
+++ b/core/custom-rules/await-playwright-promise-assertion.js
@@ -19,28 +19,17 @@ module.exports = {
           const { object, property } = expression.callee;
 
           /**
-           * If we are using an `expect()` call then
-           * we are likely in a Playwright assertion.
+           * Check to see if the property name is
+           * of a known Playwright async assertion.
            */
           if (
-            object !== undefined &&
-            object.callee !== undefined &&
-            object.callee.type === 'Identifier' &&
-            object.callee.name === 'expect'
+            property !== undefined &&
+            property.type === 'Identifier' &&
+            hasPlaywrightAsyncAssertion(property.name)
           ) {
-            /**
-             * From here, we can check if there is a known
-             * Playwright assertion. If so, then we can safely say
-             * that there was an async Playwright assert used
-             * that was not properly awaited.
-             */
-            if (
-              property.type === 'Identifier' &&
-              hasPlaywrightAsyncAssertion(property.name)
-            ) {
-              context.report({ node: node, messageId: 'awaitPlayewrightPromiseAssertion' });
-            }
+            context.report({ node: node, messageId: 'awaitPlayewrightPromiseAssertion' });
           }
+
         }
       }
     }

--- a/core/custom-rules/await-playwright-promise-assertion.js
+++ b/core/custom-rules/await-playwright-promise-assertion.js
@@ -1,7 +1,7 @@
 module.exports = {
   meta: {
     messages: {
-      awaitPlayewrightPromiseAssertion: 'This Playwright assertion returns a Promise. Add an "await" to avoid creating a flaky test.',
+      awaitPlaywrightPromiseAssertion: 'This Playwright assertion returns a Promise. Add an "await" to avoid creating a flaky test.',
     },
   },
   create(context) {
@@ -27,7 +27,7 @@ module.exports = {
             property.type === 'Identifier' &&
             hasPlaywrightAsyncAssertion(property.name)
           ) {
-            context.report({ node: node, messageId: 'awaitPlayewrightPromiseAssertion' });
+            context.report({ node: node, messageId: 'awaitPlaywrightPromiseAssertion' });
           }
         }
       }

--- a/core/custom-rules/await-playwright-promise-assertion.js
+++ b/core/custom-rules/await-playwright-promise-assertion.js
@@ -1,7 +1,7 @@
 module.exports = {
   meta: {
     messages: {
-      awaitPlayewrightPromiseAssertion: 'This Playwright assertions returns a Promise. Add an "await" to avoid creating a flaky test.',
+      awaitPlayewrightPromiseAssertion: 'This Playwright assertion returns a Promise. Add an "await" to avoid creating a flaky test.',
     },
   },
   create(context) {

--- a/core/custom-rules/await-playwright-promise-assertion.js
+++ b/core/custom-rules/await-playwright-promise-assertion.js
@@ -10,7 +10,7 @@ module.exports = {
         const expression = node.expression;
 
         /**
-         * The first expression of a properly await'ed
+         * The first expression of a properly awaited
          * Playwright assertion should be an AwaitExpression,
          * so if it goes directly to the CallExpression
          * then we potentially need to report this.
@@ -28,6 +28,12 @@ module.exports = {
             object.callee.type === 'Identifier' &&
             object.callee.name === 'expect'
           ) {
+            /**
+             * From here, we can check if there is a known
+             * Playwright assertion. If so, then we can safely say
+             * that there was an async Playwright assert used
+             * that was not properly awaited.
+             */
             if (
               property.type === 'Identifier' &&
               hasPlaywrightAsyncAssertion(property.name)
@@ -41,10 +47,15 @@ module.exports = {
   }
 };
 
+/**
+ * Returns `true` if `property` is the name
+ * of a known async Playwright assertion.
+ */
 const hasPlaywrightAsyncAssertion = (property) => {
   return ASYNC_PLAYWRIGHT_ASSERTS.includes(property);
 }
 
+// https://playwright.dev/docs/test-assertions
 const ASYNC_PLAYWRIGHT_ASSERTS = [
   'toBeChecked',
   'toBeDisabled',

--- a/core/custom-rules/await-playwright-promise-assertion.js
+++ b/core/custom-rules/await-playwright-promise-assertion.js
@@ -1,0 +1,71 @@
+module.exports = {
+  meta: {
+    messages: {
+      awaitPlayewrightPromiseAssertion: 'This Playwright assertions returns a Promise. Add an "await" to avoid creating a flaky test.',
+    },
+  },
+  create(context) {
+    return {
+      ExpressionStatement(node) {
+        const expression = node.expression;
+
+        /**
+         * The first expression of a properly await'ed
+         * Playwright assertion should be an AwaitExpression,
+         * so if it goes directly to the CallExpression
+         * then we potentially need to report this.
+         */
+        if (expression.type === 'CallExpression') {
+          const { object, property } = expression.callee;
+
+          /**
+           * If we are using an `expect()` call then
+           * we are likely in a Playwright assertion.
+           */
+          if (
+            object !== undefined &&
+            object.callee !== undefined &&
+            object.callee.type === 'Identifier' &&
+            object.callee.name === 'expect'
+          ) {
+            if (
+              property.type === 'Identifier' &&
+              hasPlaywrightAsyncAssertion(property.name)
+            ) {
+              context.report({ node: node, messageId: 'awaitPlayewrightPromiseAssertion' });
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+const hasPlaywrightAsyncAssertion = (property) => {
+  return ASYNC_PLAYWRIGHT_ASSERTS.includes(property);
+}
+
+const ASYNC_PLAYWRIGHT_ASSERTS = [
+  'toBeChecked',
+  'toBeDisabled',
+  'toBeEditable',
+  'toBeEmpty',
+  'toBeEnabled',
+  'toBeFocused',
+  'toBeHidden',
+  'toBeVisible',
+  'toContainText',
+  'toHaveAttribute',
+  'toHaveClass',
+  'toHaveCount',
+  'toHaveCSS',
+  'toHaveId',
+  'toHaveJSProperty',
+  'toHaveScreenshot',
+  'toHaveText',
+  'toHaveValue',
+  'toHaveValues',
+  'toHaveTitle',
+  'toHaveURL',
+  'toBeOK',
+];

--- a/core/custom-rules/index.js
+++ b/core/custom-rules/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
-    'no-component-on-ready-method': require('./no-component-on-ready-method.js')
+    'no-component-on-ready-method': require('./no-component-on-ready-method.js'),
+    'await-playwright-promise-assertion': require('./await-playwright-promise-assertion.js')
   }
 }

--- a/core/custom-rules/no-component-on-ready-method.js
+++ b/core/custom-rules/no-component-on-ready-method.js
@@ -1,22 +1,22 @@
 module.exports = {
-    meta: {
-      messages: {
-        noComponentOnReadyMethod: 'Using the componentOnReady method is not allowed. Use the componentOnReady helper utility in src/utils/helpers.ts instead.',
-      },
+  meta: {
+    messages: {
+      noComponentOnReadyMethod: 'Using the componentOnReady method is not allowed. Use the componentOnReady helper utility in src/utils/helpers.ts instead.',
     },
-    create(context) {
-      return {
-        CallExpression(node) {
-          /**
-           * We only want to exclude usages of componentOnReady().
-           * Checking for the existence of the componentOnReady method
-           * is a way of determining if we are in a lazy loaded build
-           * or custom elements build, so we want to allow that.
-           */
-          const callee = node.callee;
-          if (callee.type === 'MemberExpression' && callee.property.name === 'componentOnReady') {
-            context.report({ node: node, messageId: 'noComponentOnReadyMethod' });
-          }
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        /**
+         * We only want to exclude usages of componentOnReady().
+         * Checking for the existence of the componentOnReady method
+         * is a way of determining if we are in a lazy loaded build
+         * or custom elements build, so we want to allow that.
+         */
+        const callee = node.callee;
+        if (callee.type === 'MemberExpression' && callee.property.name === 'componentOnReady') {
+          context.report({ node: node, messageId: 'noComponentOnReadyMethod' });
+        }
       }
     }
   }

--- a/core/src/components/datetime/test/color/datetime.e2e.ts
+++ b/core/src/components/datetime/test/color/datetime.e2e.ts
@@ -10,16 +10,6 @@ test.describe('datetime: color', () => {
     const darkModeToggle = page.locator('ion-checkbox');
     const datetime = page.locator('ion-datetime');
 
-    // incorrect: async assert with no await
-    expect(datetime).toHaveClass('test');
-    expect(datetime).toHaveValue('test');
-
-    // correct: async assert with await
-    await expect(datetime).toHaveClass('abc');
-
-    // this is a sync assert
-    expect(datetime).toBe(true);
-
     expect(await datetime.screenshot()).toMatchSnapshot(`datetime-color-${page.getSnapshotSettings()}.png`);
 
     await darkModeToggle.evaluate((el: HTMLIonCheckboxElement) => (el.checked = true));

--- a/core/src/components/datetime/test/color/datetime.e2e.ts
+++ b/core/src/components/datetime/test/color/datetime.e2e.ts
@@ -10,6 +10,16 @@ test.describe('datetime: color', () => {
     const darkModeToggle = page.locator('ion-checkbox');
     const datetime = page.locator('ion-datetime');
 
+    // incorrect: async assert with no await
+    expect(datetime).toHaveClass('test');
+    expect(datetime).toHaveValue('test');
+
+    // correct: async assert with await
+    await expect(datetime).toHaveClass('abc');
+
+    // this is a sync assert
+    expect(datetime).toBe(true);
+
     expect(await datetime.screenshot()).toMatchSnapshot(`datetime-color-${page.getSnapshotSettings()}.png`);
 
     await darkModeToggle.evaluate((el: HTMLIonCheckboxElement) => (el.checked = true));

--- a/core/src/components/radio-group/test/search/radio-group.e2e.ts
+++ b/core/src/components/radio-group/test/search/radio-group.e2e.ts
@@ -19,7 +19,7 @@ test.describe('radio-group', () => {
       // filter radio so it is not in DOM
       await page.fill('ion-searchbar input', 'zero');
       await page.waitForChanges();
-      expect(radio).toBeHidden();
+      await expect(radio).toBeHidden();
 
       // ensure radio group has the same value
       await expect(radioGroup).toHaveJSProperty('value', 'two');


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Many Playwright assertions return Promises. Not properly awaiting these asserts causes flakiness on CI: https://github.com/ionic-team/ionic-framework/pull/26490

However, ensuring that these awaits are added is a manual process and it is easy to miss.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add a custom ESLint rule which checks the used asserts against a known list of async Playwright asserts to see if any awaits were missed.

An example of this ESLint rule in action can be found here: https://github.com/ionic-team/ionic-framework/actions/runs/3705171738/jobs/6278782816

(In addition to the example asserts I added to the datetime `color` test, this rule also caught a missing `await` in the radio-group test file 😄)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
