### PR TITLE
feat(base-components): create separate mode and platform terms

### DIFF
--- a/.github/COMPONENT-GUIDE.md
+++ b/.github/COMPONENT-GUIDE.md
@@ -328,7 +328,7 @@ The ripple effect should be added to elements for Material Design. It *requires*
 
 ```jsx
  render() {
-  const mode = getIonMode(this);
+  const mode = getIonStylesheet(this);
 
 return (
   <Host

--- a/core/api.txt
+++ b/core/api.txt
@@ -1130,7 +1130,7 @@ ion-router-link,css-prop,--color
 ion-router-outlet,shadow
 ion-router-outlet,prop,animated,boolean,true,false,false
 ion-router-outlet,prop,animation,((baseEl: any, opts?: any) => Animation) | undefined,undefined,false,false
-ion-router-outlet,prop,mode,"ios" | "md",getIonMode(this),false,false
+ion-router-outlet,prop,mode,"ios" | "md",getIonPlatform(this),false,false
 
 ion-row,shadow
 

--- a/core/api.txt
+++ b/core/api.txt
@@ -1130,7 +1130,7 @@ ion-router-link,css-prop,--color
 ion-router-outlet,shadow
 ion-router-outlet,prop,animated,boolean,true,false,false
 ion-router-outlet,prop,animation,((baseEl: any, opts?: any) => Animation) | undefined,undefined,false,false
-ion-router-outlet,prop,mode,"ios" | "md",getIonPlatform(this),false,false
+ion-router-outlet,prop,mode,"ios" | "md",getIonBehavior(this),false,false
 
 ion-row,shadow
 

--- a/core/src/components/accordion-group/accordion-group.tsx
+++ b/core/src/components/accordion-group/accordion-group.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Listen, Method, Prop, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { AccordionGroupChangeEventDetail } from '../../interface';
 import { printIonWarning } from '../../utils/logging';
 
@@ -268,7 +268,7 @@ export class AccordionGroup implements ComponentInterface {
 
   render() {
     const { disabled, readonly, expand } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
 
     return (
       <Host

--- a/core/src/components/accordion/accordion.tsx
+++ b/core/src/components/accordion/accordion.tsx
@@ -3,7 +3,7 @@ import { Component, Element, Host, Prop, State, h } from '@stencil/core';
 import { chevronDown } from 'ionicons/icons';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import { addEventListener, getElementRoot, raf, removeEventListener, transitionEndAsync } from '../../utils/helpers';
 
 const enum AccordionState {
@@ -395,7 +395,7 @@ export class Accordion implements ComponentInterface {
 
   render() {
     const { disabled, readonly } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const expanded = this.state === AccordionState.Expanded || this.state === AccordionState.Expanding;
     const headerPart = expanded ? 'header expanded' : 'header';
     const contentPart = expanded ? 'content expanded' : 'content';

--- a/core/src/components/action-sheet/action-sheet.tsx
+++ b/core/src/components/action-sheet/action-sheet.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Watch, Component, Element, Event, Host, Method, Prop, h, readTask } from '@stencil/core';
 
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type {
   ActionSheetButton,
   AnimationBuilder,
@@ -324,7 +324,7 @@ export class ActionSheet implements ComponentInterface, OverlayInterface {
      * 3. A wrapper ref does not exist
      */
     const { groupEl, wrapperEl } = this;
-    if (this.gesture || getIonPlatform(this) === 'md' || !wrapperEl || !groupEl) {
+    if (this.gesture || getIonBehavior(this) === 'md' || !wrapperEl || !groupEl) {
       return;
     }
 

--- a/core/src/components/action-sheet/action-sheet.tsx
+++ b/core/src/components/action-sheet/action-sheet.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Watch, Component, Element, Event, Host, Method, Prop, h, readTask } from '@stencil/core';
 
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type {
   ActionSheetButton,
   AnimationBuilder,
@@ -341,7 +341,7 @@ export class ActionSheet implements ComponentInterface, OverlayInterface {
 
   render() {
     const { header, htmlAttributes, overlayIndex } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const allButtons = this.getButtons();
     const cancelButton = allButtons.find((b) => b.role === 'cancel');
     const buttons = allButtons.filter((b) => b.role !== 'cancel');

--- a/core/src/components/action-sheet/action-sheet.tsx
+++ b/core/src/components/action-sheet/action-sheet.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Watch, Component, Element, Event, Host, Method, Prop, h, readTask } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type {
   ActionSheetButton,
   AnimationBuilder,
@@ -324,7 +324,7 @@ export class ActionSheet implements ComponentInterface, OverlayInterface {
      * 3. A wrapper ref does not exist
      */
     const { groupEl, wrapperEl } = this;
-    if (this.gesture || getIonMode(this) === 'md' || !wrapperEl || !groupEl) {
+    if (this.gesture || getIonPlatform(this) === 'md' || !wrapperEl || !groupEl) {
       return;
     }
 

--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Listen, Method, Prop, Watch, forceUpdate, h } from '@stencil/core';
 
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type {
   AlertButton,
   AlertInput,
@@ -346,7 +346,7 @@ export class Alert implements ComponentInterface, OverlayInterface {
      * 2. App is running in MD mode
      * 3. A wrapper ref does not exist
      */
-    if (this.gesture || getIonPlatform(this) === 'md' || !this.wrapperEl) {
+    if (this.gesture || getIonBehavior(this) === 'md' || !this.wrapperEl) {
       return;
     }
 

--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Listen, Method, Prop, Watch, forceUpdate, h } from '@stencil/core';
 
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type {
   AlertButton,
   AlertInput,
@@ -503,7 +503,7 @@ export class Alert implements ComponentInterface, OverlayInterface {
 
   private renderCheckbox() {
     const inputs = this.processedInputs;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
 
     if (inputs.length === 0) {
       return null;
@@ -652,7 +652,7 @@ export class Alert implements ComponentInterface, OverlayInterface {
 
   private renderAlertButtons() {
     const buttons = this.processedButtons;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const alertButtonGroupClass = {
       'alert-button-group': true,
       'alert-button-group-vertical': buttons.length > 2,
@@ -677,7 +677,7 @@ export class Alert implements ComponentInterface, OverlayInterface {
 
   render() {
     const { overlayIndex, header, subHeader, message, htmlAttributes } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const hdrId = `alert-${overlayIndex}-hdr`;
     const subHdrId = `alert-${overlayIndex}-sub-hdr`;
     const msgId = `alert-${overlayIndex}-msg`;

--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Listen, Method, Prop, Watch, forceUpdate, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type {
   AlertButton,
   AlertInput,
@@ -346,7 +346,7 @@ export class Alert implements ComponentInterface, OverlayInterface {
      * 2. App is running in MD mode
      * 3. A wrapper ref does not exist
      */
-    if (this.gesture || getIonMode(this) === 'md' || !this.wrapperEl) {
+    if (this.gesture || getIonPlatform(this) === 'md' || !this.wrapperEl) {
       return;
     }
 

--- a/core/src/components/app/app.tsx
+++ b/core/src/components/app/app.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface } from '@stencil/core';
 import { Build, Component, Element, Host, Method, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import { isPlatform } from '../../utils/platform';
 
 @Component({
@@ -64,7 +64,7 @@ export class App implements ComponentInterface {
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={{

--- a/core/src/components/avatar/avatar.tsx
+++ b/core/src/components/avatar/avatar.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 
 @Component({
   tag: 'ion-avatar',
@@ -14,7 +14,7 @@ import { getIonMode } from '../../global/ionic-global';
 export class Avatar implements ComponentInterface {
   render() {
     return (
-      <Host class={getIonMode(this)}>
+      <Host class={getIonStylesheet(this)}>
         <slot></slot>
       </Host>
     );

--- a/core/src/components/back-button/back-button.tsx
+++ b/core/src/components/back-button/back-button.tsx
@@ -3,7 +3,7 @@ import { Component, Element, Host, Prop, h } from '@stencil/core';
 import { arrowBackSharp, chevronBack } from 'ionicons/icons';
 
 import { config } from '../../global/config';
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type { AnimationBuilder, Color } from '../../interface';
 import type { ButtonInterface } from '../../utils/element-interface';
 import type { Attributes } from '../../utils/helpers';
@@ -135,7 +135,7 @@ export class BackButton implements ComponentInterface, ButtonInterface {
       inheritedAttributes,
     } = this;
     const showBackButton = defaultHref !== undefined;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const ariaLabel = inheritedAttributes['aria-label'] || backButtonText || 'back';
 
     return (

--- a/core/src/components/back-button/back-button.tsx
+++ b/core/src/components/back-button/back-button.tsx
@@ -3,7 +3,7 @@ import { Component, Element, Host, Prop, h } from '@stencil/core';
 import { arrowBackSharp, chevronBack } from 'ionicons/icons';
 
 import { config } from '../../global/config';
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type { AnimationBuilder, Color } from '../../interface';
 import type { ButtonInterface } from '../../utils/element-interface';
 import type { Attributes } from '../../utils/helpers';
@@ -84,7 +84,7 @@ export class BackButton implements ComponentInterface, ButtonInterface {
       return icon;
     }
 
-    if (getIonPlatform(this) === 'ios') {
+    if (getIonBehavior(this) === 'ios') {
       // default ios back button icon
       return config.get('backButtonIcon', chevronBack);
     }
@@ -94,7 +94,7 @@ export class BackButton implements ComponentInterface, ButtonInterface {
   }
 
   get backButtonText() {
-    const defaultBackButtonText = getIonPlatform(this) === 'ios' ? 'Back' : null;
+    const defaultBackButtonText = getIonBehavior(this) === 'ios' ? 'Back' : null;
     return this.text != null ? this.text : config.get('backButtonText', defaultBackButtonText);
   }
 

--- a/core/src/components/back-button/back-button.tsx
+++ b/core/src/components/back-button/back-button.tsx
@@ -3,7 +3,7 @@ import { Component, Element, Host, Prop, h } from '@stencil/core';
 import { arrowBackSharp, chevronBack } from 'ionicons/icons';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type { AnimationBuilder, Color } from '../../interface';
 import type { ButtonInterface } from '../../utils/element-interface';
 import type { Attributes } from '../../utils/helpers';
@@ -84,7 +84,7 @@ export class BackButton implements ComponentInterface, ButtonInterface {
       return icon;
     }
 
-    if (getIonMode(this) === 'ios') {
+    if (getIonPlatform(this) === 'ios') {
       // default ios back button icon
       return config.get('backButtonIcon', chevronBack);
     }
@@ -94,7 +94,7 @@ export class BackButton implements ComponentInterface, ButtonInterface {
   }
 
   get backButtonText() {
-    const defaultBackButtonText = getIonMode(this) === 'ios' ? 'Back' : null;
+    const defaultBackButtonText = getIonPlatform(this) === 'ios' ? 'Back' : null;
     return this.text != null ? this.text : config.get('backButtonText', defaultBackButtonText);
   }
 

--- a/core/src/components/backdrop/backdrop.tsx
+++ b/core/src/components/backdrop/backdrop.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Event, Host, Listen, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import { GESTURE_CONTROLLER } from '../../utils/gesture';
 
 @Component({
@@ -63,7 +63,7 @@ export class Backdrop implements ComponentInterface {
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         tabindex="-1"

--- a/core/src/components/badge/badge.tsx
+++ b/core/src/components/badge/badge.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color } from '../../interface';
 import { createColorClasses } from '../../utils/theme';
 
@@ -25,7 +25,7 @@ export class Badge implements ComponentInterface {
   @Prop({ reflect: true }) color?: Color;
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={createColorClasses(this.color, {

--- a/core/src/components/breadcrumb/breadcrumb.tsx
+++ b/core/src/components/breadcrumb/breadcrumb.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Prop, h } from '@stencil/core';
 import { chevronForwardOutline, ellipsisHorizontal } from 'ionicons/icons';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { AnimationBuilder, BreadcrumbCollapsedClickEventDetail, Color, RouterDirection } from '../../interface';
 import type { Attributes } from '../../utils/helpers';
 import { inheritAriaAttributes } from '../../utils/helpers';
@@ -165,7 +165,7 @@ export class Breadcrumb implements ComponentInterface {
     // Links can still be tabbed to when set to disabled if they have an href
     // in order to truly disable them we can keep it as an anchor but remove the href
     const href = disabled ? undefined : this.href;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const attrs =
       TagType === 'span'
         ? {}

--- a/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Listen, Prop, State, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { BreadcrumbCollapsedClickEventDetail, Color } from '../../interface';
 import { createColorClasses, hostContext } from '../../utils/theme';
 
@@ -169,7 +169,7 @@ export class Breadcrumbs implements ComponentInterface {
 
   render() {
     const { color, collapsed } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
 
     return (
       <Host

--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { AnimationBuilder, Color, RouterDirection } from '../../interface';
 import type { AnchorInterface, ButtonInterface } from '../../utils/element-interface';
 import type { Attributes } from '../../utils/helpers';
@@ -244,7 +244,7 @@ export class Button implements ComponentInterface, AnchorInterface, ButtonInterf
   };
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const {
       buttonType,
       type,

--- a/core/src/components/buttons/buttons.tsx
+++ b/core/src/components/buttons/buttons.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 
 @Component({
   tag: 'ion-buttons',
@@ -27,7 +27,7 @@ export class Buttons implements ComponentInterface {
   @Prop() collapse = false;
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={{

--- a/core/src/components/card-content/card-content.tsx
+++ b/core/src/components/card-content/card-content.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 
 /**
  * @virtualProp {"ios" | "md"} mode - The mode determines which platform styles to use.
@@ -15,7 +15,7 @@ import { getIonMode } from '../../global/ionic-global';
 })
 export class CardContent implements ComponentInterface {
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={{

--- a/core/src/components/card-header/card-header.tsx
+++ b/core/src/components/card-header/card-header.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color } from '../../interface';
 import { createColorClasses } from '../../utils/theme';
 
@@ -32,7 +32,7 @@ export class CardHeader implements ComponentInterface {
   @Prop() translucent = false;
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={createColorClasses(this.color, {

--- a/core/src/components/card-subtitle/card-subtitle.tsx
+++ b/core/src/components/card-subtitle/card-subtitle.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color } from '../../interface';
 import { createColorClasses } from '../../utils/theme';
 
@@ -25,7 +25,7 @@ export class CardSubtitle implements ComponentInterface {
   @Prop({ reflect: true }) color?: Color;
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         role="heading"

--- a/core/src/components/card-title/card-title.tsx
+++ b/core/src/components/card-title/card-title.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color } from '../../interface';
 import { createColorClasses } from '../../utils/theme';
 
@@ -25,7 +25,7 @@ export class CardTitle implements ComponentInterface {
   @Prop({ reflect: true }) color?: Color;
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         role="heading"

--- a/core/src/components/card/card.tsx
+++ b/core/src/components/card/card.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Element, Component, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { AnimationBuilder, Color, Mode, RouterDirection } from '../../interface';
 import type { AnchorInterface, ButtonInterface } from '../../utils/element-interface';
 import type { Attributes } from '../../utils/helpers';
@@ -128,7 +128,7 @@ export class Card implements ComponentInterface, AnchorInterface, ButtonInterfac
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={createColorClasses(this.color, {

--- a/core/src/components/checkbox/checkbox.tsx
+++ b/core/src/components/checkbox/checkbox.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Prop, Watch, h } from '@stencil/core';
 
 // TODO(FW-2845) - Use @utils/forms and @utils/logging when https://github.com/ionic-team/stencil/issues/3826 is resolved
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { CheckboxChangeEventDetail, Color, Mode, StyleEventDetail } from '../../interface';
 import type { LegacyFormController } from '../../utils/forms';
 import { createLegacyFormController } from '../../utils/forms';
@@ -225,7 +225,7 @@ export class Checkbox implements ComponentInterface {
       name,
       value,
     } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const path = getSVGPath(mode, indeterminate);
 
     renderHiddenInput(true, el, name, checked ? value : '', disabled);
@@ -296,7 +296,7 @@ Developers can dismiss this warning by removing their usage of the "legacy" prop
     }
 
     const { color, checked, disabled, el, getSVGPath, indeterminate, inputId, name, value } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const { label, labelId, labelText } = getAriaLabel(el, inputId);
     const path = getSVGPath(mode, indeterminate);
 

--- a/core/src/components/chip/chip.tsx
+++ b/core/src/components/chip/chip.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color } from '../../interface';
 import { createColorClasses } from '../../utils/theme';
 
@@ -32,7 +32,7 @@ export class Chip implements ComponentInterface {
   @Prop() disabled = false;
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
 
     return (
       <Host

--- a/core/src/components/col/col.tsx
+++ b/core/src/components/col/col.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Listen, Prop, forceUpdate, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import { matchBreakpoint } from '../../utils/media';
 
 const win = typeof (window as any) !== 'undefined' ? (window as any) : undefined;
@@ -249,7 +249,7 @@ export class Col implements ComponentInterface {
 
   render() {
     const isRTL = document.dir === 'rtl';
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={{

--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -125,8 +125,8 @@ export class Content implements ComponentInterface {
 
   private shouldForceOverscroll() {
     const { forceOverscroll } = this;
-    const mode = getIonPlatform(this);
-    return forceOverscroll === undefined ? mode === 'ios' && isPlatform('ios') : forceOverscroll;
+    const platform = getIonPlatform(this);
+    return forceOverscroll === undefined ? platform === 'ios' && isPlatform('ios') : forceOverscroll;
   }
 
   private resize() {

--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Listen, Method, Prop, forceUpdate, h, readTask } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type { Color, ScrollBaseDetail, ScrollDetail } from '../../interface';
 import { componentOnReady } from '../../utils/helpers';
 import { isPlatform } from '../../utils/platform';
@@ -125,7 +125,7 @@ export class Content implements ComponentInterface {
 
   private shouldForceOverscroll() {
     const { forceOverscroll } = this;
-    const mode = getIonMode(this);
+    const mode = getIonPlatform(this);
     return forceOverscroll === undefined ? mode === 'ios' && isPlatform('ios') : forceOverscroll;
   }
 

--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Listen, Method, Prop, forceUpdate, h, readTask } from '@stencil/core';
 
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type { Color, ScrollBaseDetail, ScrollDetail } from '../../interface';
 import { componentOnReady } from '../../utils/helpers';
 import { isPlatform } from '../../utils/platform';
@@ -324,7 +324,7 @@ export class Content implements ComponentInterface {
   render() {
     const { isMainContent, scrollX, scrollY, el } = this;
     const rtl = isRTL(el) ? 'rtl' : 'ltr';
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const forceOverscroll = this.shouldForceOverscroll();
     const transitionShadow = mode === 'ios';
     const TagType = isMainContent ? 'main' : ('div' as any);

--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Listen, Method, Prop, forceUpdate, h, readTask } from '@stencil/core';
 
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type { Color, ScrollBaseDetail, ScrollDetail } from '../../interface';
 import { componentOnReady } from '../../utils/helpers';
 import { isPlatform } from '../../utils/platform';
@@ -125,7 +125,7 @@ export class Content implements ComponentInterface {
 
   private shouldForceOverscroll() {
     const { forceOverscroll } = this;
-    const platform = getIonPlatform(this);
+    const platform = getIonBehavior(this);
     return forceOverscroll === undefined ? platform === 'ios' && isPlatform('ios') : forceOverscroll;
   }
 

--- a/core/src/components/datetime-button/datetime-button.tsx
+++ b/core/src/components/datetime-button/datetime-button.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, State, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color, DatetimePresentation } from '../../interface';
 import { componentOnReady, addEventListener } from '../../utils/helpers';
 import { printIonError } from '../../utils/logging';
@@ -396,7 +396,7 @@ export class DatetimeButton implements ComponentInterface {
   render() {
     const { color, dateText, timeText, selectedButton, datetimeActive, disabled } = this;
 
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
 
     return (
       <Host

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h, writeTask } from '@stencil/core';
 import { caretDownSharp, caretUpSharp, chevronBack, chevronDown, chevronForward } from 'ionicons/icons';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type {
   Color,
   DatetimePresentation,
@@ -843,7 +843,7 @@ export class Datetime implements ComponentInterface {
     const startMonth = months[0] as HTMLElement;
     const workingMonth = months[1] as HTMLElement;
     const endMonth = months[2] as HTMLElement;
-    const mode = getIonMode(this);
+    const mode = getIonPlatform(this);
     const needsiOSRubberBandFix = mode === 'ios' && typeof navigator !== 'undefined' && navigator.maxTouchPoints > 1;
 
     /**

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h, writeTask } from '@stencil/core';
 import { caretDownSharp, caretUpSharp, chevronBack, chevronDown, chevronForward } from 'ionicons/icons';
 
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type {
   Color,
   DatetimePresentation,
@@ -843,7 +843,7 @@ export class Datetime implements ComponentInterface {
     const startMonth = months[0] as HTMLElement;
     const workingMonth = months[1] as HTMLElement;
     const endMonth = months[2] as HTMLElement;
-    const platform = getIonPlatform(this);
+    const platform = getIonBehavior(this);
     const needsiOSRubberBandFix =
       platform === 'ios' && typeof navigator !== 'undefined' && navigator.maxTouchPoints > 1;
 

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -844,7 +844,8 @@ export class Datetime implements ComponentInterface {
     const workingMonth = months[1] as HTMLElement;
     const endMonth = months[2] as HTMLElement;
     const platform = getIonPlatform(this);
-    const needsiOSRubberBandFix = platform === 'ios' && typeof navigator !== 'undefined' && navigator.maxTouchPoints > 1;
+    const needsiOSRubberBandFix =
+      platform === 'ios' && typeof navigator !== 'undefined' && navigator.maxTouchPoints > 1;
 
     /**
      * Before setting up the scroll listener,

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h, writeTask } from '@stencil/core';
 import { caretDownSharp, caretUpSharp, chevronBack, chevronDown, chevronForward } from 'ionicons/icons';
 
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type {
   Color,
   DatetimePresentation,
@@ -2286,7 +2286,7 @@ export class Datetime implements ComponentInterface {
       presentation,
       size,
     } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const isMonthAndYearPresentation =
       presentation === 'year' || presentation === 'month' || presentation === 'month-year';
     const shouldShowMonthAndYear = showMonthAndYear || isMonthAndYearPresentation;

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -843,8 +843,8 @@ export class Datetime implements ComponentInterface {
     const startMonth = months[0] as HTMLElement;
     const workingMonth = months[1] as HTMLElement;
     const endMonth = months[2] as HTMLElement;
-    const mode = getIonPlatform(this);
-    const needsiOSRubberBandFix = mode === 'ios' && typeof navigator !== 'undefined' && navigator.maxTouchPoints > 1;
+    const platform = getIonPlatform(this);
+    const needsiOSRubberBandFix = platform === 'ios' && typeof navigator !== 'undefined' && navigator.maxTouchPoints > 1;
 
     /**
      * Before setting up the scroll listener,

--- a/core/src/components/fab-button/fab-button.tsx
+++ b/core/src/components/fab-button/fab-button.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Prop, h } from '@stencil/core';
 import { close } from 'ionicons/icons';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { AnimationBuilder, Color, RouterDirection } from '../../interface';
 import type { AnchorInterface, ButtonInterface } from '../../utils/element-interface';
 import { inheritAriaAttributes } from '../../utils/helpers';
@@ -152,7 +152,7 @@ export class FabButton implements ComponentInterface, AnchorInterface, ButtonInt
   render() {
     const { el, disabled, color, href, activated, show, translucent, size, inheritedAttributes } = this;
     const inList = hostContext('ion-fab-list', el);
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const TagType = href === undefined ? 'button' : ('a' as any);
     const attrs =
       TagType === 'button'

--- a/core/src/components/fab-list/fab-list.tsx
+++ b/core/src/components/fab-list/fab-list.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 
 @Component({
   tag: 'ion-fab-list',
@@ -33,7 +33,7 @@ export class FabList implements ComponentInterface {
   @Prop() side: 'start' | 'end' | 'top' | 'bottom' = 'bottom';
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={{

--- a/core/src/components/fab/fab.tsx
+++ b/core/src/components/fab/fab.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Method, Prop, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 
 @Component({
   tag: 'ion-fab',
@@ -76,7 +76,7 @@ export class Fab implements ComponentInterface {
 
   render() {
     const { horizontal, vertical, edge } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={{

--- a/core/src/components/footer/footer.tsx
+++ b/core/src/components/footer/footer.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, State, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import { findIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 import type { KeyboardController } from '../../utils/keyboard/keyboard-controller';
 import { createKeyboardController } from '../../utils/keyboard/keyboard-controller';
@@ -64,7 +64,7 @@ export class Footer implements ComponentInterface {
   }
 
   private checkCollapsibleFooter = () => {
-    const mode = getIonMode(this);
+    const mode = getIonPlatform(this);
     if (mode !== 'ios') {
       return;
     }
@@ -130,7 +130,7 @@ export class Footer implements ComponentInterface {
           [`footer-collapse-${collapse}`]: collapse !== undefined,
         }}
       >
-        {mode === 'ios' && translucent && <div class="footer-background"></div>}
+        {getIonPlatform(this) === 'ios' && translucent && <div class="footer-background"></div>}
         <slot></slot>
       </Host>
     );

--- a/core/src/components/footer/footer.tsx
+++ b/core/src/components/footer/footer.tsx
@@ -64,8 +64,8 @@ export class Footer implements ComponentInterface {
   }
 
   private checkCollapsibleFooter = () => {
-    const mode = getIonPlatform(this);
-    if (mode !== 'ios') {
+    const platform = getIonPlatform(this);
+    if (platform !== 'ios') {
       return;
     }
 

--- a/core/src/components/footer/footer.tsx
+++ b/core/src/components/footer/footer.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, State, h } from '@stencil/core';
 
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import { findIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 import type { KeyboardController } from '../../utils/keyboard/keyboard-controller';
 import { createKeyboardController } from '../../utils/keyboard/keyboard-controller';
@@ -64,7 +64,7 @@ export class Footer implements ComponentInterface {
   }
 
   private checkCollapsibleFooter = () => {
-    const platform = getIonPlatform(this);
+    const platform = getIonBehavior(this);
     if (platform !== 'ios') {
       return;
     }
@@ -130,7 +130,7 @@ export class Footer implements ComponentInterface {
           [`footer-collapse-${collapse}`]: collapse !== undefined,
         }}
       >
-        {getIonPlatform(this) === 'ios' && translucent && <div class="footer-background"></div>}
+        {getIonBehavior(this) === 'ios' && translucent && <div class="footer-background"></div>}
         <slot></slot>
       </Host>
     );

--- a/core/src/components/footer/footer.tsx
+++ b/core/src/components/footer/footer.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, State, h } from '@stencil/core';
 
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import { findIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 import type { KeyboardController } from '../../utils/keyboard/keyboard-controller';
 import { createKeyboardController } from '../../utils/keyboard/keyboard-controller';
@@ -110,7 +110,7 @@ export class Footer implements ComponentInterface {
 
   render() {
     const { translucent, collapse } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const tabs = this.el.closest('ion-tabs');
     const tabBar = tabs?.querySelector(':scope > ion-tab-bar');
 

--- a/core/src/components/grid/grid.tsx
+++ b/core/src/components/grid/grid.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 
 @Component({
   tag: 'ion-grid',
@@ -15,7 +15,7 @@ export class Grid implements ComponentInterface {
   @Prop() fixed = false;
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={{

--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, h, writeTask } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import { findIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 import type { Attributes } from '../../utils/helpers';
 import { inheritAriaAttributes } from '../../utils/helpers';
@@ -71,7 +71,7 @@ export class Header implements ComponentInterface {
   }
 
   private async checkCollapsibleHeader() {
-    const mode = getIonMode(this);
+    const mode = getIonPlatform(this);
 
     if (mode !== 'ios') {
       return;

--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, h, writeTask } from '@stencil/core';
 
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import { findIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 import type { Attributes } from '../../utils/helpers';
 import { inheritAriaAttributes } from '../../utils/helpers';
@@ -71,7 +71,7 @@ export class Header implements ComponentInterface {
   }
 
   private async checkCollapsibleHeader() {
-    const platform = getIonPlatform(this);
+    const platform = getIonBehavior(this);
 
     if (platform !== 'ios') {
       return;

--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -71,9 +71,9 @@ export class Header implements ComponentInterface {
   }
 
   private async checkCollapsibleHeader() {
-    const mode = getIonPlatform(this);
+    const platform = getIonPlatform(this);
 
-    if (mode !== 'ios') {
+    if (platform !== 'ios') {
       return;
     }
 

--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, h, writeTask } from '@stencil/core';
 
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import { findIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 import type { Attributes } from '../../utils/helpers';
 import { inheritAriaAttributes } from '../../utils/helpers';
@@ -206,7 +206,7 @@ export class Header implements ComponentInterface {
 
   render() {
     const { translucent, inheritedAttributes } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const collapse = this.collapse || 'none';
 
     // banner role must be at top level, so remove role if inside a menu

--- a/core/src/components/img/img.tsx
+++ b/core/src/components/img/img.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Prop, State, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Attributes } from '../../utils/helpers';
 import { inheritAttributes } from '../../utils/helpers';
 
@@ -111,7 +111,7 @@ export class Img implements ComponentInterface {
     const { loadSrc, alt, onLoad, loadError, inheritedAttributes } = this;
     const { draggable } = inheritedAttributes;
     return (
-      <Host class={getIonMode(this)}>
+      <Host class={getIonStylesheet(this)}>
         <img
           decoding="async"
           src={loadSrc}

--- a/core/src/components/infinite-scroll-content/infinite-scroll-content.tsx
+++ b/core/src/components/infinite-scroll-content/infinite-scroll-content.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type { SpinnerTypes } from '../../interface';
 import type { IonicSafeString } from '../../utils/sanitization';
 import { sanitizeDOMString } from '../../utils/sanitization';
@@ -42,7 +42,7 @@ export class InfiniteScrollContent implements ComponentInterface {
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={{

--- a/core/src/components/infinite-scroll-content/infinite-scroll-content.tsx
+++ b/core/src/components/infinite-scroll-content/infinite-scroll-content.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type { SpinnerTypes } from '../../interface';
 import type { IonicSafeString } from '../../utils/sanitization';
 import { sanitizeDOMString } from '../../utils/sanitization';
@@ -33,7 +33,7 @@ export class InfiniteScrollContent implements ComponentInterface {
 
   componentDidLoad() {
     if (this.loadingSpinner === undefined) {
-      const mode = getIonMode(this);
+      const mode = getIonPlatform(this);
       this.loadingSpinner = config.get(
         'infiniteLoadingSpinner',
         config.get('spinner', mode === 'ios' ? 'lines' : 'crescent')

--- a/core/src/components/infinite-scroll-content/infinite-scroll-content.tsx
+++ b/core/src/components/infinite-scroll-content/infinite-scroll-content.tsx
@@ -33,10 +33,10 @@ export class InfiniteScrollContent implements ComponentInterface {
 
   componentDidLoad() {
     if (this.loadingSpinner === undefined) {
-      const mode = getIonPlatform(this);
+      const platform = getIonPlatform(this);
       this.loadingSpinner = config.get(
         'infiniteLoadingSpinner',
-        config.get('spinner', mode === 'ios' ? 'lines' : 'crescent')
+        config.get('spinner', platform === 'ios' ? 'lines' : 'crescent')
       );
     }
   }

--- a/core/src/components/infinite-scroll-content/infinite-scroll-content.tsx
+++ b/core/src/components/infinite-scroll-content/infinite-scroll-content.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type { SpinnerTypes } from '../../interface';
 import type { IonicSafeString } from '../../utils/sanitization';
 import { sanitizeDOMString } from '../../utils/sanitization';
@@ -33,7 +33,7 @@ export class InfiniteScrollContent implements ComponentInterface {
 
   componentDidLoad() {
     if (this.loadingSpinner === undefined) {
-      const platform = getIonPlatform(this);
+      const platform = getIonBehavior(this);
       this.loadingSpinner = config.get(
         'infiniteLoadingSpinner',
         config.get('spinner', platform === 'ios' ? 'lines' : 'crescent')

--- a/core/src/components/infinite-scroll/infinite-scroll.tsx
+++ b/core/src/components/infinite-scroll/infinite-scroll.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h, readTask, writeTask } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import { findClosestIonContent, getScrollElement, printIonContentErrorMsg } from '../../utils/content';
 
 @Component({
@@ -212,7 +212,7 @@ export class InfiniteScroll implements ComponentInterface {
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const disabled = this.disabled;
     return (
       <Host

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -602,8 +602,8 @@ export class Input implements ComponentInterface {
    * when fill="outline".
    */
   private renderLabelContainer() {
-    const mode = getIonPlatform(this);
-    const hasOutlineFill = mode === 'md' && this.fill === 'outline';
+    const platform = getIonPlatform(this);
+    const hasOutlineFill = platform === 'md' && this.fill === 'outline';
 
     if (hasOutlineFill) {
       /**

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -5,7 +5,7 @@ import type { LegacyFormController } from '@utils/forms';
 import { printIonWarning } from '@utils/logging';
 import { closeCircle, closeSharp } from 'ionicons/icons';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type {
   AutocompleteTypes,
   Color,
@@ -602,7 +602,7 @@ export class Input implements ComponentInterface {
    * when fill="outline".
    */
   private renderLabelContainer() {
-    const mode = getIonMode(this);
+    const mode = getIonPlatform(this);
     const hasOutlineFill = mode === 'md' && this.fill === 'outline';
 
     if (hasOutlineFill) {

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -5,7 +5,7 @@ import type { LegacyFormController } from '@utils/forms';
 import { printIonWarning } from '@utils/logging';
 import { closeCircle, closeSharp } from 'ionicons/icons';
 
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type {
   AutocompleteTypes,
   Color,
@@ -636,7 +636,7 @@ export class Input implements ComponentInterface {
 
   private renderInput() {
     const { disabled, fill, readonly, shape, inputId, labelPlacement } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const value = this.getValue();
     const shouldRenderHighlight = mode === 'md' && fill !== 'outline';
 
@@ -740,7 +740,7 @@ Developers can dismiss this warning by removing their usage of the "legacy" prop
       this.hasLoggedDeprecationWarning = true;
     }
 
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const value = this.getValue();
     const labelId = this.inputId + '-lbl';
     const label = findItemLabel(this.el);

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -5,7 +5,7 @@ import type { LegacyFormController } from '@utils/forms';
 import { printIonWarning } from '@utils/logging';
 import { closeCircle, closeSharp } from 'ionicons/icons';
 
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type {
   AutocompleteTypes,
   Color,
@@ -602,7 +602,7 @@ export class Input implements ComponentInterface {
    * when fill="outline".
    */
   private renderLabelContainer() {
-    const platform = getIonPlatform(this);
+    const platform = getIonBehavior(this);
     const hasOutlineFill = platform === 'md' && this.fill === 'outline';
 
     if (hasOutlineFill) {

--- a/core/src/components/item-divider/item-divider.tsx
+++ b/core/src/components/item-divider/item-divider.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color } from '../../interface';
 import { createColorClasses } from '../../utils/theme';
 
@@ -40,7 +40,7 @@ export class ItemDivider implements ComponentInterface {
   @Prop() sticky = false;
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={createColorClasses(this.color, {

--- a/core/src/components/item-group/item-group.tsx
+++ b/core/src/components/item-group/item-group.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 
 @Component({
   tag: 'ion-item-group',
@@ -12,7 +12,7 @@ import { getIonMode } from '../../global/ionic-global';
 })
 export class ItemGroup implements ComponentInterface {
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         role="group"

--- a/core/src/components/item-option/item-option.tsx
+++ b/core/src/components/item-option/item-option.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color } from '../../interface';
 import type { AnchorInterface, ButtonInterface } from '../../utils/element-interface';
 import { createColorClasses } from '../../utils/theme';
@@ -88,7 +88,7 @@ export class ItemOption implements ComponentInterface, AnchorInterface, ButtonIn
   render() {
     const { disabled, expandable, href } = this;
     const TagType = href === undefined ? 'button' : ('a' as any);
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const attrs =
       TagType === 'button'
         ? { type: this.type }

--- a/core/src/components/item-options/item-options.tsx
+++ b/core/src/components/item-options/item-options.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Side } from '../../interface';
 import { isEndSide } from '../../utils/helpers';
 
@@ -35,7 +35,7 @@ export class ItemOptions implements ComponentInterface {
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const isEnd = isEndSide(this.side);
     return (
       <Host

--- a/core/src/components/item-sliding/item-sliding.tsx
+++ b/core/src/components/item-sliding/item-sliding.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Gesture, GestureDetail, Side } from '../../interface';
 import { findClosestIonContent, disableContentScrollY, resetContentScrollY } from '../../utils/content';
 import { isEndSide } from '../../utils/helpers';
@@ -442,7 +442,7 @@ export class ItemSliding implements ComponentInterface {
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={{

--- a/core/src/components/item/item.tsx
+++ b/core/src/components/item/item.tsx
@@ -3,7 +3,7 @@ import { Component, Element, Host, Listen, Prop, State, Watch, forceUpdate, h } 
 import { printIonError, printIonWarning } from '@utils/logging';
 import { chevronForward } from 'ionicons/icons';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { AnimationBuilder, Color, CssClassMap, RouterDirection, StyleEventDetail } from '../../interface';
 import type { AnchorInterface, ButtonInterface } from '../../utils/element-interface';
 import type { Attributes } from '../../utils/helpers';
@@ -365,7 +365,7 @@ export class Item implements ComponentInterface, AnchorInterface, ButtonInterfac
       inheritedAriaAttributes,
     } = this;
     const childStyles = {} as any;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const clickable = this.isClickable();
     const canActivate = this.canActivate();
     const TagType = clickable ? (href === undefined ? 'button' : 'a') : ('div' as any);

--- a/core/src/components/label/label.tsx
+++ b/core/src/components/label/label.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Prop, State, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color, StyleEventDetail } from '../../interface';
 import { createColorClasses, hostContext } from '../../utils/theme';
 
@@ -97,7 +97,7 @@ export class Label implements ComponentInterface {
 
   render() {
     const position = this.position;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={createColorClasses(this.color, {

--- a/core/src/components/list-header/list-header.tsx
+++ b/core/src/components/list-header/list-header.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color } from '../../interface';
 import { createColorClasses } from '../../utils/theme';
 
@@ -31,7 +31,7 @@ export class ListHeader implements ComponentInterface {
 
   render() {
     const { lines } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
 
     return (
       <Host

--- a/core/src/components/list/list.tsx
+++ b/core/src/components/list/list.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Method, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 
 /**
  * @virtualProp {"ios" | "md"} mode - The mode determines which platform styles to use.
@@ -42,7 +42,7 @@ export class List implements ComponentInterface {
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const { lines, inset } = this;
     return (
       <Host

--- a/core/src/components/loading/loading.tsx
+++ b/core/src/components/loading/loading.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Watch, Component, Element, Event, Host, Method, Prop, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type {
   AnimationBuilder,
   FrameworkDelegate,
@@ -204,7 +204,7 @@ export class Loading implements ComponentInterface, OverlayInterface {
 
   componentWillLoad() {
     if (this.spinner === undefined) {
-      const mode = getIonMode(this);
+      const mode = getIonPlatform(this);
       this.spinner = config.get('loadingSpinner', config.get('spinner', mode === 'ios' ? 'lines' : 'crescent'));
     }
   }

--- a/core/src/components/loading/loading.tsx
+++ b/core/src/components/loading/loading.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Watch, Component, Element, Event, Host, Method, Prop, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type {
   AnimationBuilder,
   FrameworkDelegate,
@@ -204,7 +204,7 @@ export class Loading implements ComponentInterface, OverlayInterface {
 
   componentWillLoad() {
     if (this.spinner === undefined) {
-      const platform = getIonPlatform(this);
+      const platform = getIonBehavior(this);
       this.spinner = config.get('loadingSpinner', config.get('spinner', platform === 'ios' ? 'lines' : 'crescent'));
     }
   }

--- a/core/src/components/loading/loading.tsx
+++ b/core/src/components/loading/loading.tsx
@@ -204,8 +204,8 @@ export class Loading implements ComponentInterface, OverlayInterface {
 
   componentWillLoad() {
     if (this.spinner === undefined) {
-      const mode = getIonPlatform(this);
-      this.spinner = config.get('loadingSpinner', config.get('spinner', mode === 'ios' ? 'lines' : 'crescent'));
+      const platform = getIonPlatform(this);
+      this.spinner = config.get('loadingSpinner', config.get('spinner', platform === 'ios' ? 'lines' : 'crescent'));
     }
   }
 

--- a/core/src/components/loading/loading.tsx
+++ b/core/src/components/loading/loading.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Watch, Component, Element, Event, Host, Method, Prop, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type {
   AnimationBuilder,
   FrameworkDelegate,
@@ -300,7 +300,7 @@ export class Loading implements ComponentInterface, OverlayInterface {
 
   render() {
     const { message, spinner, htmlAttributes } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         tabindex="-1"

--- a/core/src/components/menu-button/menu-button.tsx
+++ b/core/src/components/menu-button/menu-button.tsx
@@ -3,7 +3,7 @@ import { Component, Element, Host, Listen, Prop, State, h } from '@stencil/core'
 import { menuOutline, menuSharp } from 'ionicons/icons';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color } from '../../interface';
 import type { ButtonInterface } from '../../utils/element-interface';
 import type { Attributes } from '../../utils/helpers';
@@ -80,7 +80,7 @@ export class MenuButton implements ComponentInterface, ButtonInterface {
 
   render() {
     const { color, disabled, inheritedAttributes } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const menuIcon = config.get('menuIcon', mode === 'ios' ? menuOutline : menuSharp);
     const hidden = this.autoHide && !this.visible;
 

--- a/core/src/components/menu-toggle/menu-toggle.tsx
+++ b/core/src/components/menu-toggle/menu-toggle.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Listen, Prop, State, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import { menuController } from '../../utils/menu-controller';
 
 import { updateVisibility } from './menu-toggle-util';
@@ -50,7 +50,7 @@ export class MenuToggle implements ComponentInterface {
   };
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const hidden = this.autoHide && !this.visible;
 
     return (

--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Build, Component, Element, Event, Host, Listen, Method, Prop, State, Watch, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type { Animation, Gesture, GestureDetail, MenuChangeEventDetail, MenuI, Side } from '../../interface';
 import { getTimeGivenProgression } from '../../utils/animation/cubic-bezier';
 import { GESTURE_CONTROLLER } from '../../utils/gesture';
@@ -697,7 +697,7 @@ export class Menu implements ComponentInterface, MenuI {
 
   render() {
     const { isEndSide, type, disabled, isPaneVisible, inheritedAttributes } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
 
     return (
       <Host

--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Build, Component, Element, Event, Host, Listen, Method, Prop, State, Watch, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type { Animation, Gesture, GestureDetail, MenuChangeEventDetail, MenuI, Side } from '../../interface';
 import { getTimeGivenProgression } from '../../utils/animation/cubic-bezier';
 import { GESTURE_CONTROLLER } from '../../utils/gesture';
@@ -430,7 +430,7 @@ export class Menu implements ComponentInterface, MenuI {
 
   private async startAnimation(shouldOpen: boolean, animated: boolean): Promise<void> {
     const isReversed = !shouldOpen;
-    const mode = getIonMode(this);
+    const mode = getIonPlatform(this);
     const easing = mode === 'ios' ? iosEasing : mdEasing;
     const easingReverse = mode === 'ios' ? iosEasingReverse : mdEasingReverse;
     const ani = (this.animation as Animation)!

--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -430,9 +430,9 @@ export class Menu implements ComponentInterface, MenuI {
 
   private async startAnimation(shouldOpen: boolean, animated: boolean): Promise<void> {
     const isReversed = !shouldOpen;
-    const mode = getIonPlatform(this);
-    const easing = mode === 'ios' ? iosEasing : mdEasing;
-    const easingReverse = mode === 'ios' ? iosEasingReverse : mdEasingReverse;
+    const platform = getIonPlatform(this);
+    const easing = platform === 'ios' ? iosEasing : mdEasing;
+    const easingReverse = platform === 'ios' ? iosEasingReverse : mdEasingReverse;
     const ani = (this.animation as Animation)!
       .direction(isReversed ? 'reverse' : 'normal')
       .easing(isReversed ? easingReverse : easing)

--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Build, Component, Element, Event, Host, Listen, Method, Prop, State, Watch, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type { Animation, Gesture, GestureDetail, MenuChangeEventDetail, MenuI, Side } from '../../interface';
 import { getTimeGivenProgression } from '../../utils/animation/cubic-bezier';
 import { GESTURE_CONTROLLER } from '../../utils/gesture';
@@ -430,7 +430,7 @@ export class Menu implements ComponentInterface, MenuI {
 
   private async startAnimation(shouldOpen: boolean, animated: boolean): Promise<void> {
     const isReversed = !shouldOpen;
-    const platform = getIonPlatform(this);
+    const platform = getIonBehavior(this);
     const easing = platform === 'ios' ? iosEasing : mdEasing;
     const easingReverse = platform === 'ios' ? iosEasingReverse : mdEasingReverse;
     const ani = (this.animation as Animation)!

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h, writeTask } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type {
   Animation,
   AnimationBuilder,
@@ -490,7 +490,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
      * start of the animation so that it completes
      * by the time the card animation is done.
      */
-    if (hasCardModal && getIonMode(this) === 'ios') {
+    if (hasCardModal && getIonPlatform(this) === 'ios') {
       // Cache the original status bar color before the modal is presented
       this.statusBarStyle = await StatusBar.getStyle();
       setCardStatusBarDark();
@@ -532,7 +532,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
   }
 
   private initSwipeToClose() {
-    if (getIonMode(this) !== 'ios') {
+    if (getIonPlatform(this) !== 'ios') {
       return;
     }
 
@@ -661,7 +661,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
      * finishes when the dismiss animation does.
      */
     const hasCardModal = presentingElement !== undefined;
-    if (hasCardModal && getIonMode(this) === 'ios') {
+    if (hasCardModal && getIonPlatform(this) === 'ios') {
       setCardStatusBarDefault(this.statusBarStyle);
     }
 

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h, writeTask } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type {
   Animation,
   AnimationBuilder,
@@ -848,7 +848,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
     const { handle, isSheetModal, presentingElement, htmlAttributes, handleBehavior, inheritedAttributes } = this;
 
     const showHandle = handle !== false && isSheetModal;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const { modalId } = this;
     const isCardModal = presentingElement !== undefined && mode === 'ios';
     const isHandleCycle = handleBehavior === 'cycle';

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h, writeTask } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type {
   Animation,
   AnimationBuilder,
@@ -490,7 +490,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
      * start of the animation so that it completes
      * by the time the card animation is done.
      */
-    if (hasCardModal && getIonPlatform(this) === 'ios') {
+    if (hasCardModal && getIonBehavior(this) === 'ios') {
       // Cache the original status bar color before the modal is presented
       this.statusBarStyle = await StatusBar.getStyle();
       setCardStatusBarDark();
@@ -532,7 +532,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
   }
 
   private initSwipeToClose() {
-    if (getIonPlatform(this) !== 'ios') {
+    if (getIonBehavior(this) !== 'ios') {
       return;
     }
 
@@ -661,7 +661,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
      * finishes when the dismiss animation does.
      */
     const hasCardModal = presentingElement !== undefined;
-    if (hasCardModal && getIonPlatform(this) === 'ios') {
+    if (hasCardModal && getIonBehavior(this) === 'ios') {
       setCardStatusBarDefault(this.statusBarStyle);
     }
 

--- a/core/src/components/nav/nav.tsx
+++ b/core/src/components/nav/nav.tsx
@@ -111,8 +111,8 @@ export class Nav implements NavOutlet {
     this.useRouter = document.querySelector('ion-router') !== null && this.el.closest('[no-router]') === null;
 
     if (this.swipeGesture === undefined) {
-      const mode = getIonPlatform(this);
-      this.swipeGesture = config.getBoolean('swipeBackEnabled', mode === 'ios');
+      const platform = getIonPlatform(this);
+      this.swipeGesture = config.getBoolean('swipeBackEnabled', platform === 'ios');
     }
 
     this.ionNavWillLoad.emit();

--- a/core/src/components/nav/nav.tsx
+++ b/core/src/components/nav/nav.tsx
@@ -2,7 +2,7 @@ import type { EventEmitter } from '@stencil/core';
 import { Build, Component, Element, Event, Method, Prop, Watch, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type {
   Animation,
   AnimationBuilder,
@@ -111,7 +111,7 @@ export class Nav implements NavOutlet {
     this.useRouter = document.querySelector('ion-router') !== null && this.el.closest('[no-router]') === null;
 
     if (this.swipeGesture === undefined) {
-      const mode = getIonMode(this);
+      const mode = getIonPlatform(this);
       this.swipeGesture = config.getBoolean('swipeBackEnabled', mode === 'ios');
     }
 

--- a/core/src/components/nav/nav.tsx
+++ b/core/src/components/nav/nav.tsx
@@ -2,7 +2,7 @@ import type { EventEmitter } from '@stencil/core';
 import { Build, Component, Element, Event, Method, Prop, Watch, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type {
   Animation,
   AnimationBuilder,
@@ -111,7 +111,7 @@ export class Nav implements NavOutlet {
     this.useRouter = document.querySelector('ion-router') !== null && this.el.closest('[no-router]') === null;
 
     if (this.swipeGesture === undefined) {
-      const platform = getIonPlatform(this);
+      const platform = getIonBehavior(this);
       this.swipeGesture = config.getBoolean('swipeBackEnabled', platform === 'ios');
     }
 

--- a/core/src/components/nav/nav.tsx
+++ b/core/src/components/nav/nav.tsx
@@ -2,7 +2,7 @@ import type { EventEmitter } from '@stencil/core';
 import { Build, Component, Element, Event, Method, Prop, Watch, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type {
   Animation,
   AnimationBuilder,
@@ -859,7 +859,7 @@ export class Nav implements NavOutlet {
     const opts = ti.opts!;
 
     const progressCallback = opts.progressAnimation ? (ani: Animation | undefined) => (this.sbAni = ani) : undefined;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const enteringEl = enteringView.element!;
     const leavingEl = leavingView && leavingView.element!;
     const animationOpts: TransitionOptions = {

--- a/core/src/components/note/note.tsx
+++ b/core/src/components/note/note.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color } from '../../interface';
 import { createColorClasses } from '../../utils/theme';
 
@@ -25,7 +25,7 @@ export class Note implements ComponentInterface {
   @Prop({ reflect: true }) color?: Color;
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={createColorClasses(this.color, {

--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h } from '@stencil/core';
 import { isPlatform } from '@utils/platform';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color } from '../../interface';
 import { getElementRoot, raf } from '../../utils/helpers';
 import { hapticSelectionChanged, hapticSelectionEnd, hapticSelectionStart } from '../../utils/native/haptic';
@@ -339,7 +339,7 @@ export class PickerColumnInternal implements ComponentInterface {
 
   render() {
     const { items, color, isActive, numericInput } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
 
     return (
       <Host

--- a/core/src/components/picker-column/picker-column.tsx
+++ b/core/src/components/picker-column/picker-column.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Prop, Watch, h } from '@stencil/core';
 
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type { Gesture, GestureDetail, PickerColumn } from '../../interface';
 import { clamp } from '../../utils/helpers';
 import { hapticSelectionChanged, hapticSelectionEnd, hapticSelectionStart } from '../../utils/native/haptic';
@@ -362,7 +362,7 @@ export class PickerColumnCmp implements ComponentInterface {
   render() {
     const col = this.col;
     const Button = 'button' as any;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={{

--- a/core/src/components/picker-column/picker-column.tsx
+++ b/core/src/components/picker-column/picker-column.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Prop, Watch, h } from '@stencil/core';
 
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type { Gesture, GestureDetail, PickerColumn } from '../../interface';
 import { clamp } from '../../utils/helpers';
 import { hapticSelectionChanged, hapticSelectionEnd, hapticSelectionStart } from '../../utils/native/haptic';
@@ -51,7 +51,7 @@ export class PickerColumnCmp implements ComponentInterface {
     let pickerRotateFactor = 0;
     let pickerScaleFactor = 0.81;
 
-    const platform = getIonPlatform(this);
+    const platform = getIonBehavior(this);
 
     if (platform === 'ios') {
       pickerRotateFactor = -0.46;

--- a/core/src/components/picker-column/picker-column.tsx
+++ b/core/src/components/picker-column/picker-column.tsx
@@ -51,9 +51,9 @@ export class PickerColumnCmp implements ComponentInterface {
     let pickerRotateFactor = 0;
     let pickerScaleFactor = 0.81;
 
-    const mode = getIonPlatform(this);
+    const platform = getIonPlatform(this);
 
-    if (mode === 'ios') {
+    if (platform === 'ios') {
       pickerRotateFactor = -0.46;
       pickerScaleFactor = 1;
     }

--- a/core/src/components/picker-column/picker-column.tsx
+++ b/core/src/components/picker-column/picker-column.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Prop, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type { Gesture, GestureDetail, PickerColumn } from '../../interface';
 import { clamp } from '../../utils/helpers';
 import { hapticSelectionChanged, hapticSelectionEnd, hapticSelectionStart } from '../../utils/native/haptic';
@@ -51,7 +51,7 @@ export class PickerColumnCmp implements ComponentInterface {
     let pickerRotateFactor = 0;
     let pickerScaleFactor = 0.81;
 
-    const mode = getIonMode(this);
+    const mode = getIonPlatform(this);
 
     if (mode === 'ios') {
       pickerRotateFactor = -0.46;

--- a/core/src/components/picker/picker.tsx
+++ b/core/src/components/picker/picker.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type {
   AnimationBuilder,
   CssClassMap,
@@ -330,7 +330,7 @@ export class Picker implements ComponentInterface, OverlayInterface {
 
   render() {
     const { htmlAttributes } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         aria-modal="true"

--- a/core/src/components/popover/popover.tsx
+++ b/core/src/components/popover/popover.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type {
   AnimationBuilder,
   ComponentProps,
@@ -347,7 +347,7 @@ export class Popover implements ComponentInterface, PopoverInterface {
     this.parentPopover = this.el.closest(`ion-popover:not(#${this.popoverId})`) as HTMLIonPopoverElement | null;
 
     if (this.alignment === undefined) {
-      this.alignment = getIonMode(this) === 'ios' ? 'center' : 'start';
+      this.alignment = getIonPlatform(this) === 'ios' ? 'center' : 'start';
     }
   }
 

