### PR TITLE
fix(toast): screen readers announce content

### DIFF
--- a/core/src/components/toast/test/a11y/index.html
+++ b/core/src/components/toast/test/a11y/index.html
@@ -18,16 +18,16 @@
       <main>
         <h1 style="background-color: white">Toast - a11y</h1>
 
-        <button id="polite" onclick="presentToast({ message: 'This is a toast message' })">Present Toast</button>
-        <button
-          id="assertive"
-          onclick="presentToast({ message: 'This is an assertive toast message', htmlAttributes: { 'aria-live': 'assertive' } })"
-        >
-          Present Assertive Toast
-        </button>
+        <button id="inline-toast-trigger">Present Inline Toast</button>
+        <ion-toast id="inline-toast" trigger="inline-toast-trigger" icon="person" header="Inline Toast Header" message="Inline Toast Message"></ion-toast>
+
+        <button id="controller-toast-trigger" onclick="presentToast({ icon: 'person', header: 'Controller Toast Header', message: 'Controller Toast Message', buttons: ['Ok'] })">Present Controller Toast</button>
       </main>
     </ion-app>
     <script>
+      const inlineToast = document.querySelector('#inline-toast');
+      inlineToast.buttons = ['Ok'];
+
       const presentToast = async (opts) => {
         const toast = await toastController.create(opts);
 

--- a/core/src/components/toast/test/a11y/index.html
+++ b/core/src/components/toast/test/a11y/index.html
@@ -33,6 +33,8 @@
         >
           Present Controller Toast
         </button>
+
+        <button onclick="updateContent()">Update Inner Content</button>
       </main>
     </ion-app>
     <script>
@@ -43,6 +45,14 @@
         const toast = await toastController.create(opts);
 
         await toast.present();
+      };
+
+      const updateContent = () => {
+        const toasts = document.querySelectorAll('ion-toast');
+        toasts.forEach((toast) => {
+          toast.header = 'Updated Header';
+          toast.message = 'Updated Message';
+        });
       };
     </script>
   </body>

--- a/core/src/components/toast/test/a11y/index.html
+++ b/core/src/components/toast/test/a11y/index.html
@@ -18,7 +18,7 @@
       <main>
         <h1 style="background-color: white">Toast - a11y</h1>
 
-        <button id="inline-toast-trigger">Present Inline Toast</button>
+        <ion-button id="inline-toast-trigger">Present Inline Toast</ion-button>
         <ion-toast
           id="inline-toast"
           trigger="inline-toast-trigger"
@@ -27,14 +27,14 @@
           message="Inline Toast Message"
         ></ion-toast>
 
-        <button
+        <ion-button
           id="controller-toast-trigger"
           onclick="presentToast({ icon: 'person', header: 'Controller Toast Header', message: 'Controller Toast Message', buttons: ['Ok'] })"
         >
           Present Controller Toast
-        </button>
+        </ion-button>
 
-        <button onclick="updateContent()">Update Inner Content</button>
+        <ion-button onclick="updateContent()">Update Inner Content</ion-button>
       </main>
     </ion-app>
     <script>

