### PR TITLE
fix(breadcumb): set background when focused on md

### DIFF
--- a/core/src/components/breadcrumb/breadcrumb.md.scss
+++ b/core/src/components/breadcrumb/breadcrumb.md.scss
@@ -9,7 +9,7 @@
   --color-active: #{$breadcrumb-md-color-active};
   --color-hover: #{$breadcrumb-md-color-active};
   --color-focused: #{$breadcrumb-md-color-focused};
-  --background-focused: $breadcrumb-md-background-focused;
+  --background-focused: #{$breadcrumb-md-background-focused};
 }
 
 :host(.breadcrumb-active) {


### PR DESCRIPTION
Issue number: #27273

---------

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
When breadcrumb is focused in md mode, background is not set.

## What is the new behavior?
A slight background should have applied on breadcrumb when focused.


-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
