### PR TITLE
chore(jsdoc): move comment on RadioGroup

### DIFF
--- a/core/src/components/radio-group/radio-group.tsx
+++ b/core/src/components/radio-group/radio-group.tsx
@@ -4,12 +4,10 @@ import { Component, Element, Event, Host, Listen, Prop, Watch, h } from '@stenci
 import { getIonMode } from '../../global/ionic-global';
 import type { RadioGroupChangeEventDetail } from '../../interface';
 
-/**
- * The Radio Group component mandates that only one radio button
- * within the group can be selected at any given time. Since `ion-radio`
- * is a shadow DOM component, it cannot natively perform this behavior
- * using the `name` attribute.
- */
+// The Radio Group component mandates that only one radio button
+// within the group can be selected at any given time. Since `ion-radio`
+// is a shadow DOM component, it cannot natively perform this behavior
+// using the `name` attribute.
 @Component({
   tag: 'ion-radio-group',
 })

--- a/core/src/components/radio-group/radio-group.tsx
+++ b/core/src/components/radio-group/radio-group.tsx
@@ -4,10 +4,6 @@ import { Component, Element, Event, Host, Listen, Prop, Watch, h } from '@stenci
 import { getIonMode } from '../../global/ionic-global';
 import type { RadioGroupChangeEventDetail } from '../../interface';
 
-// The Radio Group component mandates that only one radio button
-// within the group can be selected at any given time. Since `ion-radio`
-// is a shadow DOM component, it cannot natively perform this behavior
-// using the `name` attribute.
 @Component({
   tag: 'ion-radio-group',
 })
@@ -89,6 +85,12 @@ export class RadioGroup implements ComponentInterface {
   private onClick = (ev: Event) => {
     ev.preventDefault();
 
+    /**
+     * The Radio Group component mandates that only one radio button
+     * within the group can be selected at any given time. Since `ion-radio`
+     * is a shadow DOM component, it cannot natively perform this behavior
+     * using the `name` attribute.
+     */
     const selectedRadio = ev.target && (ev.target as HTMLElement).closest('ion-radio');
     if (selectedRadio) {
       const currentValue = this.value;


### PR DESCRIPTION
This converts a multiline comment (like `/**...*/`) above the `RadioGroup` component class to be a series of `//` comments instead. This is done to prevent the comment from being accidentally recognized as a JSDoc comment for the class when a Stencil version incorporating this change is installed:
https://github.com/ionic-team/stencil/commit/2e4b1fcdc0b3fd41928d27cf9ee525a15b02d617

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

If you build and install Stencil from `main` you'll see a change like this in `components.d.ts`:

```diff
diff --git a/core/src/components.d.ts b/core/src/components.d.ts
index 396879d6e9..49758b6613 100644
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -2095,6 +2095,12 @@ export namespace Components {
          */
         "value"?: any | null;
     }
+    /**
+     * The Radio Group component mandates that only one radio button
+     * within the group can be selected at any given time. Since `ion-radio`
+     * is a shadow DOM component, it cannot natively perform this behavior
+     * using the `name` attribute.
+     */
     interface IonRadioGroup {
         /**
           * If `true`, the radios can be deselected.
@@ -3653,6 +3659,12 @@ declare global {
         prototype: HTMLIonRadioElement;
         new (): HTMLIonRadioElement;
     };
+    /**
+     * The Radio Group component mandates that only one radio button
+     * within the group can be selected at any given time. Since `ion-radio`
+     * is a shadow DOM component, it cannot natively perform this behavior
+     * using the `name` attribute.
+     */
     interface HTMLIonRadioGroupElement extends Components.IonRadioGroup, HTMLStencilElement {
     }
     var HTMLIonRadioGroupElement: {
@@ -6025,6 +6037,12 @@ declare namespace LocalJSX {
          */
         "value"?: any | null;
     }
+    /**
+     * The Radio Group component mandates that only one radio button
+     * within the group can be selected at any given time. Since `ion-radio`
+     * is a shadow DOM component, it cannot natively perform this behavior
+     * using the `name` attribute.
+     */
     interface IonRadioGroup {
         /**
           * If `true`, the radios can be deselected.
@@ -7283,6 +7301,12 @@ declare module "@stencil/core" {
             "ion-popover": LocalJSX.IonPopover & JSXBase.HTMLAttributes<HTMLIonPopoverElement>;
             "ion-progress-bar": LocalJSX.IonProgressBar & JSXBase.HTMLAttributes<HTMLIonProgressBarElement>;
             "ion-radio": LocalJSX.IonRadio & JSXBase.HTMLAttributes<HTMLIonRadioElement>;
+            /**
+             * The Radio Group component mandates that only one radio button
+             * within the group can be selected at any given time. Since `ion-radio`
+             * is a shadow DOM component, it cannot natively perform this behavior
+             * using the `name` attribute.
+             */
             "ion-radio-group": LocalJSX.IonRadioGroup & JSXBase.HTMLAttributes<HTMLIonRadioGroupElement>;
             "ion-range": LocalJSX.IonRange & JSXBase.HTMLAttributes<HTMLIonRangeElement>;
             "ion-refresher": LocalJSX.IonRefresher & JSXBase.HTMLAttributes<HTMLIonRefresherElement>;
```

This is no good! The comment:

https://github.com/ionic-team/ionic-framework/blob/a1580d89e2083ac94569db598e062d07f9083321/core/src/components/radio-group/radio-group.tsx#L7-L20

wasn't intended to be included that way.


## What is the new behavior?

This just changes the type of comment used in a comment immediately preceding a component class, to prevent the comment from being inadvertently used as a JSDoc comment.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
