### PR TITLE
feat(picker-column): assign custom aria-labels to column options

### DIFF
--- a/core/src/components/picker-column/picker-column.tsx
+++ b/core/src/components/picker-column/picker-column.tsx
@@ -360,7 +360,6 @@ export class PickerColumnCmp implements ComponentInterface {
 
   render() {
     const col = this.col;
-    const Button = 'button' as any;
     const mode = getIonMode(this);
     return (
       <Host
@@ -382,9 +381,13 @@ export class PickerColumnCmp implements ComponentInterface {
         )}
         <div class="picker-opts" style={{ maxWidth: col.optionsWidth! }} ref={(el) => (this.optsEl = el)}>
           {col.options.map((o, index) => (
-            <Button type="button" class={{ 'picker-opt': true, 'picker-opt-disabled': !!o.disabled }} opt-index={index}>
+            <button
+              aria-label={o.ariaLabel}
+              class={{ 'picker-opt': true, 'picker-opt-disabled': !!o.disabled }}
+              opt-index={index}
+            >
               {o.text}
-            </Button>
+            </button>
           ))}
         </div>
         {col.suffix && (

--- a/core/src/components/picker-column/test/picker-column-aria.spec.tsx
+++ b/core/src/components/picker-column/test/picker-column-aria.spec.tsx
@@ -1,0 +1,47 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import { PickerColumnCmp } from '../picker-column';
+/**
+ * Stencil has an issue where having multiple spec tests in the same file,
+ * will cause an exception to be thrown. This test is located in a separate file
+ * to avoid this issue.
+ *
+ * Example exception:
+ * ```
+ * TypeError: Cannot read properties of undefined (reading '$instanceValues$')
+    at getValue (/Users/sean/Documents/ionic/framework-next/core/node_modules/@stencil/core/internal/testing/index.js:542:282)
+    at PickerColumnCmp.get (/Users/sean/Documents/ionic/framework-next/core/node_modules/@stencil/core/internal/testing/index.js:571:13)
+    at PickerColumnCmp.refresh (/Users/sean/Documents/ionic/framework-next/core/src/components/picker-column/picker-column.tsx:304:20)
+    at Timeout._onTimeout (/Users/sean/Documents/ionic/framework-next/core/src/components/picker-column/picker-column.tsx:73:12)
+    at listOnTimeout (node:internal/timers:559:17)
+    at processTimers (node:internal/timers:502:7)
+
+ * ```
+ */
+describe('picker-column', () => {
+  it('should add aria-label to the picker column option', async () => {
+    const col = {
+      options: [
+        {
+          text: 'C#',
+          ariaLabel: 'C Sharp',
+        },
+        {
+          text: 'Java',
+        },
+      ],
+    };
+
+    const page = await newSpecPage({
+      components: [PickerColumnCmp],
+      template: () => <ion-picker-column col={col}></ion-picker-column>,
+    });
+
+    const firstOption = page.body.querySelector('ion-picker-column .picker-opt:nth-child(1)');
+    const secondOption = page.body.querySelector('ion-picker-column .picker-opt:nth-child(2)');
+
+    expect(firstOption.getAttribute('aria-label')).toBe('C Sharp');
+    expect(secondOption.getAttribute('aria-label')).toBe(null);
+  });
+});

--- a/core/src/components/picker-column/test/picker-column-aria.spec.tsx
+++ b/core/src/components/picker-column/test/picker-column-aria.spec.tsx
@@ -5,19 +5,7 @@ import { PickerColumnCmp } from '../picker-column';
 /**
  * Stencil has an issue where having multiple spec tests in the same file,
  * will cause an exception to be thrown. This test is located in a separate file
- * to avoid this issue.
- *
- * Example exception:
- * ```
- * TypeError: Cannot read properties of undefined (reading '$instanceValues$')
-    at getValue (/Users/sean/Documents/ionic/framework-next/core/node_modules/@stencil/core/internal/testing/index.js:542:282)
-    at PickerColumnCmp.get (/Users/sean/Documents/ionic/framework-next/core/node_modules/@stencil/core/internal/testing/index.js:571:13)
-    at PickerColumnCmp.refresh (/Users/sean/Documents/ionic/framework-next/core/src/components/picker-column/picker-column.tsx:304:20)
-    at Timeout._onTimeout (/Users/sean/Documents/ionic/framework-next/core/src/components/picker-column/picker-column.tsx:73:12)
-    at listOnTimeout (node:internal/timers:559:17)
-    at processTimers (node:internal/timers:502:7)
-
- * ```
+ * to avoid this issue: https://github.com/ionic-team/stencil/issues/4053
  */
 describe('picker-column', () => {
   it('should add aria-label to the picker column option', async () => {

--- a/core/src/components/picker-column/test/picker-column.spec.tsx
+++ b/core/src/components/picker-column/test/picker-column.spec.tsx
@@ -1,5 +1,6 @@
 import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
+
 import { PickerColumnCmp } from '../picker-column';
 
 describe('picker-column', () => {
@@ -13,5 +14,30 @@ describe('picker-column', () => {
 
     const pickerCol = page.body.querySelector('ion-picker-column');
     expect(pickerCol.classList.contains('test-class')).toBe(true);
+  });
+
+  it('should add aria-label to the picker column option', async () => {
+    const col = {
+      options: [
+        {
+          text: 'C#',
+          ariaLabel: 'C Sharp',
+        },
+        {
+          text: 'Java',
+        },
+      ],
+    };
+
+    const page = await newSpecPage({
+      components: [PickerColumnCmp],
+      template: () => <ion-picker-column col={col}></ion-picker-column>,
+    });
+
+    const firstOption = page.body.querySelector('ion-picker-column .picker-opt:nth-child(1)');
+    const secondOption = page.body.querySelector('ion-picker-column .picker-opt:nth-child(2)');
+
+    expect(firstOption.getAttribute('aria-label')).toBe('C Sharp');
+    expect(secondOption.getAttribute('aria-label')).toBe(null);
   });
 });

--- a/core/src/components/picker-column/test/picker-column.spec.tsx
+++ b/core/src/components/picker-column/test/picker-column.spec.tsx
@@ -15,29 +15,4 @@ describe('picker-column', () => {
     const pickerCol = page.body.querySelector('ion-picker-column');
     expect(pickerCol.classList.contains('test-class')).toBe(true);
   });
-
-  it('should add aria-label to the picker column option', async () => {
-    const col = {
-      options: [
-        {
-          text: 'C#',
-          ariaLabel: 'C Sharp',
-        },
-        {
-          text: 'Java',
-        },
-      ],
-    };
-
-    const page = await newSpecPage({
-      components: [PickerColumnCmp],
-      template: () => <ion-picker-column col={col}></ion-picker-column>,
-    });
-
-    const firstOption = page.body.querySelector('ion-picker-column .picker-opt:nth-child(1)');
-    const secondOption = page.body.querySelector('ion-picker-column .picker-opt:nth-child(2)');
-
-    expect(firstOption.getAttribute('aria-label')).toBe('C Sharp');
-    expect(secondOption.getAttribute('aria-label')).toBe(null);
-  });
 });

--- a/core/src/components/picker/picker-interface.ts
+++ b/core/src/components/picker/picker-interface.ts
@@ -57,4 +57,8 @@ export interface PickerColumnOption {
   duration?: number;
   transform?: string;
   selected?: boolean;
+  /**
+   * The optional text to assign as the aria-label on the picker column option.
+   */
+  ariaLabel?: string;
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Developers cannot assign an `aria-label` to the individual button items in a picker column.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Developers can optionally assign an `ariaLabel` to a picker column option, to assign the `aria-label` to the rendered button.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Note: Stencil has something strange happening with the spec tests. Since the picker column uses timeouts, you will receive an exception if the tests are located in the same file. The issue doesn't occur if you place the spec tests in separate files. I experimented with Jest timer mocks and this appears to be a Stencil issue. The team has asked I create a minimal reproduction for them to dig into, which will require additional time and isn't a blocker for this feature.
