### PR TITLE
fix(scroll-assist): set correct scroll padding

### DIFF
--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -63,6 +63,13 @@ export const enableScrollAssist = (
  * focus an input but not have scroll assist run again.
  */
 const setManualFocus = (el: HTMLElement) => {
+  /**
+   * If element is already focused then
+   * a new focusin event will not be dispatched
+   * to remove the SKIL_SCROLL_ASSIST attribute.
+   */
+  if (document.activeElement === el) { return; }
+
   el.setAttribute(SKIP_SCROLL_ASSIST, 'true');
   el.focus();
 };

--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -68,7 +68,9 @@ const setManualFocus = (el: HTMLElement) => {
    * a new focusin event will not be dispatched
    * to remove the SKIL_SCROLL_ASSIST attribute.
    */
-  if (document.activeElement === el) { return; }
+  if (document.activeElement === el) {
+    return;
+  }
 
   el.setAttribute(SKIP_SCROLL_ASSIST, 'true');
   el.focus();


### PR DESCRIPTION
Issue number: resolves #27257

---------

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

1. Scroll assist was appending padding data every time it ran which caused the amount of padding to infinitely grow until an input was blurred
2. Calling `inputEl.focus()` caused scroll assist to run again which caused unexpected scrolls

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `currentPadding` is either preserved or set, never incremented
- Added a special attribute to inputs that are manually focused so scroll assist knows not to re-run

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
