### PR TITLE
test(toast): toHaveScreenshot signature is correct

### DIFF
--- a/core/src/components/toast/test/basic/toast.e2e.ts
+++ b/core/src/components/toast/test/basic/toast.e2e.ts
@@ -36,8 +36,13 @@ class ToastFixture {
   async screenshot(screenshotModifier: string, el?: Locator) {
     const { page } = this;
 
-    const reference = el !== undefined ? el : page;
-    await expect(reference).toHaveScreenshot(`toast-${screenshotModifier}-${page.getSnapshotSettings()}.png`);
+    const screenshotString = `toast-${screenshotModifier}-${page.getSnapshotSettings()}.png`;
+
+    if (el === undefined) {
+      await expect(page).toHaveScreenshot(screenshotString);
+    } else {
+      await expect(el).toHaveScreenshot(screenshotString);
+    }
   }
 
   skipRTL(testRef: typeof test, reason = 'This functionality does not have RTL-specific behaviors.') {
@@ -151,7 +156,7 @@ test.describe('toast: duration config', () => {
       <ion-toast></ion-toast>
       <script>
         window.Ionic = {
-          config: { toastDuration: 5000 } 
+          config: { toastDuration: 5000 }
         }
       </script>
     `);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Running subsequent builds of Ionic yields this error:

```shell
TypeScript: ./src/components/toast/test/basic/toast.e2e.ts:40:29
           Property 'toHaveScreenshot' does not exist on type
           'MakeMatchers<void, E2EPage | Locator>'.Property
           'toHaveScreenshot' does not exist on type 'Matchers<...> &
           PlaywrightTest.Matchers<...> & { not: MakeMatchers<void, E2EPage
           | Locator>; resolves: MakeMatchers<...>; rejects:
           MakeMatchers<...>; } & SnapshotAssertions'.

     L39:    const reference = el !== undefined ? el : page;
     L40:    await expect(reference).toHaveScreenshot(`toast-${screenshotMod
     L41:  }
```
It appears that there are separate asserts depending on whether you're using a Page or a Locator. 

PageAsserts: https://playwright.dev/docs/api/class-pageassertions
LocatorAsserts: https://playwright.dev/docs/api/class-locatorassertions
Mixing Page and Locator when using `toHaveScreenshot` seems to cause this error.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updated the toast test to have separate calls to `toHaveScreenshot` so it is clear when `LocatorAsserts` are being used and when `PageAsserts` are being used.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
