### PR TITLE
test(many): use web-first assertions

### DIFF
--- a/core/src/components/action-sheet/test/isOpen/action-sheet.e2e.ts
+++ b/core/src/components/action-sheet/test/isOpen/action-sheet.e2e.ts
@@ -9,22 +9,26 @@ test.describe('action sheet: isOpen', () => {
 
   test('should open the action sheet', async ({ page }) => {
     const ionActionSheetDidPresent = await page.spyOnEvent('ionActionSheetDidPresent');
+    const actionSheet = page.locator('ion-action-sheet');
+
     await page.click('#default');
 
     await ionActionSheetDidPresent.next();
-    await page.waitForSelector('ion-action-sheet', { state: 'visible' });
+    await expect(actionSheet).toBeVisible();
   });
 
   test('should open the action sheet then close after a timeout', async ({ page }) => {
     const ionActionSheetDidPresent = await page.spyOnEvent('ionActionSheetDidPresent');
     const ionActionSheetDidDismiss = await page.spyOnEvent('ionActionSheetDidDismiss');
+    const actionSheet = page.locator('ion-action-sheet');
+
     await page.click('#timeout');
 
     await ionActionSheetDidPresent.next();
-    await page.waitForSelector('ion-action-sheet', { state: 'visible' });
+    await expect(actionSheet).toBeVisible();
 
     await ionActionSheetDidDismiss.next();
 
-    await page.waitForSelector('ion-action-sheet', { state: 'hidden' });
+    await expect(actionSheet).toBeHidden();
   });
 });

