### PR TITLE
fix(checkbox, radio): label is announced once on ios

### DIFF
--- a/core/src/components/checkbox/checkbox.tsx
+++ b/core/src/components/checkbox/checkbox.tsx
@@ -247,6 +247,17 @@ export class Checkbox implements ComponentInterface {
         })}
       >
         <label class="checkbox-wrapper">
+          <input
+            type="checkbox"
+            aria-checked={`${checked}`}
+            disabled={disabled}
+            id={inputId}
+            onChange={this.toggleChecked}
+            onFocus={() => this.onFocus()}
+            onBlur={() => this.onBlur()}
+            ref={(focusEl) => (this.focusEl = focusEl)}
+            {...inheritedAttributes}
+          />
           <div
             class={{
               'label-text-wrapper': true,
@@ -260,17 +271,6 @@ export class Checkbox implements ComponentInterface {
               {path}
             </svg>
           </div>
-          <input
-            type="checkbox"
-            aria-checked={`${checked}`}
-            disabled={disabled}
-            id={inputId}
-            onChange={this.toggleChecked}
-            onFocus={() => this.onFocus()}
-            onBlur={() => this.onBlur()}
-            ref={(focusEl) => (this.focusEl = focusEl)}
-            {...inheritedAttributes}
-          />
         </label>
       </Host>
     );

--- a/core/src/components/checkbox/checkbox.tsx
+++ b/core/src/components/checkbox/checkbox.tsx
@@ -247,6 +247,10 @@ export class Checkbox implements ComponentInterface {
         })}
       >
         <label class="checkbox-wrapper">
+          {/*
+            The native control must be rendered
+            before the visible label text due to https://bugs.webkit.org/show_bug.cgi?id=251951
+          */}
           <input
             type="checkbox"
             aria-checked={`${checked}`}

--- a/core/src/components/radio/radio.tsx
+++ b/core/src/components/radio/radio.tsx
@@ -234,6 +234,10 @@ export class Radio implements ComponentInterface {
         })}
       >
         <label class="radio-wrapper">
+          {/*
+            The native control must be rendered
+            before the visible label text due to https://bugs.webkit.org/show_bug.cgi?id=251951
+          */}
           <input
             type="radio"
             checked={checked}

--- a/core/src/components/radio/radio.tsx
+++ b/core/src/components/radio/radio.tsx
@@ -234,6 +234,14 @@ export class Radio implements ComponentInterface {
         })}
       >
         <label class="radio-wrapper">
+          <input
+            type="radio"
+            checked={checked}
+            disabled={disabled}
+            id={inputId}
+            ref={(nativeEl) => (this.nativeInput = nativeEl as HTMLInputElement)}
+            {...inheritedAttributes}
+          />
           <div
             class={{
               'label-text-wrapper': true,
@@ -243,14 +251,6 @@ export class Radio implements ComponentInterface {
             <slot></slot>
           </div>
           <div class="native-wrapper">{this.renderRadioControl()}</div>
-          <input
-            type="radio"
-            checked={checked}
-            disabled={disabled}
-            id={inputId}
-            ref={(nativeEl) => (this.nativeInput = nativeEl as HTMLInputElement)}
-            {...inheritedAttributes}
-          />
         </label>
       </Host>
     );


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
resolves https://github.com/ionic-team/ionic-framework/issues/26769

Rendering the label text before a checkbox or radio causes VoiceOver to read the label twice (once when focusing the label, then once when focusing the control)

This does not impact v6 because these components use `aria-label` instead of associating the control with a visible text node.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Render the hidden input before the label, bypassing this bug.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
