### PR TITLE
fix(tab-button): nested interactives are not rendered

### DIFF
--- a/core/src/components/tab-button/tab-button.tsx
+++ b/core/src/components/tab-button/tab-button.tsx
@@ -5,6 +5,8 @@ import { config } from '../../global/config';
 import { getIonMode } from '../../global/ionic-global';
 import type { TabBarChangedEventDetail, TabButtonClickEventDetail, TabButtonLayout } from '../../interface';
 import type { AnchorInterface } from '../../utils/element-interface';
+import type { Attributes } from '../../utils/helpers';
+import { inheritAttributes } from '../../utils/helpers';
 
 /**
  * @virtualProp {"ios" | "md"} mode - The mode determines which platform styles to use.
@@ -20,6 +22,8 @@ import type { AnchorInterface } from '../../utils/element-interface';
   shadow: true,
 })
 export class TabButton implements ComponentInterface, AnchorInterface {
+  private inheritedAttributes: Attributes = {};
+
   @Element() el!: HTMLElement;
 
   /**
@@ -88,6 +92,10 @@ export class TabButton implements ComponentInterface, AnchorInterface {
   }
 
   componentWillLoad() {
+    this.inheritedAttributes = {
+      ...inheritAttributes(this.el, ['aria-label']),
+    };
+
     if (this.layout === undefined) {
       this.layout = config.get('tabButtonLayout', 'icon-top');
     }
@@ -114,20 +122,6 @@ export class TabButton implements ComponentInterface, AnchorInterface {
     return !!this.el.querySelector('ion-icon');
   }
 
-  private get tabIndex() {
-    if (this.disabled) {
-      return -1;
-    }
-
-    const hasTabIndex = this.el.hasAttribute('tabindex');
-
-    if (hasTabIndex) {
-      return this.el.getAttribute('tabindex');
-    }
-
-    return 0;
-  }
-
   private onKeyUp = (ev: KeyboardEvent) => {
     if (ev.key === 'Enter' || ev.key === ' ') {
       this.selectTab(ev);
@@ -139,7 +133,7 @@ export class TabButton implements ComponentInterface, AnchorInterface {
   };
 
   render() {
-    const { disabled, hasIcon, hasLabel, tabIndex, href, rel, target, layout, selected, tab } = this;
+    const { disabled, hasIcon, hasLabel, href, rel, target, layout, selected, tab, inheritedAttributes } = this;
     const mode = getIonMode(this);
     const attrs = {
       download: this.download,
@@ -152,9 +146,6 @@ export class TabButton implements ComponentInterface, AnchorInterface {
       <Host
         onClick={this.onClick}
         onKeyup={this.onKeyUp}
-        role="tab"
-        tabindex={tabIndex}
-        aria-selected={selected ? 'true' : null}
         id={tab !== undefined ? `tab-button-${tab}` : null}
         class={{
           [mode]: true,
@@ -170,7 +161,16 @@ export class TabButton implements ComponentInterface, AnchorInterface {
           'ion-focusable': true,
         }}
       >
-        <a {...attrs} tabIndex={-1} class="button-native" part="native">
+        <a
+          {...attrs}
+          class="button-native"
+          part="native"
+          role="tab"
+          aria-selected={selected ? 'true' : null}
+          aria-disabled={disabled ? 'true' : null}
+          tabindex={disabled ? '-1' : undefined}
+          {...inheritedAttributes}
+        >
           <span class="button-inner">
             <slot></slot>
           </span>

--- a/core/src/components/tab-button/test/a11y/index.html
+++ b/core/src/components/tab-button/test/a11y/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Tab Button - a11y</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
+    <link href="../../../../../css/core.css" rel="stylesheet" />
+    <link href="../../../../../scripts/testing/styles.css" rel="stylesheet" />
+    <script src="../../../../../scripts/testing/scripts.js"></script>
+    <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+    <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+  </head>
+
+  <body>
+    <main>
+      <h1>Tab Button</h1>
+      <ion-tab-bar slot="bottom">
+        <ion-tab-button href="#" tab="tab-one">
+          <ion-label>Tab One</ion-label>
+          <ion-icon name="star"></ion-icon>
+        </ion-tab-button>
+
+        <ion-tab-button href="#">
+          <ion-label>Tab Two</ion-label>
+          <ion-icon name="globe"></ion-icon>
+          <ion-badge color="danger">6</ion-badge>
+        </ion-tab-button>
+
+        <ion-tab-button href="#" disabled="true">
+          <ion-label>Tab Three</ion-label>
+          <ion-icon name="logo-facebook"></ion-icon>
+          <ion-badge color="primary">6</ion-badge>
+        </ion-tab-button>
+
+        <ion-tab-button hidden>
+          <ion-label>Hidden</ion-label>
+          <ion-icon name="alert"></ion-icon>
+        </ion-tab-button>
+
+        <ion-tab-button href="#">
+          <ion-label>Tab Four</ion-label>
+          <ion-icon name="chatbox"></ion-icon>
+        </ion-tab-button>
+      </ion-tab-bar>
+    </main>
+  </body>
+</html>

--- a/core/src/components/tab-button/test/a11y/index.html
+++ b/core/src/components/tab-button/test/a11y/index.html
@@ -14,32 +14,44 @@
   <body>
     <main>
       <h1>Tab Button</h1>
-      <ion-tab-bar slot="bottom">
-        <ion-tab-button href="#" tab="tab-one">
+      <ion-tab-bar>
+        <ion-tab-button href="#">
           <ion-label>Tab One</ion-label>
-          <ion-icon name="star"></ion-icon>
+          <ion-icon aria-hidden="true" name="star"></ion-icon>
         </ion-tab-button>
 
         <ion-tab-button href="#">
           <ion-label>Tab Two</ion-label>
-          <ion-icon name="globe"></ion-icon>
-          <ion-badge color="danger">6</ion-badge>
+          <ion-icon aria-hidden="true" name="globe"></ion-icon>
+          <ion-badge aria-hidden="true" color="danger">6</ion-badge>
         </ion-tab-button>
 
         <ion-tab-button href="#" disabled="true">
           <ion-label>Tab Three</ion-label>
-          <ion-icon name="logo-facebook"></ion-icon>
-          <ion-badge color="primary">6</ion-badge>
+          <ion-icon aria-hidden="true" name="logo-facebook"></ion-icon>
+          <ion-badge aria-hidden="true" color="primary">6</ion-badge>
         </ion-tab-button>
 
         <ion-tab-button hidden>
           <ion-label>Hidden</ion-label>
-          <ion-icon name="alert"></ion-icon>
+          <ion-icon aria-hidden="true" name="alert"></ion-icon>
         </ion-tab-button>
 
         <ion-tab-button href="#">
           <ion-label>Tab Four</ion-label>
-          <ion-icon name="chatbox"></ion-icon>
+          <ion-icon aria-hidden="true" name="chatbox"></ion-icon>
+        </ion-tab-button>
+      </ion-tab-bar>
+
+      <ion-tab-bar>
+        <ion-tab-button href="#" aria-label="Tab 1">
+          <ion-icon aria-hidden="true" name="star"></ion-icon>
+        </ion-tab-button>
+        <ion-tab-button href="#" aria-label="Tab 2">
+          <ion-icon aria-hidden="true" name="globe"></ion-icon>
+        </ion-tab-button>
+        <ion-tab-button href="#" aria-label="Tab 3">
+          <ion-icon aria-hidden="true" name="chatbox"></ion-icon>
         </ion-tab-button>
       </ion-tab-bar>
     </main>

--- a/core/src/components/tab-button/test/a11y/tab-button.e2e.ts
+++ b/core/src/components/tab-button/test/a11y/tab-button.e2e.ts
@@ -1,0 +1,12 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect } from '@playwright/test';
+import { test } from '@utils/test/playwright';
+
+test.describe('tab-button: a11y', () => {
+  test('should not have any axe violations', async ({ page }) => {
+    await page.goto('/src/components/tab-button/test/a11y');
+
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/23332

This is the same issue as https://github.com/ionic-team/ionic-framework/pull/26575.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- aria-selected and role states on `ion-tab-button` have been moved to the native `<a>` inside of the Shadow DOM.
- aria-disabled has been added so screen readers can indicate that the tab button is disabled (This is a bug I discovered while fixing the original issue)
- `ariaLabel` on `ion-tab-button` is now inherited to the native `<a>` element.
- Added a11y test for tab button

Note: This has the same tradeoffs as https://github.com/ionic-team/ionic-framework/pull/26575 re: Chrome + VoiceOver on macOS.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
