### PR TITLE
test(segment): skip flaky test

### DIFF
--- a/core/src/components/segment/test/a11y/segment.e2e.ts
+++ b/core/src/components/segment/test/a11y/segment.e2e.ts
@@ -10,7 +10,8 @@ test.describe('segment: a11y', () => {
     expect(results.violations).toEqual([]);
   });
 
-  test('segment buttons should be keyboard navigable', async ({ page, browserName, skip }, testInfo) => {
+  // TODO FW-3710
+  test.skip('segment buttons should be keyboard navigable', async ({ page, browserName, skip }, testInfo) => {
     // TODO (FW-2979)
     skip.browser('webkit', 'Safari 16 only allows text fields and pop-up menus to be focused.');
     const tabKey = browserName === 'webkit' ? 'Alt+Tab' : 'Tab';
@@ -20,7 +21,7 @@ test.describe('segment: a11y', () => {
 
     await page.goto('/src/components/segment/test/a11y');
 
-    const segmentButtons = page.locator('ion-segment-button button');
+    const segmentButtons = page.locator('ion-segment-button');
 
     await page.keyboard.press(tabKey);
     await expect(segmentButtons.nth(0)).toBeFocused();

--- a/core/src/components/segment/test/a11y/segment.e2e.ts
+++ b/core/src/components/segment/test/a11y/segment.e2e.ts
@@ -20,7 +20,7 @@ test.describe('segment: a11y', () => {
 
     await page.goto('/src/components/segment/test/a11y');
 
-    const segmentButtons = page.locator('ion-segment-button');
+    const segmentButtons = page.locator('ion-segment-button button');
 
     await page.keyboard.press(tabKey);
     await expect(segmentButtons.nth(0)).toBeFocused();


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
The segment focus test is occasionally flaky: https://github.com/ionic-team/ionic-framework/actions/runs/4405347963/jobs/7716168450

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- I tried to see if checking the native `button` focus state (rather than `ion-segment-button` which isn't actually a semantic button) resolves the issue, but it did not https://github.com/ionic-team/ionic-framework/actions/runs/4409151360/jobs/7725137802. I ended up skipping the test and creating a ticket in our backlog.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
