### PR TITLE
fix(many): form components do not take up full width in slot

### DIFF
--- a/core/src/components/checkbox/checkbox.scss
+++ b/core/src/components/checkbox/checkbox.scss
@@ -43,7 +43,7 @@
 }
 
 /**
- * Select can be slotted
+ * Checkbox can be slotted
  * in components such as item and
  * toolbar which is why we do not
  * limit the below behavior to just ion-item.

--- a/core/src/components/checkbox/checkbox.scss
+++ b/core/src/components/checkbox/checkbox.scss
@@ -42,8 +42,14 @@
   height: 100%;
 }
 
-:host(.in-item[slot="start"]:not(.legacy-checkbox)),
-:host(.in-item[slot="end"]:not(.legacy-checkbox)) {
+/**
+ * Select can be slotted
+ * in components such as item and
+ * toolbar which is why we do not
+ * limit the below behavior to just ion-item.
+ */
+:host([slot="start"]:not(.legacy-checkbox)),
+:host([slot="end"]:not(.legacy-checkbox)) {
   width: auto;
 }
 

--- a/core/src/components/radio/radio.scss
+++ b/core/src/components/radio/radio.scss
@@ -76,7 +76,7 @@ input {
 }
 
 /**
- * Select can be slotted
+ * Radio can be slotted
  * in components such as item and
  * toolbar which is why we do not
  * limit the below behavior to just ion-item.

--- a/core/src/components/radio/radio.scss
+++ b/core/src/components/radio/radio.scss
@@ -75,8 +75,14 @@ input {
   height: 100%;
 }
 
-:host(.in-item[slot="start"]:not(.legacy-radio)),
-:host(.in-item[slot="end"]:not(.legacy-radio)) {
+/**
+ * Select can be slotted
+ * in components such as item and
+ * toolbar which is why we do not
+ * limit the below behavior to just ion-item.
+ */
+:host([slot="start"]:not(.legacy-radio)),
+:host([slot="end"]:not(.legacy-radio)) {
   width: auto;
 }
 

--- a/core/src/components/range/range.scss
+++ b/core/src/components/range/range.scss
@@ -168,8 +168,14 @@
   width: 100%;
 }
 
-:host(.in-item[slot="start"]),
-:host(.in-item[slot="end"]) {
+/**
+ * Select can be slotted
+ * in components such as item and
+ * toolbar which is why we do not
+ * limit the below behavior to just ion-item.
+ */
+:host([slot="start"]),
+:host([slot="end"]) {
   width: auto;
 }
 

--- a/core/src/components/range/range.scss
+++ b/core/src/components/range/range.scss
@@ -169,7 +169,7 @@
 }
 
 /**
- * Select can be slotted
+ * Range can be slotted
  * in components such as item and
  * toolbar which is why we do not
  * limit the below behavior to just ion-item.

--- a/core/src/components/select/select.scss
+++ b/core/src/components/select/select.scss
@@ -95,6 +95,12 @@
 }
 
 // TODO FW-3194 - Remove :not(.legacy-select) piece
+/**
+ * Select can be slotted
+ * in components such as item and
+ * toolbar which is why we do not
+ * limit the below behavior to just ion-item.
+ */
 :host([slot="start"]:not(.legacy-select)),
 :host([slot="end"]:not(.legacy-select)) {
   width: auto;

--- a/core/src/components/select/select.scss
+++ b/core/src/components/select/select.scss
@@ -95,8 +95,8 @@
 }
 
 // TODO FW-3194 - Remove :not(.legacy-select) piece
-:host(.in-item[slot="start"]:not(.legacy-select)),
-:host(.in-item[slot="end"]:not(.legacy-select)) {
+:host([slot="start"]:not(.legacy-select)),
+:host([slot="end"]:not(.legacy-select)) {
   width: auto;
 }
 

--- a/core/src/components/select/test/label/index.html
+++ b/core/src/components/select/test/label/index.html
@@ -33,10 +33,6 @@
           padding: 0;
         }
       }
-
-      ion-select {
-        width: 100%;
-      }
     </style>
   </head>
 
@@ -49,6 +45,20 @@
       </ion-header>
 
       <ion-content id="content" class="ion-padding">
+
+        <ion-select
+          label="Favorite Fruit"
+          placeholder="Select a fruit"
+          label-placement="start"
+          justify="start"
+        ></ion-select>
+
+        <ion-label>abc123</ion-label>
+        <ion-select
+          placeholder="Select a fruit"
+          legacy="true"
+        ></ion-select>
+
         <h1>Placement Start</h1>
         <div class="grid">
           <div class="grid-item">

--- a/core/src/components/select/test/label/index.html
+++ b/core/src/components/select/test/label/index.html
@@ -45,16 +45,6 @@
       </ion-header>
 
       <ion-content id="content" class="ion-padding">
-        <ion-select
-          label="Favorite Fruit"
-          placeholder="Select a fruit"
-          label-placement="start"
-          justify="start"
-        ></ion-select>
-
-        <ion-label>abc123</ion-label>
-        <ion-select placeholder="Select a fruit" legacy="true"></ion-select>
-
         <h1>Placement Start</h1>
         <div class="grid">
           <div class="grid-item">

--- a/core/src/components/select/test/label/index.html
+++ b/core/src/components/select/test/label/index.html
@@ -45,7 +45,6 @@
       </ion-header>
 
       <ion-content id="content" class="ion-padding">
-
         <ion-select
           label="Favorite Fruit"
           placeholder="Select a fruit"
@@ -54,10 +53,7 @@
         ></ion-select>
 
         <ion-label>abc123</ion-label>
-        <ion-select
-          placeholder="Select a fruit"
-          legacy="true"
-        ></ion-select>
+        <ion-select placeholder="Select a fruit" legacy="true"></ion-select>
 
         <h1>Placement Start</h1>
         <div class="grid">

--- a/core/src/components/toggle/toggle.scss
+++ b/core/src/components/toggle/toggle.scss
@@ -42,8 +42,14 @@
   height: 100%;
 }
 
-:host(.in-item[slot="start"]:not(.legacy-toggle)),
-:host(.in-item[slot="end"]:not(.legacy-toggle)) {
+/**
+ * Select can be slotted
+ * in components such as item and
+ * toolbar which is why we do not
+ * limit the below behavior to just ion-item.
+ */
+:host([slot="start"]:not(.legacy-toggle)),
+:host([slot="end"]:not(.legacy-toggle)) {
   width: auto;
 }
 

--- a/core/src/components/toggle/toggle.scss
+++ b/core/src/components/toggle/toggle.scss
@@ -43,7 +43,7 @@
 }
 
 /**
- * Select can be slotted
+ * Toggle can be slotted
  * in components such as item and
  * toolbar which is why we do not
  * limit the below behavior to just ion-item.


### PR DESCRIPTION
Issue number: resolves #27305

---------

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Checkbox, radio, range, select, and toggle take up 100% of its width even when in a start/end slot.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Checkbox, radio, range, select, and toggle do not take up 100% of its width even when in a start/end slot.
. The "no slot" behavior is unchanged and aligns with the legacy select.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
