### PR TITLE
refactor(ci): allow manual 'stencil nightly' builds 

### DIFF
--- a/.github/workflows/stencil-eval.yml
+++ b/.github/workflows/stencil-eval.yml
@@ -7,6 +7,8 @@ on:
     # Run every Monday-Friday
     # at 6:00 UTC (6:00 am UTC)
     - cron: '00 06 * * 1-5'
+  workflow_dispatch:
+    # allows for manual invocations in the GitHub UI
 
 # When pushing a new commit we should
 # cancel the previous test run to not
@@ -16,7 +18,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-core:
+  build-core-with-stencil-eval:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -25,7 +27,7 @@ jobs:
       - uses: ./.github/workflows/actions/build-core-stencil-eval
 
   test-core-clean-build:
-    needs: [build-core]
+    needs: [build-core-with-stencil-eval]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +36,7 @@ jobs:
       - uses: ./.github/workflows/actions/test-core-clean-build
 
   test-core-lint:
-    needs: [build-core]
+    needs: [build-core-with-stencil-eval]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -43,7 +45,7 @@ jobs:
       - uses: ./.github/workflows/actions/test-core-lint
 
   test-core-spec:
-    needs: [build-core]
+    needs: [build-core-with-stencil-eval]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -66,7 +68,7 @@ jobs:
         # to be the length of the shard array.
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
         totalShards: [20]
-    needs: [build-core]
+    needs: [build-core-with-stencil-eval]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -96,7 +98,7 @@ jobs:
         run: exit 1
 
   build-vue:
-    needs: [build-core]
+    needs: [build-core-with-stencil-eval]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -138,7 +140,7 @@ jobs:
         run: exit 1
 
   build-angular:
-    needs: [build-core]
+    needs: [build-core-with-stencil-eval]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -180,7 +182,7 @@ jobs:
         run: exit 1
 
   build-react:
-    needs: [build-core]
+    needs: [build-core-with-stencil-eval]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): In addition to a job rename, the `workflow_dispatch` trigger is added to the workflow


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Debugging this workflow requires opening a new PR, even if it fails due to a temporal issue (e.g. a flaky test)

<!-- Issues are required for both bug fixes and features. -->
Issue URL: 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds the `workflow_dispatch` event to trigger a stencil
nightly build workflow. this is being done to make it easier to debug the
nightly stencil build, by allowing us to invoke it without opening a pr
against the framework repo.

this commit also renames the 'build-core' job to
'build-core-with-stencil-eval', to help differentiate the job associated
with this workflow from the 'build-core' job found in the primary ci
workflow

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
