### PR TITLE
test(accordion): remove undefined check in test

### DIFF
--- a/core/src/components/accordion/test/basic/accordion.e2e.ts
+++ b/core/src/components/accordion/test/basic/accordion.e2e.ts
@@ -15,7 +15,7 @@ test.describe('accordion: ionChange', () => {
   test.beforeEach(({ skip }) => {
     skip.rtl();
   });
-  test.only('should fire ionChange when interacting with accordions', async ({ page }) => {
+  test('should fire ionChange when interacting with accordions', async ({ page }) => {
     await page.setContent(`
       <ion-accordion-group value="second">
         <ion-accordion value="first">

--- a/core/src/components/accordion/test/basic/accordion.e2e.ts
+++ b/core/src/components/accordion/test/basic/accordion.e2e.ts
@@ -15,7 +15,7 @@ test.describe('accordion: ionChange', () => {
   test.beforeEach(({ skip }) => {
     skip.rtl();
   });
-  test('should fire ionChange when interacting with accordions', async ({ page }) => {
+  test.only('should fire ionChange when interacting with accordions', async ({ page }) => {
     await page.setContent(`
       <ion-accordion-group value="second">
         <ion-accordion value="first">
@@ -41,9 +41,6 @@ test.describe('accordion: ionChange', () => {
 
     await accordionHeaders.nth(1).click();
     await expect(ionChange).toHaveReceivedEventDetail({ value: 'second' });
-
-    await accordionHeaders.nth(1).click();
-    await expect(ionChange).toHaveReceivedEventDetail({ value: undefined });
 
     await accordionHeaders.nth(2).click();
     await expect(ionChange).toHaveReceivedEventDetail({ value: 'third' });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
The `ionChange` event test occasionally flakes on CI: https://github.com/ionic-team/ionic-framework/actions/runs/4670357292/jobs/8270028536

It appears that when clicking the same accordion again the test expects the `ionChange` event to receive a detail payload of `undefined`. However, this is wrong because `ionChange` should not fire at all if the value does not change.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removes the `undefined` check from the test. This check does not seem necessary as clicking the `nth(2)` accordion should then update the payload.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
