### PR TITLE
chore(ci): sync scripts now account for dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 log.txt
 *.sublime-project
 *.sublime-workspace
+*.tgz
 
 .idea/
 .vscode/

--- a/angular/scripts/sync.sh
+++ b/angular/scripts/sync.sh
@@ -9,4 +9,4 @@ npm pack ../core
 npm pack ./
 
 # Install Dependencies
-npm install *.tgz
+npm install *.tgz --no-save

--- a/angular/scripts/sync.sh
+++ b/angular/scripts/sync.sh
@@ -2,8 +2,11 @@
 
 set -e
 
-# Copy core dist
-rm -rf node_modules/@ionic/core/dist node_modules/@ionic/core/components
-cp -a ../core/dist node_modules/@ionic/core/dist
-cp -a ../core/components node_modules/@ionic/core/components
-cp -a ../core/package.json node_modules/@ionic/core/package.json
+# Pack @ionic/core
+npm pack ../core
+
+# Pack @ionic/angular
+npm pack ./
+
+# Install Dependencies
+npm install *.tgz

--- a/angular/test/base/scripts/sync.sh
+++ b/angular/test/base/scripts/sync.sh
@@ -2,19 +2,14 @@
 
 set -e
 
-# Copy angular dist
-rm -rf node_modules/@ionic/angular
-cp -a ../../../dist node_modules/@ionic/angular
+# Pack @ionic/core
+npm pack ../../../../core
 
-# Copy angular server
-rm -rf node_modules/@ionic/angular-server
-cp -a ../../../../packages/angular-server/dist node_modules/@ionic/angular-server
+# Pack @ionic/angular
+npm pack ../../../
 
-# # Copy core dist
-rm -rf node_modules/@ionic/core
-mkdir node_modules/@ionic/core
-cp -a ../../../../core/css node_modules/@ionic/core/css
-cp -a ../../../../core/dist node_modules/@ionic/core/dist
-cp -a ../../../../core/hydrate node_modules/@ionic/core/hydrate
-cp -a ../../../../core/loader node_modules/@ionic/core/loader
-cp -a ../../../../core/package.json node_modules/@ionic/core/package.json
+# Pack @ionic/angular-server
+npm pack ../../../../packages/angular-server
+
+# Install Dependencies
+npm install *.tgz

--- a/angular/test/base/scripts/sync.sh
+++ b/angular/test/base/scripts/sync.sh
@@ -6,10 +6,10 @@ set -e
 npm pack ../../../../core
 
 # Pack @ionic/angular
-npm pack ../../../
+npm pack ../../../dist
 
 # Pack @ionic/angular-server
-npm pack ../../../../packages/angular-server
+npm pack ../../../../packages/angular-server/dist
 
 # Install Dependencies
 npm install *.tgz --no-save

--- a/angular/test/base/scripts/sync.sh
+++ b/angular/test/base/scripts/sync.sh
@@ -12,4 +12,4 @@ npm pack ../../../
 npm pack ../../../../packages/angular-server
 
 # Install Dependencies
-npm install *.tgz
+npm install *.tgz --no-save

--- a/packages/react-router/test-app/scripts/sync.sh
+++ b/packages/react-router/test-app/scripts/sync.sh
@@ -12,4 +12,4 @@ npm pack ../../react
 npm pack ../
 
 # Install Dependencies
-npm install *.tgz
+npm install *.tgz --no-save

--- a/packages/react-router/test-app/scripts/sync.sh
+++ b/packages/react-router/test-app/scripts/sync.sh
@@ -2,19 +2,14 @@
 
 set -e
 
-# Copy ionic react dist
-rm -rf node_modules/@ionic/react/dist node_modules/@ionic/react/css
-cp -a ../../react/dist node_modules/@ionic/react/dist
-cp -a ../../react/css node_modules/@ionic/react/css
-cp -a ../../react/package.json node_modules/@ionic/react/package.json
+# Pack @ionic/core
+npm pack ../../../core
 
-# Copy ionic react router dist
-rm -rf node_modules/@ionic/react-router/dist
-cp -a ../dist node_modules/@ionic/react-router/dist
-cp -a ../package.json node_modules/@ionic/react-router/package.json
+# Pack @ionic/react
+npm pack ../../react
 
-# Copy core dist and components
-rm -rf node_modules/@ionic/core/dist node_modules/@ionic/core/components
-cp -a ../../../core/package.json node_modules/@ionic/core/package.json
-cp -a ../../../core/dist node_modules/@ionic/core/dist
-cp -a ../../../core/components node_modules/@ionic/core/components
+# Pack @ionic/react-router
+npm pack ../
+
+# Install Dependencies
+npm install *.tgz

--- a/packages/react/test-app/scripts/sync.sh
+++ b/packages/react/test-app/scripts/sync.sh
@@ -2,19 +2,14 @@
 
 set -e
 
-# Copy ionic react dist
-rm -rf node_modules/@ionic/react/dist node_modules/@ionic/react/css
-cp -a ../dist node_modules/@ionic/react/dist
-cp -a ../css node_modules/@ionic/react/css
-cp -a ../package.json node_modules/@ionic/react/package.json
+# Pack @ionic/core
+npm pack ../../../core
 
-# Copy ionic react router dist
-rm -rf node_modules/@ionic/react-router/dist
-cp -a ../../react-router/dist node_modules/@ionic/react-router/dist
-cp -a ../../react-router/package.json node_modules/@ionic/react-router/package.json
+# Pack @ionic/react
+npm pack ../
 
