### PR TITLE
Update input.tsx

### DIFF
--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -298,7 +298,7 @@ export class Input implements ComponentInterface {
     const nativeInput = this.nativeInput;
     if (nativeInput) {
       nativeInput.removeEventListener('compositionstart', this.onCompositionStart);
-      nativeInput.removeEventListener('compositionEnd', this.onCompositionEnd);
+      nativeInput.removeEventListener('compositionend', this.onCompositionEnd);
     }
   }
 


### PR DESCRIPTION
Fix an issue where the compositionEnd event listener is not removed from the native element, due to a typo in the name of the event.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The event listener is not removed.

Issue URL: https://github.com/ionic-team/ionic-framework/issues/26805

## What is the new behavior?

The event listener is properly removed, allowing the element (and the Stencil component) to be released.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

