### PR TITLE
chore(ci): fix stencil nightly legacy check

### DIFF
--- a/.github/workflows/stencil-nightly.yml
+++ b/.github/workflows/stencil-nightly.yml
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check build matrix status
-        if: ${{ needs.test-core-screenshot.result != 'success' }}
+        if: ${{ needs.test-core-screenshot-legacy.result != 'success' }}
         run: exit 1
 
   build-vue:


### PR DESCRIPTION
Issue number: #

---------

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

the legacy screenshot test verification step can fail due to improper configuration
## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the name of the legacy screenshot test so that we properly gate on verifying that the legacy tests passed

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I tested this by kicking off the workflow - https://github.com/ionic-team/ionic-framework/actions/runs/4830665737

Yesterday, I [put up a PR](https://github.com/ionic-team/ionic-framework/pull/27298)  that did the same. However, I failed to verify it succeeded (since we don't gate on Stencil nightly) - only that it started (since that was the point of failure yesterday).

Today, I have verified that it passes all the way through
![Screenshot 2023-04-28 at 9 12 25 AM](https://user-images.githubusercontent.com/1930213/235156949-67aa1b35-d141-4951-9f2c-c0722f11a520.png)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
