### PR TITLE
chore(ci): remove --no-package-lock flag

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -14,7 +14,7 @@ jobs:
       # as lerna will fail when there is a leading 0
       # See https://github.com/lerna/lerna/issues/2840
       - name: Install Dependencies
-        run: npm ci --no-package-lock
+        run: npm ci
         shell: bash
       - id: create-dev-hash
         name: Create Dev Hash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
       # as lerna will fail when there is a leading 0
       # See https://github.com/lerna/lerna/issues/2840
       - name: Install Dependencies
-        run: npm ci --no-package-lock
+        run: npm ci
         shell: bash
       - id: create-nightly-hash
         name: Create Nightly Hash


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Original Discussion: https://github.com/ionic-team/stencil-ds-output-targets/pull/327#discussion_r1176950960

This flag was left over from our migration from custom build scripts to Lerna. Since we use `npm ci` the `--no-package-lock` flag is not needed.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removes `--no-package-lock` from build scripts.
- Here is an example test run of a dev build succeeding without the `--no-package-lock` flag: https://github.com/ionic-team/ionic-framework/actions/runs/4801503002

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
