### PR TITLE
test(radio): skip legacy flaky test

### DIFF
--- a/core/src/components/radio/test/legacy/a11y/radio.e2e.ts
+++ b/core/src/components/radio/test/legacy/a11y/radio.e2e.ts
@@ -1,7 +1,8 @@
 import { expect } from '@playwright/test';
 import { test } from '@utils/test/playwright';
 
-test.describe('radio: a11y', () => {
+// TODO FW-3747
+test.describe.skip('radio: a11y', () => {
   test.beforeEach(({ skip }) => {
     skip.rtl();
   });
@@ -21,8 +22,7 @@ test.describe('radio: a11y', () => {
     await page.keyboard.press(`Shift+${tabKey}`);
     await expect(firstGroupRadios.nth(0)).toBeFocused();
   });
-  // TODO FW-3956
-  test.skip('using arrow keys should move between enabled radios within group', async ({ page, browserName }) => {
+  test('using arrow keys should move between enabled radios within group', async ({ page, browserName }) => {
     const tabKey = browserName === 'webkit' ? 'Alt+Tab' : 'Tab';
     await page.goto(`/src/components/radio/test/legacy/a11y`);
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
I forgot to skip the legacy radio test in https://github.com/ionic-team/ionic-framework/pull/27126.

I also discovered we had duplicate flaky radio keyboard test tech debt tickets.

https://github.com/ionic-team/ionic-framework/actions/runs/4658963827/jobs/8245309480?pr=27125

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- skipped legacy radio test
- closed FW-3956 in favor of FW-3747

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
