### PR TITLE
fix(button): ellipsis text in a button when it is too long to wrap

### DIFF
--- a/core/src/components/button/button.scss
+++ b/core/src/components/button/button.scss
@@ -209,6 +209,15 @@
   z-index: 1;
 }
 
+.button-text {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+::slotted([slot=start]),
+::slotted([slot=end]) {
+  flex-shrink: 0;
+}
 
 // Button Icons
 // --------------------------------------------------

--- a/core/src/components/button/button.scss
+++ b/core/src/components/button/button.scss
@@ -211,6 +211,7 @@
 
 .button-text {
   text-overflow: ellipsis;
+
   overflow: hidden;
 }
 

--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -313,7 +313,9 @@ export class Button implements ComponentInterface, AnchorInterface, ButtonInterf
           <span class="button-inner">
             <slot name="icon-only"></slot>
             <slot name="start"></slot>
-            <slot></slot>
+            <span class="button-text">
+              <slot></slot>
+            </span>
             <slot name="end"></slot>
           </span>
           {mode === 'md' && <ion-ripple-effect type={this.rippleType}></ion-ripple-effect>}

--- a/core/src/components/button/test/wrap/button.e2e.ts
+++ b/core/src/components/button/test/wrap/button.e2e.ts
@@ -1,0 +1,97 @@
+import { expect } from '@playwright/test';
+import { configs, test } from '@utils/test/playwright';
+
+configs({ directions: ['ltr'] }).forEach(({ title, screenshot, config }) => {
+  test.describe(title('button: wrap'), () => {
+    test('should render button with long text', async ({ page }) => {
+      await page.setContent(
+        `
+        <ion-button>This is the button that never ends it just goes on and on my friends</ion-button>
+      `,
+        config
+      );
+
+      const wrapper = page.locator('ion-button');
+
+      await expect(wrapper).toHaveScreenshot(screenshot(`button-wrap`));
+    });
+
+    test('should render button with long text and icons', async ({ page }) => {
+      await page.setContent(
+        `
+        <ion-button>
+          <ion-icon slot="start" name="heart"></ion-icon>
+          This is the button that never ends it just goes on and on my friends
+          <ion-icon slot="end" name="star"></ion-icon>
+        </ion-button>
+      `,
+        config
+      );
+
+      const wrapper = page.locator('ion-button');
+
+      await expect(wrapper).toHaveScreenshot(screenshot(`button-wrap-icons`));
+    });
+
+    test('should render block button with long text', async ({ page }) => {
+      await page.setContent(
+        `
+        <ion-button expand="block">This is the button that never ends it just goes on and on my friends</ion-button>
+      `,
+        config
+      );
+
+      const wrapper = page.locator('ion-button');
+
+      await expect(wrapper).toHaveScreenshot(screenshot(`button-wrap-block`));
+    });
+
+    test('should render block button with long text and icons', async ({ page }) => {
+      await page.setContent(
+        `
+        <ion-button expand="block">
+          <ion-icon slot="start" name="heart"></ion-icon>
+          This is the button that never ends it just goes on and on my friends
+          <ion-icon slot="end" name="star"></ion-icon>
+        </ion-button>
+      `,
+        config
+      );
+
+      const wrapper = page.locator('ion-button');
+
+      await expect(wrapper).toHaveScreenshot(screenshot(`button-wrap-block-icons`));
+    });
+
+    test('should render full button with long text', async ({ page }) => {
+      await page.setContent(
+        `
+        <ion-button expand="full">This is the button that never ends it just goes on and on my friends</ion-button>
+      `,
+        config
+      );
+
+      const wrapper = page.locator('ion-button');
+
+      await expect(wrapper).toHaveScreenshot(screenshot(`button-wrap-full`));
+    });
+
+    test('should render full button with long text and icons', async ({ page }) => {
+      await page.setContent(
+        `
+        <ion-button expand="full">
+          <ion-icon slot="start" name="heart"></ion-icon>
+          This is the button that never ends it just goes on and on my friends
+          <ion-icon slot="end" name="star"></ion-icon>
+        </ion-button>
+      `,
+        config
+      );
+
+      const wrapper = page.locator('ion-button');
+
+      await expect(wrapper).toHaveScreenshot(screenshot(`button-wrap-full-icons`));
+    });
+
+  });
+});

--- a/core/src/components/button/test/wrap/button.e2e.ts
+++ b/core/src/components/button/test/wrap/button.e2e.ts
@@ -11,9 +11,9 @@ configs({ directions: ['ltr'] }).forEach(({ title, screenshot, config }) => {
         config
       );
 
-      const wrapper = page.locator('ion-button');
+      const button = page.locator('ion-button');
 
-      await expect(wrapper).toHaveScreenshot(screenshot(`button-wrap`));
+      await expect(button).toHaveScreenshot(screenshot(`button-wrap`));
     });
 
     test('should render button with long text and icons', async ({ page }) => {
@@ -28,9 +28,9 @@ configs({ directions: ['ltr'] }).forEach(({ title, screenshot, config }) => {
         config
       );
 
-      const wrapper = page.locator('ion-button');
+      const button = page.locator('ion-button');
 
-      await expect(wrapper).toHaveScreenshot(screenshot(`button-wrap-icons`));
+      await expect(button).toHaveScreenshot(screenshot(`button-wrap-icons`));
     });
 
     test('should render block button with long text', async ({ page }) => {
@@ -41,9 +41,9 @@ configs({ directions: ['ltr'] }).forEach(({ title, screenshot, config }) => {
         config
       );
 
-      const wrapper = page.locator('ion-button');
+      const button = page.locator('ion-button');
 
-      await expect(wrapper).toHaveScreenshot(screenshot(`button-wrap-block`));
+      await expect(button).toHaveScreenshot(screenshot(`button-wrap-block`));
     });
 
     test('should render block button with long text and icons', async ({ page }) => {
@@ -58,9 +58,9 @@ configs({ directions: ['ltr'] }).forEach(({ title, screenshot, config }) => {
         config
       );
 
-      const wrapper = page.locator('ion-button');
+      const button = page.locator('ion-button');
 
-      await expect(wrapper).toHaveScreenshot(screenshot(`button-wrap-block-icons`));
+      await expect(button).toHaveScreenshot(screenshot(`button-wrap-block-icons`));
     });
 
     test('should render full button with long text', async ({ page }) => {
@@ -71,9 +71,9 @@ configs({ directions: ['ltr'] }).forEach(({ title, screenshot, config }) => {
         config
       );
 
-      const wrapper = page.locator('ion-button');
+      const button = page.locator('ion-button');
 
-      await expect(wrapper).toHaveScreenshot(screenshot(`button-wrap-full`));
+      await expect(button).toHaveScreenshot(screenshot(`button-wrap-full`));
     });
 
     test('should render full button with long text and icons', async ({ page }) => {
@@ -88,10 +88,9 @@ configs({ directions: ['ltr'] }).forEach(({ title, screenshot, config }) => {
         config
       );
 
-      const wrapper = page.locator('ion-button');
+      const button = page.locator('ion-button');
 
-      await expect(wrapper).toHaveScreenshot(screenshot(`button-wrap-full-icons`));
+      await expect(button).toHaveScreenshot(screenshot(`button-wrap-full-icons`));
     });
-
   });
 });

--- a/core/src/components/button/test/wrap/index.html
+++ b/core/src/components/button/test/wrap/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Button - Wrap</title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
+    <link href="../../../../../css/ionic.bundle.css" rel="stylesheet" />
+    <link href="../../../../../scripts/testing/styles.css" rel="stylesheet" />
+    <script src="../../../../../scripts/testing/scripts.js"></script>
+    <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+    <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+
+    <style>
+      h2 {
+        font-size: 12px;
+        font-weight: normal;
+
+        color: #6f7378;
+
+        margin-top: 10px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content class="ion-padding" no-bounce>
+        <h2>Default</h2>
+        <ion-button>Default</ion-button>
+        <ion-button>This is the button that never ends it just goes on and on my friends</ion-button>
+        <ion-button>
+          <ion-icon slot="start" name="heart"></ion-icon>
+          This is the button that never ends it just goes on and on my friends
+          <ion-icon slot="end" name="star"></ion-icon>
+        </ion-button>
+
+        <h2>Block</h2>
+        <ion-button expand="block">Default</ion-button>
+        <ion-button expand="block">This is the button that never ends it just goes on and on my friends</ion-button>
+        <ion-button expand="block">
+          <ion-icon slot="start" name="heart"></ion-icon>
+          This is the button that never ends it just goes on and on my friends
+          <ion-icon slot="end" name="star"></ion-icon>
+        </ion-button>
+
+        <h2>Full</h2>
+        <ion-button expand="full">Default</ion-button>
+        <ion-button expand="full">This is the button that never ends it just goes on and on my friends</ion-button>
+        <ion-button expand="full">
+          <ion-icon slot="start" name="heart"></ion-icon>
+          This is the button that never ends it just goes on and on my friends
+          <ion-icon slot="end" name="star"></ion-icon>
+        </ion-button>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>


### PR DESCRIPTION
Issue number: #8700

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
The text in a button is slotted in the default slot as a text node. Text nodes cannot be targeted using `::slotted(*)`. The default behavior when text is really long in a button is to align it in the center and overflow it on both sides (but the overflow is not visible). Due to this we are unable to target the slotted text without adding another wrapper element and targeting that or having the user add their own wrapper class and style that.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds a wrapper around the default slot and styles the overflow on this wrapper
- Adds flex-shrink to slotted `start` and `end` elements so icons do not disappear from the text growing
- Adds tests for long text in a button

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

When the original issue was created we were using the `ion-button` component in other components (see [toast](https://github.com/ionic-team/ionic-framework/blob/8671efe78b46806ff9070c71fead403cfd2da525/packages/core/src/components/toast/toast.tsx#L152)). As of this PR I can only see it being used by [`ion-datetime`](https://github.com/ionic-team/ionic-framework/blob/154aa1dbf609f2cd4b4c24c787df11236a0a767a/core/src/components/datetime/datetime.tsx#L1396). I think this should have minimal impact on other components. 