### PR TITLE
test(datetime): fix flaky test

### DIFF
--- a/core/src/components/datetime/test/presentation/datetime.e2e.ts
+++ b/core/src/components/datetime/test/presentation/datetime.e2e.ts
@@ -108,45 +108,42 @@ test.describe('datetime: presentation', () => {
   });
 });
 
-// TODO: FW-3018
-test.skip('datetime: presentation: time', () => {
-  let timePickerFixture: TimePickerFixture;
-
-  test.beforeEach(async ({ page }) => {
-    timePickerFixture = new TimePickerFixture(page);
-    await timePickerFixture.goto();
+test.describe('datetime: presentation: time', () => {
+  test.beforeEach(async ({ skip }) => {
+    skip.rtl();
+    skip.mode('md');
   });
 
-  test('changing value from AM to AM should update the text', async () => {
-    await timePickerFixture.setValue('04:20:00');
-    await timePickerFixture.expectTime('4', '20', 'AM');
+  test('changing value from AM to AM should update the text', async ({ page }) => {
+    const timePickerFixture = new TimePickerFixture(page);
+    await timePickerFixture.goto('04:20:00');
 
     await timePickerFixture.setValue('11:03:00');
-    await timePickerFixture.expectTime('11', '03', 'AM');
+    await timePickerFixture.expectTime(11, 3, 'am');
   });
 
-  test('changing value from AM to PM should update the text', async () => {
-    await timePickerFixture.setValue('05:30:00');
-    await timePickerFixture.expectTime('5', '30', 'AM');
+  test('changing value from AM to PM should update the text', async ({ page }) => {
+    const timePickerFixture = new TimePickerFixture(page);
+    await timePickerFixture.goto('05:30:00');
 
     await timePickerFixture.setValue('16:40:00');
-    await timePickerFixture.expectTime('4', '40', 'PM');
+    await timePickerFixture.expectTime(16, 40, 'pm');
   });
 
-  test('changing the value from PM to AM should update the text', async () => {
-    await timePickerFixture.setValue('16:40:00');
-    await timePickerFixture.expectTime('4', '40', 'PM');
+  test('changing the value from PM to AM should update the text', async ({ page }) => {
+    const timePickerFixture = new TimePickerFixture(page);
+    await timePickerFixture.goto('16:40:00');
 
     await timePickerFixture.setValue('04:20:00');
-    await timePickerFixture.expectTime('4', '20', 'AM');
+    await timePickerFixture.expectTime(4, 20, 'am');
   });
 
-  test('changing the value from PM to PM should update the text', async () => {
-    await timePickerFixture.setValue('16:40:00');
-    await timePickerFixture.expectTime('4', '40', 'PM');
+  test('changing the value from PM to PM should update the text', async ({ page }) => {
+    const timePickerFixture = new TimePickerFixture(page);
+    await timePickerFixture.goto('16:40:00');
 
     await timePickerFixture.setValue('19:32:00');
-    await timePickerFixture.expectTime('7', '32', 'PM');
+    await timePickerFixture.expectTime(19, 32, 'pm');
   });
 });
 
@@ -159,35 +156,27 @@ class TimePickerFixture {
     this.page = page;
   }
 
-  async goto() {
+  async goto(value: string) {
     await this.page.setContent(`
-      <ion-datetime presentation="time" value="2022-03-10T13:00:00"></ion-datetime>
+      <ion-datetime presentation="time" value="${value}"></ion-datetime>
     `);
     await this.page.waitForSelector('.datetime-ready');
     this.timePicker = this.page.locator('ion-datetime');
   }
 
   async setValue(value: string) {
-    const ionChange = await this.page.spyOnEvent('ionChange');
     await this.timePicker.evaluate((el: HTMLIonDatetimeElement, newValue: string) => {
       el.value = newValue;
     }, value);
 
-    await ionChange.next();
-
-    // Changing the value can take longer than the default 100ms to repaint
-    await this.page.waitForChanges(300);
+    await this.page.waitForChanges();
   }
 
-  async expectTime(hour: string, minute: string, ampm: string) {
-    expect(
-      await this.timePicker.locator('ion-picker-column-internal:nth-child(1) .picker-item-active').textContent()
-    ).toBe(hour);
-    expect(
-      await this.timePicker.locator('ion-picker-column-internal:nth-child(2) .picker-item-active').textContent()
-    ).toBe(minute);
-    expect(
-      await this.timePicker.locator('ion-picker-column-internal:nth-child(3) .picker-item-active').textContent()
-    ).toBe(ampm);
+  async expectTime(hour: number, minute: number, ampm: string) {
+    const pickerColumns = this.timePicker.locator('ion-picker-column-internal');
+
+    await expect(pickerColumns.nth(0)).toHaveJSProperty('value', hour);
+    await expect(pickerColumns.nth(1)).toHaveJSProperty('value', minute);
+    await expect(pickerColumns.nth(2)).toHaveJSProperty('value', ampm);
   }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
This test suite was previously flaky and was skipped as a result: https://github.com/ionic-team/ionic-framework/actions/runs/3652722081/jobs/6171464242

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Made a few changes:
- Skipped the test on RTL mode and MD mode. This test behavior does not differ between configurations.
- Updated the fixture to initialize the page with the starting value instead of updating the value mid test and waiting. This significantly improves the performance of the test.
- The `expectTime` check now looks at the values of picker column internal instead of looking at the DOM. This means that we only need to wait for the datetime to update, not the datetime _and_ the picker column internal (since datetime sets the value on picker column internal). This improves test performance while reducing flakiness. Tests to ensure that the picker column re-renders is covered in https://github.com/ionic-team/ionic-framework/blob/7c57b4f39e00a1ab6c0481a5d672fd8a5c299a0f/core/src/components/picker-column-internal/test/basic/picker-column-internal.e2e.ts#L24

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
