### PR TITLE
feat(router): export hook interfaces 

### DIFF
--- a/core/src/interface.d.ts
+++ b/core/src/interface.d.ts
@@ -22,6 +22,7 @@ export * from './components/picker/picker-interface';
 export * from './components/popover/popover-interface';
 export * from './components/radio-group/radio-group-interface';
 export * from './components/range/range-interface';
+export * from './components/route/route-interface';
 export * from './components/router/utils/interface';
 export * from './components/refresher/refresher-interface';
 export * from './components/reorder-group/reorder-group-interface';


### PR DESCRIPTION
I'd like to import `NavigationHookResult` from @ionic/core. In my case, to generate a typings file that allows SvelteKit developers to have a typings file consistent with the core-package. Now I am adding the `NavigationHookResult` type definition myself in the svelteHTML typings file. Because `NavigationHookResult` is not re-exported to the developer surface.

This change allows me to import it and uses the same pattern for exporting as all other types

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
No big problem - just I am creating typings for SvelteKit developers and NavigationHookResult is not exported by core package, so I need to copy/paste it from route/route-interface.d.ts into my own file - which is not sustainable.


<!-- Issues are required for both bug fixes and features. -->
No issue posted.


## What is the new behavior?
NavigationHookResult exported by core, so anyone can consume it via type import

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
See https://github.com/Tommertom/svelte-ionic-npm/blob/main/index.d.ts with the implementation for which I rather use an import from core package.

