### PR TITLE
fix(range): assign auto increment id by default

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -192,6 +192,8 @@ Ionic now listens on the `keydown` event instead of the `keyup` event when deter
 
 - Range no longer clamps assigned values within bounds. Developers will need to validate the value they are assigning to `ion-range` is within the `min` and `max` bounds when programmatically assigning a value. 
 
+- The `name` property defaults to `ion-r-${rangeIds++}` where `rangeIds` is a number that is incremented for every instance of `ion-range`.
+
 <h4 id="version-7x-searchbar">Searchbar</h4>
 
 - `ionChange` is no longer emitted when the `value` of `ion-searchbar` is modified externally. `ionChange` is only emitted from user committed changes, such as typing in the searchbar and the searchbar losing focus.

--- a/core/api.txt
+++ b/core/api.txt
@@ -1034,7 +1034,7 @@ ion-range,prop,legacy,boolean | undefined,undefined,false,false
 ion-range,prop,max,number,100,false,false
 ion-range,prop,min,number,0,false,false
 ion-range,prop,mode,"ios" | "md",undefined,false,false
-ion-range,prop,name,string,'',false,false
+ion-range,prop,name,string,this.rangeId,false,false
 ion-range,prop,pin,boolean,false,false,false
 ion-range,prop,pinFormatter,(value: number) => string | number,(value: number): number => Math.round(value),false,false
 ion-range,prop,snaps,boolean,false,false,false

--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -46,7 +46,7 @@ import type {
   shadow: true,
 })
 export class Range implements ComponentInterface {
-  private rangeId?: string = `ion-r-${rangeIds++}`;
+  private rangeId: string = `ion-r-${rangeIds++}`;
   private didLoad = false;
   private noUpdate = false;
   private rect!: ClientRect;
@@ -94,7 +94,7 @@ export class Range implements ComponentInterface {
   /**
    * The name of the control, which is submitted with the form data.
    */
-  @Prop() name = '';
+  @Prop() name = this.rangeId;
 
   /**
    * Show two knobs.

--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -553,7 +553,7 @@ export class Range implements ComponentInterface {
   private renderLegacyRange() {
     if (!this.hasLoggedDeprecationWarning) {
       printIonWarning(
-        `Using ion-range with an ion-label has been deprecated. To migrate, remove the ion-label and pass your label directly into ion-toggle instead.
+        `Using ion-range with an ion-label has been deprecated. To migrate, remove the ion-label and pass your label directly into ion-range instead.
 
 Example: <ion-range><div slot="label">Volume:</div></ion-range>
 

--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -46,7 +46,7 @@ import type {
   shadow: true,
 })
 export class Range implements ComponentInterface {
-  private rangeId?: string;
+  private rangeId?: string = `ion-r-${rangeIds++}`;
   private didLoad = false;
   private noUpdate = false;
   private rect!: ClientRect;
@@ -90,8 +90,6 @@ export class Range implements ComponentInterface {
      */
     this.ionInput = debounce === undefined ? originalIonInput ?? ionInput : debounceEvent(ionInput, debounce);
   }
-
-  // TODO: In Ionic Framework v6 this should initialize to this.rangeId like the other form components do.
 
   /**
    * The name of the control, which is submitted with the form data.
@@ -302,7 +300,9 @@ export class Range implements ComponentInterface {
      * If user has custom ID set then we should
      * not assign the default incrementing ID.
      */
-    this.rangeId = this.el.hasAttribute('id') ? this.el.getAttribute('id')! : `ion-r-${rangeIds++}`;
+    if (this.el.hasAttribute('id')) {
+      this.rangeId = this.el.getAttribute('id')!;
+    }
 
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
@@ -555,7 +555,7 @@ export class Range implements ComponentInterface {
       printIonWarning(
         `Using ion-range with an ion-label has been deprecated. To migrate, remove the ion-label and pass your label directly into ion-toggle instead.
 
-Example: <ion-range>Volume:</ion-range>
+Example: <ion-range><div slot="label">Volume:</div></ion-range>
 
 For ranges that do not have a visible label, developers should use "aria-label" so screen readers can announce the purpose of the range.
 

--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -46,7 +46,7 @@ import type {
   shadow: true,
 })
 export class Range implements ComponentInterface {
-  private rangeId: string = `ion-r-${rangeIds++}`;
+  private rangeId = `ion-r-${rangeIds++}`;
   private didLoad = false;
   private noUpdate = false;
   private rect!: ClientRect;

--- a/core/src/components/range/test/range.spec.ts
+++ b/core/src/components/range/test/range.spec.ts
@@ -75,4 +75,4 @@ describe('range id', () => {
     const range = page.body.querySelector('ion-range');
     expect(range.getAttribute('id')).toBe('my-custom-range');
   });
-})
+});

--- a/core/src/components/range/test/range.spec.ts
+++ b/core/src/components/range/test/range.spec.ts
@@ -1,3 +1,4 @@
+import { newSpecPage } from '@stencil/core/testing';
 import { Range } from '../range';
 
 let sharedRange;
@@ -61,3 +62,17 @@ describe('Range', () => {
     });
   });
 });
+
+describe('range id', () => {
+  it('should render custom id if passed', async () => {
+    const page = await newSpecPage({
+      components: [Range],
+      html: `<ion-range id="my-custom-range">
+        <div slot="label">Range</div>
+      </ion-range>`,
+    });
+
+    const range = page.body.querySelector('ion-range');
+    expect(range.getAttribute('id')).toBe('my-custom-range');
+  });
+})


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: Internal

Range defaults the `name` property to the empty string which does not align with the other form components. I also noticed that the example usage in the deprecation message is wrong -- it should pass a label into the named slot not the default slot.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `name` property defaults to `ion-r-${rangeIds++}`.
- Warning message has correct usage
- Added tests

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
