### PR TITLE
fix(many): component wrappers inherit height

### DIFF
--- a/core/src/components/checkbox/checkbox.scss
+++ b/core/src/components/checkbox/checkbox.scss
@@ -30,7 +30,7 @@
   display: inline-block;
 
   position: relative;
-  
+
   cursor: pointer;
 
   user-select: none;
@@ -59,7 +59,7 @@
   @include input-cover();
 
   display: flex;
-  
+
   align-items: center;
 
   opacity: 0;
@@ -72,8 +72,8 @@
 
   align-items: center;
 
-  height: 100%;
-  
+  height: inherit;
+
   cursor: inherit;
 }
 

--- a/core/src/components/input/input.scss
+++ b/core/src/components/input/input.scss
@@ -285,7 +285,7 @@
 
   align-items: stretch;
 
-  height: 100%;
+  height: inherit;
 
   min-height: inherit;
 

--- a/core/src/components/radio/radio.scss
+++ b/core/src/components/radio/radio.scss
@@ -85,7 +85,7 @@ input {
 
   align-items: center;
 
-  height: 100%;
+  height: inherit;
 
   min-height: inherit;
 

--- a/core/src/components/range/range.scss
+++ b/core/src/components/range/range.scss
@@ -186,7 +186,7 @@
 
   align-items: center;
 
-  height: 100%;
+  height: inherit;
 }
 
 // Range Label

--- a/core/src/components/select/select.scss
+++ b/core/src/components/select/select.scss
@@ -191,7 +191,7 @@ button {
 
   align-items: center;
 
-  height: 100%;
+  height: inherit;
 
   /**
    * This allows developers to set the height

--- a/core/src/components/toggle/toggle.scss
+++ b/core/src/components/toggle/toggle.scss
@@ -83,7 +83,7 @@ input {
 
   align-items: center;
 
-  height: 100%;
+  height: inherit;
 
   transition: background-color 15ms linear;
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: https://github.com/ionic-team/ionic-docs/pull/2698#discussion_r1067231054

Amanda noted that the component height was taking up the full height of the `ion-content` container. This was caused by us adding `height: 100%` to the component `.*-wrapper` elements.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Changed the height to `inherit` instead of `100%`. This will allow developers to set the `height` on the host of the component.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
