### PR TITLE
chore(): add missing screenshot function

### DIFF
--- a/core/src/components/item-sliding/test/basic/item-sliding.e2e.ts
+++ b/core/src/components/item-sliding/test/basic/item-sliding.e2e.ts
@@ -6,7 +6,7 @@ import { testSlidingItem } from '../test.utils';
 /**
  * item-sliding doesn't have mode-specific styling
  */
-configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
+configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, screenshot, config }) => {
   test.describe(title('item-sliding: basic'), () => {
     // TODO FW-3006
     test.skip('should not have visual regressions', async ({ page, browserName }, testInfo) => {

--- a/core/src/components/list/test/lines/list.e2e.ts
+++ b/core/src/components/list/test/lines/list.e2e.ts
@@ -13,14 +13,14 @@ configs().forEach(({ title, screenshot, config }) => {
     test('lines="inset" should render correctly', async ({ page }) => {
       await page.goto(`/src/components/list/test/lines`, config);
 
-      const list = page.locator('ion-list[lines="inset"]', config);
+      const list = page.locator('ion-list[lines="inset"]');
 
       await expect(list).toHaveScreenshot(screenshot(`list-lines-inset`));
     });
     test('lines="none" should render correctly', async ({ page }) => {
       await page.goto(`/src/components/list/test/lines`, config);
 
-      const list = page.locator('ion-list[lines="none"]', config);
+      const list = page.locator('ion-list[lines="none"]');
 
       await expect(list).toHaveScreenshot(screenshot(`list-lines-none`));
     });


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
 
item sliding tests were missing a `screenshot` function

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added the function
- Also removed stray `config` params

This was not caught because these tests are currently skipped.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
