### PR TITLE
fix(types): export DatetimeHighlightStyle

### DIFF
--- a/core/src/interface.d.ts
+++ b/core/src/interface.d.ts
@@ -9,7 +9,7 @@ export { ActionSheetOptions } from './components/action-sheet/action-sheet-inter
 export { BreadcrumbCustomEvent } from './components/breadcrumb/breadcrumb-interface';
 export { ScrollBaseCustomEvent, ScrollCallback, ScrollCustomEvent } from './components/content/content-interface';
 export { CheckboxCustomEvent } from './components/checkbox/checkbox-interface';
-export { DatetimeCustomEvent } from './components/datetime/datetime-interface';
+export { DatetimeCustomEvent, DatetimeHighlightStyle } from './components/datetime/datetime-interface';
 export { InfiniteScrollCustomEvent } from './components/infinite-scroll/infinite-scroll-interface';
 export { InputCustomEvent } from './components/input/input-interface';
 export { CounterFormatter } from './components/item/item-interface';


### PR DESCRIPTION
Issue number: Resolves #27353

---------

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`DatetimeHighlightStyle` is not automatically exported from `@ionic/core`, since the type is not directly referenced on a prop. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Manually exports `DatetimeHighlightStyle` to consumers

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
