### PR TITLE
test(popover): enable dismissOnSelect test for firefox

### DIFF
--- a/core/src/components/popover/test/dismissOnSelect/popover.e2e.ts
+++ b/core/src/components/popover/test/dismissOnSelect/popover.e2e.ts
@@ -23,13 +23,7 @@ test.describe('popover: dismissOnSelect', async () => {
     await expect(popover).toBeVisible();
   });
 
-  test('should not dismiss a popover when clicking a click trigger', async ({ page, skip }) => {
-    // TODO FW-1486
-    skip.browser(
-      'firefox',
-      'Parent popover disappears when click trigger is clicked. Cannot replicate locally. Needs further investigation.'
-    );
-
+  test('should not dismiss a popover when clicking a click trigger', async ({ page }) => {
     const ionPopoverDidPresent = await page.spyOnEvent('ionPopoverDidPresent');
 
     await openPopover(page, 'click-trigger');


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Tests


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The popover tests for `dismissOnSelect` are skipped on Firefox, due to: https://github.com/microsoft/playwright/issues/20168

<!-- Issues are required for both bug fixes and features. -->
Issue URL: Internal


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Re-enables the test, now that we are on Playwright v1.31.1

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
