### PR TITLE
fix(vue): range emits ionInput

### DIFF
--- a/core/stencil.config.ts
+++ b/core/stencil.config.ts
@@ -136,13 +136,13 @@ export const config: Config = {
           externalEvent: 'ionChange'
         },
         {
-          elements: ['ion-datetime', 'ion-radio-group', 'ion-radio', 'ion-range', 'ion-segment', 'ion-segment-button', 'ion-select', 'ion-accordion-group'],
+          elements: ['ion-datetime', 'ion-radio-group', 'ion-radio', 'ion-segment', 'ion-segment-button', 'ion-select', 'ion-accordion-group'],
           targetAttr: 'value',
           event: 'v-ion-change',
           externalEvent: 'ionChange'
         },
         {
-          elements: ['ion-input', 'ion-searchbar', 'ion-textarea'],
+          elements: ['ion-input', 'ion-range', 'ion-searchbar', 'ion-textarea'],
           targetAttr: 'value',
           event: 'v-ion-input',
           externalEvent: 'ionInput'

--- a/packages/vue/src/proxies.ts
+++ b/packages/vue/src/proxies.ts
@@ -627,7 +627,7 @@ export const IonRange = /*@__PURE__*/ defineContainer<JSX.IonRange, JSX.IonRange
   'ionKnobMoveStart',
   'ionKnobMoveEnd'
 ],
-'value', 'v-ion-change', 'ionChange');
+'value', 'v-ion-input', 'ionInput');
 
 
 export const IonRefresher = /*@__PURE__*/ defineContainer<JSX.IonRefresher>('ion-refresher', defineIonRefresher, [


### PR DESCRIPTION
Issue number: resolves #27292

---------

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`ion-range` does not emit `ionInput` because Ionic Vue expects all components that emit `ionInput to emit `v-ion-input` instead: https://github.com/ionic-team/ionic-framework/blob/a667b3e5b35dc0aee476b787a2489cc3d3566d4e/packages/vue/src/ionic-vue.ts#L19

This is done because these components need to update their v-model before the `ionInput` event is emitted to the developer application.

As part of this, I discovered that `ion-range` does not update its `v-model` value on `ionInput`. As a comparison, a native range input does get its value updated on `input`: https://play.vuejs.org/#eNo9jD0OwjAMRq9isgQGqFhRWomNG7BkqVq3VMqPlbiVUJS7Y4rE+D4/v6LuRJdtRXVTJg9pIYaMvFJnw+IpJoYCCSeoMKXoQYuqbbBhiCEz+DxD+70f9QOdi/CMyY0HfbLBNL+chAQYPbmeUQjAvK5dKftzraYR2tcl0MrAb8LWqtSHGa2C7ezjiE4W0a0S0zT/mKofKENCRQ==

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The `IonRange` component now has v-model support for `ionInput` which a) causes v-model to be updated on `ionInput` and b) causes `ionInput` to be emitted in developer applications

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
