### PR TITLE
fix(vue): components have correct name in Vue Dev Tools

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -24,7 +24,7 @@
         "@stencil/angular-output-target": "^0.6.0",
         "@stencil/react-output-target": "^0.5.0",
         "@stencil/sass": "^3.0.0",
-        "@stencil/vue-output-target": "^0.8.1",
+        "@stencil/vue-output-target": "^0.6.1-dev.11681238809.11549fe0",
         "@types/jest": "^27.5.2",
         "@types/node": "^14.6.0",
         "@typescript-eslint/eslint-plugin": "^5.17.0",
@@ -1624,9 +1624,9 @@
       }
     },
     "node_modules/@stencil/vue-output-target": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.8.1.tgz",
-      "integrity": "sha512-nSpwTvDa+i1Du8wxzX8OWp0QTS5DQmiwVNjdzQWBzeI77fCvS5mTMBsXwXbtURkR7emkm/ktMU05wXX8mnbWiQ==",
+      "version": "0.6.1-dev.11681238809.11549fe0",
+      "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.6.1-dev.11681238809.11549fe0.tgz",
+      "integrity": "sha512-nKuyvG1Mu42tYkmUYZe2sWHNNshHO8VSAvPNWiGDyHhTDDLXcoKjW8iWYk9c2Igd60g/31YxmfgYTd16kChjrg==",
       "dev": true,
       "peerDependencies": {
         "@stencil/core": "^2.9.0 || ^3.0.0"
@@ -11486,9 +11486,9 @@
       "requires": {}
     },
     "@stencil/vue-output-target": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.8.1.tgz",
-      "integrity": "sha512-nSpwTvDa+i1Du8wxzX8OWp0QTS5DQmiwVNjdzQWBzeI77fCvS5mTMBsXwXbtURkR7emkm/ktMU05wXX8mnbWiQ==",
+      "version": "0.6.1-dev.11681238809.11549fe0",
+      "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.6.1-dev.11681238809.11549fe0.tgz",
+      "integrity": "sha512-nKuyvG1Mu42tYkmUYZe2sWHNNshHO8VSAvPNWiGDyHhTDDLXcoKjW8iWYk9c2Igd60g/31YxmfgYTd16kChjrg==",
       "dev": true,
       "requires": {}
     },

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -24,7 +24,7 @@
         "@stencil/angular-output-target": "^0.6.0",
         "@stencil/react-output-target": "^0.5.0",
         "@stencil/sass": "^3.0.0",
-        "@stencil/vue-output-target": "^0.6.1-dev.11681238809.11549fe0",
+        "@stencil/vue-output-target": "^0.8.2",
         "@types/jest": "^27.5.2",
         "@types/node": "^14.6.0",
         "@typescript-eslint/eslint-plugin": "^5.17.0",
@@ -1624,9 +1624,9 @@
       }
     },
     "node_modules/@stencil/vue-output-target": {
-      "version": "0.6.1-dev.11681238809.11549fe0",
-      "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.6.1-dev.11681238809.11549fe0.tgz",
-      "integrity": "sha512-nKuyvG1Mu42tYkmUYZe2sWHNNshHO8VSAvPNWiGDyHhTDDLXcoKjW8iWYk9c2Igd60g/31YxmfgYTd16kChjrg==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.8.2.tgz",
+      "integrity": "sha512-Z+igq/pz7z9bSRH0tVxHvD/m13B6MPM+i2DZRboGt3uyTKeD1vLZQz3BLCfPeBtEXp2Xlz4d18Z8d7c4abFKbg==",
       "dev": true,
       "peerDependencies": {
         "@stencil/core": "^2.9.0 || ^3.0.0"
@@ -11486,9 +11486,9 @@
       "requires": {}
     },
     "@stencil/vue-output-target": {
-      "version": "0.6.1-dev.11681238809.11549fe0",
-      "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.6.1-dev.11681238809.11549fe0.tgz",
-      "integrity": "sha512-nKuyvG1Mu42tYkmUYZe2sWHNNshHO8VSAvPNWiGDyHhTDDLXcoKjW8iWYk9c2Igd60g/31YxmfgYTd16kChjrg==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@stencil/vue-output-target/-/vue-output-target-0.8.2.tgz",
+      "integrity": "sha512-Z+igq/pz7z9bSRH0tVxHvD/m13B6MPM+i2DZRboGt3uyTKeD1vLZQz3BLCfPeBtEXp2Xlz4d18Z8d7c4abFKbg==",
       "dev": true,
       "requires": {}
     },

--- a/core/package.json
+++ b/core/package.json
@@ -46,7 +46,7 @@
     "@stencil/angular-output-target": "^0.6.0",
     "@stencil/react-output-target": "^0.5.0",
     "@stencil/sass": "^3.0.0",
-    "@stencil/vue-output-target": "^0.6.1-dev.11681238809.11549fe0",
+    "@stencil/vue-output-target": "^0.8.2",
     "@types/jest": "^27.5.2",
     "@types/node": "^14.6.0",
     "@typescript-eslint/eslint-plugin": "^5.17.0",

--- a/core/package.json
+++ b/core/package.json
@@ -46,7 +46,7 @@
     "@stencil/angular-output-target": "^0.6.0",
     "@stencil/react-output-target": "^0.5.0",
     "@stencil/sass": "^3.0.0",
-    "@stencil/vue-output-target": "^0.8.1",
+    "@stencil/vue-output-target": "^0.6.1-dev.11681238809.11549fe0",
     "@types/jest": "^27.5.2",
     "@types/node": "^14.6.0",
     "@typescript-eslint/eslint-plugin": "^5.17.0",

--- a/packages/vue/src/components/IonApp.ts
+++ b/packages/vue/src/components/IonApp.ts
@@ -16,6 +16,8 @@ export const IonApp = /*@__PURE__*/ defineComponent((_, { attrs, slots }) => {
   };
 });
 