--- a/core/src/components/action-sheet/test/isOpen/action-sheet.e2e.ts
+++ b/core/src/components/action-sheet/test/isOpen/action-sheet.e2e.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('action sheet: isOpen', () => {

--- a/core/src/components/action-sheet/test/trigger/action-sheet.e2e.ts
+++ b/core/src/components/action-sheet/test/trigger/action-sheet.e2e.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('action sheet: trigger', () => {

--- a/core/src/components/action-sheet/test/trigger/action-sheet.e2e.ts
+++ b/core/src/components/action-sheet/test/trigger/action-sheet.e2e.ts
@@ -9,15 +9,18 @@ test.describe('action sheet: trigger', () => {
 
   test('should open the action sheet', async ({ page }) => {
     const ionActionSheetDidPresent = await page.spyOnEvent('ionActionSheetDidPresent');
+    const actionSheet = page.locator('#default-action-sheet');
+
     await page.click('#default');
 
     await ionActionSheetDidPresent.next();
-    await page.waitForSelector('#default-action-sheet', { state: 'visible' });
+    await expect(actionSheet).toBeVisible();
   });
 
   test('should present a previously presented action sheet', async ({ page }) => {
     const ionActionSheetDidPresent = await page.spyOnEvent('ionActionSheetDidPresent');
     const ionActionSheetDidDismiss = await page.spyOnEvent('ionActionSheetDidDismiss');
+    const actionSheet = page.locator('#timeout-action-sheet');
 
     await page.click('#timeout');
 
@@ -26,6 +29,6 @@ test.describe('action sheet: trigger', () => {
     await page.click('#timeout');
 
     await ionActionSheetDidPresent.next();
-    await page.waitForSelector('#timeout-action-sheet', { state: 'visible' });
+    await expect(actionSheet).toBeVisible();
   });
 });

--- a/core/src/components/alert/test/isOpen/alert.e2e.ts
+++ b/core/src/components/alert/test/isOpen/alert.e2e.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('alert: isOpen', () => {
@@ -9,22 +10,25 @@ test.describe('alert: isOpen', () => {
 
   test('should open the alert', async ({ page }) => {
     const ionAlertDidPresent = await page.spyOnEvent('ionAlertDidPresent');
+    const alert = page.locator('ion-alert');
+
     await page.click('#default');
 
     await ionAlertDidPresent.next();
-    await page.waitForSelector('ion-alert', { state: 'visible' });
+    await expect(alert).toBeVisible();
   });
 
   test('should open the alert then close after a timeout', async ({ page }) => {
     const ionAlertDidPresent = await page.spyOnEvent('ionAlertDidPresent');
     const ionAlertDidDismiss = await page.spyOnEvent('ionAlertDidDismiss');
+    const alert = page.locator('ion-alert');
+
     await page.click('#timeout');
 
     await ionAlertDidPresent.next();
-    await page.waitForSelector('ion-alert', { state: 'visible' });
+    await expect(alert).toBeVisible();
 
     await ionAlertDidDismiss.next();
-
-    await page.waitForSelector('ion-alert', { state: 'hidden' });
+    await expect(alert).toBeHidden();
   });
 });

--- a/core/src/components/alert/test/trigger/alert.e2e.ts
+++ b/core/src/components/alert/test/trigger/alert.e2e.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('alert: trigger', () => {
@@ -9,15 +10,18 @@ test.describe('alert: trigger', () => {
 
   test('should open the alert', async ({ page }) => {
     const ionAlertDidPresent = await page.spyOnEvent('ionAlertDidPresent');
+    const alert = page.locator('#default-alert');
+
     await page.click('#default');
 
     await ionAlertDidPresent.next();
-    await page.waitForSelector('#default-alert', { state: 'visible' });
+    await expect(alert).toBeVisible();
   });
 
   test('should present a previously presented alert', async ({ page }) => {
     const ionAlertDidPresent = await page.spyOnEvent('ionAlertDidPresent');
     const ionAlertDidDismiss = await page.spyOnEvent('ionAlertDidDismiss');
+    const alert = page.locator('#timeout-alert');
 
     await page.click('#timeout');
 
@@ -26,6 +30,6 @@ test.describe('alert: trigger', () => {
     await page.click('#timeout');
 
     await ionAlertDidPresent.next();
-    await page.waitForSelector('#timeout-alert', { state: 'visible' });
+    await expect(alert).toBeVisible();
   });
 });

--- a/core/src/components/loading/test/isOpen/loading.e2e.ts
+++ b/core/src/components/loading/test/isOpen/loading.e2e.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('loading: isOpen', () => {
@@ -9,22 +10,25 @@ test.describe('loading: isOpen', () => {
 
   test('should open the loading indicator', async ({ page }) => {
     const ionLoadingDidPresent = await page.spyOnEvent('ionLoadingDidPresent');
+    const loading = page.locator('ion-loading');
+
     await page.click('#default');
 
     await ionLoadingDidPresent.next();
-    await page.waitForSelector('ion-loading', { state: 'visible' });
+    await expect(loading).toBeVisible();
   });
 
   test('should open the loading indicator then close after a timeout', async ({ page }) => {
     const ionLoadingDidPresent = await page.spyOnEvent('ionLoadingDidPresent');
     const ionLoadingDidDismiss = await page.spyOnEvent('ionLoadingDidDismiss');
+    const loading = page.locator('ion-loading');
+
     await page.click('#timeout');
 
     await ionLoadingDidPresent.next();
-    await page.waitForSelector('ion-loading', { state: 'visible' });
+    await expect(loading).toBeVisible();
 
     await ionLoadingDidDismiss.next();
-
-    await page.waitForSelector('ion-loading', { state: 'hidden' });
+    await expect(loading).toBeHidden();
   });
 });

--- a/core/src/components/loading/test/trigger/loading.e2e.ts
+++ b/core/src/components/loading/test/trigger/loading.e2e.ts
@@ -10,7 +10,7 @@ test.describe('loading: trigger', () => {
 
   test('should open the loading indicator', async ({ page }) => {
     const ionLoadingDidPresent = await page.spyOnEvent('ionLoadingDidPresent');
-    const loading = page.locator('ion-loading#default-loading');
+    const loading = page.locator('#default-loading');
     await page.click('#default');
 
     await ionLoadingDidPresent.next();
@@ -20,7 +20,7 @@ test.describe('loading: trigger', () => {
   test('should present a previously presented loading indicator', async ({ page }) => {
     const ionLoadingDidPresent = await page.spyOnEvent('ionLoadingDidPresent');
     const ionLoadingDidDismiss = await page.spyOnEvent('ionLoadingDidDismiss');
-    const loading = page.locator('ion-loading#timeout-loading');
+    const loading = page.locator('#timeout-loading');
 
     await page.click('#timeout');
 

--- a/core/src/components/loading/test/trigger/loading.e2e.ts
+++ b/core/src/components/loading/test/trigger/loading.e2e.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('loading: trigger', () => {
@@ -9,15 +10,17 @@ test.describe('loading: trigger', () => {
 
   test('should open the loading indicator', async ({ page }) => {
     const ionLoadingDidPresent = await page.spyOnEvent('ionLoadingDidPresent');
+    const loading = page.locator('ion-loading#default-loading');
     await page.click('#default');
 
     await ionLoadingDidPresent.next();
-    await page.waitForSelector('#default-loading', { state: 'visible' });
+    await expect(loading).toBeVisible();
   });
 
   test('should present a previously presented loading indicator', async ({ page }) => {
     const ionLoadingDidPresent = await page.spyOnEvent('ionLoadingDidPresent');
     const ionLoadingDidDismiss = await page.spyOnEvent('ionLoadingDidDismiss');
+    const loading = page.locator('ion-loading#timeout-loading');
 
     await page.click('#timeout');
 
@@ -26,6 +29,6 @@ test.describe('loading: trigger', () => {
     await page.click('#timeout');
 
     await ionLoadingDidPresent.next();
-    await page.waitForSelector('#timeout-loading', { state: 'visible' });
+    await expect(loading).toBeVisible();
   });
 });

--- a/core/src/components/menu/test/a11y/menu.e2e.ts
+++ b/core/src/components/menu/test/a11y/menu.e2e.ts
@@ -15,7 +15,7 @@ test.describe('menu: a11y', () => {
     const button = page.locator('#open-menu');
 
     await button.click();
-    await page.waitForSelector('ion-menu', { state: 'visible' });
+    await expect(menu).toBeVisible();
 
     await expect(menu).toHaveAttribute('role', 'navigation');
 

--- a/core/src/components/modal/test/isOpen/modal.e2e.ts
+++ b/core/src/components/modal/test/isOpen/modal.e2e.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('modal: isOpen', () => {
@@ -9,22 +10,25 @@ test.describe('modal: isOpen', () => {
 
   test('should open the modal', async ({ page }) => {
     const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+    const modal = page.locator('ion-modal');
+
     await page.click('#default');
 
     await ionModalDidPresent.next();
-    await page.waitForSelector('ion-modal', { state: 'visible' });
+    await expect(modal).toBeVisible();
   });
 
   test('should open the modal then close after a timeout', async ({ page }) => {
     const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
     const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
+    const modal = page.locator('ion-modal');
+
     await page.click('#timeout');
 
     await ionModalDidPresent.next();
-    await page.waitForSelector('ion-modal', { state: 'visible' });
+    await expect(modal).toBeVisible();
 
     await ionModalDidDismiss.next();
-
-    await page.waitForSelector('ion-modal', { state: 'hidden' });
+    await expect(modal).toBeHidden();
   });
 });

--- a/core/src/components/modal/test/sheet/modal.e2e.ts
+++ b/core/src/components/modal/test/sheet/modal.e2e.ts
@@ -33,6 +33,7 @@ test.describe('sheet modal: backdrop', () => {
   });
   test('should present another sheet modal when clicking an inactive backdrop', async ({ page }) => {
     const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+    const modal = page.locator('.custom-height');
 
     await page.click('#backdrop-inactive');
     await ionModalDidPresent.next();
@@ -40,7 +41,7 @@ test.describe('sheet modal: backdrop', () => {
     await page.click('#custom-height-modal');
     await ionModalDidPresent.next();
 
-    await page.waitForSelector('.custom-height', { state: 'visible' });
+    await expect(modal).toBeVisible();
   });
   test('input outside sheet modal should be focusable when backdrop is inactive', async ({ page }) => {
     const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');

--- a/core/src/components/picker/test/isOpen/picker.e2e.ts
+++ b/core/src/components/picker/test/isOpen/picker.e2e.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('picker: isOpen', () => {
@@ -9,22 +10,25 @@ test.describe('picker: isOpen', () => {
 
   test('should open the picker', async ({ page }) => {
     const ionPickerDidPresent = await page.spyOnEvent('ionPickerDidPresent');
+    const picker = page.locator('ion-picker');
+
     await page.click('#default');
 
     await ionPickerDidPresent.next();
-    await page.waitForSelector('ion-picker', { state: 'visible' });
+    await expect(picker).toBeVisible();
   });
 
   test('should open the picker then close after a timeout', async ({ page }) => {
     const ionPickerDidPresent = await page.spyOnEvent('ionPickerDidPresent');
     const ionPickerDidDismiss = await page.spyOnEvent('ionPickerDidDismiss');
+    const picker = page.locator('ion-picker');
+
     await page.click('#timeout');
 
     await ionPickerDidPresent.next();
-    await page.waitForSelector('ion-picker', { state: 'visible' });
+    await expect(picker).toBeVisible();
 
     await ionPickerDidDismiss.next();
-
-    await page.waitForSelector('ion-picker', { state: 'hidden' });
+    await expect(picker).toBeHidden();
   });
 });

--- a/core/src/components/picker/test/trigger/picker.e2e.ts
+++ b/core/src/components/picker/test/trigger/picker.e2e.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('picker: trigger', () => {
@@ -9,15 +10,18 @@ test.describe('picker: trigger', () => {
 
   test('should open the picker', async ({ page }) => {
     const ionPickerDidPresent = await page.spyOnEvent('ionPickerDidPresent');
+    const picker = page.locator('#default-picker');
+
     await page.click('#default');
 
     await ionPickerDidPresent.next();
-    await page.waitForSelector('#default-picker', { state: 'visible' });
+    await expect(picker).toBeVisible();
   });
 
   test('should present a previously presented picker', async ({ page }) => {
     const ionPickerDidPresent = await page.spyOnEvent('ionPickerDidPresent');
     const ionPickerDidDismiss = await page.spyOnEvent('ionPickerDidDismiss');
+    const picker = page.locator('#timeout-picker');
 
     await page.click('#timeout');
 
@@ -26,6 +30,6 @@ test.describe('picker: trigger', () => {
     await page.click('#timeout');
 
     await ionPickerDidPresent.next();
-    await page.waitForSelector('#timeout-picker', { state: 'visible' });
+    await expect(picker).toBeVisible();
   });
 });

--- a/core/src/components/toast/test/isOpen/toast.e2e.ts
+++ b/core/src/components/toast/test/isOpen/toast.e2e.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('toast: isOpen', () => {
@@ -9,22 +10,25 @@ test.describe('toast: isOpen', () => {
 
   test('should open the toast', async ({ page }) => {
     const ionToastDidPresent = await page.spyOnEvent('ionToastDidPresent');
+    const toast = page.locator('ion-toast');
+
     await page.click('#default');
 
     await ionToastDidPresent.next();
-    await page.waitForSelector('ion-toast', { state: 'visible' });
+    await expect(toast).toBeVisible();
   });
 
   test('should open the toast then close after a timeout', async ({ page }) => {
     const ionToastDidPresent = await page.spyOnEvent('ionToastDidPresent');
     const ionToastDidDismiss = await page.spyOnEvent('ionToastDidDismiss');
+    const toast = page.locator('ion-toast');
+
     await page.click('#timeout');
 
     await ionToastDidPresent.next();
-    await page.waitForSelector('ion-toast', { state: 'visible' });
+    await expect(toast).toBeVisible();
 
     await ionToastDidDismiss.next();
-
-    await page.waitForSelector('ion-toast', { state: 'hidden' });
+    await expect(toast).toBeHidden();
   });
 });

--- a/core/src/components/toast/test/trigger/toast.e2e.ts
+++ b/core/src/components/toast/test/trigger/toast.e2e.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
 test.describe('toast: trigger', () => {
@@ -9,15 +10,18 @@ test.describe('toast: trigger', () => {
 
   test('should open the toast', async ({ page }) => {
     const ionToastDidPresent = await page.spyOnEvent('ionToastDidPresent');
+    const toast = page.locator('#default-toast');
+
     await page.click('#default');
 
     await ionToastDidPresent.next();
-    await page.waitForSelector('#default-toast', { state: 'visible' });
+    await expect(alert).toBeVisible();
   });
 
   test('should present a previously presented toast', async ({ page }) => {
     const ionToastDidPresent = await page.spyOnEvent('ionToastDidPresent');
     const ionToastDidDismiss = await page.spyOnEvent('ionToastDidDismiss');
+    const toast = page.locator('#timeout-toast');
 
     await page.click('#timeout');
 
@@ -26,6 +30,6 @@ test.describe('toast: trigger', () => {
     await page.click('#timeout');
 
     await ionToastDidPresent.next();
-    await page.waitForSelector('#timeout-toast', { state: 'visible' });
+    await expect(alert).toBeVisible();
   });
 });

--- a/core/src/components/toast/test/trigger/toast.e2e.ts
+++ b/core/src/components/toast/test/trigger/toast.e2e.ts
@@ -15,7 +15,7 @@ test.describe('toast: trigger', () => {
     await page.click('#default');
 
     await ionToastDidPresent.next();
-    await expect(alert).toBeVisible();
+    await expect(toast).toBeVisible();
   });
 
   test('should present a previously presented toast', async ({ page }) => {
@@ -30,6 +30,6 @@ test.describe('toast: trigger', () => {
     await page.click('#timeout');
 
     await ionToastDidPresent.next();
-    await expect(alert).toBeVisible();
+    await expect(toast).toBeVisible();
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: N/A

Playwright recommends using Locators with web-first assertions instead of using `waitForSelector`: https://playwright.dev/docs/api/class-frame#frame-wait-for-selector


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removes waitForSelector usages for checking if components are visible in favor of the `toBeVisible` or `toBeHidden` assertions.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
