### PR TITLE
chore(readme): update migration guides to correct links

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ an [issue](https://github.com/ionic-team/ionic/issues/new) on this repository.
 
 Already have an Ionic app? These guides will help you migrate to the latest versions.
 
-* [Migrate from v6 to v7](https://ionicframework.com/docs/v7/updating/7-0)
-* [Migrate from v5 to v6](https://ionicframework.com/docs/reference/migration#migrating-from-ionic-5x-to-ionic-6x)
-* [Migrate from v4 to v5](https://ionicframework.com/docs/reference/migration#migrating-from-ionic-4x-to-ionic-5x)
-* [Migrate from v3 to v4](https://ionicframework.com/docs/reference/migration#migrating-from-ionic-30-to-ionic-40)
+* [Migrate from v6 to v7](https://ionicframework.com/docs/updating/7-0)
+* [Migrate from v5 to v6](https://ionicframework.com/docs/updating/6-0)
+* [Migrate from v4 to v5](https://ionicframework.com/docs/updating/5-0)
+* [Migrate from v3 to v4](https://ionicframework.com/docs/updating/4-0)
 
 ### Examples
 


### PR DESCRIPTION
The links for the migration guides in the README are incorrect: https://github.com/ionic-team/ionic-framework/blob/main/README.md#migration-guides