### PR TITLE
fix(form): legacy deprecation is logged correctly

### DIFF
--- a/core/src/utils/forms/form-controller.ts
+++ b/core/src/utils/forms/form-controller.ts
@@ -8,7 +8,7 @@ type HTMLLegacyFormControlElement = HTMLElement & { label?: string; legacy?: boo
  */
 export const createLegacyFormController = (el: HTMLLegacyFormControlElement): LegacyFormController => {
   const controlEl: HTMLLegacyFormControlElement = el;
-  let legacyControl;
+  let legacyControl: boolean | undefined;
 
   const hasLegacyControl = () => {
     if (legacyControl === undefined) {

--- a/core/src/utils/forms/form-controller.ts
+++ b/core/src/utils/forms/form-controller.ts
@@ -8,27 +8,28 @@ type HTMLLegacyFormControlElement = HTMLElement & { label?: string; legacy?: boo
  */
 export const createLegacyFormController = (el: HTMLLegacyFormControlElement): LegacyFormController => {
   const controlEl: HTMLLegacyFormControlElement = el;
-  let legacyControl = true;
-
-  /**
-   * Detect if developers are using the legacy form control syntax
-   * so a deprecation warning is logged. This warning can be disabled
-   * by either using the new `label` property or setting `aria-label`
-   * on the control.
-   * Alternatively, components that use a slot for the label
-   * can check to see if the component has slotted text
-   * in the light DOM.
-   */
-  const hasLabelProp = (controlEl as any).label !== undefined || hasLabelSlot(controlEl);
-  const hasAriaLabelAttribute = controlEl.hasAttribute('aria-label') || controlEl.hasAttribute('aria-labelledby');
-
-  /**
-   * Developers can manually opt-out of the modern form markup
-   * by setting `legacy="true"` on components.
-   */
-  legacyControl = controlEl.legacy === true || (!hasLabelProp && !hasAriaLabelAttribute);
+  let legacyControl;
 
   const hasLegacyControl = () => {
+    if (legacyControl === undefined) {
+      /**
+       * Detect if developers are using the legacy form control syntax
+       * so a deprecation warning is logged. This warning can be disabled
+       * by either using the new `label` property or setting `aria-label`
+       * on the control.
+       * Alternatively, components that use a slot for the label
+       * can check to see if the component has slotted text
+       * in the light DOM.
+       */
+      const hasLabelProp = (controlEl as any).label !== undefined || hasLabelSlot(controlEl);
+      const hasAriaLabelAttribute = controlEl.hasAttribute('aria-label') || controlEl.hasAttribute('aria-labelledby');
+
+      /**
+       * Developers can manually opt-out of the modern form markup
+       * by setting `legacy="true"` on components.
+       */
+      legacyControl = controlEl.legacy === true || (!hasLabelProp && !hasAriaLabelAttribute);
+    }
     return legacyControl;
   };
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Ken noted that the legacy deprecation message was being logged incorrectly when running Angular unit tests. This was happening because the legacy control check was happening before any slotted content (i.e. a label in `ion-toggle`) was available in the DOM. As a result, the form controller incorrectly thought the control instance was using the legacy syntax.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Delayed the legacy control check until the first time `hasLegacyControl` is called as opposed to running the check the moment the component class is created. Since `hasLegacyControl` is called in Stencil lifecycle hooks, this should ensure that slotted content is available in the DOM.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
