### PR TITLE
fix(overlays): focus trap refs cleared on dismiss

### DIFF
--- a/core/src/utils/overlays-interface.ts
+++ b/core/src/utils/overlays-interface.ts
@@ -8,7 +8,7 @@ export interface OverlayEventDetail<T = any> {
 }
 
 export interface OverlayInterface {
-  el: HTMLElement;
+  el: HTMLIonOverlayElement;
   animated: boolean;
   keyboardClose: boolean;
   overlayIndex: number;

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -522,6 +522,14 @@ export const dismiss = async <OverlayDismissOptions>(
      */
     overlay.el.classList.add('overlay-hidden');
     overlay.el.style.removeProperty('pointer-events');
+
+    /**
+     * Clear any focus trapping references
+     * when the overlay is dismissed.
+     */
+    if (overlay.el.lastFocus !== undefined) {
+      overlay.el.lastFocus = undefined;
+    }
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Part of https://github.com/ionic-team/ionic-framework/issues/26833

Our focus trapping util stores the last element that was focused in `overlayEl.lastFocus`. However, this is never cleared when the overlay is dismissed. This results in the overlay keeping a strong reference to some other element. `lastFocus` is only utilized while the overlay is presented, so we should clear it on dismiss.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `lastFocus` is cleared when the overlay is dismissed.
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