-# Copy core dist
-rm -rf node_modules/@ionic/core/dist node_modules/@ionic/core/components
-cp -a ../../../core/dist node_modules/@ionic/core/dist
-cp -a ../../../core/package.json node_modules/@ionic/core/package.json
-cp -a ../../../core/components node_modules/@ionic/core/components
+# Pack @ionic/react-router
+npm pack ../../react-router
+
+# Install Dependencies
+npm install *.tgz

--- a/packages/react/test-app/scripts/sync.sh
+++ b/packages/react/test-app/scripts/sync.sh
@@ -12,4 +12,4 @@ npm pack ../
 npm pack ../../react-router
 
 # Install Dependencies
-npm install *.tgz
+npm install *.tgz --no-save

--- a/packages/vue-router/scripts/sync.sh
+++ b/packages/vue-router/scripts/sync.sh
@@ -2,14 +2,14 @@
 
 set -e
 
-# Copy ionic vue dist
-rm -rf node_modules/@ionic/vue/dist node_modules/@ionic/vue/css
-cp -a ../vue/dist node_modules/@ionic/vue/dist
-cp -a ../vue/css node_modules/@ionic/vue/css
-cp -a ../vue/package.json node_modules/@ionic/vue/package.json
+# Pack @ionic/core
+npm pack ../../core
 
-# Copy core dist
-rm -rf node_modules/@ionic/core/dist node_modules/@ionic/core/components
-cp -a ../../core/dist node_modules/@ionic/core/dist
-cp -a ../../core/components node_modules/@ionic/core/components
-cp -a ../../core/package.json node_modules/@ionic/core/package.json
+# Pack @ionic/vue
+npm pack ../vue
+
+# Pack @ionic/vue-router
+npm pack ./
+
+# Install Dependencies
+npm install *.tgz

--- a/packages/vue-router/scripts/sync.sh
+++ b/packages/vue-router/scripts/sync.sh
@@ -12,4 +12,4 @@ npm pack ../vue
 npm pack ./
 
 # Install Dependencies
-npm install *.tgz
+npm install *.tgz --no-save

--- a/packages/vue/scripts/sync.sh
+++ b/packages/vue/scripts/sync.sh
@@ -2,8 +2,14 @@
 
 set -e
 
-# Copy core dist
-rm -rf node_modules/@ionic/core/dist node_modules/@ionic/core/components
-cp -a ../../core/dist node_modules/@ionic/core/dist
-cp -a ../../core/components node_modules/@ionic/core/components
-cp -a ../../core/package.json node_modules/@ionic/core/package.json
+# Pack @ionic/core
+npm pack ../../core
+
+# Pack @ionic/vue
+npm pack ./
+
+# Pack @ionic/vue-router
+npm pack ../vue-router
+
+# Install Dependencies
+npm install *.tgz

--- a/packages/vue/scripts/sync.sh
+++ b/packages/vue/scripts/sync.sh
@@ -12,4 +12,4 @@ npm pack ./
 npm pack ../vue-router
 
 # Install Dependencies
-npm install *.tgz
+npm install *.tgz --no-save

--- a/packages/vue/test/base/scripts/sync.sh
+++ b/packages/vue/test/base/scripts/sync.sh
@@ -12,4 +12,4 @@ npm pack ../../../
 npm pack ../../../../vue-router
 
 # Install Dependencies
-npm install *.tgz
+npm install *.tgz --no-save

--- a/packages/vue/test/base/scripts/sync.sh
+++ b/packages/vue/test/base/scripts/sync.sh
@@ -2,19 +2,14 @@
 
 set -e
 
-# Copy ionic vue dist
-rm -rf node_modules/@ionic/vue/dist node_modules/@ionic/vue/css
-cp -a ../../../dist node_modules/@ionic/vue/dist
-cp -a ../../../css node_modules/@ionic/vue/css
-cp -a ../../../package.json node_modules/@ionic/vue/package.json
+# Pack @ionic/core
+npm pack ../../../../../core
 
-# Copy ionic vue router dist
-rm -rf node_modules/@ionic/vue-router/dist
-cp -a ../../../../vue-router/dist node_modules/@ionic/vue-router/dist
-cp -a ../../../../vue-router/package.json node_modules/@ionic/vue-router/package.json
+# Pack @ionic/vue
+npm pack ../../../
 
-# Copy core dist and components
-rm -rf node_modules/@ionic/core/dist node_modules/@ionic/core/components
-cp -a ../../../../../core/package.json node_modules/@ionic/core/package.json
-cp -a ../../../../../core/dist node_modules/@ionic/core/dist
-cp -a ../../../../../core/components node_modules/@ionic/core/components
+# Pack @ionic/vue-router
+npm pack ../../../../vue-router
+
+# Install Dependencies
+npm install *.tgz


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Our sync scripts only copy Ionic dependencies to E2E test applications. This resulted in Stencil Nightly Builds beginning to fail (https://github.com/ionic-team/ionic-framework/actions/runs/3899619536/jobs/6659530912). This was happening because the version of Stencil that Ionic Core required was not installed in the test application. Instead, an older version was installed. Versions of Ionic built with the newer version of Stencil expect a `setNonce` API to be exported. Since the sync scripts did not cause the new version of Stencil to be installed, builds failed as that `setNonce` API did not exist.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The new sync scripts pack each dependency and perform an NPM install. This causes both the local package _and_ its dependencies to be installed.
 
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
