### PR TITLE
fix(select-popover): migrate inner checkboxes/radios to new syntax

### DIFF
--- a/core/src/components/select-popover/select-popover.ios.scss
+++ b/core/src/components/select-popover/select-popover.ios.scss
@@ -1,13 +1,6 @@
 @import "./select-popover";
 @import "./select-popover.ios.vars";
 
-// TODO: remove and make ion-items lines="full" instead once
-// https://github.com/ionic-team/ionic-framework/issues/26955 is fixed
-ion-list ion-item {
-  --inner-border-width: 0;
-  border-bottom: 0.55px var(--border-style) var(--border-color);
-}
-
 ion-list ion-checkbox::part(container) {
   @include margin(2px, 8px, 0, 0);
 }

--- a/core/src/components/select-popover/select-popover.ios.scss
+++ b/core/src/components/select-popover/select-popover.ios.scss
@@ -1,3 +1,17 @@
 @import "./select-popover";
 @import "./select-popover.ios.vars";
 
+// TODO: remove and make ion-items lines="full" instead once
+// https://github.com/ionic-team/ionic-framework/issues/26955 is fixed
+ion-list ion-item {
+  --inner-border-width: 0;
+  border-bottom: 0.55px var(--border-style) var(--border-color);
+}
+
+ion-list ion-checkbox::part(container) {
+  @include margin(2px, 8px, 0, 0);
+}
+
+ion-list ion-radio {
+  @include margin(0, 11px, 0, 0);
+}

--- a/core/src/components/select-popover/select-popover.md.scss
+++ b/core/src/components/select-popover/select-popover.md.scss
@@ -1,12 +1,22 @@
 @import "./select-popover";
 @import "./select-popover.md.vars";
 
-ion-list ion-radio {
-  opacity: 0;
+ion-list ion-radio::part(container) {
+  display: none;
 }
 
 ion-item {
   --inner-border-width: 0;
+}
+
+// multiple selection only
+// avoids ion-items wrapped in ion-radio-group
+ion-list > ion-item::part(native) {
+  --padding-start: 8px;
+}
+
+ion-list ion-checkbox::part(container) {
+  @include margin(18px, 24px, 18px, 12px);
 }
 
 .item-radio-checked {

--- a/core/src/components/select-popover/select-popover.md.scss
+++ b/core/src/components/select-popover/select-popover.md.scss
@@ -2,7 +2,7 @@
 @import "./select-popover.md.vars";
 
 ion-list ion-radio::part(container) {
-  display: none;
+  opacity: 0;
 }
 
 ion-item {

--- a/core/src/components/select-popover/select-popover.scss
+++ b/core/src/components/select-popover/select-popover.scss
@@ -8,3 +8,8 @@ ion-list-header,
 ion-label {
   @include margin(0);
 }
+
+ion-checkbox {
+  width: 100%;
+  margin-inline-end: 0;
+}

--- a/core/src/components/select-popover/select-popover.tsx
+++ b/core/src/components/select-popover/select-popover.tsx
@@ -128,7 +128,9 @@ export class SelectPopover implements ComponentInterface {
             this.setChecked(ev);
             this.callOptionHandler(ev);
           }}
-        >{option.text}</ion-checkbox>
+        >
+          {option.text}
+        </ion-checkbox>
       </ion-item>
     ));
   }
@@ -156,7 +158,9 @@ export class SelectPopover implements ComponentInterface {
                   this.dismissParentPopover();
                 }
               }}
-            >{option.text}</ion-radio>
+            >
+              {option.text}
+            </ion-radio>
           </ion-item>
         ))}
       </ion-radio-group>

--- a/core/src/components/select-popover/select-popover.tsx
+++ b/core/src/components/select-popover/select-popover.tsx
@@ -122,13 +122,13 @@ export class SelectPopover implements ComponentInterface {
           value={option.value}
           disabled={option.disabled}
           checked={option.checked}
-          legacy={true}
+          labelPlacement="end"
+          justify="start"
           onIonChange={(ev) => {
             this.setChecked(ev);
             this.callOptionHandler(ev);
           }}
-        ></ion-checkbox>
-        <ion-label>{option.text}</ion-label>
+        >{option.text}</ion-checkbox>
       </ion-item>
     ));
   }
@@ -140,11 +140,11 @@ export class SelectPopover implements ComponentInterface {
       <ion-radio-group value={checked} onIonChange={(ev) => this.callOptionHandler(ev)}>
         {options.map((option) => (
           <ion-item class={getClassMap(option.cssClass)}>
-            <ion-label>{option.text}</ion-label>
             <ion-radio
               value={option.value}
               disabled={option.disabled}
-              legacy={true}
+              labelPlacement="start"
+              justify="space-between"
               onClick={() => this.dismissParentPopover()}
               onKeyUp={(ev) => {
                 if (ev.key === ' ') {
@@ -156,7 +156,7 @@ export class SelectPopover implements ComponentInterface {
                   this.dismissParentPopover();
                 }
               }}
-            ></ion-radio>
+            >{option.text}</ion-radio>
           </ion-item>
         ))}
       </ion-radio-group>

--- a/core/src/components/select-popover/select-popover.tsx
+++ b/core/src/components/select-popover/select-popover.tsx
@@ -118,7 +118,6 @@ export class SelectPopover implements ComponentInterface {
     return options.map((option) => (
       <ion-item class={getClassMap(option.cssClass)}>
         <ion-checkbox
-          slot="start"
           value={option.value}
           disabled={option.disabled}
           checked={option.checked}

--- a/core/src/components/select-popover/test/basic/select-popover.e2e.ts
+++ b/core/src/components/select-popover/test/basic/select-popover.e2e.ts
@@ -46,7 +46,9 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
         await expect(selectPopoverPage.popover).not.toBeVisible();
       });
 
-      test('pressing Space on an unselected option should dismiss the popover', async () => {
+      test('pressing Space on an unselected option should dismiss the popover', async ({ skip }) => {
+        skip.browser('firefox', 'https://github.com/ionic-team/ionic-framework/issues/27438');
+
         await selectPopoverPage.setup(config, options, false);
 
         await selectPopoverPage.pressSpaceOnOption('apple');

--- a/core/src/components/select/test/basic/select.e2e.ts
+++ b/core/src/components/select/test/basic/select.e2e.ts
@@ -43,6 +43,8 @@ configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
         // TODO (FW-2979)
         skip.browser('webkit', 'Safari 16 only allows text fields and pop-up menus to be focused.');
 
+        skip.browser('firefox', 'https://github.com/ionic-team/ionic-framework/issues/27438');
+
         const ionPopoverDidPresent = await page.spyOnEvent('ionPopoverDidPresent');
 
         await page.click('#customPopoverSelect');


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`ion-select` with `interface="popover"` triggers console warnings when opened, due to the radios and checkboxes inside still using the legacy form control syntax.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Controls migrated. Some extra styling was also added to maintain the same margins as before, since the new syntax has a slightly different look in that regard.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

Well, sort of. This PR will cause selects to run into https://github.com/ionic-team/ionic-framework/issues/27268 and https://github.com/ionic-team/ionic-framework/issues/27438.


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->