### PR TITLE
fix(many): innerHTML is disabled by default

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -35,6 +35,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
   - [Textarea](#version-7x-textarea)
   - [Toggle](#version-7x-toggle)
   - [Virtual Scroll](#version-7x-virtual-scroll)
+- [Config](#version-7x-config)
 - [Types](#version-7x-types)
   - [Overlay Attribute Interfaces](#version-7x-overlay-attribute-interfaces)
 - [JavaScript Frameworks](#version-7x-javascript-frameworks)
@@ -296,6 +297,10 @@ Developers using the component will need to migrate to a virtual scroll solution
 - [Vue](https://ionicframework.com/docs/vue/virtual-scroll)
 
 Any references to the virtual scroll types from `@ionic/core` have been removed. Please remove or replace these types: `Cell`, `VirtualNode`, `CellType`, `NodeChange`, `HeaderFn`, `ItemHeightFn`, `FooterHeightFn`, `ItemRenderFn` and `DomRenderFn`.
+
+<h2 id="version-7x-config">Config</h2>
+
+- `innerHTMLTemplatesEnabled` defaults to `false`. Developers who wish to use the `innerHTML` functionality inside of `ion-alert`, `ion-infinite-scroll-content`, `ion-loading`, `ion-refresher-content`, and `ion-toast` must set this config to `true` and properly sanitize their content.
 
 <h2 id="version-7x-types">Types</h2>
 

--- a/core/src/components/alert/test/alert.spec.ts
+++ b/core/src/components/alert/test/alert.spec.ts
@@ -3,7 +3,7 @@ import { Alert } from '../alert';
 import { config } from '../../../global/config';
 
 describe('alert: custom html', () => {
-  it('should allow for custom html by default', async () => {
+  it('should not allow for custom html by default', async () => {
     const page = await newSpecPage({
       components: [Alert],
       html: `<ion-alert message="<button class='custom-html'>Custom Text</button>"></ion-alert>`,
@@ -11,7 +11,7 @@ describe('alert: custom html', () => {
 
     const content = page.body.querySelector('.alert-message');
     expect(content.textContent).toContain('Custom Text');
-    expect(content.querySelector('button.custom-html')).not.toBe(null);
+    expect(content.querySelector('button.custom-html')).toBe(null);
   });
 
   it('should allow for custom html', async () => {

--- a/core/src/components/alert/test/basic/index.html
+++ b/core/src/components/alert/test/basic/index.html
@@ -58,6 +58,12 @@
     </ion-app>
 
     <script>
+      window.Ionic = {
+        config: {
+          innerHTMLTemplatesEnabled: true,
+        },
+      };
+
       async function openAlert(opts) {
         const alert = await alertController.create(opts);
         await alert.present();

--- a/core/src/components/infinite-scroll-content/test/infinite-scroll-content.spec.ts
+++ b/core/src/components/infinite-scroll-content/test/infinite-scroll-content.spec.ts
@@ -3,7 +3,7 @@ import { InfiniteScrollContent } from '../infinite-scroll-content';
 import { config } from '../../../global/config';
 
 describe('infinite-scroll-content: custom html', () => {
-  it('should allow for custom html by default', async () => {
+  it('should not allow for custom html by default', async () => {
     const page = await newSpecPage({
       components: [InfiniteScrollContent],
       html: `<ion-infinite-scroll-content loading-text="<button class='custom-html'>Custom Text</button>"></ion-infinite-scroll-content>`,
@@ -11,7 +11,7 @@ describe('infinite-scroll-content: custom html', () => {
 
     const content = page.body.querySelector('.infinite-loading-text');
     expect(content.textContent).toContain('Custom Text');
-    expect(content.querySelector('button.custom-html')).not.toBe(null);
+    expect(content.querySelector('button.custom-html')).toBe(null);
   });
 
   it('should allow for custom html', async () => {

--- a/core/src/components/loading/test/basic/index.html
+++ b/core/src/components/loading/test/basic/index.html
@@ -100,6 +100,12 @@
       </ion-content>
     </ion-app>
     <script>
+      window.Ionic = {
+        config: {
+          innerHTMLTemplatesEnabled: true,
+        },
+      };
+
       async function openLoading(opts) {
         const loading = await loadingController.create(opts);
         await loading.present();

--- a/core/src/components/loading/test/loading.spec.ts
+++ b/core/src/components/loading/test/loading.spec.ts
@@ -3,7 +3,7 @@ import { Loading } from '../loading';
 import { config } from '../../../global/config';
 
 describe('alert: custom html', () => {
-  it('should allow for custom html by default', async () => {
+  it('should not allow for custom html by default', async () => {
     const page = await newSpecPage({
       components: [Loading],
       html: `<ion-loading message="<button class='custom-html'>Custom Text</button>"></ion-loading>`,
@@ -11,7 +11,7 @@ describe('alert: custom html', () => {
 
     const content = page.body.querySelector('.loading-content');
     expect(content.textContent).toContain('Custom Text');
-    expect(content.querySelector('button.custom-html')).not.toBe(null);
+    expect(content.querySelector('button.custom-html')).toBe(null);
   });
 
   it('should allow for custom html', async () => {

--- a/core/src/components/refresher-content/test/refresher-content.spec.ts
+++ b/core/src/components/refresher-content/test/refresher-content.spec.ts
@@ -3,7 +3,7 @@ import { RefresherContent } from '../refresher-content';
 import { config } from '../../../global/config';
 
 describe('refresher-content: custom html', () => {
-  it('should allow for custom html by default', async () => {
+  it('should not allow for custom html by default', async () => {
     const page = await newSpecPage({
       components: [RefresherContent],
       html: `<ion-refresher-content pulling-text="<button class='custom-pulling-html'>Custom Pulling Text</button>" refreshing-text="<button class='custom-refreshing-html'>Custom Refreshing Text</button>"></ion-refresher-content>`,
@@ -11,11 +11,11 @@ describe('refresher-content: custom html', () => {
 
     const pullingContent = page.body.querySelector('.refresher-pulling-text');
     expect(pullingContent.textContent).toContain('Custom Pulling Text');
-    expect(pullingContent.querySelector('button.custom-pulling-html')).not.toBe(null);
+    expect(pullingContent.querySelector('button.custom-pulling-html')).toBe(null);
 
     const refreshingContent = page.body.querySelector('.refresher-refreshing-text');
     expect(refreshingContent.textContent).toContain('Custom Refreshing Text');
-    expect(refreshingContent.querySelector('button.custom-refreshing-html')).not.toBe(null);
+    expect(refreshingContent.querySelector('button.custom-refreshing-html')).toBe(null);
   });
 
   it('should allow for custom html', async () => {

--- a/core/src/components/toast/test/basic/index.html
+++ b/core/src/components/toast/test/basic/index.html
@@ -195,6 +195,12 @@
       </ion-content>
     </ion-app>
     <script>
+      window.Ionic = {
+        config: {
+          innerHTMLTemplatesEnabled: true,
+        },
+      };
+
       window.addEventListener('ionToastDidDismiss', function (e) {
         console.log('didDismiss', e);
       });

--- a/core/src/components/toast/test/toast.spec.ts
+++ b/core/src/components/toast/test/toast.spec.ts
@@ -3,7 +3,7 @@ import { Toast } from '../toast';
 import { config } from '../../../global/config';
 
 describe('alert: custom html', () => {
-  it('should allow for custom html by default', async () => {
+  it('should not allow for custom html by default', async () => {
     const page = await newSpecPage({
       components: [Toast],
       html: `<ion-toast message="<button class='custom-html'>Custom Text</button>"></ion-toast>`,
@@ -12,7 +12,7 @@ describe('alert: custom html', () => {
     const toast = page.body.querySelector('ion-toast');
     const content = toast.shadowRoot.querySelector('.toast-message');
     expect(content.textContent).toContain('Custom Text');
-    expect(content.querySelector('button.custom-html')).not.toBe(null);
+    expect(content.querySelector('button.custom-html')).toBe(null);
   });
 
   it('should allow for custom html', async () => {

--- a/core/src/utils/config.ts
+++ b/core/src/utils/config.ts
@@ -249,4 +249,4 @@ export const getMode = (): Mode => {
   return 'md';
 };
 
-export const ENABLE_HTML_CONTENT_DEFAULT = true;
+export const ENABLE_HTML_CONTENT_DEFAULT = false;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
As per the `innerHTMLTemplatesEnabled` design doc, this flag should default to `false` on Ionic 7 to de-risk the use of `innerHTML` functionality in Ionic. This change requires developers to opt-in to dangerously setting `innerHTML` content inside of Ionic components. As a result of this change (and combined with documentation published on our site), developers should be more informed of the risks of using `innerHTML` as well as the need for using a reliable sanitizer if they choose to use `innerHTML`.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `innerHTMLTemplatesEnabled` defaults to `false`.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
