### PR TITLE
fix(select): setting options async updates rendered text

### DIFF
--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -1,5 +1,5 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
-import { Component, Element, Event, Host, Method, Prop, State, Watch, h } from '@stencil/core';
+import { Component, Element, Event, Host, Method, Prop, State, Watch, h, forceUpdate } from '@stencil/core';
 
 import { getIonMode } from '../../global/ionic-global';
 import type {
@@ -166,6 +166,14 @@ export class Select implements ComponentInterface {
 
     this.mutationO = watchForOptions<HTMLIonSelectOptionElement>(this.el, 'ion-select-option', async () => {
       this.updateOverlayOptions();
+
+      /**
+       * We need to re-render the component
+       * because one of the new ion-select-option
+       * elements may match the value. In this case,
+       * the rendered selected text should be updated.
+       */
+      forceUpdate(this);
     });
   }
 

--- a/core/src/components/select/test/async/index.html
+++ b/core/src/components/select/test/async/index.html
@@ -29,11 +29,15 @@
       <ion-select id="actionSheet" interface="action-sheet" placeholder="A Placeholder"></ion-select>
     </ion-item>
 
+    <ion-select id="with-value" placeholder="With Value" value="bird"></ion-select>
+
+    <button id="set-contents" onclick="setContents()">Set Contents</button>
+
     <script>
       let selects = document.querySelectorAll('ion-select');
       const options = ['bird', 'dog', 'shark', 'lizard'];
 
-      setTimeout(() => {
+      const setContents = () => {
         selects.forEach((select) => {
           options.forEach((option) => {
             let o = document.createElement('ion-select-option');
@@ -44,10 +48,8 @@
           });
 
           select.value = options[0];
-
-          window.dispatchEvent(new CustomEvent('selectValueSet'));
         });
-      }, 1000);
+      };
     </script>
   </body>
 </html>

--- a/core/src/components/select/test/async/select.e2e.ts
+++ b/core/src/components/select/test/async/select.e2e.ts
@@ -5,7 +5,7 @@ test.describe('select: async', () => {
   test.beforeEach(async ({ skip }) => {
     skip.rtl('This is checking internal logic. RTL tests are not needed');
     skip.mode('md');
-  })
+  });
   test('should correctly set the value after a delay', async ({ page }) => {
     await page.goto(`/src/components/select/test/async`);
     const selectValueSet = await page.spyOnEvent('selectValueSet');

--- a/core/src/components/select/test/async/select.e2e.ts
+++ b/core/src/components/select/test/async/select.e2e.ts
@@ -25,7 +25,6 @@ test.describe('select: async', () => {
 
     await selectValueSet.next();
 
-    await expect(select).toHaveJSProperty('value', 'bird');
     await expect(select.locator('.select-text')).toHaveText('bird');
   });
 });

--- a/core/src/components/select/test/async/select.e2e.ts
+++ b/core/src/components/select/test/async/select.e2e.ts
@@ -24,6 +24,7 @@ test.describe('select: async', () => {
     const select = await page.locator('#with-value');
 
     await selectValueSet.next();
+    await page.waitForChanges();
 
     await expect(select.locator('.select-text')).toHaveText('bird');
   });

--- a/core/src/components/select/test/async/select.e2e.ts
+++ b/core/src/components/select/test/async/select.e2e.ts
@@ -2,9 +2,11 @@ import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('select: async', () => {
-  test('should correctly set the value after a delay', async ({ page, skip }) => {
+  test.beforeEach(async ({ skip }) => {
     skip.rtl('This is checking internal logic. RTL tests are not needed');
-
+    skip.mode('md');
+  })
+  test('should correctly set the value after a delay', async ({ page }) => {
     await page.goto(`/src/components/select/test/async`);
     const selectValueSet = await page.spyOnEvent('selectValueSet');
 
@@ -13,5 +15,17 @@ test.describe('select: async', () => {
     await selectValueSet.next();
 
     await expect(select).toHaveJSProperty('value', 'bird');
+  });
+
+  test('should re-render when options update but value is already set', async ({ page }) => {
+    await page.goto(`/src/components/select/test/async`);
+    const selectValueSet = await page.spyOnEvent('selectValueSet');
+
+    const select = await page.locator('#with-value');
+
+    await selectValueSet.next();
+
+    await expect(select).toHaveJSProperty('value', 'bird');
+    await expect(select.locator('.select-text')).toHaveText('bird');
   });
 });

--- a/core/src/components/select/test/async/select.e2e.ts
+++ b/core/src/components/select/test/async/select.e2e.ts
@@ -2,29 +2,22 @@ import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('select: async', () => {
-  test.beforeEach(async ({ skip }) => {
+  test.beforeEach(async ({ page, skip }) => {
     skip.rtl('This is checking internal logic. RTL tests are not needed');
     skip.mode('md');
+
+    await page.goto(`/src/components/select/test/async`);
   });
   test('should correctly set the value after a delay', async ({ page }) => {
-    await page.goto(`/src/components/select/test/async`);
-    const selectValueSet = await page.spyOnEvent('selectValueSet');
-
-    const select = await page.locator('#default');
-
-    await selectValueSet.next();
+    const select = page.locator('#default');
+    await page.click('#set-contents');
 
     await expect(select).toHaveJSProperty('value', 'bird');
   });
 
   test('should re-render when options update but value is already set', async ({ page }) => {
-    await page.goto(`/src/components/select/test/async`);
-    const selectValueSet = await page.spyOnEvent('selectValueSet');
-
-    const select = await page.locator('#with-value');
-
-    await selectValueSet.next();
-    await page.waitForChanges();
+    const select = page.locator('#with-value');
+    await page.click('#set-contents');
 
     await expect(select.locator('.select-text')).toHaveText('bird');
   });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/19324

Updating IonSelectOptions does not re-render the IonSelect component (these are not props and ion-select is not using `<slot>`). As a result, the selected text of an IonSelect does not update. I fixed this issue back in 2019 in https://github.com/ionic-team/ionic-framework/commit/1c9c18b5eaa5807b802829586ec5fffb53f0d345. However, this behavior regressed in https://github.com/ionic-team/ionic-framework/commit/48a27636c76c1a05dc6d878be26cbe028552cbf7#diff-62cbe1fafe96a79e15c9c13dbafef8698860cfb31976445de7e1773079061eb6L153. I failed to include a proper test case, which is why this was not caught.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When IonSelectOption is mounted the component will now re-render.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
