### PR TITLE
refactor(input): migrate composition events to JSX bindings

### DIFF
--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -367,13 +367,6 @@ export class Input implements ComponentInterface {
 
   componentDidLoad() {
     this.originalIonInput = this.ionInput;
-    const nativeInput = this.nativeInput;
-    if (nativeInput) {
-      // TODO: FW-729 Update to JSX bindings when Stencil resolves bug with:
-      // https://github.com/ionic-team/stencil/issues/3235
-      nativeInput.addEventListener('compositionstart', this.onCompositionStart);
-      nativeInput.addEventListener('compositionend', this.onCompositionEnd);
-    }
   }
 
   disconnectedCallback() {
@@ -383,11 +376,6 @@ export class Input implements ComponentInterface {
           detail: this.el,
         })
       );
-    }
-    const nativeInput = this.nativeInput;
-    if (nativeInput) {
-      nativeInput.removeEventListener('compositionstart', this.onCompositionStart);
-      nativeInput.removeEventListener('compositionend', this.onCompositionEnd);
     }
   }
 
@@ -690,6 +678,8 @@ export class Input implements ComponentInterface {
               onBlur={this.onBlur}
               onFocus={this.onFocus}
               onKeyDown={this.onKeydown}
+              onCompositionstart={this.onCompositionStart}
+              onCompositionend={this.onCompositionEnd}
               {...this.inheritedAttributes}
             />
             {this.clearInput && !readonly && !disabled && (


### PR DESCRIPTION
Updates the `compositionstart` and `compositionend` events on input to use JSX bindings since issue https://github.com/ionic-team/stencil/issues/3235 was resolved in Stencil v3.