### PR TITLE
fix(IonicSlides): remove unnecessary autoplay option

### DIFF
--- a/core/src/components/slides/IonicSlides.ts
+++ b/core/src/components/slides/IonicSlides.ts
@@ -16,7 +16,6 @@ export const IonicSlides = (opts: any) => {
     slidesOffsetBefore: 0,
     slidesOffsetAfter: 0,
     touchEventsTarget: 'container',
-    autoplay: false,
     freeMode: false,
     freeModeMomentum: true,
     freeModeMomentumRatio: 1,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Repo/branch for testing: https://github.com/amandaejohnston/sandbox-ionic-angular/tree/swiper-migration-testing

When using the `IonicSlides` module with Swiper Element (https://swiperjs.com/element) and setting `autoplay` to `true`, a conflict occurs that leads to the slider flipping wildly between slides:

https://user-images.githubusercontent.com/90629384/223832678-21eaf2f2-1903-4268-af99-49a0d3084275.mp4


<!-- Issues are required for both bug fixes and features. -->
Issue URL: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

`autoplay` removed from the IonicSlides module to avoid the conflict. The default value in the Swiper API is `false` anyway, so the line wasn't doing anything.

Dev build: `6.6.2-dev.11678305229.18ce1c10`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
