### PR TITLE
chore(template): ask for issue number instead of URL

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Issue URL:
+Issue number: #
 
 ---------
 


### PR DESCRIPTION
Now that the PR description is used as the default commit message, the issue a PR resolves is specified directly in the PR description. However, the conventional-commits tool isn't smart enough to recognize full issue URLs, only the issue number (e.g. `resolves #12345`). This PR updates the template to nudge the description in this direction.