### PR TITLE
fix(radio): checked state is updated when value changes

### DIFF
--- a/core/src/components/radio/radio.tsx
+++ b/core/src/components/radio/radio.tsx
@@ -60,6 +60,16 @@ export class Radio implements ComponentInterface {
    */
   @Prop() value?: any | null;
 
+  @Watch('value')
+  valueChanged() {
+    /**
+     * The new value of the radio may
+     * match the radio group's value,
+     * so we see if it should be checked.
+     */
+    this.updateState();
+  }
+
   /**
    * Emitted when the styles change.
    * @internal

--- a/core/src/components/radio/test/radio.spec.ts
+++ b/core/src/components/radio/test/radio.spec.ts
@@ -1,4 +1,6 @@
 import { Radio } from '../radio.tsx';
+import { RadioGroup } from '../../radio-group/radio-group.tsx';
+import { newSpecPage } from '@stencil/core/testing';
 
 describe('ion-radio', () => {
   it('should set a default value', async () => {
@@ -7,5 +9,25 @@ describe('ion-radio', () => {
     await radio.connectedCallback();
 
     expect(radio.value).toEqual('ion-rb-0');
+  });
+
+  it('should update the checked state when updating the value', async () => {
+    const page = await newSpecPage({
+      components: [Radio, RadioGroup],
+      html: `
+        <ion-radio-group value="a">
+          <ion-radio value="other-value"></ion-radio>
+        </ion-radio-group>
+      `,
+    });
+
+    const radio = page.root.querySelector('ion-radio');
+    expect(radio.classList.contains('radio-checked')).toBe(false);
+
+    radio.value = 'a';
+
+    await page.waitForChanges();
+
+    expect(radio.classList.contains('radio-checked')).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: Internal ticket

If a radio initializes with a `value` that does not match the parent radio group `value` but then has its value updated to match the parent radio group value, the checked state does not update. This is because we only run `this.updateState` on `connectedCallback` and whenever the value of the parent radio group changes.


```html
<ion-radio-group value="a">
  <ion-radio value="other-value"></ion-radio>
</ion-radio-group>
```

Using dev tools change the value of `ion-radio` to `"a"` and observe that the checked state does not update.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `this.updateState` runs when the radio's `value` prop changes.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
