### PR TITLE
fix(modal): keyboard listener removed on dismiss

### DIFF
--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -333,7 +333,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
     if (this.gesture) {
       this.gesture.enable(enable);
     } else if (enable) {
-      await this.initSwipeToClose();
+      this.initSwipeToClose();
     }
   }
 
@@ -559,7 +559,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
     if (this.isSheetModal) {
       this.initSheetGesture();
     } else if (hasCardModal) {
-      await this.initSwipeToClose();
+      this.initSwipeToClose();
     }
 
     /* tslint:disable-next-line */

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -532,6 +532,38 @@ export class Modal implements ComponentInterface, OverlayInterface {
       backdropBreakpoint: this.backdropBreakpoint,
     });
 
+    /* tslint:disable-next-line */
+    if (typeof window !== 'undefined') {
+      /**
+       * This needs to be setup before any
+       * non-transition async work so it can be dereferenced
+       * in the dismiss method. The dismiss method
+       * only waits for the entering transition
+       * to finish. It does not wait for all of the `present`
+       * method to resolve.
+       */
+      this.keyboardOpenCallback = () => {
+        if (this.gesture) {
+          /**
+           * When the native keyboard is opened and the webview
+           * is resized, the gesture implementation will become unresponsive
+           * and enter a free-scroll mode.
+           *
+           * When the keyboard is opened, we disable the gesture for
+           * a single frame and re-enable once the contents have repositioned
+           * from the keyboard placement.
+           */
+          this.gesture.enable(false);
+          raf(() => {
+            if (this.gesture) {
+              this.gesture.enable(true);
+            }
+          });
+        }
+      };
+      window.addEventListener(KEYBOARD_DID_OPEN, this.keyboardOpenCallback);
+    }
+
     /**
      * TODO (FW-937) - In the next major release of Ionic, all card modals
      * will be swipeable by default. canDismiss will be used to determine if the
@@ -560,30 +592,6 @@ export class Modal implements ComponentInterface, OverlayInterface {
       this.initSheetGesture();
     } else if (hasCardModal) {
       this.initSwipeToClose();
-    }
-
-    /* tslint:disable-next-line */
-    if (typeof window !== 'undefined') {
-      this.keyboardOpenCallback = () => {
-        if (this.gesture) {
-          /**
-           * When the native keyboard is opened and the webview
-           * is resized, the gesture implementation will become unresponsive
-           * and enter a free-scroll mode.
-           *
-           * When the keyboard is opened, we disable the gesture for
-           * a single frame and re-enable once the contents have repositioned
-           * from the keyboard placement.
-           */
-          this.gesture.enable(false);
-          raf(() => {
-            if (this.gesture) {
-              this.gesture.enable(true);
-            }
-          });
-        }
-      };
-      window.addEventListener(KEYBOARD_DID_OPEN, this.keyboardOpenCallback);
     }
 
     this.currentTransition = undefined;
@@ -725,6 +733,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
     /* tslint:disable-next-line */
     if (typeof window !== 'undefined' && this.keyboardOpenCallback) {
       window.removeEventListener(KEYBOARD_DID_OPEN, this.keyboardOpenCallback);
+      this.keyboardOpenCallback = undefined;
     }
 
     /**


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Part of https://github.com/ionic-team/ionic-framework/issues/26833

The keyboard listener is added after the transition completes. This means that if you present and dismiss a modal quickly, the dismiss method will run before the keyboard listener is added. This is because the dismiss method only waits for the transition to finish before proceeding. As a result, the keyboard listener is never removed.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updated the present method to create the keyboard listener before the transition runs, that way it can always be removed in `dismiss`. Note that the callback already checks to see if the gesture is configured so we can safely add this listener before the gestures are fully configured.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
