### PR TITLE
fix(vue): cache attached view reference

### DIFF
--- a/packages/vue/src/framework-delegate.ts
+++ b/packages/vue/src/framework-delegate.ts
@@ -17,7 +17,7 @@ export const VueDelegate = (
   // TODO(FW-2969): types
   const attachViewToDom = (
     parentElement: HTMLElement,
-    component: any,
+    componentOrTagName: any | string,
     componentProps: any = {},
     classes?: string[]
   ) => {
@@ -37,10 +37,17 @@ export const VueDelegate = (
     const hostComponent = h(
       Teleport,
       { to: div },
-      h(component, { ...componentProps })
+      h(componentOrTagName, { ...componentProps })
     );
 
-    refMap.set(component, hostComponent);
+    /**
+     * Ionic Framework will use what is returned from `attachViewToDom`
+     * as the `component` argument in `removeViewFromDom`.
+     *
+     * We will store a reference to the div element and the host component,
+     * so we can later look-up and unmount the correct instance.
+     */
+    refMap.set(div, hostComponent);
 
     addFn(hostComponent);
 

--- a/packages/vue/test/base/src/router/index.ts
+++ b/packages/vue/test/base/src/router/index.ts
@@ -67,6 +67,14 @@ const routes: Array<RouteRecordRaw> = [
     component: () => import('@/views/Navigation.vue')
   },
   {
+    path: '/components',
+    component: () => import('@/views/Components.vue'),
+  },
+  {
+    path: '/components/select',
+    component: () => import('@/views/Select.vue')
+  },
+  {
     path: '/nested',
     component: () => import('@/views/RouterOutlet.vue'),
     children: [
@@ -140,7 +148,7 @@ const routes: Array<RouteRecordRaw> = [
         component: () => import('@/views/Tab3Secondary.vue')
       }
     ]
-  }
+  },
 ]
 
 const router = createRouter({

--- a/packages/vue/test/base/src/views/Components.vue
+++ b/packages/vue/test/base/src/views/Components.vue
@@ -1,0 +1,20 @@
+<template>
+  <ion-page>
+    <ion-content>
+      <ion-list>
+        <ion-item button router-link="/components/select">
+          <ion-label>Select</ion-label>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { IonPage, IonContent, IonList, IonItem, IonLabel } from "@ionic/vue";
+
+export default defineComponent({
+  components: { IonPage, IonContent, IonList, IonItem, IonLabel },
+});
+</script>

--- a/packages/vue/test/base/src/views/Home.vue
+++ b/packages/vue/test/base/src/views/Home.vue
@@ -53,15 +53,28 @@
         <ion-item button router-link="/delayed-redirect" id="delayed-redirect">
           <ion-label>Delayed Redirect</ion-label>
         </ion-item>
+        <ion-item button router-link="/components">
+          <ion-label>Components</ion-label>
+        </ion-item>
       </ion-list>
-
     </ion-content>
   </ion-page>
 </template>
 
 <script lang="ts">
-import { IonButtons, IonBackButton, IonContent, IonHeader, IonItem, IonLabel, IonList, IonPage, IonTitle, IonToolbar } from '@ionic/vue';
-import { defineComponent } from 'vue';
+import {
+  IonButtons,
+  IonBackButton,
+  IonContent,
+  IonHeader,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonPage,
+  IonTitle,
+  IonToolbar,
+} from "@ionic/vue";
+import { defineComponent } from "vue";
 
 export default defineComponent({
   components: {
@@ -74,7 +87,7 @@ export default defineComponent({
     IonList,
     IonPage,
     IonTitle,
-    IonToolbar
-  }
+    IonToolbar,
+  },
 });
 </script>

--- a/packages/vue/test/base/src/views/Select.vue
+++ b/packages/vue/test/base/src/views/Select.vue
@@ -1,0 +1,52 @@
+<template>
+  <ion-page>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Select</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content>
+      <ion-item>
+        <ion-label>Select Popover</ion-label>
+        <ion-select
+          id="select-popover"
+          interface="popover"
+          placeholder="Select fruit"
+        >
+          <ion-select-option value="apples">Apples</ion-select-option>
+          <ion-select-option value="oranges">Oranges</ion-select-option>
+          <ion-select-option value="bananas">Bananas</ion-select-option>
+        </ion-select>
+      </ion-item>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script lang="ts">
+import {
+  IonPage,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonItem,
+  IonLabel,
+  IonSelect,
+  IonSelectOption,
+} from "@ionic/vue";
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  components: {
+    IonPage,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonItem,
+    IonLabel,
+    IonSelect,
+    IonSelectOption,
+  },
+});
+</script>

--- a/packages/vue/test/base/tests/e2e/specs/select.cy.js
+++ b/packages/vue/test/base/tests/e2e/specs/select.cy.js
@@ -1,0 +1,10 @@
+describe("Components: Select", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:8080/components/select");
+  });
+
+  it("should open a popover overlay interface", () => {
+    cy.get("#select-popover").click();
+    cy.get("ion-popover").should("exist").should("be.visible");
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Developers using Vue can run into an error when using an `ion-select` that presents a popover of options. The Vue delegate was incorrectly assuming that a component instance would always be passed as the argument to `attachViewToDom`.

This is not the case for `ion-select`, where a string of the tag name is used: https://github.com/ionic-team/ionic-framework/blob/main/core/src/components/select/select.tsx#L414

<!-- Issues are required for both bug fixes and features. -->
Issue URL: https://github.com/ionic-team/ionic-framework/issues/26643#issuecomment-1406611223
resolves https://github.com/ionic-team/ionic-framework/issues/26695

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Caches the reference to the created element, so the `WeakMap` always receives an object to that can be used for looking up and unmounting an overlay.
- Refactored the property to better signal that it can be an "object" (`any`) or a string. Note: Because any will overwrite the types, this does nothing from a typings perspective. This is just a visual signal to a developer. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Repro: https://github.com/acoldfox/ionic-select-issue (you will need to install the dev-build to verify)

Dev-build: `6.5.2-dev.11674852369.1c9fe737`