### PR TITLE
fix(content): fullscreen values are recomputed on visible content

### DIFF
--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -149,6 +149,16 @@ export class Content implements ComponentInterface {
     }
 
     this.resizeTimeout = setTimeout(() => {
+      /**
+       * Resize should only happen
+       * if the content is visible.
+       * When the content is hidden
+       * then offsetParent will be null.
+       */
+      if (this.el.offsetParent === null) {
+        return;
+      }
+
       this.resize();
     }, 100);
   }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/26844

I did not account for the case where `ion-content` was active but not visible. This caused the fix in https://github.com/ionic-team/ionic-framework/commit/7b879fec3d30b61c00faad035698ff643afaa78e to not work correctly for non-active tabs.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `this.resize()` only fires on the `resize` event if the content is visible

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
