### PR TITLE
fix(select): focusing item works in firefox

### DIFF
--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -206,11 +206,24 @@ export class Select implements ComponentInterface {
     if (this.interface === 'popover') {
       let indexOfSelected = this.childOpts.map((o) => o.value).indexOf(this.value);
       indexOfSelected = indexOfSelected > -1 ? indexOfSelected : 0; // default to first option if nothing selected
-      const selectedEl = overlay.querySelector<HTMLElement>(
+      const selectedItem = overlay.querySelector<HTMLElement>(
         `.select-interface-option:nth-child(${indexOfSelected + 1})`
       );
-      if (selectedEl) {
-        focusElement(selectedEl);
+
+      if (selectedItem) {
+        focusElement(selectedItem);
+
+        /**
+         * Browsers such as Firefox do not
+         * correctly delegate focus when manually
+         * focusing an element with delegatesFocus.
+         * We work around this by manually focusing
+         * the interactive element.
+         */
+        const interactiveEl = selectedItem.querySelector<HTMLElement>('ion-radio, ion-checkbox');
+        if (interactiveEl) {
+          interactiveEl.focus();
+        }
       }
     }
 

--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -219,6 +219,10 @@ export class Select implements ComponentInterface {
          * focusing an element with delegatesFocus.
          * We work around this by manually focusing
          * the interactive element.
+         * ion-radio and ion-checkbox are the only
+         * elements that ion-select-popover uses, so
+         * we only need to worry about those two components
+         * when focusing.
          */
         const interactiveEl = selectedItem.querySelector<HTMLElement>('ion-radio, ion-checkbox');
         if (interactiveEl) {

--- a/core/src/components/select/test/basic/select.e2e.ts
+++ b/core/src/components/select/test/basic/select.e2e.ts
@@ -72,7 +72,7 @@ test.describe('select: basic', () => {
   });
 
   test.describe('select: popover', () => {
-    test('it should open a popover select', async ({ page, browserName, skip }) => {
+    test('it should open a popover select', async ({ page, skip }) => {
       // TODO (FW-2979)
       skip.browser('webkit', 'Safari 16 only allows text fields and pop-up menus to be focused.');
 
@@ -85,12 +85,9 @@ test.describe('select: basic', () => {
 
       const popover = page.locator('ion-popover');
 
-      // TODO(FW-1436)
-      if (browserName !== 'firefox') {
-        // select has no value, so first option should be focused by default
-        const popoverOption1 = await popover.locator('.select-interface-option:first-of-type ion-radio');
-        await expect(popoverOption1).toBeFocused();
-      }
+      // select has no value, so first option should be focused by default
+      const popoverOption1 = popover.locator('.select-interface-option:first-of-type ion-radio');
+      await expect(popoverOption1).toBeFocused();
 
       expect(await page.screenshot({ animations: 'disabled' })).toMatchSnapshot(
         `select-popover-diff-${page.getSnapshotSettings()}.png`


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: Internal ticket

We had previously disabled the `ion-select` popover focus test on Firefox because it did not work. Upon further investigation, this appears to be a Firefox bug where `delegatesFocus` does not work correctly when manually focusing an element. This appears to be somewhat related to https://github.com/ionic-team/ionic-framework/issues/25070.

As a result of this, the `ion-radio` or `ion-checkbox` was never getting focused only on Firefox.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added additional logic to manually focus the inner radio/checkbox element
There should be no behavior change for non-Firefox browsers as the element will have already been focused.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
