### PR TITLE
docs(breadcrumb): remove documentation for nonexistent APIs

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -193,8 +193,6 @@ ion-breadcrumbs,prop,itemsBeforeCollapse,number,1,false,false
 ion-breadcrumbs,prop,maxItems,number | undefined,undefined,false,false
 ion-breadcrumbs,prop,mode,"ios" | "md",undefined,false,false
 ion-breadcrumbs,event,ionCollapsedClick,BreadcrumbCollapsedClickEventDetail,true
-ion-breadcrumbs,css-prop,--background
-ion-breadcrumbs,css-prop,--color
 
 ion-button,shadow
 ion-button,prop,buttonType,string,'button',false,false

--- a/core/src/components/breadcrumbs/breadcrumbs.scss
+++ b/core/src/components/breadcrumbs/breadcrumbs.scss
@@ -4,10 +4,6 @@
 // --------------------------------------------------
 
 :host {
-  /**
-   * @prop --background: Background of the breadcrumbs
-   * @prop --color: Text color of the breadcrumbs
-   */
   @include font-smoothing();
 
   display: flex;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/26625

The `--color` and `--background` vars are documented as being available for `ion-breadcrumbs`. However, these APIs were not implemented in the final release of the component. The APIs were implemented during development but were later removed as they were not necessary (`color` is set on the `ion-breadcrumb` instead and `background` works as it normally does with `ion-breadcrumbs`).

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removes the documentation for `--color` and `--background` on `ion-breadcrumbs`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

This is not a breaking change because there is no change in behavior (the functionality was never implemented).

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
