### PR TITLE
docs(tabs): document methods only available for vanilla

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -2888,16 +2888,16 @@ export namespace Components {
     interface IonTabs {
         "getRouteId": () => Promise<RouteID | undefined>;
         /**
-          * Get the currently selected tab. This method is only available for vanilla or Stencil JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
+          * Get the currently selected tab. This method is only available for vanilla JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
          */
         "getSelected": () => Promise<string | undefined>;
         /**
-          * Get a specific tab by the value of its `tab` property or an element reference. This method is only available for vanilla or Stencil JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
+          * Get a specific tab by the value of its `tab` property or an element reference. This method is only available for vanilla JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
           * @param tab The tab instance to select. If passed a string, it should be the value of the tab's `tab` property.
          */
         "getTab": (tab: string | HTMLIonTabElement) => Promise<HTMLIonTabElement | undefined>;
         /**
-          * Select a tab by the value of its `tab` property or an element reference. This method is only available for vanilla or Stencil JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
+          * Select a tab by the value of its `tab` property or an element reference. This method is only available for vanilla JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
           * @param tab The tab instance to select. If passed a string, it should be the value of the tab's `tab` property.
          */
         "select": (tab: string | HTMLIonTabElement) => Promise<boolean>;

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -2888,16 +2888,16 @@ export namespace Components {
     interface IonTabs {
         "getRouteId": () => Promise<RouteID | undefined>;
         /**
-          * Get the currently selected tab.
+          * Get the currently selected tab. This method is only available for vanilla or Stencil JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
          */
         "getSelected": () => Promise<string | undefined>;
         /**
-          * Get a specific tab by the value of its `tab` property or an element reference.
+          * Get a specific tab by the value of its `tab` property or an element reference. This method is only available for vanilla or Stencil JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
           * @param tab The tab instance to select. If passed a string, it should be the value of the tab's `tab` property.
          */
         "getTab": (tab: string | HTMLIonTabElement) => Promise<HTMLIonTabElement | undefined>;
         /**
-          * Select a tab by the value of its `tab` property or an element reference.
+          * Select a tab by the value of its `tab` property or an element reference. This method is only available for vanilla or Stencil JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
           * @param tab The tab instance to select. If passed a string, it should be the value of the tab's `tab` property.
          */
         "select": (tab: string | HTMLIonTabElement) => Promise<boolean>;

--- a/core/src/components/tabs/tabs.tsx
+++ b/core/src/components/tabs/tabs.tsx
@@ -63,7 +63,7 @@ export class Tabs implements NavOutlet {
   }
 
   /**
-   * Select a tab by the value of its `tab` property or an element reference. This method is only available for vanilla or Stencil JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
+   * Select a tab by the value of its `tab` property or an element reference. This method is only available for vanilla JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
    *
    * @param tab The tab instance to select. If passed a string, it should be the value of the tab's `tab` property.
    */
@@ -81,7 +81,7 @@ export class Tabs implements NavOutlet {
   }
 
   /**
-   * Get a specific tab by the value of its `tab` property or an element reference. This method is only available for vanilla or Stencil JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
+   * Get a specific tab by the value of its `tab` property or an element reference. This method is only available for vanilla JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
    *
    * @param tab The tab instance to select. If passed a string, it should be the value of the tab's `tab` property.
    */
@@ -91,7 +91,7 @@ export class Tabs implements NavOutlet {
   }
 
   /**
-   * Get the currently selected tab. This method is only available for vanilla or Stencil JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
+   * Get the currently selected tab. This method is only available for vanilla JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
    */
   @Method()
   getSelected(): Promise<string | undefined> {

--- a/core/src/components/tabs/tabs.tsx
+++ b/core/src/components/tabs/tabs.tsx
@@ -63,7 +63,7 @@ export class Tabs implements NavOutlet {
   }
 
   /**
-   * Select a tab by the value of its `tab` property or an element reference.
+   * Select a tab by the value of its `tab` property or an element reference. This method is only available for vanilla or Stencil JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
    *
    * @param tab The tab instance to select. If passed a string, it should be the value of the tab's `tab` property.
    */
@@ -81,7 +81,7 @@ export class Tabs implements NavOutlet {
   }
 
   /**
-   * Get a specific tab by the value of its `tab` property or an element reference.
+   * Get a specific tab by the value of its `tab` property or an element reference. This method is only available for vanilla or Stencil JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
    *
    * @param tab The tab instance to select. If passed a string, it should be the value of the tab's `tab` property.
    */
@@ -91,7 +91,7 @@ export class Tabs implements NavOutlet {
   }
 
   /**
-   * Get the currently selected tab.
+   * Get the currently selected tab. This method is only available for vanilla or Stencil JavaScript projects. The Angular, React, and Vue implementations of tabs are coupled to each framework's router.
    */
   @Method()
   getSelected(): Promise<string | undefined> {


### PR DESCRIPTION
When using Angular, React, or Vue, the use of tabs is coupled to the framework's routing. These methods are only available when using tabs with vanilla JavaScript.

Issue number: N/A

---------

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds more context to the description of the methods on tabs

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
