### PR TITLE
refactor(many): clarify deprecation warning

### DIFF
--- a/core/src/components/checkbox/checkbox.tsx
+++ b/core/src/components/checkbox/checkbox.tsx
@@ -283,12 +283,10 @@ export class Checkbox implements ComponentInterface {
   private renderLegacyCheckbox() {
     if (!this.hasLoggedDeprecationWarning) {
       printIonWarning(
-        `Using ion-checkbox with an ion-label has been deprecated. To migrate, remove the ion-label and pass your label directly into ion-checkbox instead.
+        `ion-checkbox now requires providing a label with either the default slot or the "aria-label" attribute. To migrate, remove any usage of "ion-label" and pass the label text to either the component or the "aria-label" attribute.
+
 Example: <ion-checkbox>Label</ion-checkbox>
-
-For checkboxes that do not have a visible label, developers should use "aria-label" so screen readers can announce the purpose of the checkbox.
-
-For checkboxes that do not render the label immediately next to the checkbox, developers may continue to use "ion-label" but must manually associate the label with the checkbox by using "aria-labelledby".
+Example with aria-label: <ion-checkbox aria-label="Label"></ion-checkbox>
 
 Developers can use the "legacy" property to continue using the legacy form markup. This property will be removed in an upcoming major release of Ionic where this form control will use the modern form markup.`,
         this.el

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -723,6 +723,7 @@ export class Input implements ComponentInterface {
         `ion-input now requires providing a label with either the "label" property or the "aria-label" attribute. To migrate, remove any usage of "ion-label" and pass the label text to either the "label" property or the "aria-label" attribute.
 
 Example: <ion-input label="Email"></ion-input>
+Example with aria-label: <ion-input aria-label="Email"></ion-input>
 
 For inputs that do not render the label immediately next to the input, developers may continue to use "ion-label" but must manually associate the label with the input by using "aria-labelledby".`,
         this.el

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -720,11 +720,9 @@ export class Input implements ComponentInterface {
   private renderLegacyInput() {
     if (!this.hasLoggedDeprecationWarning) {
       printIonWarning(
-        `Using ion-input with an ion-label has been deprecated. To migrate, remove the ion-label and use the "label" property on ion-input instead.
+        `ion-input now requires the use of either the "label" property or the "aria-label" attribute. To migrate, remove any usage of "ion-label" and pass the label text to either the "label" property or the "aria-label" attribute.
 
 Example: <ion-input label="Email"></ion-input>
-
-For inputs that do not have a visible label, developers should use "aria-label" so screen readers can announce the purpose of the input.
 
 For inputs that do not render the label immediately next to the input, developers may continue to use "ion-label" but must manually associate the label with the input by using "aria-labelledby".`,
         this.el
@@ -734,7 +732,9 @@ For inputs that do not render the label immediately next to the input, developer
         printIonWarning(
           `ion-input is being used with the "legacy" property enabled which will forcibly enable the legacy form markup. This property will be removed in an upcoming major release of Ionic where this form control will use the modern form markup.
 
-Developers can dismiss this warning by removing their usage of the "legacy" property and using the new input syntax.`,
+Developers can dismiss this warning by removing their usage of the "legacy" property and using the new input syntax.
+
+Developers can use the "legacy" property to continue using the legacy form markup. This property will be removed in an upcoming major release of Ionic where this form control will use the modern form markup.`,
           this.el
         );
       }

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -735,9 +735,7 @@ Developers can use the "legacy" property to continue using the legacy form marku
         printIonWarning(
           `ion-input is being used with the "legacy" property enabled which will forcibly enable the legacy form markup. This property will be removed in an upcoming major release of Ionic where this form control will use the modern form markup.
 
-Developers can dismiss this warning by removing their usage of the "legacy" property and using the new input syntax.
-
-Developers can use the "legacy" property to continue using the legacy form markup. This property will be removed in an upcoming major release of Ionic where this form control will use the modern form markup.`,
+Developers can dismiss this warning by removing their usage of the "legacy" property and using the new input syntax.`,
           this.el
         );
       }

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -725,7 +725,9 @@ export class Input implements ComponentInterface {
 Example: <ion-input label="Email"></ion-input>
 Example with aria-label: <ion-input aria-label="Email"></ion-input>
 
-For inputs that do not render the label immediately next to the input, developers may continue to use "ion-label" but must manually associate the label with the input by using "aria-labelledby".`,
+For inputs that do not render the label immediately next to the input, developers may continue to use "ion-label" but must manually associate the label with the input by using "aria-labelledby".
+
+Developers can use the "legacy" property to continue using the legacy form markup. This property will be removed in an upcoming major release of Ionic where this form control will use the modern form markup.`,
         this.el
       );
 

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -720,7 +720,7 @@ export class Input implements ComponentInterface {
   private renderLegacyInput() {
     if (!this.hasLoggedDeprecationWarning) {
       printIonWarning(
-        `ion-input now requires the use of either the "label" property or the "aria-label" attribute. To migrate, remove any usage of "ion-label" and pass the label text to either the "label" property or the "aria-label" attribute.
+        `ion-input now requires providing a label with either the "label" property or the "aria-label" attribute. To migrate, remove any usage of "ion-label" and pass the label text to either the "label" property or the "aria-label" attribute.
 
 Example: <ion-input label="Email"></ion-input>
 

--- a/core/src/components/radio/radio.tsx
+++ b/core/src/components/radio/radio.tsx
@@ -263,12 +263,12 @@ export class Radio implements ComponentInterface {
   private renderLegacyRadio() {
     if (!this.hasLoggedDeprecationWarning) {
       printIonWarning(
-        `Using ion-radio with an ion-label has been deprecated. To migrate, remove the ion-label and pass your label directly into ion-radio instead.
-Example: <ion-radio>Option Label:</ion-radio>
+        `ion-radio now requires providing a label with either the default slot or the "aria-label" attribute. To migrate, remove any usage of "ion-label" and pass the label text to either the component or the "aria-label" attribute.
 
-For radios that do not have a visible label, developers should use "aria-label" so screen readers can announce the purpose of the radio.
+Example: <ion-radio>Option Label</ion-radio>
+Example with aria-label: <ion-radio aria-label="Option Label"></ion-radio>
 
-For radios that do not render the label immediately next to the radio, developers may continue to use "ion-label" but must manually associate the label with the radio by using "aria-labelledby".`,
+Developers can use the "legacy" property to continue using the legacy form markup. This property will be removed in an upcoming major release of Ionic where this form control will use the modern form markup.`,
         this.el
       );
 

--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -553,13 +553,12 @@ export class Range implements ComponentInterface {
   private renderLegacyRange() {
     if (!this.hasLoggedDeprecationWarning) {
       printIonWarning(
-        `Using ion-range with an ion-label has been deprecated. To migrate, remove the ion-label and pass your label directly into ion-range instead.
+        `ion-range now requires providing a label with either the label slot or the "aria-label" attribute. To migrate, remove any usage of "ion-label" and pass the label text to either the component or the "aria-label" attribute.
 
-Example: <ion-range><div slot="label">Volume:</div></ion-range>
+Example: <ion-range><div slot="label">Volume</div></ion-range>
+Example with aria-label: <ion-range aria-label="Volume"></ion-range>
 
-For ranges that do not have a visible label, developers should use "aria-label" so screen readers can announce the purpose of the range.
-
-For ranges that do not render the label immediately next to the range, developers may continue to use "ion-label" but must manually associate the label with the range by using "aria-labelledby".`,
+Developers can use the "legacy" property to continue using the legacy form markup. This property will be removed in an upcoming major release of Ionic where this form control will use the modern form markup.`,
         this.el
       );
 

--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -779,13 +779,12 @@ export class Select implements ComponentInterface {
   private renderLegacySelect() {
     if (!this.hasLoggedDeprecationWarning) {
       printIonWarning(
-        `Using ion-select with an ion-label has been deprecated. To migrate, remove the ion-label and use the "label" property on ion-select instead.
+        `ion-select now requires providing a label with either the "label" property or the "aria-label" attribute. To migrate, remove any usage of "ion-label" and pass the label text to either the "label" property or the "aria-label" attribute.
 
 Example: <ion-select label="Favorite Color">...</ion-select>
+Example with aria-label: <ion-select aria-label="Favorite Color">...</ion-select>
 
-For selects that do not have a visible label, developers should use "aria-label" so screen readers can announce the purpose of the select.
-
-For selects that do not render the label immediately next to the select, developers may continue to use "ion-label" but must manually associate the label with the select by using "aria-labelledby".`,
+Developers can use the "legacy" property to continue using the legacy form markup. This property will be removed in an upcoming major release of Ionic where this form control will use the modern form markup.`,
         this.el
       );
 

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -465,8 +465,13 @@ export class Textarea implements ComponentInterface {
   private renderLegacyTextarea() {
     if (!this.hasLoggedDeprecationWarning) {
       printIonWarning(
-        `Using ion-textarea with an ion-label has been deprecated. To migrate, remove the ion-label and use the "label" property on ion-textarea instead.
-For textareas that do not have a visible label, developers should use "aria-label" so screen readers can announce the purpose of the textarea.`,
+        `ion-textarea now requires the use of either the "label" property or the "aria-label" attribute. To migrate, remove any usage of "ion-label" and pass the label text to either the "label" property or the "aria-label" attribute.
+
+Example: <ion-textarea label="Comments"></ion-textarea>
+
+For textareas that do not render the label immediately next to the input, developers may continue to use "ion-label" but must manually associate the label with the textarea by using "aria-labelledby".
+
+Developers can use the "legacy" property to continue using the legacy form markup. This property will be removed in an upcoming major release of Ionic where this form control will use the modern form markup.`,
         this.el
       );
       this.hasLoggedDeprecationWarning = true;

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -465,7 +465,7 @@ export class Textarea implements ComponentInterface {
   private renderLegacyTextarea() {
     if (!this.hasLoggedDeprecationWarning) {
       printIonWarning(
-        `ion-textarea now requires the use of either the "label" property or the "aria-label" attribute. To migrate, remove any usage of "ion-label" and pass the label text to either the "label" property or the "aria-label" attribute.
+        `ion-textarea now requires providing a label with either the "label" property or the "aria-label" attribute. To migrate, remove any usage of "ion-label" and pass the label text to either the "label" property or the "aria-label" attribute.
 
 Example: <ion-textarea label="Comments"></ion-textarea>
 

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -468,6 +468,7 @@ export class Textarea implements ComponentInterface {
         `ion-textarea now requires providing a label with either the "label" property or the "aria-label" attribute. To migrate, remove any usage of "ion-label" and pass the label text to either the "label" property or the "aria-label" attribute.
 
 Example: <ion-textarea label="Comments"></ion-textarea>
+Example with aria-label: <ion-textarea aria-label="Comments"></ion-textarea>
 
 For textareas that do not render the label immediately next to the input, developers may continue to use "ion-label" but must manually associate the label with the textarea by using "aria-labelledby".
 

--- a/core/src/components/toggle/toggle.tsx
+++ b/core/src/components/toggle/toggle.tsx
@@ -350,13 +350,12 @@ export class Toggle implements ComponentInterface {
   private renderLegacyToggle() {
     if (!this.hasLoggedDeprecationWarning) {
       printIonWarning(
-        `Using ion-toggle with an ion-label has been deprecated. To migrate, remove the ion-label and pass your label directly into ion-toggle instead.
+        `ion-toggle now requires providing a label with either the default slot or the "aria-label" attribute. To migrate, remove any usage of "ion-label" and pass the label text to either the component or the "aria-label" attribute.
 
-Example: <ion-toggle>Email:</ion-toggle>
+Example: <ion-toggle>Email</ion-toggle>
+Example with aria-label: <ion-toggle aria-label="Email"></ion-toggle>
 
-For toggles that do not have a visible label, developers should use "aria-label" so screen readers can announce the purpose of the toggle.
-
-For toggles that do not render the label immediately next to the toggle, developers may continue to use "ion-label" but must manually associate the label with the toggle by using "aria-labelledby".`,
+Developers can use the "legacy" property to continue using the legacy form markup. This property will be removed in an upcoming major release of Ionic where this form control will use the modern form markup.`,
         this.el
       );
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Developers have noted that the form control deprecation warning is confusing: https://github.com/ionic-team/ionic-framework/issues/26829

This is because we assume devs always use `ion-label`. However, devs could use `<ion-select>` without a label and they would still get the deprecation warning. The deprecation warning should be logged, but the reason we give for why it is logged is confusing since it assumes the presence of `ion-label`. 

Additionally, several of the shadow dom components noted you could use `aria-labelledby` with an `ion-label`. This is incorrect as `aria-labelledby` does not work across shadow dom boundaries. This was likely a copy and paste mistake from `ion-input` and `ion-textarea` which do not use shadow dom.

Finally, I noticed that many of the components never mentioned the `legacy` prop in the deprecation warning.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removes the `ion-label` assumption and states that devs must now pass the label to the component via a prop/slot (depending on the component) or an aria-label
- Added examples for passing the label using aria-label
- Only checkbox had a note about using the `legacy` prop, so I added that comment to the remaining form control components too
- Remove the aria-labelledby wording from the shadow dom components

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
