### PR TITLE
docs(input,searchbar): setFocus usage within overlays

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -1270,7 +1270,7 @@ export namespace Components {
          */
         "required": boolean;
         /**
-          * Sets focus on the native `input` in `ion-input`. Use this method instead of the global `input.focus()`.  Developers who wish to focus an input when a page enters should call `setFocus()` in the `ionViewDidEnter()` lifecycle method.
+          * Sets focus on the native `input` in `ion-input`. Use this method instead of the global `input.focus()`.  Developers who wish to focus an input when a page enters should call `setFocus()` in the `ionViewDidEnter()` lifecycle method.  Focusing an input within an overlay should be done after the overlay has completed its transition.
          */
         "setFocus": () => Promise<void>;
         /**
@@ -2583,7 +2583,7 @@ export namespace Components {
          */
         "searchIcon"?: string;
         /**
-          * Sets focus on the specified `ion-searchbar`. Use this method instead of the global `input.focus()`.
+          * Sets focus on the native `input` in `ion-searchbar`. Use this method instead of the global `input.focus()`.  Developers who wish to focus an input when a page enters should call `setFocus()` in the `ionViewDidEnter()` lifecycle method.  Focusing an input within an overlay should be done after the overlay has completed its transition.
          */
         "setFocus": () => Promise<void>;
         /**

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -1270,7 +1270,7 @@ export namespace Components {
          */
         "required": boolean;
         /**
-          * Sets focus on the native `input` in `ion-input`. Use this method instead of the global `input.focus()`.  Developers who wish to focus an input when a page enters should call `setFocus()` in the `ionViewDidEnter()` lifecycle method.  Focusing an input within an overlay should be done after the overlay has completed its transition.
+          * Sets focus on the native `input` in `ion-input`. Use this method instead of the global `input.focus()`.  Developers who wish to focus an input when a page enters should call `setFocus()` in the `ionViewDidEnter()` lifecycle method.  Developers who wish to focus an input when an overlay is presented should call `setFocus` after `didPresent` has resolved.
          */
         "setFocus": () => Promise<void>;
         /**
@@ -2583,7 +2583,7 @@ export namespace Components {
          */
         "searchIcon"?: string;
         /**
-          * Sets focus on the native `input` in `ion-searchbar`. Use this method instead of the global `input.focus()`.  Developers who wish to focus an input when a page enters should call `setFocus()` in the `ionViewDidEnter()` lifecycle method.  Focusing an input within an overlay should be done after the overlay has completed its transition.
+          * Sets focus on the native `input` in `ion-searchbar`. Use this method instead of the global `input.focus()`.  Developers who wish to focus an input when a page enters should call `setFocus()` in the `ionViewDidEnter()` lifecycle method.  Developers who wish to focus an input when an overlay is presented should call `setFocus` after `didPresent` has resolved.
          */
         "setFocus": () => Promise<void>;
         /**

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -397,9 +397,9 @@ export class Input implements ComponentInterface {
    *
    * Developers who wish to focus an input when a page enters
    * should call `setFocus()` in the `ionViewDidEnter()` lifecycle method.
-   * 
-   * Focusing an input within an overlay should be done after the overlay has
-   * completed its transition. 
+   *
+   * Developers who wish to focus an input when an overlay is presented
+   * should call `setFocus` after `didPresent` has resolved.
    */
   @Method()
   async setFocus() {

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -397,6 +397,9 @@ export class Input implements ComponentInterface {
    *
    * Developers who wish to focus an input when a page enters
    * should call `setFocus()` in the `ionViewDidEnter()` lifecycle method.
+   * 
+   * Focusing an input within an overlay should be done after the overlay has
+   * completed its transition. 
    */
   @Method()
   async setFocus() {

--- a/core/src/components/searchbar/searchbar.tsx
+++ b/core/src/components/searchbar/searchbar.tsx
@@ -243,8 +243,14 @@ export class Searchbar implements ComponentInterface {
   }
 
   /**
-   * Sets focus on the specified `ion-searchbar`. Use this method instead of the global
+   * Sets focus on the native `input` in `ion-searchbar`. Use this method instead of the global
    * `input.focus()`.
+   *
+   * Developers who wish to focus an input when a page enters
+   * should call `setFocus()` in the `ionViewDidEnter()` lifecycle method.
+   * 
+   * Focusing an input within an overlay should be done after the overlay has
+   * completed its transition. 
    */
   @Method()
   async setFocus() {

--- a/core/src/components/searchbar/searchbar.tsx
+++ b/core/src/components/searchbar/searchbar.tsx
@@ -248,9 +248,9 @@ export class Searchbar implements ComponentInterface {
    *
    * Developers who wish to focus an input when a page enters
    * should call `setFocus()` in the `ionViewDidEnter()` lifecycle method.
-   * 
-   * Focusing an input within an overlay should be done after the overlay has
-   * completed its transition. 
+   *
+   * Developers who wish to focus an input when an overlay is presented
+   * should call `setFocus` after `didPresent` has resolved.
    */
   @Method()
   async setFocus() {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The `setFocus` method does not mention extra implementation details required when working within an overlay. 

<!-- Issues are required for both bug fixes and features. -->
Issue URL: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds additional detail about how to use `setFocus()` when inside an overlay
- Aligns the `ion-searchbar` documentation to match the `ion-input` documentation

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
