### PR TITLE
test(textarea): skip autogrow test due to flakiness

### DIFF
--- a/core/src/components/textarea/test/autogrow/textarea.e2e.ts
+++ b/core/src/components/textarea/test/autogrow/textarea.e2e.ts
@@ -10,7 +10,8 @@ test.describe('textarea: autogrow', () => {
     await expect(page).toHaveScreenshot(`textarea-autogrow-diff-${page.getSnapshotSettings()}.png`);
   });
 
-  test('should grow when typing', async ({ page }) => {
+  // TODO(FW-3920): Autogrow test is flaky
+  test.skip('should grow when typing', async ({ page }) => {
     await page.setContent(`
       <ion-textarea aria-label="Textarea" auto-grow="true"></ion-textarea>
     `);

--- a/core/src/components/textarea/test/legacy/autogrow/textarea.e2e.ts
+++ b/core/src/components/textarea/test/legacy/autogrow/textarea.e2e.ts
@@ -10,7 +10,8 @@ test.describe('textarea: autogrow', () => {
     expect(await page.screenshot()).toMatchSnapshot(`textarea-autogrow-diff-${page.getSnapshotSettings()}.png`);
   });
 
-  test('should grow when typing', async ({ page }) => {
+  // TODO(FW-3920): Autogrow test is flaky
+  test.skip('should grow when typing', async ({ page }) => {
     await page.setContent(
       `
       <ion-app>


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See the [contributing guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation) for details.
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Skipping tests


## What is the current behavior?

The autogrow tests are flaky and tend to fail.

Issue URL:  N/A


## What is the new behavior?

- Skipping tests until they are fixed at a later time.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

N/A
