### PR TITLE
fix(sanitizer): improve reliability of sanitizer

### DIFF
--- a/core/src/utils/sanitization/index.ts
+++ b/core/src/utils/sanitization/index.ts
@@ -103,10 +103,21 @@ const sanitizeElement = (element: any) => {
     // that attempt to do any JS funny-business
     const attributeValue = attribute.value;
 
-    /* eslint-disable-next-line */
-    if (attributeValue != null && attributeValue.toLowerCase().includes('javascript:')) {
+    /**
+     * We also need to check the property value
+     * as javascript: can allow special characters
+     * such as &Tab; and still be valid (i.e. java&Tab;script)
+     */
+    const propertyValue = element[attributeName];
+
+    /* eslint-disable */
+    if (
+      (attributeValue != null && attributeValue.toLowerCase().includes('javascript:')) ||
+      (propertyValue != null && propertyValue.toLowerCase().includes('javascript:'))
+    ) {
       element.removeAttribute(attributeName);
     }
+    /* eslint-enable */
   }
 
   /**

--- a/core/src/utils/sanitization/index.ts
+++ b/core/src/utils/sanitization/index.ts
@@ -89,6 +89,17 @@ const sanitizeElement = (element: any) => {
     return;
   }
 
+  /**
+   * If attributes is not a NamedNodeMap
+   * then we should remove the element entirely.
+   * This helps avoid DOM Clobbering attacks where
+   * attributes is overridden.
+   */
+  if (typeof NamedNodeMap !== 'undefined' && !(element.attributes instanceof NamedNodeMap)) {
+    element.remove();
+    return;
+  }
+
   for (let i = element.attributes.length - 1; i >= 0; i--) {
     const attribute = element.attributes.item(i);
     const attributeName = attribute.name;

--- a/core/src/utils/sanitization/index.ts
+++ b/core/src/utils/sanitization/index.ts
@@ -13,6 +13,16 @@ export const sanitizeDOMString = (untrustedString: IonicSafeString | string | un
     }
 
     /**
+     * onload is fired when appending to a document
+     * fragment in Chrome. If a string
+     * contains onload then we should not
+     * attempt to add this to the fragment.
+     */
+    if (untrustedString.includes('onload=')) {
+      return '';
+    }
+
+    /**
      * Create a document fragment
      * separate from the main DOM,
      * create a div to do our work in

--- a/core/src/utils/sanitization/test/sanitization.spec.ts
+++ b/core/src/utils/sanitization/test/sanitization.spec.ts
@@ -30,6 +30,9 @@ describe('sanitizeDOMString', () => {
     expect(sanitizeDOMString('<a href="javascript:alert(document.cookie)">harmless link</a>')).toEqual(
       '<a>harmless link</a>'
     );
+    expect(sanitizeDOMString('<a href="javascr&Tab;ipt:alert(document.cookie)">harmless link</a>')).toEqual(
+      '<a>harmless link</a>'
+    );
   });
 
   it('filter <a> href JS + class attribute', () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
We received a report about 3 XSS attack vectors:

 1. `onload` is fired in Chrome when the untrusted string is appended to the document fragment. Even though we later remove the `onload` attribute, Chrome has already executed the code.
 2. `javascript:` code can be executed by adding special characters to the `javascript:` string. For example, adding `java&Tab;script:` is still interpreted by the browser as `javascript:`.
 3. Sanitizer is susceptible to DOM clobbering by overriding `Element.attributes`. This allows attackers to add blocked attributes to their string.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updated the sanitizer to return the empty string if `onload=` is detected anywhere in the untrusted string.
- Updated the sanitizer to also check the property values for `javascript:`.
- Updated the sanitizer to remove the element if its `attributes` is not of type `NamedNodeMap` which is what a non-clobbered `Element.attributes` should be: https://developer.mozilla.org/en-US/docs/Web/API/NamedNodeMap

Note: Long term we should move away from this custom sanitizer. This custom sanitizer was made in response to an older XSS vulnerability to mitigate that issue while avoiding breaking custom HTML functionality. A couple options:

1. Swap out our integration for [DOMPurify](https://www.npmjs.com/package/dompurify). Would need to evaluate this solution.
2. Remove custom HTML support from these components. This would be breaking change, but it's also worth evaluating whether this feature is even used today.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