--- a/core/src/components/popover/popover.tsx
+++ b/core/src/components/popover/popover.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h } from '@stencil/core';
 
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type {
   AnimationBuilder,
   ComponentProps,
@@ -652,7 +652,7 @@ export class Popover implements ComponentInterface, PopoverInterface {
   };
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const { onLifecycle, popoverId, parentPopover, dismissOnSelect, side, arrow, htmlAttributes } = this;
     const desktop = isPlatform('desktop');
     const enableArrow = arrow && !parentPopover;

--- a/core/src/components/popover/popover.tsx
+++ b/core/src/components/popover/popover.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h } from '@stencil/core';
 
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type {
   AnimationBuilder,
   ComponentProps,
@@ -347,7 +347,7 @@ export class Popover implements ComponentInterface, PopoverInterface {
     this.parentPopover = this.el.closest(`ion-popover:not(#${this.popoverId})`) as HTMLIonPopoverElement | null;
 
     if (this.alignment === undefined) {
-      this.alignment = getIonPlatform(this) === 'ios' ? 'center' : 'start';
+      this.alignment = getIonBehavior(this) === 'ios' ? 'center' : 'start';
     }
   }
 

--- a/core/src/components/progress-bar/progress-bar.tsx
+++ b/core/src/components/progress-bar/progress-bar.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color } from '../../interface';
 import { clamp } from '../../utils/helpers';
 import { createColorClasses } from '../../utils/theme';
