### PR TITLE
fix(segment): change events fires when clicking

### DIFF
--- a/core/src/components/segment/segment.tsx
+++ b/core/src/components/segment/segment.tsx
@@ -24,7 +24,6 @@ import type { SegmentChangeEventDetail } from './segment-interface';
 })
 export class Segment implements ComponentInterface {
   private gesture?: Gesture;
-  private checked?: HTMLIonSegmentButtonElement;
 
   // Value before the segment is dragged
   private valueBeforeGesture?: string;
@@ -227,6 +226,10 @@ export class Segment implements ComponentInterface {
     return Array.from(this.el.querySelectorAll('ion-segment-button'));
   }
 
+  private get checked() {
+    return this.getButtons().find((button) => button.value === this.value);
+  }
+
   /**
    * The gesture blocks the segment button ripple. This
    * function adds the ripple based on the checked segment
@@ -340,9 +343,6 @@ export class Segment implements ComponentInterface {
     const buttons = this.getButtons();
     const index = buttons.findIndex((button) => button.value === this.value);
     const next = index + 1;
-
-    // Keep track of the currently checked button
-    this.checked = buttons.find((button) => button.value === this.value);
 
     for (const button of buttons) {
       button.classList.remove('segment-button-after-checked');
@@ -474,8 +474,6 @@ export class Segment implements ComponentInterface {
         this.setCheckedClasses();
       }
     }
-
-    this.checked = current;
   };
 
   private getSegmentButton = (selector: 'first' | 'last' | 'next' | 'previous'): HTMLIonSegmentButtonElement | null => {
@@ -533,7 +531,7 @@ export class Segment implements ComponentInterface {
 
     if (keyDownSelectsButton) {
       const previous = this.checked;
-      this.checkButton(this.checked || current, current);
+      this.checkButton(previous || current, current);
       if (current !== previous) {
         this.emitValueChange();
       }

--- a/core/src/components/segment/test/segment-events.e2e.ts
+++ b/core/src/components/segment/test/segment-events.e2e.ts
@@ -200,5 +200,5 @@ test.describe('segment: events: ionChange', () => {
 
     await ionChangeSpy.next();
     expect(ionChangeSpy).toHaveReceivedEventDetail({ value: '1' });
-  })
+  });
 });

--- a/core/src/components/segment/test/segment-events.e2e.ts
+++ b/core/src/components/segment/test/segment-events.e2e.ts
@@ -198,7 +198,7 @@ test.describe('segment: events: ionChange', () => {
 
     await segmentButtons.nth(0).click();
 
-    await ionChange.next();
+    await ionChangeSpy.next();
     expect(ionChangeSpy).toHaveReceivedEventDetail({ value: '1' });
   })
 });

--- a/core/src/components/segment/test/segment-events.e2e.ts
+++ b/core/src/components/segment/test/segment-events.e2e.ts
@@ -175,4 +175,32 @@ test.describe('segment: events: ionChange', () => {
     expect(ionChangeSpy).toHaveReceivedEventTimes(0);
     expect(await segment.evaluate((el: HTMLIonSegmentElement) => el.value)).toBe('2');
   });
+
+  test.only('should emit when clicking after changing value programmatically', async ({ page }) => {
+    test.info().annotations.push({
+      type: 'issue',
+      description: 'https://github.com/ionic-team/ionic-framework/issues/27002',
+    });
+
+    await page.setContent(`
+      <ion-segment value="1">
+        <ion-segment-button value="1">One</ion-segment-button>
+        <ion-segment-button value="2">Two</ion-segment-button>
+        <ion-segment-button value="3">Three</ion-segment-button>
+      </ion-segment>
+    `);
+
+    const segment = page.locator('ion-segment');
+    const ionChangeSpy = await page.spyOnEvent('ionChange');
+
+    await segment.evaluate((el: HTMLIonSegmentElement) => (el.value = '2'));
+
+    expect(ionChangeSpy).toHaveReceivedEventTimes(0);
+    expect(await segment.evaluate((el: HTMLIonSegmentElement) => el.value)).toBe('2');
+
+    await segment.nth(0).click();
+
+    await ionChangeSpy.next();
+    expect(ionChangeSpy).toHaveReceivedEventDetail({ value: '1' });
+  })
 });

--- a/core/src/components/segment/test/segment-events.e2e.ts
+++ b/core/src/components/segment/test/segment-events.e2e.ts
@@ -183,7 +183,7 @@ test.describe('segment: events: ionChange', () => {
     });
 
     await page.setContent(`
-      <ion-segment value="1">
+      <ion-segment value="1" swipe-gesture="false">
         <ion-segment-button value="1">One</ion-segment-button>
         <ion-segment-button value="2">Two</ion-segment-button>
         <ion-segment-button value="3">Three</ion-segment-button>
@@ -191,16 +191,14 @@ test.describe('segment: events: ionChange', () => {
     `);
 
     const segment = page.locator('ion-segment');
+    const segmentButtons = segment.locator('ion-segment-button');
     const ionChangeSpy = await page.spyOnEvent('ionChange');
 
     await segment.evaluate((el: HTMLIonSegmentElement) => (el.value = '2'));
 
-    expect(ionChangeSpy).toHaveReceivedEventTimes(0);
-    expect(await segment.evaluate((el: HTMLIonSegmentElement) => el.value)).toBe('2');
+    await segmentButtons.nth(0).click();
 
-    await segment.nth(0).click();
-
-    await ionChangeSpy.next();
+    await ionChange.next();
     expect(ionChangeSpy).toHaveReceivedEventDetail({ value: '1' });
   })
 });

--- a/core/src/components/segment/test/segment-events.e2e.ts
+++ b/core/src/components/segment/test/segment-events.e2e.ts
@@ -176,7 +176,7 @@ test.describe('segment: events: ionChange', () => {
     expect(await segment.evaluate((el: HTMLIonSegmentElement) => el.value)).toBe('2');
   });
 
-  test.only('should emit when clicking after changing value programmatically', async ({ page }) => {
+  test('should emit when clicking after changing value programmatically', async ({ page }) => {
     test.info().annotations.push({
       type: 'issue',
       description: 'https://github.com/ionic-team/ionic-framework/issues/27002',


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/27002

The `onClick` listener checks to see if the currently checked `ion-segment-button` is different than the `ion-segment-button` that was clicked in order to determine if it needs to fire `ionChange`: https://github.com/ionic-team/ionic-framework/blob/79ba8816f4d073ba553df58f06b53ee83705aef7/core/src/components/segment/segment.tsx#L466

We determine the current button by looking at `this.checked` which is a cached reference to the currently checked `ion-segment-button`. This cache is updated in two locations:

1. When `setCheckedClasses` is called: https://github.com/ionic-team/ionic-framework/blob/79ba8816f4d073ba553df58f06b53ee83705aef7/core/src/components/segment/segment.tsx#L345
2. At the end of `onClick`: https://github.com/ionic-team/ionic-framework/blob/79ba8816f4d073ba553df58f06b53ee83705aef7/core/src/components/segment/segment.tsx#L478

`setCheckedClasses` is called in `onClick`, but it's only called _after_ we have already decided whether or not to fire `ionChange`. As a result, it is possible to not have `ionChange` fire when clicking a segment after programmatically updating the segment value.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Segment now fires `ionChange` when the checked button changes.

The fastest/easiest way to fix this would have been to update `valueChanged` and cache `this.checked` in there too. However, I don't think that is the right call. The main issue here is we are caching the segment button when we really do not need to. Continuing to use this cache means we need to keep fixing when the cache gets updates as this component evolves.

The performance gains from caching the button is pretty minimal as the `querySelector` used for `getButtons` is pretty quick since we are only looking within the scope of `ion-segment`.

I opted to remove the cache and use a getter instead to fix the bug and avoid other stale cache issues in the future related to `this.checked`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
