### PR TITLE
fix(modal): dialog styles work on old chrome versions

### DIFF
--- a/core/src/css/core.scss
+++ b/core/src/css/core.scss
@@ -164,7 +164,7 @@ html.ios ion-modal.modal-card .ion-page {
  * These changes allow certain dimension values
  * such as fit-content to work correctly.
  */
-ion-modal .ion-page:not(ion-nav .ion-page) {
+ion-modal > .ion-page {
   position: relative;
 
   contain: layout style;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/26745

We used a complex `:not` selector to fix an issue noted in https://github.com/ionic-team/ionic-framework/pull/25689. The better solution was to use `ion-modal > .ion-page`. However, at the time of #25689 there was a bug where `.ion-page` was mounted multiple times with inline modals in Ionic Angular. This bug no longer reproduces in the Angular playgrounds: https://ionicframework.com/docs/api/modal#custom-dialogs


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Custom dialog styles now use `ion-modal > .ion-page` to target the immediate child of the modal.

Note: I am merging this into `feature-6.6` to de-risk this. I tested this, and it works correctly on the custom dialog playgrounds.

Dev Build: 6.5.3-dev.11675782754.10ad7d4a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
