### PR TITLE
fix(content): fullscreen works when rotating device

### DIFF
--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -30,6 +30,7 @@ export class Content implements ComponentInterface {
   private scrollEl?: HTMLElement;
   private backgroundContentEl?: HTMLElement;
   private isMainContent = true;
+  private resizeTimeout: ReturnType<typeof setTimeout> | null = null;
 
   // Detail is used in a hot loop in the scroll event, by allocating it here
   // V8 will be able to inline any read/write to it since it's a monomorphic class.
@@ -121,6 +122,35 @@ export class Content implements ComponentInterface {
   @Listen('appload', { target: 'window' })
   onAppLoad() {
     this.resize();
+  }
+
+  /**
+   * Rotating certain devices can update
+   * the safe area insets. As a result,
+   * the fullscreen feature on ion-content
+   * needs to be recalculated.
+   *
+   * We listen for "resize" because we
+   * do not care what the orientation of
+   * the device is. Other APIs
+   * such as ScreenOrientation or
+   * the deviceorientation event must have
+   * permission from the user first whereas
+   * the "resize" event does not.
+   *
+   * We also throttle the callback to minimize
+   * thrashing when quickly resizing a window.
+   */
+  @Listen('resize', { target: 'window' })
+  onResize() {
+    if (this.resizeTimeout) {
+      clearTimeout(this.resizeTimeout);
+      this.resizeTimeout = null;
+    }
+
+    this.resizeTimeout = setTimeout(() => {
+      this.resize();
+    }, 100);
   }
 
   private shouldForceOverscroll() {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/26743

Rotating the device can cause safe area values to change. This means that the fullscreen values on ion-content, --offset-top and --offset-bottom, can be invalidated. We do not listen for these device orientation changes, so blank space can sometimes appear above headers or below footers.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds a throttled `resize` event listener that calls the `this.resize()` method to recalculate the fullscreen valeus.

I considered the following alternatives:

1. [ScreenOrientation API](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation): This has a change event we could listen for, but it is not supported on iOS.
2. [deviceorientation](https://developer.mozilla.org/en-US/docs/Web/API/Window/deviceorientation_event): This has cross-browser support but requires a permission prompt in order to use. This means that all Ionic apps that use `ion-content` would need to prompt the user for access data from the orientation sensor on their devices.

The `resize` event has cross-browser support and does not have any permissions restrictions. The above two features also give us more information than we need. We don't care _what_ the orientation is, we just want to know when the orientation changes.

I also added the resize callback in a 100ms timeout to avoid any layout thrashing since `this.resize` accesses some element properties that can force layouts to occur. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
