### PR TITLE
chore(sass): upgrade sass, @stencil-sass

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -23,7 +23,7 @@
         "@rollup/plugin-virtual": "^2.0.3",
         "@stencil/angular-output-target": "^0.5.0",
         "@stencil/react-output-target": "^0.4.0",
-        "@stencil/sass": "^2.0.3",
+        "@stencil/sass": "^3.0.0-dev.2023.2.16.0",
         "@stencil/vue-output-target": "^0.7.0",
         "@types/jest": "^27.5.2",
         "@types/node": "^14.6.0",
@@ -1621,9 +1621,9 @@
       }
     },
     "node_modules/@stencil/sass": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-2.0.3.tgz",
-      "integrity": "sha512-ypS+0f6bJH2qXqrNAHirlYOWFax+qKKOIePLs7cu4LfKFr4ZVJSGRFBdgaeRrZMUhJWnhjV6io2uDldhrQhnMg==",
+      "version": "3.0.0-dev.2023.2.16.0",
+      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-3.0.0-dev.2023.2.16.0.tgz",
+      "integrity": "sha512-9kgpaN8WTtRXZq+V7W5M/+UHTrcywYHhkH4VMwgfjXSglYVfHu6So+HsC3GGmPcx7WE4p8/ClaaHkWKhx6BYsQ==",
       "dev": true,
       "peerDependencies": {
         "@stencil/core": ">=2.0.0 || >=3.0.0-beta.0"
@@ -11602,9 +11602,9 @@
       "requires": {}
     },
     "@stencil/sass": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-2.0.3.tgz",
-      "integrity": "sha512-ypS+0f6bJH2qXqrNAHirlYOWFax+qKKOIePLs7cu4LfKFr4ZVJSGRFBdgaeRrZMUhJWnhjV6io2uDldhrQhnMg==",
+      "version": "3.0.0-dev.2023.2.16.0",
+      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-3.0.0-dev.2023.2.16.0.tgz",
+      "integrity": "sha512-9kgpaN8WTtRXZq+V7W5M/+UHTrcywYHhkH4VMwgfjXSglYVfHu6So+HsC3GGmPcx7WE4p8/ClaaHkWKhx6BYsQ==",
       "dev": true,
       "requires": {}
     },

--- a/core/package.json
+++ b/core/package.json
@@ -45,7 +45,7 @@
     "@rollup/plugin-virtual": "^2.0.3",
     "@stencil/angular-output-target": "^0.5.0",
     "@stencil/react-output-target": "^0.4.0",
-    "@stencil/sass": "^2.0.3",
+    "@stencil/sass": "^3.0.0-dev.2023.2.16.0",
     "@stencil/vue-output-target": "^0.7.0",
     "@types/jest": "^27.5.2",
     "@types/node": "^14.6.0",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Use the latest version of Sass in Ionic Framework


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The existing version of `@stencil/sass` uses a version of Sass that is [almost a year and a half old](https://github.com/sass/dart-sass/releases/tag/1.42.1)


<!-- Issues are required for both bug fixes and features. -->
Issue URL:  N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit increments the version of `@stencil/sass` used by the ionic framework to include a version of the package that uses sass v1.58.3

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

I'm marking this PR as introducing a major change as we're bumping a core library to a new major version. However, I believe we have minimized that risk by:
- Testing this in Stencil (see [the associated PR](https://github.com/ionic-team/stencil-sass/pull/229))
- Building a dev build of the library, having it run Ionic's CI workflow on the dev build prior to publish
- Marking this version of `@stencil/sass` as a pre-release
- Manually testing certain complex components (e.g. datetime) manually at the suggestion of the Ionic Framework team
- Introducing this change only for Framework v7, while v7 is in a beta period.

### Testing

 It is theoretically possible that Sass output is not the same between versions of the library. An end user of Ionic Framework could be using to override the styles of Ionic Framework components, and if that output from Sass were to change, it's possible the styling of their components could break. To test how likely this was, the output building Ionic Framework Core with this branch and the output of building Ionic Framework Core with it's immediate parent (the most recent commit on `feature-7.0` when this branch was last rebased, 7312b0696d6b9ceb2e4518cad2ab29d45d2eddbe (https://github.com/ionic-team/ionic-framework/pull/26817)) were compared. The idea was we could look at the differences and be able to make end users aware of anything that jumped out to us.

In comparing the output, I saw two types of changes:
1. Some minor whitespace changes, where alignment is fixed in the output css:
```diff

@supports (margin-inline-start: 0) or (-webkit-margin-start: 0) {
  :host(.textarea-label-placement-stacked) .label-text-wrapper,
-:host(.textarea-label-placement-floating) .label-text-wrapper {
+ :host(.textarea-label-placement-floating) .label-text-wrapper {
    padding-left: unset;
    padding-right: unset;
    -webkit-padding-start: 0px;
    padding-inline-start: 0px;
    -webkit-padding-end: 0px;
    padding-inline-end: 0px;
  }
}
```
2. For `ion-modal`, using `max` would previously be compiled away. This is no longer the case
```scss
/** original */
  @supports not (width: max(0px, 1px)) {
    :host(.modal-card) {
      --height: calc(100% - 40px);
    }
  }
```
Would become 
```css
@supports not (width: 1px)
```
But now becomes
```css
@supports not (width: max(0px, 1px))
```


<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I'd like to land this for the next v7 beta, as-is (assuming no comments/things to change from the team). If no issues are reported against the beta that includes this version of `@stencil/sass`, then roughly this time next week I’ll publish `@stencil/sass@3.0.0` (make it GA) and put up another PR against `feature-7.0`