### PR TITLE
fix(textarea): inherit tabindex to inner textarea

### DIFF
--- a/core/src/components/input/test/input.spec.ts
+++ b/core/src/components/input/test/input.spec.ts
@@ -1,0 +1,14 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { Input } from '../input';
+
+it('should inherit attributes', async () => {
+  const page = await newSpecPage({
+    components: [Input],
+    html: '<ion-input title="my title" tabindex="-1" data-form-type="password"></ion-input>'
+  });
+
+  const nativeEl = page.body.querySelector('ion-input input');
+  expect(nativeEl.getAttribute('title')).toBe('my title');
+  expect(nativeEl.getAttribute('tabindex')).toBe('-1');
+  expect(nativeEl.getAttribute('data-form-type')).toBe('password');
+})

--- a/core/src/components/input/test/input.spec.ts
+++ b/core/src/components/input/test/input.spec.ts
@@ -4,11 +4,11 @@ import { Input } from '../input';
 it('should inherit attributes', async () => {
   const page = await newSpecPage({
     components: [Input],
-    html: '<ion-input title="my title" tabindex="-1" data-form-type="password"></ion-input>'
+    html: '<ion-input title="my title" tabindex="-1" data-form-type="password"></ion-input>',
   });
 
   const nativeEl = page.body.querySelector('ion-input input');
   expect(nativeEl.getAttribute('title')).toBe('my title');
   expect(nativeEl.getAttribute('tabindex')).toBe('-1');
   expect(nativeEl.getAttribute('data-form-type')).toBe('password');
-})
+});

--- a/core/src/components/textarea/test/textarea.spec.ts
+++ b/core/src/components/textarea/test/textarea.spec.ts
@@ -4,11 +4,11 @@ import { Textarea } from '../textarea';
 it('should inherit attributes', async () => {
   const page = await newSpecPage({
     components: [Textarea],
-    html: '<ion-textarea title="my title" tabindex="-1" data-form-type="password"></ion-textarea>'
+    html: '<ion-textarea title="my title" tabindex="-1" data-form-type="password"></ion-textarea>',
   });
 
   const nativeEl = page.body.querySelector('ion-textarea textarea');
   expect(nativeEl.getAttribute('title')).toBe('my title');
   expect(nativeEl.getAttribute('tabindex')).toBe('-1');
   expect(nativeEl.getAttribute('data-form-type')).toBe('password');
-})
+});

--- a/core/src/components/textarea/test/textarea.spec.ts
+++ b/core/src/components/textarea/test/textarea.spec.ts
@@ -1,0 +1,14 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { Textarea } from '../textarea';
+
+it('should inherit attributes', async () => {
+  const page = await newSpecPage({
+    components: [Textarea],
+    html: '<ion-textarea title="my title" tabindex="-1" data-form-type="password"></ion-textarea>'
+  });
+
+  const nativeEl = page.body.querySelector('ion-textarea textarea');
+  expect(nativeEl.getAttribute('title')).toBe('my title');
+  expect(nativeEl.getAttribute('tabindex')).toBe('-1');
+  expect(nativeEl.getAttribute('data-form-type')).toBe('password');
+})

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -223,7 +223,7 @@ export class Textarea implements ComponentInterface {
   componentWillLoad() {
     this.inheritedAttributes = {
       ...inheritAriaAttributes(this.el),
-      ...inheritAttributes(this.el, ['data-form-type', 'title']),
+      ...inheritAttributes(this.el, ['data-form-type', 'title', 'tabindex']),
     };
   }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/26944

Input inherits tabindex, but textarea does not.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added tests
- Textarea now inherits tabindex

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