--- a/core/src/components/toast/test/a11y/index.html
+++ b/core/src/components/toast/test/a11y/index.html
@@ -49,6 +49,11 @@
 
       const updateContent = () => {
         const toasts = document.querySelectorAll('ion-toast');
+        /**
+         * Note: Multiple updates to the props
+         * may cause screen readers like NVDA to announce
+         * the entire content multiple times.
+         */
         toasts.forEach((toast) => {
           toast.header = 'Updated Header';
           toast.message = 'Updated Message';

--- a/core/src/components/toast/test/a11y/index.html
+++ b/core/src/components/toast/test/a11y/index.html
@@ -19,9 +19,20 @@
         <h1 style="background-color: white">Toast - a11y</h1>
 
         <button id="inline-toast-trigger">Present Inline Toast</button>
-        <ion-toast id="inline-toast" trigger="inline-toast-trigger" icon="person" header="Inline Toast Header" message="Inline Toast Message"></ion-toast>
+        <ion-toast
+          id="inline-toast"
+          trigger="inline-toast-trigger"
+          icon="person"
+          header="Inline Toast Header"
+          message="Inline Toast Message"
+        ></ion-toast>
 
-        <button id="controller-toast-trigger" onclick="presentToast({ icon: 'person', header: 'Controller Toast Header', message: 'Controller Toast Message', buttons: ['Ok'] })">Present Controller Toast</button>
+        <button
+          id="controller-toast-trigger"
+          onclick="presentToast({ icon: 'person', header: 'Controller Toast Header', message: 'Controller Toast Message', buttons: ['Ok'] })"
+        >
+          Present Controller Toast
+        </button>
       </main>
     </ion-app>
     <script>

--- a/core/src/components/toast/test/a11y/toast.e2e.ts
+++ b/core/src/components/toast/test/a11y/toast.e2e.ts
@@ -7,12 +7,10 @@ test.describe('toast: a11y', () => {
     test.skip(testInfo.project.metadata.rtl === true, 'This test does not check LTR vs RTL layouts');
     await page.goto(`/src/components/toast/test/a11y`);
   });
-  test('should not have any axe violations with polite toasts', async ({ page }) => {
+  test('should not have any axe violations with inline toasts', async ({ page }) => {
     const ionToastDidPresent = await page.spyOnEvent('ionToastDidPresent');
 
-    const politeButton = page.locator('#polite');
-    await politeButton.click();
-
+    await page.click('#inline-toast-trigger');
     await ionToastDidPresent.next();
 
     /**
@@ -23,12 +21,10 @@ test.describe('toast: a11y', () => {
     const results = await new AxeBuilder({ page }).disableRules('color-contrast').analyze();
     expect(results.violations).toEqual([]);
   });
-  test('should not have any axe violations with assertive toasts', async ({ page }) => {
+  test('should not have any axe violations with controller toasts', async ({ page }) => {
     const ionToastDidPresent = await page.spyOnEvent('ionToastDidPresent');
 
-    const politeButton = page.locator('#assertive');
-    await politeButton.click();
-
+    await page.click('#controller-toast-trigger');
     await ionToastDidPresent.next();
 
     /**

--- a/core/src/components/toast/test/toast.spec.ts
+++ b/core/src/components/toast/test/toast.spec.ts
@@ -87,4 +87,4 @@ describe('toast: a11y smoke test', () => {
     expect(header.getAttribute('aria-hidden')).toBe(null);
     expect(message.getAttribute('aria-hidden')).toBe(null);
   });
-})
+});

--- a/core/src/components/toast/test/toast.spec.ts
+++ b/core/src/components/toast/test/toast.spec.ts
@@ -2,7 +2,7 @@ import { newSpecPage } from '@stencil/core/testing';
 import { Toast } from '../toast';
 import { config } from '../../../global/config';
 
-describe('alert: custom html', () => {
+describe('toast: custom html', () => {
   it('should not allow for custom html by default', async () => {
     const page = await newSpecPage({
       components: [Toast],

--- a/core/src/components/toast/test/toast.spec.ts
+++ b/core/src/components/toast/test/toast.spec.ts
@@ -41,3 +41,50 @@ describe('toast: custom html', () => {
     expect(content.querySelector('button.custom-html')).toBe(null);
   });
 });
+
+/**
+ * These tests check if the aria-hidden attributes are being
+ * removed on present. Without this functionality, screen readers
+ * would not announce toast content correctly.
+ */
+describe('toast: a11y smoke test', () => {
+  it('should have aria-hidden content when dismissed', async () => {
+    const page = await newSpecPage({
+      components: [Toast],
+      html: `<ion-toast message="Message" header="Header"></ion-toast>`,
+    });
+
+    const toast = page.body.querySelector('ion-toast');
+    const header = toast.shadowRoot.querySelector('.toast-header');
+    const message = toast.shadowRoot.querySelector('.toast-message');
+
+    expect(header.getAttribute('aria-hidden')).toBe('true');
+    expect(message.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('should not have aria-hidden content when presented', async () => {
+    const page = await newSpecPage({
+      components: [Toast],
+      html: `
+        <ion-app>
+          <ion-toast animated="false" message="Message" header="Header"></ion-toast>
+        </ion-app>
+      `,
+    });
+
+    const toast = page.body.querySelector('ion-toast');
+
+    /**
+     * Wait for present method to resolve
+     * and for state change to take effect.
+     */
+    await toast.present();
+    await page.waitForChanges();
+
+    const header = toast.shadowRoot.querySelector('.toast-header');
+    const message = toast.shadowRoot.querySelector('.toast-message');
+
+    expect(header.getAttribute('aria-hidden')).toBe(null);
+    expect(message.getAttribute('aria-hidden')).toBe(null);
+  });
+})

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -55,6 +55,11 @@ export class Toast implements ComponentInterface, OverlayInterface {
 
   presented = false;
 
+  /**
+   * When `true`, content inside of .toast-content
+   * will have aria-hidden elements removed causing
+   * screen readers to announce the remaining content.
+   */
   @State() revealContentToScreenReader = false;
 
   @Element() el!: HTMLIonToastElement;
@@ -413,6 +418,11 @@ export class Toast implements ComponentInterface, OverlayInterface {
     );
   }
 
+  /**
+   * Render the `message` property.
+   * @param key - A key to give the element a stable identity. This is used to improve compatibility with screen readers.
+   * @param ariaHidden - If "true" then content will be hidden from screen readers.
+   */
   private renderToastMessage(key: string, ariaHidden: 'true' | null = null) {
     const { customHTMLEnabled, message } = this;
     if (customHTMLEnabled) {
@@ -434,6 +444,11 @@ export class Toast implements ComponentInterface, OverlayInterface {
     );
   }
 
+  /**
+   * Render the `header` property.
+   * @param key - A key to give the element a stable identity. This is used to improve compatibility with screen readers.
+   * @param ariaHidden - If "true" then content will be hidden from screen readers.
+   */
   private renderHeader(key: string, ariaHidden: 'true' | null = null) {
     return (
       <div key={key} class="toast-header" aria-hidden={ariaHidden} part="header">

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -276,6 +276,11 @@ export class Toast implements ComponentInterface, OverlayInterface {
     );
     await this.currentTransition;
 
+    /**
+     * Content is revealed to screen readers after
+     * the transition to avoid jank since this
+     * state updates will cause a re-render.
+     */
     this.revealContentToScreenReader = true;
 
     this.currentTransition = undefined;

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -55,14 +55,6 @@ export class Toast implements ComponentInterface, OverlayInterface {
 
   presented = false;
 
-  /**
-   * Some screen readers such as NVDA do not
-   * announce content with aria-live that
-   * is initially hidden. To work around this,
-   * we set aria-hidden="true" and then remove
-   * the aria-hidden once the toast content is
-   * fully visible.
-   */
   @State() revealContentToScreenReader = false;
 
   @Element() el!: HTMLIonToastElement;
@@ -480,9 +472,38 @@ export class Toast implements ComponentInterface, OverlayInterface {
               <ion-icon class="toast-icon" part="icon" icon={this.icon} lazy={false} aria-hidden="true"></ion-icon>
             )}
 
+            {/*
+              This creates a live region where screen readers
+              only announce the header and the message. Elements
+              such as icons and buttons should not be announced.
+              aria-live and aria-atomic here are redundant, but we
+              add them to maximize browser compatibility.
+
+              Toasts are meant to be subtle notifications that do
+              not interrupt the user which is why this has
+              a "status" role and a "polite" presentation.
+            */}
             <div class="toast-content" role="status" aria-atomic="true" aria-live="polite">
+              {/*
+                This logic below is done to improve consistency
+                across platforms when showing and updating live regions.
+
+                TalkBack and VoiceOver announce the live region content
+                when the toast is shown, but NVDA does not. As a result,
+                we need to trigger a DOM update so NVDA detects changes and
+                announces an update to the live region. We do this after
+                the toast is fully visible to avoid jank during the presenting
+                animation.
+
+                The "key" attribute is used here to force Stencil to render
+                new nodes and not re-use nodes. Otherwise, NVDA would not
+                detect any changes to the live region.
+
+                The "old" content is hidden using aria-hidden otherwise
+                VoiceOver will announce the toast content twice when presenting.
+              */}
               {!revealContentToScreenReader && this.header !== undefined && (
-                <div key="oldHeader" aria-hidden="true" class="toast-header" part="header">
+                <div key="oldHeader" class="toast-header" aria-hidden="true" part="header">
                   {this.header}
                 </div>
               )}

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -422,7 +422,7 @@ export class Toast implements ComponentInterface, OverlayInterface {
   }
 
   private renderToastMessage() {
-    const { customHTMLEnabled, message } = this;
+    const { customHTMLEnabled, message, revealContentToScreenReader } = this;
     if (customHTMLEnabled) {
       return <div class="toast-message" part="message" innerHTML={sanitizeDOMString(message)}></div>;
     }
@@ -482,17 +482,31 @@ export class Toast implements ComponentInterface, OverlayInterface {
 
             <div
               class="toast-content"
-              role="region"
+              role="status"
               aria-atomic="true"
               aria-live="polite"
-              aria-hidden={revealContentToScreenReader ? null : 'true'}
             >
-              {this.header !== undefined && (
-                <div class="toast-header" part="header">
+              {!revealContentToScreenReader && this.header !== undefined && (
+                <div key="a" aria-hidden="true" class="toast-header" part="header">
                   {this.header}
                 </div>
               )}
-              {this.message !== undefined && this.renderToastMessage()}
+              {!revealContentToScreenReader && this.message !== undefined && (
+                <div key="c" class="toast-message" aria-hidden="true" part="message">
+                  {this.message}
+                </div>
+              )}
+
+              {revealContentToScreenReader && this.header !== undefined && (
+                <div key="b" class="toast-header" part="header">
+                  {this.header}
+                </div>
+              )}
+              {revealContentToScreenReader && this.message !== undefined && (
+                <div key="d" class="toast-message" part="message">
+                  {this.message}
+                </div>
+              )}
             </div>
 
             {this.renderButtons(endButtons, 'end')}

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -413,15 +413,31 @@ export class Toast implements ComponentInterface, OverlayInterface {
     );
   }
 
-  private renderToastMessage() {
+  private renderToastMessage(key: string, ariaHidden: 'true' | null = null) {
     const { customHTMLEnabled, message } = this;
     if (customHTMLEnabled) {
-      return <div class="toast-message" part="message" innerHTML={sanitizeDOMString(message)}></div>;
+      return (
+        <div
+          key={key}
+          aria-hidden={ariaHidden}
+          class="toast-message"
+          part="message"
+          innerHTML={sanitizeDOMString(message)}
+        ></div>
+      );
     }
 
     return (
-      <div class="toast-message" part="message">
+      <div key={key} aria-hidden={ariaHidden} class="toast-message" part="message">
         {message}
+      </div>
+    );
+  }
+
+  private renderHeader(key: string, ariaHidden: 'true' | null = null) {
+    return (
+      <div key={key} class="toast-header" aria-hidden={ariaHidden} part="header">
+        {this.header}
       </div>
     );
   }
@@ -502,27 +518,12 @@ export class Toast implements ComponentInterface, OverlayInterface {
                 The "old" content is hidden using aria-hidden otherwise
                 VoiceOver will announce the toast content twice when presenting.
               */}
-              {!revealContentToScreenReader && this.header !== undefined && (
-                <div key="oldHeader" class="toast-header" aria-hidden="true" part="header">
-                  {this.header}
-                </div>
-              )}
-              {!revealContentToScreenReader && this.message !== undefined && (
-                <div key="oldMessage" class="toast-message" aria-hidden="true" part="message">
-                  {this.message}
-                </div>
-              )}
-
-              {revealContentToScreenReader && this.header !== undefined && (
-                <div key="header" class="toast-header" part="header">
-                  {this.header}
-                </div>
-              )}
-              {revealContentToScreenReader && this.message !== undefined && (
-                <div key="message" class="toast-message" part="message">
-                  {this.message}
-                </div>
-              )}
+              {!revealContentToScreenReader && this.header !== undefined && this.renderHeader('oldHeader', 'true')}
+              {!revealContentToScreenReader &&
+                this.message !== undefined &&
+                this.renderToastMessage('oldMessage', 'true')}
+              {revealContentToScreenReader && this.header !== undefined && this.renderHeader('header')}
+              {revealContentToScreenReader && this.message !== undefined && this.renderToastMessage('header')}
             </div>
 
             {this.renderButtons(endButtons, 'end')}

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -431,7 +431,6 @@ export class Toast implements ComponentInterface, OverlayInterface {
       [`toast-${this.position}`]: true,
       [`toast-layout-${layout}`]: true,
     };
-    const role = allButtons.length > 0 ? 'dialog' : 'status';
 
     /**
      * Stacked buttons are only meant to be
@@ -446,9 +445,6 @@ export class Toast implements ComponentInterface, OverlayInterface {
 
     return (
       <Host
-        aria-live="polite"
-        aria-atomic="true"
-        role={role}
         tabindex="-1"
         {...(this.htmlAttributes as any)}
         style={{
@@ -470,7 +466,7 @@ export class Toast implements ComponentInterface, OverlayInterface {
               <ion-icon class="toast-icon" part="icon" icon={this.icon} lazy={false} aria-hidden="true"></ion-icon>
             )}
 
-            <div class="toast-content">
+            <div class="toast-content" role="status" aria-live="polite">
               {this.header !== undefined && (
                 <div class="toast-header" part="header">
                   {this.header}

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -422,7 +422,7 @@ export class Toast implements ComponentInterface, OverlayInterface {
   }
 
   private renderToastMessage() {
-    const { customHTMLEnabled, message, revealContentToScreenReader } = this;
+    const { customHTMLEnabled, message } = this;
     if (customHTMLEnabled) {
       return <div class="toast-message" part="message" innerHTML={sanitizeDOMString(message)}></div>;
     }
@@ -480,30 +480,25 @@ export class Toast implements ComponentInterface, OverlayInterface {
               <ion-icon class="toast-icon" part="icon" icon={this.icon} lazy={false} aria-hidden="true"></ion-icon>
             )}
 
-            <div
-              class="toast-content"
-              role="status"
-              aria-atomic="true"
-              aria-live="polite"
-            >
+            <div class="toast-content" role="status" aria-atomic="true" aria-live="polite">
               {!revealContentToScreenReader && this.header !== undefined && (
-                <div key="a" aria-hidden="true" class="toast-header" part="header">
+                <div key="oldHeader" aria-hidden="true" class="toast-header" part="header">
                   {this.header}
                 </div>
               )}
               {!revealContentToScreenReader && this.message !== undefined && (
-                <div key="c" class="toast-message" aria-hidden="true" part="message">
+                <div key="oldMessage" class="toast-message" aria-hidden="true" part="message">
                   {this.message}
                 </div>
               )}
 
               {revealContentToScreenReader && this.header !== undefined && (
-                <div key="b" class="toast-header" part="header">
+                <div key="header" class="toast-header" part="header">
                   {this.header}
                 </div>
               )}
               {revealContentToScreenReader && this.message !== undefined && (
-                <div key="d" class="toast-message" part="message">
+                <div key="message" class="toast-message" part="message">
                   {this.message}
                 </div>
               )}

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -463,7 +463,7 @@ export class Toast implements ComponentInterface, OverlayInterface {
   }
 
   render() {
-    const { layout, el, revealContentToScreenReader } = this;
+    const { layout, el, revealContentToScreenReader, header, message } = this;
     const allButtons = this.getButtons();
     const startButtons = allButtons.filter((b) => b.side === 'start');
     const endButtons = allButtons.filter((b) => b.side !== 'start');
@@ -538,12 +538,10 @@ export class Toast implements ComponentInterface, OverlayInterface {
                 The "old" content is hidden using aria-hidden otherwise
                 VoiceOver will announce the toast content twice when presenting.
               */}
-              {!revealContentToScreenReader && this.header !== undefined && this.renderHeader('oldHeader', 'true')}
-              {!revealContentToScreenReader &&
-                this.message !== undefined &&
-                this.renderToastMessage('oldMessage', 'true')}
-              {revealContentToScreenReader && this.header !== undefined && this.renderHeader('header')}
-              {revealContentToScreenReader && this.message !== undefined && this.renderToastMessage('header')}
+              {!revealContentToScreenReader && header !== undefined && this.renderHeader('oldHeader', 'true')}
+              {!revealContentToScreenReader && message !== undefined && this.renderToastMessage('oldMessage', 'true')}
+              {revealContentToScreenReader && header !== undefined && this.renderHeader('header')}
+              {revealContentToScreenReader && message !== undefined && this.renderToastMessage('header')}
             </div>
 
             {this.renderButtons(endButtons, 'end')}


### PR DESCRIPTION
Issue URL: resolves #25866

---------

Docs PR: https://github.com/ionic-team/ionic-docs/pull/2914

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->

NVDA is not announcing toasts on present.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Toast has a "status" role and "polite" announcement.
- We also revisited the intended behavior of toasts to better align with the Material Design v2 spec: https://m2.material.io/components/snackbars/web#accessibility

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: 7.0.3-dev.11681482468.19d7784f