### PR TITLE
feat(input): validate maxlength and mask placeholder for input masking

### DIFF
--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -9,6 +9,7 @@ import { createLegacyFormController } from '../../utils/forms';
 import type { Attributes } from '../../utils/helpers';
 import { inheritAriaAttributes, debounceEvent, findItemLabel, inheritAttributes } from '../../utils/helpers';
 import type { MaskFormat, MaskPlaceholder, MaskVisibility } from '../../utils/input-masking';
+import { validateMaskPlaceholder, validateMaskMaxLength } from '../../utils/input-masking';
 import { printIonWarning } from '../../utils/logging';
 import { createColorClasses, hostContext } from '../../utils/theme';
 
@@ -367,10 +368,15 @@ export class Input implements ComponentInterface {
   }
 
   componentWillLoad() {
+    const { el, mask } = this;
+
     this.inheritedAttributes = {
-      ...inheritAriaAttributes(this.el),
-      ...inheritAttributes(this.el, ['tabindex', 'title', 'data-form-type']),
+      ...inheritAriaAttributes(el),
+      ...inheritAttributes(el, ['tabindex', 'title', 'data-form-type']),
     };
+
+    validateMaskMaxLength(this.maxlength, mask);
+    validateMaskPlaceholder(this.maskPlaceholder, mask);
   }
 
   connectedCallback() {

--- a/core/src/utils/input-masking/index.ts
+++ b/core/src/utils/input-masking/index.ts
@@ -1,1 +1,2 @@
 export * from './input-masking-interface';
+export * from './validate';

--- a/core/src/utils/input-masking/validate.spec.ts
+++ b/core/src/utils/input-masking/validate.spec.ts
@@ -1,0 +1,26 @@
+import { validateMaskPlaceholder, validateMaskMaxLength } from './validate';
+
+describe('validateMaskMaxLength', () => {
+  it('should return true if maxlength or mask is undefined', () => {
+    expect(validateMaskMaxLength(undefined, undefined)).toBe(true);
+    expect(validateMaskMaxLength(10, undefined)).toBe(true);
+    expect(validateMaskMaxLength(undefined, '###')).toBe(true);
+  });
+
+  it('should return false if maxlength and mask are defined', () => {
+    expect(validateMaskMaxLength(10, '###')).toBe(false);
+  });
+});
+
+describe('validateMaskPlaceholder', () => {
+  it('should return true if maskPlaceholder or mask is undefined', () => {
+    expect(validateMaskPlaceholder(undefined, undefined)).toBe(true);
+    expect(validateMaskPlaceholder('_', undefined)).toBe(true);
+    expect(validateMaskPlaceholder(undefined, '###')).toBe(true);
+  });
+
+  it('should return false if maskPlaceholder and mask are defined and maskPlaceholder is not a single character or has a different length than the mask', () => {
+    expect(validateMaskPlaceholder('##', '###')).toBe(false);
+    expect(validateMaskPlaceholder('####', '###')).toBe(false);
+  });
+});

--- a/core/src/utils/input-masking/validate.ts
+++ b/core/src/utils/input-masking/validate.ts
@@ -1,0 +1,23 @@
+import { printIonWarning } from '@utils/logging';
+
+import type { MaskFormat, MaskPlaceholder } from './input-masking-interface';
+
+function validateMaskMaxLength(maxLength: number | undefined, mask: MaskFormat | undefined) {
+  if (maxLength !== undefined && mask !== undefined) {
+    printIonWarning('maxlength property should not be used with masking. Use a mask that has a fixed length instead.');
+    return false;
+  }
+  return true;
+}
+
+function validateMaskPlaceholder(maskPlaceholder: MaskPlaceholder, mask: MaskFormat | undefined) {
+  if (mask !== undefined && maskPlaceholder !== undefined) {
+    if (maskPlaceholder?.length !== 1 && maskPlaceholder?.length !== mask.length) {
+      printIonWarning('maskPlaceholder should either be a single character or have the same length as the mask.');
+      return false;
+    }
+  }
+  return true;
+}
+
+export { validateMaskMaxLength, validateMaskPlaceholder };


### PR DESCRIPTION
Issue number: Internal

---------

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds validation to `ion-input` for the expected configurations for input masking.
- Developers will receive a warning when using `maxlength` with a `mask`.
- Developers will receive a warning when using a `maskPlaceholder` that is not a single character or does not match the `mask` length.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
