### PR TITLE
fix(menu): refs are not destroyed on unmount

### DIFF
--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -234,7 +234,16 @@ export class Menu implements ComponentInterface, MenuI {
     this.updateState();
   }
 
-  disconnectedCallback() {
+  async disconnectedCallback() {
+    /**
+     * The menu should be closed when it is
+     * unmounted from the DOM.
+     * This is an async call, so we need to wait for
+     * this to finish otherwise contentEl
+     * will not have MENU_CONTENT_OPEN removed.
+     */
+    await this.close(false);
+
     this.blocker.destroy();
     menuController._unregister(this);
     if (this.animation) {
@@ -246,7 +255,7 @@ export class Menu implements ComponentInterface, MenuI {
     }
 
     this.animation = undefined;
-    this.contentEl = this.backdropEl = this.menuInnerEl = undefined;
+    this.contentEl = undefined;
   }
 
   @Listen('ionSplitPaneVisible', { target: 'body' })


### PR DESCRIPTION
This is a port of https://github.com/ionic-team/ionic-framework/pull/27141 to Ionic v6