### PR TITLE
fix(menu): refs are not destroyed on unmount

### DIFF
--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -253,7 +253,7 @@ export class Menu implements ComponentInterface, MenuI {
     }
 
     this.animation = undefined;
-    this.contentEl = this.backdropEl = this.menuInnerEl = undefined;
+    this.contentEl = undefined;
   }
 
   @Listen('ionSplitPaneVisible', { target: 'body' })

--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -242,6 +242,12 @@ export class Menu implements ComponentInterface, MenuI {
   }
 
   disconnectedCallback() {
+    /**
+     * The menu should be closed when it is
+     * unmounted from the DOM.
+     */
+    this.close(false);
+
     this.blocker.destroy();
     menuController._unregister(this);
     if (this.animation) {
@@ -251,15 +257,6 @@ export class Menu implements ComponentInterface, MenuI {
       this.gesture.destroy();
       this.gesture = undefined;
     }
-
-    /**
-     * The menu should be closed when it is
-     * unmounted from the DOM. Note: Do not
-     * call this.close() since events will
-     * not fire as expected due to the component
-     * no longer being in the DOM.
-     */
-    this._isOpen = false;
 
     this.animation = undefined;
     this.contentEl = undefined;

--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -241,12 +241,15 @@ export class Menu implements ComponentInterface, MenuI {
     this.updateState();
   }
 
-  disconnectedCallback() {
+  async disconnectedCallback() {
     /**
      * The menu should be closed when it is
      * unmounted from the DOM.
+     * This is an async call, so we need to wait for
+     * this to finish otherwise contentEl
+     * will not have MENU_CONTENT_OPEN removed.
      */
-    this.close(false);
+    await this.close(false);
 
     this.blocker.destroy();
     menuController._unregister(this);

--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -37,7 +37,6 @@ export class Menu implements ComponentInterface, MenuI {
   private lastOnEnd = 0;
   private gesture?: Gesture;
   private blocker = GESTURE_CONTROLLER.createBlocker({ disableScroll: true });
-  private openOnConnect = false;
 
   isAnimating = false;
   width!: number;
@@ -218,15 +217,6 @@ export class Menu implements ComponentInterface, MenuI {
     // register this menu with the app's menu controller
     menuController._register(this);
 
-    /**
-     * Re-open the menu if needed
-     * when it is re-added to the DOM.
-     */
-    if (this.openOnConnect) {
-      this.open(false);
-      this.openOnConnect = false;
-    }
-
     this.gesture = (await import('../../utils/gesture')).createGesture({
       el: document,
       gestureName: 'menu-swipe',
@@ -263,17 +253,13 @@ export class Menu implements ComponentInterface, MenuI {
     }
 
     /**
-     * If the menu is open when it is unmounted,
-     * it should still be open if it is re-mounted.
-     * Note that we do not call this.close() here
-     * because the element is already disconnected
-     * from the DOM, so willClose and didClose events
-     * will not fire as expected.
+     * The menu should be closed when it is
+     * unmounted from the DOM. Note: Do not
+     * call this.close() since events will
+     * not fire as expected due to the component
+     * no longer being in the DOM.
      */
-    if (this._isOpen) {
-      this._isOpen = false;
-      this.openOnConnect = true;
-    }
+    this._isOpen = false;
 
     this.animation = undefined;
     this.contentEl = undefined;

--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -37,6 +37,7 @@ export class Menu implements ComponentInterface, MenuI {
   private lastOnEnd = 0;
   private gesture?: Gesture;
   private blocker = GESTURE_CONTROLLER.createBlocker({ disableScroll: true });
+  private openOnConnect = false;
 
   isAnimating = false;
   width!: number;
@@ -217,6 +218,15 @@ export class Menu implements ComponentInterface, MenuI {
     // register this menu with the app's menu controller
     menuController._register(this);
 
+    /**
+     * Re-open the menu if needed
+     * when it is re-added to the DOM.
+     */
+    if (this.openOnConnect) {
+      this.open(false);
+      this.openOnConnect = false;
+    }
+
     this.gesture = (await import('../../utils/gesture')).createGesture({
       el: document,
       gestureName: 'menu-swipe',
@@ -250,6 +260,19 @@ export class Menu implements ComponentInterface, MenuI {
     if (this.gesture) {
       this.gesture.destroy();
       this.gesture = undefined;
+    }
+
+    /**
+     * If the menu is open when it is unmounted,
+     * it should still be open if it is re-mounted.
+     * Note that we do not call this.close() here
+     * because the element is already disconnected
+     * from the DOM, so willClose and didClose events
+     * will not fire as expected.
+     */
+    if (this._isOpen) {
+      this._isOpen = false;
+      this.openOnConnect = true;
     }
 
     this.animation = undefined;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/24907

`ion-menu` currently clears the `menuInnerEl` and `backdropEl` refs created by Stencil when `disconnectedCallback` is fired. If the `ion-menu` component is re-mounted but _not_ re-rendered, those refs will still be `undefined` when the `open` method is called, resulting in the linked issue. Note that if the `ion-menu` re-renders before `open` is called then this issue does not reproduce.

This clearing behavior was added ~6 years ago before we utilized Stencil refs: https://github.com/ionic-team/ionic-framework/blob/687b37ad3e3237b874473817bb7b59143ac113ce/packages/core/src/components/menu/menu.tsx#L136-L137

During this time we had to manually create and clear the element references.

Several years later we moved to using Stencil refs, but we did not remove the logic that clears the refs: https://github.com/ionic-team/ionic-framework/commit/d83d8eed12b0b7e852feffd77d51c9f5a92e6640

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Menu no longer sets `menuInnerEl` and `backdropEl` to `undefined` in `disconnectedCallback`.
- The `close` method is called so that the state is reset prior to the menu being re-added. I observed that without this, the animation to re-present a menu did not work correctly.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