+IonApp.name = "IonApp";
+
 /**
  * When rendering user components inside of
  * ion-modal, or ion-popover the component

--- a/packages/vue/src/components/IonApp.ts
+++ b/packages/vue/src/components/IonApp.ts
@@ -16,7 +16,7 @@ export const IonApp = /*@__PURE__*/ defineComponent((_, { attrs, slots }) => {
   };
 });
 
-IonApp.displayName = "IonApp";
+IonApp.name = "IonApp";
 
 /**
  * When rendering user components inside of

--- a/packages/vue/src/components/IonApp.ts
+++ b/packages/vue/src/components/IonApp.ts
@@ -16,7 +16,7 @@ export const IonApp = /*@__PURE__*/ defineComponent((_, { attrs, slots }) => {
   };
 });
 
-IonApp.name = "IonApp";
+IonApp.displayName = "IonApp";
 
 /**
  * When rendering user components inside of

--- a/packages/vue/src/components/IonBackButton.ts
+++ b/packages/vue/src/components/IonBackButton.ts
@@ -37,4 +37,4 @@ export const IonBackButton = /*@__PURE__*/ defineComponent(
   }
 );
 
-IonBackButton.displayName = "IonBackButton";
+IonBackButton.name = "IonBackButton";

--- a/packages/vue/src/components/IonBackButton.ts
+++ b/packages/vue/src/components/IonBackButton.ts
@@ -37,4 +37,4 @@ export const IonBackButton = /*@__PURE__*/ defineComponent(
   }
 );
 
-IonBackButton.name = "IonBackButton";
+IonBackButton.displayName = "IonBackButton";

--- a/packages/vue/src/components/IonBackButton.ts
+++ b/packages/vue/src/components/IonBackButton.ts
@@ -36,3 +36,5 @@ export const IonBackButton = /*@__PURE__*/ defineComponent(
     };
   }
 );
+
+IonBackButton.name = "IonBackButton";

--- a/packages/vue/src/components/IonNav.ts
+++ b/packages/vue/src/components/IonNav.ts
@@ -22,3 +22,5 @@ export const IonNav = /*@__PURE__*/ defineComponent(() => {
     return h("ion-nav", { delegate }, views.value);
   };
 });
+
+IonNav.name = "IonNav";

--- a/packages/vue/src/components/IonNav.ts
+++ b/packages/vue/src/components/IonNav.ts
@@ -23,4 +23,4 @@ export const IonNav = /*@__PURE__*/ defineComponent(() => {
   };
 });
 
-IonNav.name = "IonNav";
+IonNav.displayName = "IonNav";

--- a/packages/vue/src/components/IonNav.ts
+++ b/packages/vue/src/components/IonNav.ts
@@ -23,4 +23,4 @@ export const IonNav = /*@__PURE__*/ defineComponent(() => {
   };
 });
 
-IonNav.displayName = "IonNav";
+IonNav.name = "IonNav";

--- a/packages/vue/src/vue-component-lib/overlays.ts
+++ b/packages/vue/src/vue-component-lib/overlays.ts
@@ -173,7 +173,7 @@ export const defineOverlayContainer = <Props extends object>(name: string, defin
 
   const Container = (controller !== undefined) ? createControllerComponent() : createInlineComponent();
 
-  Container.displayName = name;
+  Container.name = name;
 
   Container.props = {
     'isOpen': DEFAULT_EMPTY_PROP

--- a/packages/vue/src/vue-component-lib/utils.ts
+++ b/packages/vue/src/vue-component-lib/utils.ts
@@ -184,7 +184,7 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
     };
   });
 
-  Container.displayName = name;
+  Container.name = name;
 
   Container.props = {
     [ROUTER_LINK_VALUE]: DEFAULT_EMPTY_PROP,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves #25199

Vue components show up as "Anonymous Component" in Vue Dev Tools. This is caused by our use of `displayName` instead of `name`. This required a fix in the Vue Output Target package. See https://github.com/ionic-team/stencil-ds-output-targets/pull/257 for more info.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updates the Vue Output Target dependency
- Functional components created manually in Ionic Vue now set `name` instead of `displayName`. Note: Non-functional components were never impacted by this bug.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


Dev build: `7.0.2-dev.11681308435.141a05de`