### PR TITLE
fix(select): modern component takes up full line

### DIFF
--- a/core/src/components/select/select.ios.scss
+++ b/core/src/components/select/select.ios.scss
@@ -4,6 +4,7 @@
 // iOS Select
 // --------------------------------------------------
 
+// TODO FW-3194 - Remove this
 :host(.legacy-select) {
   --padding-top: #{$select-ios-padding-top};
   --padding-end: #{$select-ios-padding-end};
@@ -11,6 +12,7 @@
   --padding-start: #{$select-ios-padding-start};
 }
 
+// TODO FW-3194 - Move this to host
 :host(:not(.legacy-select)) {
   min-height: 44px;
 }

--- a/core/src/components/select/select.md.scss
+++ b/core/src/components/select/select.md.scss
@@ -11,6 +11,7 @@
   --border-color: #{$item-md-border-color};
 }
 
+// TODO FW-3194 - Remove this
 :host(.legacy-select) {
   --padding-top: #{$select-md-padding-top};
   --padding-end: #{$select-md-padding-end};
@@ -18,6 +19,7 @@
   --padding-start: #{$select-md-padding-start};
 }
 
+// TODO FW-3194 - Move this to host
 :host(:not(.legacy-select)) {
   min-height: 56px;
 }

--- a/core/src/components/select/select.scss
+++ b/core/src/components/select/select.scss
@@ -48,6 +48,8 @@
   display: block;
   position: relative;
 
+  width: 100%;
+
   font-family: $font-family-base;
 
   cursor: pointer;
@@ -75,11 +77,6 @@
   position: static;
 
   max-width: 45%;
-}
-
-:host(.in-item:not(.legacy-select)) {
-  width: 100%;
-  height: 100%;
 }
 
 :host(.select-disabled) {

--- a/core/src/components/select/select.scss
+++ b/core/src/components/select/select.scss
@@ -48,13 +48,15 @@
   display: block;
   position: relative;
 
-  width: 100%;
-
   font-family: $font-family-base;
 
   cursor: pointer;
 
   z-index: $z-index-item-input;
+}
+
+:host(:not(.legacy-select)) {
+  width: 100%;
 }
 
 :host(.ion-color) {

--- a/core/src/components/select/select.scss
+++ b/core/src/components/select/select.scss
@@ -55,6 +55,7 @@
   z-index: $z-index-item-input;
 }
 
+// TODO FW-3194 - Move this to host
 :host(:not(.legacy-select)) {
   width: 100%;
 }
@@ -63,6 +64,7 @@
   --highlight-color-focused: #{current-color(base)};
 }
 
+// TODO FW-3194 - Remove this
 :host(.legacy-select) {
   @include padding(var(--padding-top), var(--padding-end), var(--padding-bottom), var(--padding-start));
 
@@ -75,6 +77,7 @@
 
 // Select Used in ion-item
 // --------------------------------------------------
+// TODO FW-3194 - Remove this
 :host(.in-item.legacy-select) {
   position: static;
 
@@ -96,6 +99,7 @@
   opacity: var(--placeholder-opacity);
 }
 
+// TODO FW-3194 - Remove this
 :host(.legacy-select) label {
   @include input-cover();
 

--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -751,6 +751,7 @@ export class Select implements ComponentInterface {
     );
   }
 
+  // TODO FW-3194 - Remove this
   private renderLegacySelect() {
     if (!this.hasLoggedDeprecationWarning) {
       printIonWarning(


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
While working on the documentation I discovered that the select was missing `width: 100%` which allows it to take up the full line. This was due to old code that only applied with `.in-item`. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updated select to align with the new `ion-input` code to apply `width: 100%` and remove the `.in-item` code. (The height: 100% should not be needed when inside of ion-item)
- I also added TODOs to remove the legacy syntax

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
