### PR TITLE
fix(picker-column-internal): hide empty picker items from screenreaders

### DIFF
--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -403,9 +403,9 @@ export class PickerColumnInternal implements ComponentInterface {
           ['picker-column-numeric-input']: numericInput,
         })}
       >
-        <div class="picker-item picker-item-empty">&nbsp;</div>
-        <div class="picker-item picker-item-empty">&nbsp;</div>
-        <div class="picker-item picker-item-empty">&nbsp;</div>
+        <div class="picker-item picker-item-empty" aria-hidden="true">&nbsp;</div>
+        <div class="picker-item picker-item-empty" aria-hidden="true">&nbsp;</div>
+        <div class="picker-item picker-item-empty" aria-hidden="true">&nbsp;</div>
         {items.map((item, index) => {
           {
             /*
@@ -435,9 +435,9 @@ export class PickerColumnInternal implements ComponentInterface {
             </button>
           );
         })}
-        <div class="picker-item picker-item-empty">&nbsp;</div>
-        <div class="picker-item picker-item-empty">&nbsp;</div>
-        <div class="picker-item picker-item-empty">&nbsp;</div>
+        <div class="picker-item picker-item-empty" aria-hidden="true">&nbsp;</div>
+        <div class="picker-item picker-item-empty" aria-hidden="true">&nbsp;</div>
+        <div class="picker-item picker-item-empty" aria-hidden="true">&nbsp;</div>
       </Host>
     );
   }

--- a/core/src/components/picker-column-internal/picker-column-internal.tsx
+++ b/core/src/components/picker-column-internal/picker-column-internal.tsx
@@ -403,9 +403,15 @@ export class PickerColumnInternal implements ComponentInterface {
           ['picker-column-numeric-input']: numericInput,
         })}
       >
-        <div class="picker-item picker-item-empty" aria-hidden="true">&nbsp;</div>
-        <div class="picker-item picker-item-empty" aria-hidden="true">&nbsp;</div>
-        <div class="picker-item picker-item-empty" aria-hidden="true">&nbsp;</div>
+        <div class="picker-item picker-item-empty" aria-hidden="true">
+          &nbsp;
+        </div>
+        <div class="picker-item picker-item-empty" aria-hidden="true">
+          &nbsp;
+        </div>
+        <div class="picker-item picker-item-empty" aria-hidden="true">
+          &nbsp;
+        </div>
         {items.map((item, index) => {
           {
             /*
@@ -435,9 +441,15 @@ export class PickerColumnInternal implements ComponentInterface {
             </button>
           );
         })}
-        <div class="picker-item picker-item-empty" aria-hidden="true">&nbsp;</div>
-        <div class="picker-item picker-item-empty" aria-hidden="true">&nbsp;</div>
-        <div class="picker-item picker-item-empty" aria-hidden="true">&nbsp;</div>
+        <div class="picker-item picker-item-empty" aria-hidden="true">
+          &nbsp;
+        </div>
+        <div class="picker-item picker-item-empty" aria-hidden="true">
+          &nbsp;
+        </div>
+        <div class="picker-item picker-item-empty" aria-hidden="true">
+          &nbsp;
+        </div>
       </Host>
     );
   }


### PR DESCRIPTION
backport https://github.com/ionic-team/ionic-framework/pull/27038 to 6.7