@@ -58,7 +58,7 @@ export class ProgressBar implements ComponentInterface {
   render() {
     const { color, type, reversed, value, buffer } = this;
     const paused = config.getBoolean('_testing');
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         role="progressbar"

--- a/core/src/components/radio-group/radio-group.tsx
+++ b/core/src/components/radio-group/radio-group.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Listen, Prop, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { RadioGroupChangeEventDetail } from '../../interface';
 
 /**
@@ -188,7 +188,7 @@ export class RadioGroup implements ComponentInterface {
 
   render() {
     const { label, labelId } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
 
     return <Host role="radiogroup" aria-labelledby={label ? labelId : null} onClick={this.onClick} class={mode}></Host>;
   }

--- a/core/src/components/radio/radio.tsx
+++ b/core/src/components/radio/radio.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color, StyleEventDetail } from '../../interface';
 import { addEventListener, getAriaLabel, removeEventListener } from '../../utils/helpers';
 import { createColorClasses, hostContext } from '../../utils/theme';
@@ -144,7 +144,7 @@ export class Radio implements ComponentInterface {
 
   render() {
     const { inputId, disabled, checked, color, el, buttonTabindex } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const { label, labelId, labelText } = getAriaLabel(el, inputId);
 
     return (

--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Prop, State, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type {
   Color,
   Gesture,
@@ -576,7 +576,7 @@ Developers can dismiss this warning by removing their usage of the "legacy" prop
 
     const { el, pressedKnob, disabled, pin, rangeId } = this;
 
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
 
     renderHiddenInput(true, el, this.name, JSON.stringify(this.getValue()), disabled);
 
@@ -604,7 +604,7 @@ Developers can dismiss this warning by removing their usage of the "legacy" prop
   private renderRange() {
     const { disabled, el, rangeId, pin, pressedKnob, labelPlacement } = this;
 
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
 
     renderHiddenInput(true, el, this.name, JSON.stringify(this.getValue()), disabled);
 

--- a/core/src/components/refresher-content/refresher-content.tsx
+++ b/core/src/components/refresher-content/refresher-content.tsx
@@ -3,7 +3,7 @@ import { Component, Element, Host, Prop, h } from '@stencil/core';
 import { arrowDown, caretBackSharp } from 'ionicons/icons';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type { SpinnerTypes } from '../../interface';
 import { isPlatform } from '../../utils/platform';
 import type { IonicSafeString } from '../../utils/sanitization';
@@ -52,7 +52,7 @@ export class RefresherContent implements ComponentInterface {
 
   componentWillLoad() {
     if (this.pullingIcon === undefined) {
-      const mode = getIonMode(this);
+      const mode = getIonPlatform(this);
       const overflowRefresher = (this.el.style as any).webkitOverflowScrolling !== undefined ? 'lines' : arrowDown;
       this.pullingIcon = config.get(
         'refreshingIcon',
@@ -60,7 +60,7 @@ export class RefresherContent implements ComponentInterface {
       );
     }
     if (this.refreshingSpinner === undefined) {
-      const mode = getIonMode(this);
+      const mode = getIonPlatform(this);
       this.refreshingSpinner = config.get(
         'refreshingSpinner',
         config.get('spinner', mode === 'ios' ? 'lines' : 'circular')

--- a/core/src/components/refresher-content/refresher-content.tsx
+++ b/core/src/components/refresher-content/refresher-content.tsx
@@ -52,18 +52,18 @@ export class RefresherContent implements ComponentInterface {
 
   componentWillLoad() {
     if (this.pullingIcon === undefined) {
-      const mode = getIonPlatform(this);
+      const platform = getIonPlatform(this);
       const overflowRefresher = (this.el.style as any).webkitOverflowScrolling !== undefined ? 'lines' : arrowDown;
       this.pullingIcon = config.get(
         'refreshingIcon',
-        mode === 'ios' && isPlatform('mobile') ? config.get('spinner', overflowRefresher) : 'circular'
+        platform === 'ios' && isPlatform('mobile') ? config.get('spinner', overflowRefresher) : 'circular'
       );
     }
     if (this.refreshingSpinner === undefined) {
-      const mode = getIonPlatform(this);
+      const platform = getIonPlatform(this);
       this.refreshingSpinner = config.get(
         'refreshingSpinner',
-        config.get('spinner', mode === 'ios' ? 'lines' : 'circular')
+        config.get('spinner', platform === 'ios' ? 'lines' : 'circular')
       );
     }
   }

--- a/core/src/components/refresher-content/refresher-content.tsx
+++ b/core/src/components/refresher-content/refresher-content.tsx
@@ -3,7 +3,7 @@ import { Component, Element, Host, Prop, h } from '@stencil/core';
 import { arrowDown, caretBackSharp } from 'ionicons/icons';
 
 import { config } from '../../global/config';
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type { SpinnerTypes } from '../../interface';
 import { isPlatform } from '../../utils/platform';
 import type { IonicSafeString } from '../../utils/sanitization';
@@ -71,7 +71,7 @@ export class RefresherContent implements ComponentInterface {
   render() {
     const pullingIcon = this.pullingIcon;
     const hasSpinner = pullingIcon != null && (SPINNERS[pullingIcon] as any) !== undefined;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
 
     return (
       <Host class={mode}>

--- a/core/src/components/refresher-content/refresher-content.tsx
+++ b/core/src/components/refresher-content/refresher-content.tsx
@@ -3,7 +3,7 @@ import { Component, Element, Host, Prop, h } from '@stencil/core';
 import { arrowDown, caretBackSharp } from 'ionicons/icons';
 
 import { config } from '../../global/config';
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type { SpinnerTypes } from '../../interface';
 import { isPlatform } from '../../utils/platform';
 import type { IonicSafeString } from '../../utils/sanitization';
@@ -52,7 +52,7 @@ export class RefresherContent implements ComponentInterface {
 
   componentWillLoad() {
     if (this.pullingIcon === undefined) {
-      const platform = getIonPlatform(this);
+      const platform = getIonBehavior(this);
       const overflowRefresher = (this.el.style as any).webkitOverflowScrolling !== undefined ? 'lines' : arrowDown;
       this.pullingIcon = config.get(
         'refreshingIcon',
@@ -60,7 +60,7 @@ export class RefresherContent implements ComponentInterface {
       );
     }
     if (this.refreshingSpinner === undefined) {
-      const platform = getIonPlatform(this);
+      const platform = getIonBehavior(this);
       this.refreshingSpinner = config.get(
         'refreshingSpinner',
         config.get('spinner', platform === 'ios' ? 'lines' : 'circular')

--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h, readTask, writeTask } from '@stencil/core';
 
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type { Animation, Gesture, GestureDetail, RefresherEventDetail } from '../../interface';
 import { getTimeGivenProgression } from '../../utils/animation/cubic-bezier';
 import {
@@ -140,7 +140,7 @@ export class Refresher implements ComponentInterface {
   @Event() ionStart!: EventEmitter<void>;
 
   private async checkNativeRefresher() {
-    const useNativeRefresher = await shouldUseNativeRefresher(this.el, getIonMode(this));
+    const useNativeRefresher = await shouldUseNativeRefresher(this.el, getIonStylesheet(this));
     if (useNativeRefresher && !this.nativeRefresher) {
       const contentEl = this.el.closest('ion-content');
       this.setupNativeRefresher(contentEl);
@@ -427,7 +427,7 @@ export class Refresher implements ComponentInterface {
       'ion-refresher-content .refresher-refreshing ion-spinner'
     ) as HTMLIonSpinnerElement;
 
-    if (getIonMode(this) === 'ios') {
+    if (getIonStylesheet(this) === 'ios') {
       this.setupiOSNativeRefresher(pullingSpinner, refreshingSpinner);
     } else {
       this.setupMDNativeRefresher(contentEl, pullingSpinner, refreshingSpinner);
@@ -735,7 +735,7 @@ export class Refresher implements ComponentInterface {
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         slot="fixed"

--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h, readTask, writeTask } from '@stencil/core';
 
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type { Animation, Gesture, GestureDetail, RefresherEventDetail } from '../../interface';
 import { getTimeGivenProgression } from '../../utils/animation/cubic-bezier';
 import {
@@ -161,7 +161,7 @@ export class Refresher implements ComponentInterface {
   private async resetNativeRefresher(el: HTMLElement | undefined, state: RefresherState) {
     this.state = state;
 
-    if (getIonPlatform(this) === 'ios') {
+    if (getIonBehavior(this) === 'ios') {
       await translateElement(el, undefined, 300);
     } else {
       await transitionEndAsync(this.el.querySelector('.refresher-refreshing-icon'), 200);
@@ -466,7 +466,7 @@ export class Refresher implements ComponentInterface {
        */
       this.backgroundContentEl = await contentEl.getBackgroundElement();
 
-      if (await shouldUseNativeRefresher(this.el, getIonPlatform(this))) {
+      if (await shouldUseNativeRefresher(this.el, getIonBehavior(this))) {
         this.setupNativeRefresher(contentEl);
       } else {
         this.gesture = (await import('../../utils/gesture')).createGesture({

--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h, readTask, writeTask } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type { Animation, Gesture, GestureDetail, RefresherEventDetail } from '../../interface';
 import { getTimeGivenProgression } from '../../utils/animation/cubic-bezier';
 import {
@@ -161,7 +161,7 @@ export class Refresher implements ComponentInterface {
   private async resetNativeRefresher(el: HTMLElement | undefined, state: RefresherState) {
     this.state = state;
 
-    if (getIonMode(this) === 'ios') {
+    if (getIonPlatform(this) === 'ios') {
       await translateElement(el, undefined, 300);
     } else {
       await transitionEndAsync(this.el.querySelector('.refresher-refreshing-icon'), 200);
@@ -466,7 +466,7 @@ export class Refresher implements ComponentInterface {
        */
       this.backgroundContentEl = await contentEl.getBackgroundElement();
 
-      if (await shouldUseNativeRefresher(this.el, getIonMode(this))) {
+      if (await shouldUseNativeRefresher(this.el, getIonPlatform(this))) {
         this.setupNativeRefresher(contentEl);
       } else {
         this.gesture = (await import('../../utils/gesture')).createGesture({

--- a/core/src/components/reorder-group/reorder-group.tsx
+++ b/core/src/components/reorder-group/reorder-group.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Gesture, GestureDetail, ItemReorderEventDetail } from '../../interface';
 import { findClosestIonContent, getScrollElement } from '../../utils/content';
 import { raf } from '../../utils/helpers';
@@ -297,7 +297,7 @@ export class ReorderGroup implements ComponentInterface {
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={{

--- a/core/src/components/reorder/reorder.tsx
+++ b/core/src/components/reorder/reorder.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Listen, h } from '@stencil/core';
 import { reorderThreeOutline, reorderTwoSharp } from 'ionicons/icons';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 
 /**
  * @part icon - The icon of the reorder handle (uses ion-icon).
@@ -32,7 +32,7 @@ export class Reorder implements ComponentInterface {
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const reorderIcon = mode === 'ios' ? reorderThreeOutline : reorderTwoSharp;
     return (
       <Host class={mode}>

--- a/core/src/components/ripple-effect/ripple-effect.tsx
+++ b/core/src/components/ripple-effect/ripple-effect.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Method, Prop, h, readTask, writeTask } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 
 @Component({
   tag: 'ion-ripple-effect',
@@ -78,7 +78,7 @@ export class RippleEffect implements ComponentInterface {
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         role="presentation"

--- a/core/src/components/router-link/router-link.tsx
+++ b/core/src/components/router-link/router-link.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { AnimationBuilder, Color, RouterDirection } from '../../interface';
 import { createColorClasses, openURL } from '../../utils/theme';
 
@@ -54,7 +54,7 @@ export class RouterLink implements ComponentInterface {
   };
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const attrs = {
       href: this.href,
       rel: this.rel,

--- a/core/src/components/router-outlet/route-outlet.tsx
+++ b/core/src/components/router-outlet/route-outlet.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Method, Prop, Watch, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonPlatform } from '../../global/ionic-global';
+import { getIonBehavior } from '../../global/ionic-global';
 import type {
   Animation,
   AnimationBuilder,
@@ -41,7 +41,7 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
   /**
    * The mode determines which platform styles to use.
    */
-  @Prop({ mutable: true }) mode = getIonPlatform(this);
+  @Prop({ mutable: true }) mode = getIonBehavior(this);
 
   /** @internal */
   @Prop() delegate?: FrameworkDelegate;

--- a/core/src/components/router-outlet/route-outlet.tsx
+++ b/core/src/components/router-outlet/route-outlet.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Method, Prop, Watch, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonPlatform } from '../../global/ionic-global';
 import type {
   Animation,
   AnimationBuilder,
@@ -41,7 +41,7 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
   /**
    * The mode determines which platform styles to use.
    */
-  @Prop({ mutable: true }) mode = getIonMode(this);
+  @Prop({ mutable: true }) mode = getIonPlatform(this);
 
   /** @internal */
   @Prop() delegate?: FrameworkDelegate;

--- a/core/src/components/row/row.tsx
+++ b/core/src/components/row/row.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 
 @Component({
   tag: 'ion-row',
@@ -11,7 +11,7 @@ import { getIonMode } from '../../global/ionic-global';
 export class Row implements ComponentInterface {
   render() {
     return (
-      <Host class={getIonMode(this)}>
+      <Host class={getIonStylesheet(this)}>
         <slot></slot>
       </Host>
     );

--- a/core/src/components/searchbar/searchbar.tsx
+++ b/core/src/components/searchbar/searchbar.tsx
@@ -3,7 +3,7 @@ import { Component, Element, Event, Host, Method, Prop, State, Watch, forceUpdat
 import { arrowBackSharp, closeCircle, closeSharp, searchOutline, searchSharp } from 'ionicons/icons';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { AutocompleteTypes, Color, SearchbarChangeEventDetail, StyleEventDetail } from '../../interface';
 import { debounceEvent, raf } from '../../utils/helpers';
 import { isRTL } from '../../utils/rtl';
@@ -391,7 +391,7 @@ export class Searchbar implements ComponentInterface {
   private positionElements() {
     const value = this.getValue();
     const prevAlignLeft = this.shouldAlignLeft;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const shouldAlignLeft = !this.animated || value.trim() !== '' || !!this.focused;
     this.shouldAlignLeft = shouldAlignLeft;
 
@@ -521,7 +521,7 @@ export class Searchbar implements ComponentInterface {
   render() {
     const { cancelButtonText } = this;
     const animated = this.animated && config.getBoolean('animated', true);
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const clearIcon = this.clearIcon || (mode === 'ios' ? closeCircle : closeSharp);
     const searchIcon = this.searchIcon || (mode === 'ios' ? searchOutline : searchSharp);
     const shouldShowCancelButton = this.shouldShowCancelButton();

--- a/core/src/components/segment-button/segment-button.tsx
+++ b/core/src/components/segment-button/segment-button.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, State, forceUpdate, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { SegmentButtonLayout } from '../../interface';
 import type { ButtonInterface } from '../../utils/element-interface';
 import { addEventListener, removeEventListener } from '../../utils/helpers';
@@ -93,7 +93,7 @@ export class SegmentButton implements ComponentInterface, ButtonInterface {
 
   render() {
     const { checked, type, disabled, hasIcon, hasLabel, layout, segmentEl, tabIndex } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const hasSegmentColor = () => segmentEl?.color !== undefined;
     return (
       <Host

--- a/core/src/components/segment/segment.tsx
+++ b/core/src/components/segment/segment.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Listen, Prop, State, Watch, h, writeTask } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color, SegmentChangeEventDetail, StyleEventDetail } from '../../interface';
 import type { Gesture, GestureDetail } from '../../utils/gesture';
 import { pointerCoord } from '../../utils/helpers';
@@ -553,7 +553,7 @@ export class Segment implements ComponentInterface {
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         role="tablist"

--- a/core/src/components/select-option/select-option.tsx
+++ b/core/src/components/select-option/select-option.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 
 @Component({
   tag: 'ion-select-option',
@@ -24,7 +24,7 @@ export class SelectOption implements ComponentInterface {
   @Prop() value?: any | null;
 
   render() {
-    return <Host role="option" id={this.inputId} class={getIonMode(this)}></Host>;
+    return <Host role="option" id={this.inputId} class={getIonStylesheet(this)}></Host>;
   }
 }
 

--- a/core/src/components/select-popover/select-popover.tsx
+++ b/core/src/components/select-popover/select-popover.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Listen, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { SelectPopoverOption } from '../../interface';
 import { safeCall } from '../../utils/overlays';
 import { getClassMap } from '../../utils/theme';
@@ -148,7 +148,7 @@ export class SelectPopover implements ComponentInterface {
     const hasSubHeaderOrMessage = subHeader !== undefined || message !== undefined;
 
     return (
-      <Host class={getIonMode(this)}>
+      <Host class={getIonStylesheet(this)}>
         <ion-list>
           {header !== undefined && <ion-list-header>{header}</ion-list-header>}
           {hasSubHeaderOrMessage && (

--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h } from '@stencil/core';
 import { caretDownSharp } from 'ionicons/icons';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type {
   ActionSheetButton,
   ActionSheetOptions,
@@ -348,7 +348,7 @@ export class Select implements ComponentInterface {
 
   private async openPopover(ev: UIEvent) {
     const interfaceOptions = this.interfaceOptions;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const showBackdrop = mode === 'md' ? false : true;
     const multiple = this.multiple;
     const value = this.value;
@@ -408,7 +408,7 @@ export class Select implements ComponentInterface {
   }
 
   private async openActionSheet() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const interfaceOptions = this.interfaceOptions;
     const actionSheetOpts: ActionSheetOptions = {
       mode,
@@ -439,7 +439,7 @@ export class Select implements ComponentInterface {
 
     const interfaceOptions = this.interfaceOptions;
     const inputType = this.multiple ? 'checkbox' : 'radio';
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
 
     const alertOpts: AlertOptions = {
       mode,
@@ -547,7 +547,7 @@ export class Select implements ComponentInterface {
 
   render() {
     const { disabled, el, inputId, isExpanded, name, placeholder, value } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const { labelText, labelId } = getAriaLabel(el, inputId);
 
     renderHiddenInput(true, el, name, parseValue(value), disabled);

--- a/core/src/components/skeleton-text/skeleton-text.tsx
+++ b/core/src/components/skeleton-text/skeleton-text.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import { hostContext } from '../../utils/theme';
 
 @Component({
@@ -21,7 +21,7 @@ export class SkeletonText implements ComponentInterface {
   render() {
     const animated = this.animated && config.getBoolean('animated', true);
     const inMedia = hostContext('ion-avatar', this.el) || hostContext('ion-thumbnail', this.el);
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
 
     return (
       <Host

--- a/core/src/components/spinner/spinner.tsx
+++ b/core/src/components/spinner/spinner.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
 import type { Color, SpinnerConfig, SpinnerTypes } from '../../interface';
 import { createColorClasses } from '../../utils/theme';
 
@@ -48,7 +48,7 @@ export class Spinner implements ComponentInterface {
 
   render() {
     const self = this;
-    const mode = getIonMode(self);
+    const mode = getIonStylesheet(self);
     const spinnerName = self.getName();
     const spinner = SPINNERS[spinnerName] ?? SPINNERS['lines'];
     const duration = typeof self.duration === 'number' && self.duration > 10 ? self.duration : spinner.dur;

--- a/core/src/components/spinner/spinner.tsx
+++ b/core/src/components/spinner/spinner.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonStylesheet, getIonPlatform } from '../../global/ionic-global';
+import { getIonStylesheet, getIonBehavior } from '../../global/ionic-global';
 import type { Color, SpinnerConfig, SpinnerTypes } from '../../interface';
 import { createColorClasses } from '../../utils/theme';
 
@@ -39,7 +39,7 @@ export class Spinner implements ComponentInterface {
 
   private getName(): SpinnerTypes {
     const spinnerName = this.name || config.get('spinner');
-    const platform = getIonPlatform(this);
+    const platform = getIonBehavior(this);
     if (spinnerName) {
       return spinnerName;
     }

--- a/core/src/components/spinner/spinner.tsx
+++ b/core/src/components/spinner/spinner.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonMode, getIonPlatform } from '../../global/ionic-global';
 import type { Color, SpinnerConfig, SpinnerTypes } from '../../interface';
 import { createColorClasses } from '../../utils/theme';
 
@@ -39,7 +39,7 @@ export class Spinner implements ComponentInterface {
 
   private getName(): SpinnerTypes {
     const spinnerName = this.name || config.get('spinner');
-    const mode = getIonMode(this);
+    const mode = getIonPlatform(this);
     if (spinnerName) {
       return spinnerName;
     }

--- a/core/src/components/spinner/spinner.tsx
+++ b/core/src/components/spinner/spinner.tsx
@@ -39,11 +39,11 @@ export class Spinner implements ComponentInterface {
 
   private getName(): SpinnerTypes {
     const spinnerName = this.name || config.get('spinner');
-    const mode = getIonPlatform(this);
+    const platform = getIonPlatform(this);
     if (spinnerName) {
       return spinnerName;
     }
-    return mode === 'ios' ? 'lines' : 'circular';
+    return platform === 'ios' ? 'lines' : 'circular';
   }
 
   render() {

--- a/core/src/components/split-pane/split-pane.tsx
+++ b/core/src/components/split-pane/split-pane.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Build, Component, Element, Event, Host, Prop, State, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 
 const SPLIT_PANE_MAIN = 'split-pane-main';
 const SPLIT_PANE_SIDE = 'split-pane-side';
@@ -156,7 +156,7 @@ export class SplitPane implements ComponentInterface {
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={{

--- a/core/src/components/tab-bar/tab-bar.tsx
+++ b/core/src/components/tab-bar/tab-bar.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Prop, State, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color, TabBarChangedEventDetail } from '../../interface';
 import type { KeyboardController } from '../../utils/keyboard/keyboard-controller';
 import { createKeyboardController } from '../../utils/keyboard/keyboard-controller';
@@ -73,7 +73,7 @@ export class TabBar implements ComponentInterface {
 
   render() {
     const { color, translucent, keyboardVisible } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const shouldHide = keyboardVisible && this.el.getAttribute('slot') !== 'top';
 
     return (

--- a/core/src/components/tab-button/tab-button.tsx
+++ b/core/src/components/tab-button/tab-button.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Listen, Prop, h } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { TabBarChangedEventDetail, TabButtonClickEventDetail, TabButtonLayout } from '../../interface';
 import type { AnchorInterface } from '../../utils/element-interface';
 
@@ -140,7 +140,7 @@ export class TabButton implements ComponentInterface, AnchorInterface {
 
   render() {
     const { disabled, hasIcon, hasLabel, tabIndex, href, rel, target, layout, selected, tab } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const attrs = {
       download: this.download,
       href,

--- a/core/src/components/text/text.tsx
+++ b/core/src/components/text/text.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, Prop, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color } from '../../interface';
 import { createColorClasses } from '../../utils/theme';
 
@@ -22,7 +22,7 @@ export class Text implements ComponentInterface {
   @Prop({ reflect: true }) color?: Color;
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     return (
       <Host
         class={createColorClasses(this.color, {

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Build, Component, Element, Event, Host, Method, Prop, State, Watch, h, writeTask } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color, StyleEventDetail, TextareaChangeEventDetail, TextareaInputEventDetail } from '../../interface';
 import type { Attributes } from '../../utils/helpers';
 import { inheritAriaAttributes, debounceEvent, findItemLabel, inheritAttributes } from '../../utils/helpers';
@@ -389,7 +389,7 @@ export class Textarea implements ComponentInterface {
   };
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const value = this.getValue();
     const labelId = this.inputId + '-lbl';
     const label = findItemLabel(this.el);

--- a/core/src/components/thumbnail/thumbnail.tsx
+++ b/core/src/components/thumbnail/thumbnail.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Host, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 
 @Component({
   tag: 'ion-thumbnail',
@@ -11,7 +11,7 @@ import { getIonMode } from '../../global/ionic-global';
 export class Thumbnail implements ComponentInterface {
   render() {
     return (
-      <Host class={getIonMode(this)}>
+      <Host class={getIonStylesheet(this)}>
         <slot></slot>
       </Host>
     );

--- a/core/src/components/title/title.tsx
+++ b/core/src/components/title/title.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Prop, Watch, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color, StyleEventDetail } from '../../interface';
 import { createColorClasses } from '../../utils/theme';
 
@@ -56,7 +56,7 @@ export class ToolbarTitle implements ComponentInterface {
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const size = this.getSize();
 
     return (

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -2,7 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Watch, Component, Element, Event, h, Host, Method, Prop } from '@stencil/core';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type {
   AnimationBuilder,
   Color,
@@ -365,7 +365,7 @@ export class Toast implements ComponentInterface, OverlayInterface {
       return;
     }
 
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const buttonGroupsClasses = {
       'toast-button-group': true,
       [`toast-button-group-${side}`]: true,
@@ -399,7 +399,7 @@ export class Toast implements ComponentInterface, OverlayInterface {
     const allButtons = this.getButtons();
     const startButtons = allButtons.filter((b) => b.side === 'start');
     const endButtons = allButtons.filter((b) => b.side !== 'start');
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const wrapperClass = {
       'toast-wrapper': true,
       [`toast-${this.position}`]: true,

--- a/core/src/components/toggle/toggle.tsx
+++ b/core/src/components/toggle/toggle.tsx
@@ -4,7 +4,7 @@ import { Component, Element, Event, Host, Prop, State, Watch, h } from '@stencil
 import { checkmarkOutline, removeOutline, ellipseOutline } from 'ionicons/icons';
 
 import { config } from '../../global/config';
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color, Gesture, GestureDetail, Mode, StyleEventDetail, ToggleChangeEventDetail } from '../../interface';
 import type { LegacyFormController } from '../../utils/forms';
 import { createLegacyFormController } from '../../utils/forms';
@@ -266,7 +266,7 @@ export class Toggle implements ComponentInterface {
   }
 
   private renderToggleControl() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
 
     const { enableOnOffLabels, checked } = this;
     return (
@@ -298,7 +298,7 @@ export class Toggle implements ComponentInterface {
   private renderToggle() {
     const { activated, color, checked, disabled, el, justify, labelPlacement, inputId, name } = this;
 
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const value = this.getValue();
     const rtl = isRTL(el) ? 'rtl' : 'ltr';
     renderHiddenInput(true, el, name, checked ? value : '', disabled);
@@ -368,7 +368,7 @@ Developers can dismiss this warning by removing their usage of the "legacy" prop
     }
 
     const { activated, color, checked, disabled, el, inputId, name } = this;
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const { label, labelId, labelText } = getAriaLabel(el, inputId);
     const value = this.getValue();
     const rtl = isRTL(el) ? 'rtl' : 'ltr';

--- a/core/src/components/toolbar/toolbar.tsx
+++ b/core/src/components/toolbar/toolbar.tsx
@@ -1,7 +1,7 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Listen, Prop, forceUpdate, h } from '@stencil/core';
 
-import { getIonMode } from '../../global/ionic-global';
+import { getIonStylesheet } from '../../global/ionic-global';
 import type { Color, CssClassMap, StyleEventDetail } from '../../interface';
 import { createColorClasses, hostContext } from '../../utils/theme';
 
@@ -82,7 +82,7 @@ export class Toolbar implements ComponentInterface {
   }
 
   render() {
-    const mode = getIonMode(this);
+    const mode = getIonStylesheet(this);
     const childStyles = {};
     this.childrenStyles.forEach((value) => {
       Object.assign(childStyles, value);

--- a/core/src/global/base-components.ts
+++ b/core/src/global/base-components.ts
@@ -43,8 +43,9 @@ const initializeBaseComponentsCache = (includeCmp?: string[], excludeCmp?: strin
 };
 
 /**
- * Determines if a component is
- * using base components.
+ * Determines if a component is using base components.
+ * This should be used when the component is created
+ * for the first time.
  */
 export const isBaseComponent = (elm: HTMLElement, config: Config) => {
   /**
@@ -53,17 +54,6 @@ export const isBaseComponent = (elm: HTMLElement, config: Config) => {
    */
   if (!isIonicElement(elm)) {
     return false;
-  }
-
-  /**
-   * If a component has already been initialized
-   * then it will have the useBase property set.
-   * This lets us check the component instance and
-   * avoid the global look up.
-   */
-  const useBase = (elm as any).useBase;
-  if (useBase !== undefined) {
-    return useBase;
   }
 
   /**

--- a/core/src/global/base-components.ts
+++ b/core/src/global/base-components.ts
@@ -55,7 +55,25 @@ export const isBaseComponent = (elm: HTMLElement, config: Config) => {
     return false;
   }
 
-  // TODO check if useBase property is set on element also add tests
+  /**
+   * If a component has already been initialized
+   * then it will have the useBase property set.
+   * This lets us check the component instance and
+   * avoid the global look up.
+   */
+  const useBase = (elm as any).useBase;
+  if (useBase !== undefined) {
+    return useBase;
+  }
+
+  /**
+   * If the component is not already initialized
+   * then we need to see if the developer has
+   * set use-base as an attribute on the element.
+   */
+  if (elm.hasAttribute('use-base')) {
+    return elm.getAttribute('use-base') === 'true';
+  }
 
   const baseComponents = config.get('baseComponents');
 

--- a/core/src/global/ionic-global.ts
+++ b/core/src/global/ionic-global.ts
@@ -34,7 +34,7 @@ export const getIonMode = (ref?: any): Mode => {
  * using the mode.
  */
 export const getIonPlatform = (ref?: any): Platform => {
-  return ref.el.platform || getIonMode(ref);
+  return (ref?.el?.platform) ?? getIonMode(ref);
 };
 
 export const initialize = (userConfig: IonicConfig = {}) => {

--- a/core/src/global/ionic-global.ts
+++ b/core/src/global/ionic-global.ts
@@ -34,7 +34,7 @@ export const getIonMode = (ref?: any): Mode => {
  * using the mode.
  */
 export const getIonPlatform = (ref?: any): Platform => {
-  return (ref?.el?.platform) ?? getIonMode(ref);
+  return ref?.el?.platform ?? getIonMode(ref);
 };
 
 export const initialize = (userConfig: IonicConfig = {}) => {

--- a/core/src/global/ionic-global.ts
+++ b/core/src/global/ionic-global.ts
@@ -117,7 +117,7 @@ export const initialize = (userConfig: IonicConfig = {}) => {
     let useBase = false;
     if (isIonicElement(baseEl)) {
       useBase = isBaseComponent(baseEl, config);
-      baseEl.useBase = false;
+      baseEl.useBase = useBase;
     }
 
     while (elm) {

--- a/core/src/global/ionic-global.ts
+++ b/core/src/global/ionic-global.ts
@@ -30,9 +30,11 @@ export const getIonMode = (ref?: any): Mode => {
  * and does not impact the visual styles associated with
  * this instance. The capabilities can be set using the "mode"
  * global config or property on the component.
+ * If no platform is specified then we fallback to
+ * using the mode.
  */
 export const getIonPlatform = (ref?: any): Platform => {
-  return ref.el.platform;
+  return ref.el.platform || getIonMode(ref);
 };
 
 export const initialize = (userConfig: IonicConfig = {}) => {

--- a/core/src/global/ionic-global.ts
+++ b/core/src/global/ionic-global.ts
@@ -19,7 +19,7 @@ type Platform = 'ios' | 'md';
  * customized using the "baseComponents" global config or the
  * "useBase" property on the component.
  */
-export const getIonMode = (ref?: any): Mode => {
+export const getIonStylesheet = (ref?: any): Mode => {
   return (ref && getMode(ref)) || defaultMode;
 };
 
@@ -32,11 +32,11 @@ export const getIonMode = (ref?: any): Mode => {
  * global config or property on the component.
  *
  * If no platform is specified then we fallback to
- * using getIonMode. This can happen when a component
+ * using getIonStylesheet. This can happen when a component
  * has no per-mode stylesheets (such as ion-spinner).
  */
-export const getIonPlatform = (ref?: any): Platform => {
-  return ref?.el?.platform ?? getIonMode(ref);
+export const getIonBehavior = (ref?: any): Platform => {
+  return ref?.el?.platform ?? getIonStylesheet(ref);
 };
 
 export const initialize = (userConfig: IonicConfig = {}) => {

--- a/core/src/global/ionic-global.ts
+++ b/core/src/global/ionic-global.ts
@@ -30,8 +30,10 @@ export const getIonMode = (ref?: any): Mode => {
  * and does not impact the visual styles associated with
  * this instance. The capabilities can be set using the "mode"
  * global config or property on the component.
+ *
  * If no platform is specified then we fallback to
- * using the mode.
+ * using getIonMode. This can happen when a component
+ * has no per-mode stylesheets (such as ion-spinner).
  */
 export const getIonPlatform = (ref?: any): Platform => {
   return ref?.el?.platform ?? getIonMode(ref);
@@ -105,6 +107,19 @@ export const initialize = (userConfig: IonicConfig = {}) => {
 
   setMode((elm: any) => {
     const baseEl = elm;
+
+    /**
+     * The useBase virtualProp only
+     * exists on Ionic components, so
+     * we do not need to track useBase
+     * on non-Ionic components.
+     */
+    let useBase = false;
+    if (isIonicElement(baseEl)) {
+      useBase = isBaseComponent(baseEl, config);
+      baseEl.useBase = false;
+    }
+
     while (elm) {
       const elmMode = (elm as any).mode || elm.getAttribute('mode');
       if (elmMode) {
@@ -114,9 +129,7 @@ export const initialize = (userConfig: IonicConfig = {}) => {
            * capabilities if base components are enabled, so we keep
            * track of the platform separately.
            */
-          const useBase = isBaseComponent(baseEl, config);
           baseEl.platform = elmMode;
-          baseEl.useBase = useBase;
           return useBase ? 'base' : elmMode;
         } else if (isIonicElement(elm)) {
           console.warn('Invalid ionic mode: "' + elmMode + '", expected: "ios" or "md"');
@@ -130,9 +143,7 @@ export const initialize = (userConfig: IonicConfig = {}) => {
      * capabilities if base components are enabled, so we keep
      * track of the platform separately.
      */
-    const useBase = isBaseComponent(baseEl, config);
     baseEl.platform = defaultMode;
-    baseEl.useBase = useBase;
     return useBase ? 'base' : defaultMode;
   });
 };

--- a/core/src/global/ionic-global.ts
+++ b/core/src/global/ionic-global.ts
@@ -14,11 +14,10 @@ type Platform = 'ios' | 'md';
 
 /**
  * Given a Stencil component class, return the visual
- * styles associated with this instance. This
- * can be set using the "mode" global config or
- * property on the component. It can be further customized
- * using the "baseComponents" global config or the "useBase"
- * property on the component.
+ * styles associated with this instance. By default, the visual
+ * styles are inherited from the platform. This can be further
+ * customized using the "baseComponents" global config or the
+ * "useBase" property on the component.
  */
 export const getIonMode = (ref?: any): Mode => {
   return (ref && getMode(ref)) || defaultMode;

--- a/core/src/global/test/base-components.spec.ts
+++ b/core/src/global/test/base-components.spec.ts
@@ -57,24 +57,6 @@ describe('isBaseComponent()', () => {
     });
   });
   describe('component instance', () => {
-    it('should return true when useBase property is set to true on the component instance', () => {
-      const config = new Config();
-      config.reset({});
-
-      const el = document.createElement('ion-badge');
-      el.useBase = true;
-
-      expect(isBaseComponent(el, config)).toBe(true);
-    });
-    it('should return false when useBase property is set to false on the component instance', () => {
-      const config = new Config();
-      config.reset({});
-
-      const el = document.createElement('ion-badge');
-      el.useBase = false;
-
-      expect(isBaseComponent(el, config)).toBe(false);
-    });
     it('should return true when use-base attribute is set to "true" on the component instance', () => {
       const config = new Config();
       config.reset({});

--- a/core/src/global/test/base-components.spec.ts
+++ b/core/src/global/test/base-components.spec.ts
@@ -5,53 +5,93 @@ describe('isBaseComponent()', () => {
   beforeEach(() => {
     resetBaseComponentsCache();
   });
-  it('should return true when baseComponents has been enabled globally', () => {
-    const config = new Config();
-    config.reset({ baseComponents: true });
-    const el = document.createElement('ion-badge');
+  describe('global config', () => {
+    it('should return true when baseComponents has been enabled globally', () => {
+      const config = new Config();
+      config.reset({ baseComponents: true });
+      const el = document.createElement('ion-badge');
 
-    expect(isBaseComponent(el, config)).toBe(true);
+      expect(isBaseComponent(el, config)).toBe(true);
+    });
+    it('should return false when baseComponents has not been enabled globally', () => {
+      const config = new Config();
+      config.reset({});
+      const el = document.createElement('ion-badge');
+
+      expect(isBaseComponent(el, config)).toBe(false);
+    });
+    it('should return false when baseComponents has been disabled globally', () => {
+      const config = new Config();
+      config.reset({ baseComponents: false });
+      const el = document.createElement('ion-badge');
+
+      expect(isBaseComponent(el, config)).toBe(false);
+    });
+    it('should return true when component is included in includeComponents', () => {
+      const config = new Config();
+      config.reset({ baseComponents: { includeComponents: ['ion-badge'] } });
+      const el = document.createElement('ion-badge');
+
+      expect(isBaseComponent(el, config)).toBe(true);
+    });
+    it('should return false when component is not included in includeComponents', () => {
+      const config = new Config();
+      config.reset({ baseComponents: { includeComponents: ['ion-button'] } });
+      const el = document.createElement('ion-badge');
+
+      expect(isBaseComponent(el, config)).toBe(false);
+    });
+    it('should return false when component is included in excludeComponents', () => {
+      const config = new Config();
+      config.reset({ baseComponents: { excludeComponents: ['ion-badge'] } });
+      const el = document.createElement('ion-badge');
+
+      expect(isBaseComponent(el, config)).toBe(false);
+    });
+    it('should return true when component is not included in excludeComponents', () => {
+      const config = new Config();
+      config.reset({ baseComponents: { excludeComponents: ['ion-button'] } });
+      const el = document.createElement('ion-badge');
+
+      expect(isBaseComponent(el, config)).toBe(true);
+    });
   });
-  it('should return false when baseComponents has not been enabled globally', () => {
-    const config = new Config();
-    config.reset({});
-    const el = document.createElement('ion-badge');
+  describe('component instance', () => {
+    it('should return true when useBase property is set to true on the component instance', () => {
+      const config = new Config();
+      config.reset({});
 
-    expect(isBaseComponent(el, config)).toBe(false);
-  });
-  it('should return false when baseComponents has been disabled globally', () => {
-    const config = new Config();
-    config.reset({ baseComponents: false });
-    const el = document.createElement('ion-badge');
+      const el = document.createElement('ion-badge');
+      el.useBase = true;
 
-    expect(isBaseComponent(el, config)).toBe(false);
-  });
-  it('should return true when component is included in includeComponents', () => {
-    const config = new Config();
-    config.reset({ baseComponents: { includeComponents: ['ion-badge'] } });
-    const el = document.createElement('ion-badge');
+      expect(isBaseComponent(el, config)).toBe(true);
+    });
+    it('should return false when useBase property is set to false on the component instance', () => {
+      const config = new Config();
+      config.reset({});
 
-    expect(isBaseComponent(el, config)).toBe(true);
-  });
-  it('should return false when component is not included in includeComponents', () => {
-    const config = new Config();
-    config.reset({ baseComponents: { includeComponents: ['ion-button'] } });
-    const el = document.createElement('ion-badge');
+      const el = document.createElement('ion-badge');
+      el.useBase = false;
 
-    expect(isBaseComponent(el, config)).toBe(false);
-  });
-  it('should return false when component is included in excludeComponents', () => {
-    const config = new Config();
-    config.reset({ baseComponents: { excludeComponents: ['ion-badge'] } });
-    const el = document.createElement('ion-badge');
+      expect(isBaseComponent(el, config)).toBe(false);
+    });
+    it('should return true when use-base attribute is set to "true" on the component instance', () => {
+      const config = new Config();
+      config.reset({});
 
-    expect(isBaseComponent(el, config)).toBe(false);
-  });
-  it('should return true when component is not included in excludeComponents', () => {
-    const config = new Config();
-    config.reset({ baseComponents: { excludeComponents: ['ion-button'] } });
-    const el = document.createElement('ion-badge');
+      const el = document.createElement('ion-badge');
+      el.setAttribute('use-base', 'true');
 
-    expect(isBaseComponent(el, config)).toBe(true);
+      expect(isBaseComponent(el, config)).toBe(true);
+    });
+    it('should return false when use-base attribute is set to "false" on the component instance', () => {
+      const config = new Config();
+      config.reset({});
+
+      const el = document.createElement('ion-badge');
+      el.setAttribute('use-base', 'false');
+
+      expect(isBaseComponent(el, config)).toBe(false);
+    });
   });
 });

--- a/core/src/global/test/platform.spec.ts
+++ b/core/src/global/test/platform.spec.ts
@@ -1,0 +1,15 @@
+import { getIonPlatform } from '../ionic-global';
+
+describe('getIonPlatform()', () => {
+  it('should return the component platform', () => {
+    const iosEl = document.createElement('ion-badge');
+    iosEl.platform = 'ios';
+
+    expect(getIonPlatform({ el: iosEl })).toBe('ios');
+
+    const androidEl = document.createElement('ion-badge');
+    androidEl.platform = 'android';
+
+    expect(getIonPlatform({ el: androidEl })).toBe('android');
+  });
+});

--- a/core/src/global/test/platform.spec.ts
+++ b/core/src/global/test/platform.spec.ts
@@ -1,15 +1,15 @@
-import { getIonPlatform } from '../ionic-global';
+import { getIonBehavior } from '../ionic-global';
 
-describe('getIonPlatform()', () => {
+describe('getIonBehavior()', () => {
   it('should return the component platform', () => {
     const iosEl = document.createElement('ion-badge');
     iosEl.platform = 'ios';
 
-    expect(getIonPlatform({ el: iosEl })).toBe('ios');
+    expect(getIonBehavior({ el: iosEl })).toBe('ios');
 
     const androidEl = document.createElement('ion-badge');
     androidEl.platform = 'android';
 
-    expect(getIonPlatform({ el: androidEl })).toBe('android');
+    expect(getIonBehavior({ el: androidEl })).toBe('android');
   });
 });

--- a/core/src/utils/config.ts
+++ b/core/src/utils/config.ts
@@ -213,6 +213,9 @@ export interface IonicConfig {
   platform?: PlatformConfig;
 
   /**
+   * EXPERIMENTAL: Base Components is in developer preview.
+   * Breaking changes may happen at any time.
+   *
    * When `true`, all components will be rendered without
    * iOS or MD styles, providing only the structural styles.
    * When `false`, all components will be rendered with iOS or

--- a/core/src/utils/menu-controller/animations/overlay.ts
+++ b/core/src/utils/menu-controller/animations/overlay.ts
@@ -28,8 +28,8 @@ export const menuOverlayAnimation = (menu: MenuI): Animation => {
 
   menuAnimation.addElement(menu.menuInnerEl!).fromTo('transform', `translateX(${closedX})`, `translateX(${openedX})`);
 
-  const mode = getIonPlatform(menu);
-  const isIos = mode === 'ios';
+  const platform = getIonPlatform(menu);
+  const isIos = platform === 'ios';
   const opacity = isIos ? 0.2 : 0.25;
 
   backdropAnimation.addElement(menu.backdropEl!).fromTo('opacity', 0.01, opacity);

--- a/core/src/utils/menu-controller/animations/overlay.ts
+++ b/core/src/utils/menu-controller/animations/overlay.ts
@@ -1,4 +1,4 @@
-import { getIonPlatform } from '../../../global/ionic-global';
+import { getIonBehavior } from '../../../global/ionic-global';
 import type { Animation, MenuI } from '../../../interface';
 import { createAnimation } from '../../animation/animation';
 
@@ -28,7 +28,7 @@ export const menuOverlayAnimation = (menu: MenuI): Animation => {
 
   menuAnimation.addElement(menu.menuInnerEl!).fromTo('transform', `translateX(${closedX})`, `translateX(${openedX})`);
 
-  const platform = getIonPlatform(menu);
+  const platform = getIonBehavior(menu);
   const isIos = platform === 'ios';
   const opacity = isIos ? 0.2 : 0.25;
 

--- a/core/src/utils/menu-controller/animations/overlay.ts
+++ b/core/src/utils/menu-controller/animations/overlay.ts
@@ -1,4 +1,4 @@
-import { getIonMode } from '../../../global/ionic-global';
+import { getIonPlatform } from '../../../global/ionic-global';
 import type { Animation, MenuI } from '../../../interface';
 import { createAnimation } from '../../animation/animation';
 
@@ -28,7 +28,7 @@ export const menuOverlayAnimation = (menu: MenuI): Animation => {
 
   menuAnimation.addElement(menu.menuInnerEl!).fromTo('transform', `translateX(${closedX})`, `translateX(${openedX})`);
 
-  const mode = getIonMode(menu);
+  const mode = getIonPlatform(menu);
   const isIos = mode === 'ios';
   const opacity = isIos ? 0.2 : 0.25;
 

--- a/core/src/utils/menu-controller/animations/push.ts
+++ b/core/src/utils/menu-controller/animations/push.ts
@@ -1,4 +1,4 @@
-import { getIonMode } from '../../../global/ionic-global';
+import { getIonPlatform } from '../../../global/ionic-global';
 import type { Animation, MenuI } from '../../../interface';
 import { createAnimation } from '../../animation/animation';
 
@@ -13,7 +13,7 @@ export const menuPushAnimation = (menu: MenuI): Animation => {
   let contentOpenedX: string;
   let menuClosedX: string;
 
-  const mode = getIonMode(menu);
+  const mode = getIonPlatform(menu);
   const width = menu.width;
 
   if (menu.isEndSide) {

--- a/core/src/utils/menu-controller/animations/push.ts
+++ b/core/src/utils/menu-controller/animations/push.ts
@@ -1,4 +1,4 @@
-import { getIonPlatform } from '../../../global/ionic-global';
+import { getIonBehavior } from '../../../global/ionic-global';
 import type { Animation, MenuI } from '../../../interface';
 import { createAnimation } from '../../animation/animation';
 
@@ -13,7 +13,7 @@ export const menuPushAnimation = (menu: MenuI): Animation => {
   let contentOpenedX: string;
   let menuClosedX: string;
 
-  const platform = getIonPlatform(menu);
+  const platform = getIonBehavior(menu);
   const width = menu.width;
 
   if (menu.isEndSide) {

--- a/core/src/utils/menu-controller/animations/push.ts
+++ b/core/src/utils/menu-controller/animations/push.ts
@@ -13,7 +13,7 @@ export const menuPushAnimation = (menu: MenuI): Animation => {
   let contentOpenedX: string;
   let menuClosedX: string;
 
-  const mode = getIonPlatform(menu);
+  const platform = getIonPlatform(menu);
   const width = menu.width;
 
   if (menu.isEndSide) {
@@ -34,5 +34,5 @@ export const menuPushAnimation = (menu: MenuI): Animation => {
 
   const backdropAnimation = createAnimation().addElement(menu.backdropEl!).fromTo('opacity', 0.01, 0.32);
 
-  return baseAnimation(mode === 'ios').addAnimation([menuAnimation, contentAnimation, backdropAnimation]);
+  return baseAnimation(platform === 'ios').addAnimation([menuAnimation, contentAnimation, backdropAnimation]);
 };

--- a/core/src/utils/menu-controller/animations/reveal.ts
+++ b/core/src/utils/menu-controller/animations/reveal.ts
@@ -10,11 +10,11 @@ import { baseAnimation } from './base';
  * The menu itself, which is under the content, does not move.
  */
 export const menuRevealAnimation = (menu: MenuI): Animation => {
-  const mode = getIonPlatform(menu);
+  const platform = getIonPlatform(menu);
   const openedX = menu.width * (menu.isEndSide ? -1 : 1) + 'px';
   const contentOpen = createAnimation()
     .addElement(menu.contentEl!) // REVIEW
     .fromTo('transform', 'translateX(0px)', `translateX(${openedX})`);
 
-  return baseAnimation(mode === 'ios').addAnimation(contentOpen);
+  return baseAnimation(platform === 'ios').addAnimation(contentOpen);
 };

--- a/core/src/utils/menu-controller/animations/reveal.ts
+++ b/core/src/utils/menu-controller/animations/reveal.ts
@@ -1,4 +1,4 @@
-import { getIonMode } from '../../../global/ionic-global';
+import { getIonPlatform } from '../../../global/ionic-global';
 import type { Animation, MenuI } from '../../../interface';
 import { createAnimation } from '../../animation/animation';
 
@@ -10,7 +10,7 @@ import { baseAnimation } from './base';
  * The menu itself, which is under the content, does not move.
  */
 export const menuRevealAnimation = (menu: MenuI): Animation => {
-  const mode = getIonMode(menu);
+  const mode = getIonPlatform(menu);
   const openedX = menu.width * (menu.isEndSide ? -1 : 1) + 'px';
   const contentOpen = createAnimation()
     .addElement(menu.contentEl!) // REVIEW

--- a/core/src/utils/menu-controller/animations/reveal.ts
+++ b/core/src/utils/menu-controller/animations/reveal.ts
@@ -1,4 +1,4 @@
-import { getIonPlatform } from '../../../global/ionic-global';
+import { getIonBehavior } from '../../../global/ionic-global';
 import type { Animation, MenuI } from '../../../interface';
 import { createAnimation } from '../../animation/animation';
 
@@ -10,7 +10,7 @@ import { baseAnimation } from './base';
  * The menu itself, which is under the content, does not move.
  */
 export const menuRevealAnimation = (menu: MenuI): Animation => {
-  const platform = getIonPlatform(menu);
+  const platform = getIonBehavior(menu);
   const openedX = menu.width * (menu.isEndSide ? -1 : 1) + 'px';
   const contentOpen = createAnimation()
     .addElement(menu.contentEl!) // REVIEW

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -1,5 +1,5 @@
 import { config } from '../global/config';
-import { getIonMode } from '../global/ionic-global';
+import { getIonPlatform } from '../global/ionic-global';
 import type {
   ActionSheetOptions,
   AlertOptions,
@@ -419,7 +419,7 @@ export const present = async <OverlayPresentOptions>(
   overlay.willPresent.emit();
   overlay.willPresentShorthand?.emit();
 
-  const mode = getIonMode(overlay);
+  const mode = getIonPlatform(overlay);
   // get the user's animation fn if one was provided
   const animationBuilder = overlay.enterAnimation
     ? overlay.enterAnimation
@@ -503,7 +503,7 @@ export const dismiss = async <OverlayDismissOptions>(
     overlay.willDismiss.emit({ data, role });
     overlay.willDismissShorthand?.emit({ data, role });
 
-    const mode = getIonMode(overlay);
+    const mode = getIonPlatform(overlay);
     const animationBuilder = overlay.leaveAnimation
       ? overlay.leaveAnimation
       : config.get(name, mode === 'ios' ? iosLeaveAnimation : mdLeaveAnimation);

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -1,5 +1,5 @@
 import { config } from '../global/config';
-import { getIonPlatform } from '../global/ionic-global';
+import { getIonBehavior } from '../global/ionic-global';
 import type {
   ActionSheetOptions,
   AlertOptions,
@@ -419,7 +419,7 @@ export const present = async <OverlayPresentOptions>(
   overlay.willPresent.emit();
   overlay.willPresentShorthand?.emit();
 
-  const platform = getIonPlatform(overlay);
+  const platform = getIonBehavior(overlay);
   // get the user's animation fn if one was provided
   const animationBuilder = overlay.enterAnimation
     ? overlay.enterAnimation
@@ -503,7 +503,7 @@ export const dismiss = async <OverlayDismissOptions>(
     overlay.willDismiss.emit({ data, role });
     overlay.willDismissShorthand?.emit({ data, role });
 
-    const platform = getIonPlatform(overlay);
+    const platform = getIonBehavior(overlay);
     const animationBuilder = overlay.leaveAnimation
       ? overlay.leaveAnimation
       : config.get(name, platform === 'ios' ? iosLeaveAnimation : mdLeaveAnimation);

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -419,11 +419,11 @@ export const present = async <OverlayPresentOptions>(
   overlay.willPresent.emit();
   overlay.willPresentShorthand?.emit();
 
-  const mode = getIonPlatform(overlay);
+  const platform = getIonPlatform(overlay);
   // get the user's animation fn if one was provided
   const animationBuilder = overlay.enterAnimation
     ? overlay.enterAnimation
-    : config.get(name, mode === 'ios' ? iosEnterAnimation : mdEnterAnimation);
+    : config.get(name, platform === 'ios' ? iosEnterAnimation : mdEnterAnimation);
 
   const completed = await overlayAnimation(overlay, animationBuilder, overlay.el, opts);
   if (completed) {
@@ -503,10 +503,10 @@ export const dismiss = async <OverlayDismissOptions>(
     overlay.willDismiss.emit({ data, role });
     overlay.willDismissShorthand?.emit({ data, role });
 
-    const mode = getIonPlatform(overlay);
+    const platform = getIonPlatform(overlay);
     const animationBuilder = overlay.leaveAnimation
       ? overlay.leaveAnimation
-      : config.get(name, mode === 'ios' ? iosLeaveAnimation : mdLeaveAnimation);
+      : config.get(name, platform === 'ios' ? iosLeaveAnimation : mdLeaveAnimation);
 
     // If dismissed via gesture, no need to play leaving animation again
     if (role !== GESTURE) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Ionic's "mode" option currently controls both the visuals and functionalities of components. Setting `<ion-modal mode="ios">` loads the iOS stylesheet for modal and enables the use of the card modal, a feature only available on the iOS platform. However, it is currently impossible to clear and iOS styles while retaining the functionality.

For example, if developers wanted to apply heavy customizations to how the card modal looks, they would first need to manually disable each iOS style they did not want before applying their custom styles. This is tedious and results in developers having to fight against the platform styles in order to get an app that does not look like a "cookie-cutter" iOS or MD app.

Base Components solves this problem by creating a new API that only controls the visuals of an application. This means that developers can retain iOS-specific behaviors such as swipe to go back and the card modal while customizing the look of their application.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

**Note** There should be no functional changes as a result of this PR. Components are still unable to opt-in to use base components. This PR focuses on the architecture/bookkeeping required to ensure there is a clear separation between mode visuals and platform functionality.

However, you can test this manually by doing the following:

1. Add `base: '[component].scss'` to the `styleUrls` object for a component
2. Use the `baseComponents` global config or the `use-base` attribute to enable base components.
This functionality will be hooked up in a future PR.

This PR does a few things: 

**getIonBehavior**
Internally, we separate the visuals from the functionality by creating a new `getIonBehavior` function. While `getIonMode` tells developers which stylesheet is loaded for a component, `getIonBehavior` tells developers which platform the component is tailoring its capabilities for.

Example: `getIonMode(this) === 'base' && getIonBehavior(this) === 'ios'` means that a component has no visual opinionation but functions as it would on an iOS device.

**getIonStylesheet** (formerly `getIonMode`)

`getIonMode` has traditionally been used to detect the visual and functional style that an app is running in. `getIonMode`'s behavior has been preserved for backwards compatibility. Developers can still use `mode` (either via the global config or via the property on a component) to set both the visuals and the functionalities at once. Components that use `getIonMode` to render the platform class on the host still do this. However, this class may sometimes be `'base'` instead of `'ios'` or `'md'`. This allows developers to target instances of components that are using base components.

To better show the separation between visuals and functionality, `getIonMode` has been renamed to `getIonStylesheet`. This function is used to determine the stylesheet that Stencil has loaded.

Example:

A developer can write the following:
```html
<!-- Assume mode="ios" globally -->
<ion-button id="first" use-base="true">Button</ion-button>
<ion-button id="second">Button</ion-button>
```

Which would render out to
```html
<ion-button id="first" use-base="true" class="base ...">Button</ion-button>
<ion-button id="second" class="ios ...">Button</ion-button>
```

From here, developers can target just the button instance that uses base components:

```css
ion-button.base {
  --background: green; // only the button using base components receives a green background
}
```

Developers who opt an entire component in (using the global config) do not need to target this `.base` class. Instead they can target just `ion-button` since every instance of the button would use base components in this scenario.

**API**

The API has been marked as experimental. Base components will remain in developer preview for now so we can collect feedback from the community. This also means we can make breaking changes to this feature outside of the typical major release cycle.

**setMode**

The `setMode` function is used by Stencil to load the correct stylesheet (see `styleUrls` in `ion-button` for an example). If `setMode` returns `'ios'` then the `'ios'` stylesheet would be loaded for that instance of the component.

This function has been updated to return `'base'` if an instance of a component is using base components. This will cause Stencil to only load the base/structural stylesheet for that instance of a component.

We also set the `platform` and `useBase` properties so we can correctly track the platform capabilities of each component (see `getIonPlatform` above).

**Component Consumption**

Several components have been updated to migrate their internal usage of `getIonMode` to `getIonPlatform`. I only modified components where the code was trying to determine the capabilities of a component. The `getIonMode` usage to determine the visuals of a component (or anything related to public APIs for styling) have remained untouched.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
