### PR TITLE
fix(segment): nested interactives are not rendered

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -2483,6 +2483,7 @@ export namespace Components {
           * The mode determines which platform styles to use.
          */
         "mode"?: "ios" | "md";
+        "setFocus": () => Promise<void>;
         /**
           * The type of the button.
          */

--- a/core/src/components/segment-button/segment-button.tsx
+++ b/core/src/components/segment-button/segment-button.tsx
@@ -1,5 +1,5 @@
 import type { ComponentInterface } from '@stencil/core';
-import { Component, Element, Host, Prop, State, forceUpdate, h } from '@stencil/core';
+import { Component, Element, Host, Prop, Method, State, forceUpdate, h } from '@stencil/core';
 
 import { getIonMode } from '../../global/ionic-global';
 import type { SegmentButtonLayout } from '../../interface';
@@ -26,6 +26,7 @@ let ids = 0;
 })
 export class SegmentButton implements ComponentInterface, ButtonInterface {
   private segmentEl: HTMLIonSegmentElement | null = null;
+  private nativeEl: HTMLButtonElement | undefined;
 
   @Element() el!: HTMLElement;
 
@@ -87,20 +88,26 @@ export class SegmentButton implements ComponentInterface, ButtonInterface {
     }
   };
 
-  private get tabIndex() {
-    return this.checked && !this.disabled ? 0 : -1;
+  /**
+   * @internal
+   * Focuses the native <button> element
+   * inside of ion-segment-button.
+   */
+  @Method()
+  async setFocus() {
+    const { nativeEl } = this;
+
+    if (nativeEl !== undefined) {
+      nativeEl.focus();
+    }
   }
 
   render() {
-    const { checked, type, disabled, hasIcon, hasLabel, layout, segmentEl, tabIndex } = this;
+    const { checked, type, disabled, hasIcon, hasLabel, layout, segmentEl } = this;
     const mode = getIonMode(this);
     const hasSegmentColor = () => segmentEl?.color !== undefined;
     return (
       <Host
-        role="tab"
-        aria-selected={checked ? 'true' : 'false'}
-        aria-disabled={disabled ? 'true' : null}
-        tabIndex={tabIndex}
         class={{
           [mode]: true,
           'in-toolbar': hostContext('ion-toolbar', this.el),
@@ -119,7 +126,15 @@ export class SegmentButton implements ComponentInterface, ButtonInterface {
           'ion-focusable': true,
         }}
       >
-        <button type={type} tabIndex={-1} class="button-native" part="native" disabled={disabled}>
+        <button
+          aria-selected={checked ? 'true' : 'false'}
+          role="tab"
+          ref={(el) => (this.nativeEl = el)}
+          type={type}
+          class="button-native"
+          part="native"
+          disabled={disabled}
+        >
           <span class="button-inner">
             <slot></slot>
           </span>

--- a/core/src/components/segment-button/segment-button.tsx
+++ b/core/src/components/segment-button/segment-button.tsx
@@ -4,7 +4,8 @@ import { Component, Element, Host, Prop, Method, State, forceUpdate, h } from '@
 import { getIonMode } from '../../global/ionic-global';
 import type { SegmentButtonLayout } from '../../interface';
 import type { ButtonInterface } from '../../utils/element-interface';
-import { addEventListener, removeEventListener } from '../../utils/helpers';
+import type { Attributes } from '../../utils/helpers';
+import { addEventListener, removeEventListener, inheritAttributes } from '../../utils/helpers';
 import { hostContext } from '../../utils/theme';
 
 let ids = 0;
@@ -27,6 +28,7 @@ let ids = 0;
 export class SegmentButton implements ComponentInterface, ButtonInterface {
   private segmentEl: HTMLIonSegmentElement | null = null;
   private nativeEl: HTMLButtonElement | undefined;
+  private inheritedAttributes: Attributes = {};
 
   @Element() el!: HTMLElement;
 
@@ -68,6 +70,12 @@ export class SegmentButton implements ComponentInterface, ButtonInterface {
       removeEventListener(segmentEl, 'ionStyle', this.updateStyle);
       this.segmentEl = null;
     }
+  }
+
+  componentWillLoad() {
+    this.inheritedAttributes = {
+      ...inheritAttributes(this.el, ['aria-label']),
+    };
   }
 
   private get hasLabel() {
@@ -134,6 +142,7 @@ export class SegmentButton implements ComponentInterface, ButtonInterface {
           class="button-native"
           part="native"
           disabled={disabled}
+          {...this.inheritedAttributes}
         >
           <span class="button-inner">
             <slot></slot>

--- a/core/src/components/segment/segment.tsx
+++ b/core/src/components/segment/segment.tsx
@@ -165,7 +165,6 @@ export class Segment implements ComponentInterface {
 
   async componentDidLoad() {
     this.setCheckedClasses();
-    this.ensureFocusable();
 
     this.gesture = (await import('../../utils/gesture')).createGesture({
       el: this.el,
@@ -519,19 +518,7 @@ export class Segment implements ComponentInterface {
       const previous = this.checked || current;
       this.checkButton(previous, current);
     }
-    current.focus();
-  }
-
-  /* By default, focus is delegated to the selected `ion-segment-button`.
-   * If there is no selected button, focus will instead pass to the first child button.
-   **/
-  private ensureFocusable() {
-    if (this.value !== undefined) {
-      return;
-    }
-
-    const buttons = this.getButtons();
-    buttons[0]?.setAttribute('tabindex', '0');
+    current.setFocus();
   }
 
   render() {

--- a/core/src/components/segment/test/a11y/index.html
+++ b/core/src/components/segment/test/a11y/index.html
@@ -26,6 +26,20 @@
             <ion-label>Shared Links</ion-label>
           </ion-segment-button>
         </ion-segment>
+
+        <br /><br />
+
+        <ion-segment aria-label="Tab Options" color="dark" select-on-focus>
+          <ion-segment-button aria-label="Bookmarks" value="bookmarks">
+            <ion-icon aria-hidden="true" name="bookmark"></ion-icon>
+          </ion-segment-button>
+          <ion-segment-button aria-label="Reading List" value="reading-list">
+            <ion-icon aria-hidden="true" name="glasses"></ion-icon>
+          </ion-segment-button>
+          <ion-segment-button aria-label="Shared Links" value="shared-links">
+            <ion-icon aria-hidden="true" name="link"></ion-icon>
+          </ion-segment-button>
+        </ion-segment>
       </ion-content>
     </ion-app>
   </body>

--- a/core/src/components/segment/test/a11y/screen-readers.md
+++ b/core/src/components/segment/test/a11y/screen-readers.md
@@ -1,12 +1,12 @@
-"native" refers to this sample: https://w3c.github.io/aria-practices/examples/tabs/tabs-2/tabs.html
+"native" refers to this sample: https://www.w3.org/WAI/ARIA/apg/example-index/tabs/tabs-manual
 
 ### Tabbing to Segment Button
 
 |                          | native                                           | Ionic                                            |
 | ------------------------ | ------------------------------------------------ | ------------------------------------------------ |
-| VoiceOver macOS - Chrome | BOOKMARKS, tab, 1 of 3, Tab Options, tab group   | BOOKMARKS, tab, 1 of 3, Tab Options, tab group   |
+| VoiceOver macOS - Chrome | BOOKMARKS, tab, 1 of 3, Tab Options, tab group   | BOOKMARKS, tab, 1 of 1, Tab Options, tab group   |
 | VoiceOver macOS - Safari | BOOKMARKS, tab, 1 of 3, Tab Options, tab group   | BOOKMARKS, tab, 1 of 3, Tab Options, tab group   |
-| VoiceOver iOS            | Bookmarks, tab                                   | Bookmarks, tab                                   |
+| VoiceOver iOS            | Bookmarks, tab, 1 of 3                           | Bookmarks, tab, 1 of 3                           |
 | Android TalkBack         | Bookmarks, tab                                   | Bookmarks, tab                                   |
 | Windows NVDA             | Tab Options, tab control, BOOKMARKS, tab, 1 of 3 | Tab Options, tab control, BOOKMARKS, tab, 1 of 3 |
 
@@ -14,11 +14,12 @@
 
 |                          | native                                                   | Ionic                    |
 | ------------------------ | -------------------------------------------------------- | ------------------------ |
-| VoiceOver macOS - Chrome | BOOKMARKS, selected, tab, 1 of 3, Tab Options, tab group | BOOKMARKS, selected, tab, 1 of 3, Tab Options, tab group |
+| VoiceOver macOS - Chrome | BOOKMARKS, selected, tab, 1 of 3, Tab Options, tab group | BOOKMARKS, selected, tab, 1 of 1, Tab Options, tab group |
 | VoiceOver macOS - Safari | BOOKMARKS, selected, tab, 1 of 3, Tab Options, tab group | BOOKMARKS, selected, tab, 1 of 3, Tab Options, tab group |
-| VoiceOver iOS            | selected, Bookmarks, tab                                 | selected, Bookmarks, tab |
+| VoiceOver iOS            | selected, Bookmarks, tab, 1 of 3                         | selected, Bookmarks, tab, 1 of 3 |
 | Android TalkBack         | selected                                                 | selected                       |
 | Windows NVDA             | BOOKMARKS, tab, 1 of 3, selected                         | BOOKMARKS, tab, 1 of 3, selected                       |
 
 Note: The `aria-label` for tablist is typically only read on the first interaction.
 
+VoiceOver + Chrome announces the wrong tab count due to the `role="tab"` being in the Shadow DOM: https://bugs.chromium.org/p/chromium/issues/detail?id=1405462

--- a/core/src/components/segment/test/a11y/segment.e2e.ts
+++ b/core/src/components/segment/test/a11y/segment.e2e.ts
@@ -6,8 +6,7 @@ test.describe('segment: a11y', () => {
   test('should not have any axe violations', async ({ page }) => {
     await page.goto('/src/components/segment/test/a11y');
 
-    // TODO(FW-403): Re-enable rule once segment button is updated to avoid nested-interactive
-    const results = await new AxeBuilder({ page }).disableRules('nested-interactive').analyze();
+    const results = await new AxeBuilder({ page }).analyze();
     expect(results.violations).toEqual([]);
   });
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: Internal ticket

Axe test warns of nested interactive in `ion-segment-button`. This is happening because `ion-segment-button` has `role="tab"` on the host element but then renders a `<button>` in its Shadow DOM. Axe thinks that both the host and the nested button are interactive.

This was added in https://github.com/ionic-team/ionic-framework/pull/23145 before Axe warned about nested interactive (so this was never caught). The original fix was architected this way due to a bug in Chrome on macOS where it does not read the total tab count correctly due to the `role="tab"` elements being in the Shadow DOM.
However, the workaround that avoided this issue introduced the nested interactive issue.

I filed https://bugs.chromium.org/p/chromium/issues/detail?id=1405462 with the Chrome team. I think it is better to avoid the nested interactive issue at the expense of surfacing this Chrome bug. The nested interactive issue is an actual bug that we introduced and impacts all platforms that use assistive tech. The incorrect count bug is a Chrome bug and is limited to Chrome on macOS. The surface area of the Chrome bug is smaller than the nested interactive bug.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- aria-selected and role states on `ion-segment-button` have been moved to the native `<button>` element inside of the Shadow DOM.
- Segment now calls the internal `setFocus` method on `ion-segment-button` so that the native button element is focused instead of the host element.
- `ariaLabel` on `ion-segment-button` is now inherited to the native `<button>` element.

Notable Changes:

1. Axe will no longer warn about "nested interactives"
2. VoiceOver with Chrome on macOS will now read "tab `n` of 1"  even if there is more than 1 tab in the tab group.

Not impacted by this change:

- TalkBack on Android
- VoiceOver on iOS
- VoiceOver with Safari on macOS
- NVDA on Windows

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
