### PR TITLE
feat(input): input masking insertion - on hold, do not review

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -553,7 +553,7 @@ ion-input,prop,inputmode,"decimal" | "email" | "none" | "numeric" | "search" | "
 ion-input,prop,label,string | undefined,undefined,false,false
 ion-input,prop,labelPlacement,"end" | "fixed" | "floating" | "stacked" | "start",'start',false,false
 ion-input,prop,legacy,boolean | undefined,undefined,false,false
-ion-input,prop,mask,(string | RegExp)[] | RegExp | undefined,undefined,false,false
+ion-input,prop,mask,(string | RegExp)[] | RegExp | string | undefined,undefined,false,false
 ion-input,prop,maskPlaceholder,null | string | undefined,'_',false,false
 ion-input,prop,maskVisibility,"always" | "focus" | "never" | undefined,'always',false,false
 ion-input,prop,max,number | string | undefined,undefined,false,false

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -1230,7 +1230,7 @@ export namespace Components {
         /**
           * The predefined format of the user's input. For example, you can set a mask that only accepts digits, or you can configure a more complex pattern like a phone number or credit card number.  The mask supports two formats: 1. A valid [regular expression pattern](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) 2. An array containing regular expression and fixed character patterns  The fixed characters in the mask cannot be erased or replaced by the user. For example in a phone number mask, the `(`, `)` and `-` are examples of fixed characters.
          */
-        "mask"?: MaskExpression;
+        "mask"?: MaskExpression | string;
         /**
           * Character or string to cover unfilled parts of the mask. The default character is `_`. If set to `null`, `undefined` or an empty string, unfilled parts will be empty as in a regular input.
          */
@@ -5272,7 +5272,7 @@ declare namespace LocalJSX {
         /**
           * The predefined format of the user's input. For example, you can set a mask that only accepts digits, or you can configure a more complex pattern like a phone number or credit card number.  The mask supports two formats: 1. A valid [regular expression pattern](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) 2. An array containing regular expression and fixed character patterns  The fixed characters in the mask cannot be erased or replaced by the user. For example in a phone number mask, the `(`, `)` and `-` are examples of fixed characters.
          */
-        "mask"?: MaskExpression;
+        "mask"?: MaskExpression | string;
         /**
           * Character or string to cover unfilled parts of the mask. The default character is `_`. If set to `null`, `undefined` or an empty string, unfilled parts will be empty as in a regular input.
          */

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -374,6 +374,14 @@ export class Input implements ComponentInterface {
     this.emitStyle();
   }
 
+  @Watch('mask')
+  protected maskChanged() {
+    if (this.maskController) {
+      this.maskController.destroy();
+    }
+    this.initInputMask();
+  }
+
   componentWillLoad() {
     const { el } = this;
 
@@ -400,18 +408,9 @@ export class Input implements ComponentInterface {
   }
 
   componentDidLoad() {
-    const { mask, nativeInput } = this;
-
     this.originalIonInput = this.ionInput;
 
-    if (mask !== undefined && nativeInput) {
-      const formattedMask = formatMask(mask);
-      if (formattedMask) {
-        this.maskController = new MaskController(nativeInput, {
-          mask: formattedMask,
-        });
-      }
-    }
+    this.initInputMask();
   }
 
   disconnectedCallback() {
@@ -482,6 +481,18 @@ export class Input implements ComponentInterface {
   private shouldClearOnEdit() {
     const { type, clearOnEdit } = this;
     return clearOnEdit === undefined ? type === 'password' : clearOnEdit;
+  }
+
+  private initInputMask() {
+    const { mask, nativeInput } = this;
+    if (mask !== undefined && nativeInput) {
+      const formattedMask = formatMask(mask);
+      if (formattedMask) {
+        this.maskController = new MaskController(nativeInput, {
+          mask: formattedMask,
+        });
+      }
+    }
   }
 
   private getValue(): string {

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -8,7 +8,7 @@ import type { LegacyFormController } from '../../utils/forms';
 import { createLegacyFormController } from '../../utils/forms';
 import type { Attributes } from '../../utils/helpers';
 import { inheritAriaAttributes, debounceEvent, findItemLabel, inheritAttributes } from '../../utils/helpers';
-import { MaskController } from '../../utils/input-masking';
+import { MaskController, formatMask } from '../../utils/input-masking';
 import type { MaskExpression, MaskPlaceholder, MaskVisibility } from '../../utils/input-masking/public-api';
 import { printIonWarning } from '../../utils/logging';
 import { createColorClasses, hostContext } from '../../utils/theme';
@@ -288,7 +288,7 @@ export class Input implements ComponentInterface {
    * in a phone number mask, the `(`, `)` and `-` are examples of fixed characters.
    *
    */
-  @Prop() mask?: MaskExpression;
+  @Prop() mask?: MaskExpression | string;
 
   /**
    * The visibility of the mask placeholder. With `always`, the placeholder will be
@@ -405,9 +405,12 @@ export class Input implements ComponentInterface {
     this.originalIonInput = this.ionInput;
 
     if (mask !== undefined && nativeInput) {
-      this.maskController = new MaskController(nativeInput, {
-        mask,
-      });
+      const formattedMask = formatMask(mask);
+      if (formattedMask) {
+        this.maskController = new MaskController(nativeInput, {
+          mask: formattedMask,
+        });
+      }
     }
   }
 

--- a/core/src/components/input/test/mask/index.html
+++ b/core/src/components/input/test/mask/index.html
@@ -19,6 +19,7 @@
         grid-row-gap: 20px;
         grid-column-gap: 20px;
       }
+
       h2 {
         font-size: 12px;
         font-weight: normal;
@@ -27,6 +28,7 @@
 
         margin-top: 10px;
       }
+
       @media screen and (max-width: 800px) {
         .grid {
           grid-template-columns: 1fr;
@@ -40,7 +42,7 @@
     <ion-app>
       <ion-header>
         <ion-toolbar>
-          <ion-title>Input - Item</ion-title>
+          <ion-title>Input - Mask</ion-title>
         </ion-toolbar>
       </ion-header>
 
@@ -50,6 +52,17 @@
             <h2>US Phone Number</h2>
 
             <ion-input id="input-phone-us" label="Phone"></ion-input>
+          </div>
+          <div class="grid-item">
+            <ion-card>
+              <ion-card-header>
+                <ion-card-title>Dynamic Mask</ion-card-title>
+              </ion-card-header>
+              <ion-card-content>
+                <ion-input id="dynamicMaskInput" label="Enter a mask"></ion-input>
+                <ion-input id="dynamicExample" label="Example"></ion-input>
+              </ion-card-content>
+            </ion-card>
           </div>
         </div>
       </ion-content>
@@ -76,6 +89,22 @@
         /\d/,
         /\d/,
       ];
+
+      inputPhoneUS.addEventListener('ionInput', (ev) => {
+        console.log('** ionInput event **', ev.detail);
+      });
+
+      inputPhoneUS.addEventListener('ionChange', (ev) => {
+        console.log('** ionChange event **', ev.detail);
+      });
+
+      const dynamicMaskInput = document.querySelector('#dynamicMaskInput');
+      dynamicMaskInput.addEventListener('ionChange', (ev) => {
+        const mask = ev.detail.value;
+        const exampleInput = document.querySelector('#dynamicExample');
+        console.log('setting the mask to: ', mask);
+        exampleInput.mask = mask;
+      });
     </script>
   </body>
 </html>

--- a/core/src/components/input/test/mask/input.e2e.ts
+++ b/core/src/components/input/test/mask/input.e2e.ts
@@ -1,0 +1,44 @@
+import { configs } from '@utils/test/playwright';
+
+import { test } from './mask-fixture';
+
+configs({
+  modes: ['md'],
+  directions: ['ltr'],
+}).forEach(({ title, config }) => {
+  test.describe(title('input: mask'), () => {
+    test('should mask the input', async ({ maskPage }) => {
+      // US Phone number
+      await maskPage.init(config, [
+        '+',
+        '1',
+        ' ',
+        '(',
+        /\d/,
+        /\d/,
+        /\d/,
+        ')',
+        ' ',
+        /\d/,
+        /\d/,
+        /\d/,
+        '-',
+        /\d/,
+        /\d/,
+        /\d/,
+        /\d/,
+      ]);
+
+      await maskPage.typeAndBlur('5555555555');
+      await maskPage.expectValue('+1 (555) 555-5555');
+    });
+
+    test('should mask the input with a string', async ({ maskPage }) => {
+      // Only allow lowercase letters
+      await maskPage.init(config, '[a-z]$');
+
+      await maskPage.typeAndBlur('5abc123d');
+      await maskPage.expectValue('abcd');
+    });
+  });
+});

--- a/core/src/components/input/test/mask/mask-fixture.ts
+++ b/core/src/components/input/test/mask/mask-fixture.ts
@@ -1,0 +1,57 @@
+import { expect } from '@playwright/test';
+import type { E2ELocator, E2EPage, TestConfig } from '@utils/test/playwright';
+import { test as base } from '@utils/test/playwright';
+import type { MaskExpression } from 'src/interface';
+
+const stringifyMask = (mask: MaskExpression | string): string => {
+  if (typeof mask === 'string') {
+    return `'${mask}'`;
+  }
+  if (Array.isArray(mask)) {
+    return `[${mask.map(stringifyMask).join(', ')}]`;
+  }
+  return mask.toString();
+};
+
+class MaskPage {
+  ionInput!: E2ELocator;
+  nativeInput!: E2ELocator;
+
+  constructor(private page: E2EPage) {}
+
+  async init(config: TestConfig, mask: MaskExpression | string) {
+    await this.page.setContent(
+      `<ion-input></ion-input>
+      <script>
+        const input = document.querySelector('ion-input');
+        input.mask = ${stringifyMask(mask)};
+      </script>
+    `,
+      config
+    );
+
+    this.ionInput = this.page.locator('ion-input');
+    this.nativeInput = this.page.locator('ion-input input');
+  }
+
+  async typeAndBlur(value: string) {
+    await this.ionInput.click();
+
+    await this.ionInput.type(value, { delay: 50 });
+    await this.ionInput.blur();
+  }
+
+  async expectValue(value: string) {
+    expect(await this.ionInput.evaluate((node: HTMLIonInputElement) => node.value)).toBe(value);
+  }
+}
+
+type MaskFixtures = {
+  maskPage: MaskPage;
+};
+
+export const test = base.extend<MaskFixtures>({
+  maskPage: async ({ page }, use) => {
+    await use(new MaskPage(page));
+  },
+});

--- a/core/src/utils/input-masking/classes/index.ts
+++ b/core/src/utils/input-masking/classes/index.ts
@@ -1,1 +1,2 @@
 export { MaskHistory } from './mask-history';
+export { MaskModel } from './mask-model/mask-model';

--- a/core/src/utils/input-masking/classes/mask-model/mask-model.ts
+++ b/core/src/utils/input-masking/classes/mask-model/mask-model.ts
@@ -1,0 +1,141 @@
+import type { ElementState, MaskExpression, MaskOptions, SelectionRange } from '../../types/mask-interface';
+import { areElementStatesEqual } from '../../utils';
+
+import { applyOverwriteMode } from './utils/apply-overwrite-mode';
+import { calibrateValueByMask } from './utils/calibrate-value-by-mask';
+import { removeFixedMaskCharacters } from './utils/remove-fixed-mask-characters';
+
+export class MaskModel implements ElementState {
+  value = '';
+  selection: SelectionRange = [0, 0];
+
+  constructor(readonly initialElementState: ElementState, private readonly maskOptions: Required<MaskOptions>) {
+    const { value, selection } = calibrateValueByMask(initialElementState, this.getMaskExpression(initialElementState));
+
+    this.value = value;
+    this.selection = selection;
+  }
+
+  /**
+   * Inserts new characters into the input value at the specified selection range.
+   *
+   * @param selectionRange - An array containing the start and end indices of the selection range where new characters should be inserted.
+   * @param newCharacters - The string of new characters to insert into the input value.
+   * @throws An error if the resulting masked value is invalid or the new characters do not change the value.
+   */
+  addCharacters([from, to]: SelectionRange, newCharacters: string): void {
+    const { value } = this;
+
+    // Get the mask expression for the updated value with the new characters inserted.
+    const maskExpression = this.getMaskExpression({
+      value: value.slice(0, from) + newCharacters + value.slice(to),
+      selection: [from + newCharacters.length, from + newCharacters.length],
+    });
+
+    // Create an initial element state with the original value and selection.
+    const initialElementState = { value, selection: [from, to] } as ElementState;
+
+    // Remove fixed mask characters from the value within the selection range.
+    const unmaskedElementState = removeFixedMaskCharacters(initialElementState, maskExpression);
+
+    // Apply the overwrite mode to the new characters and get the updated selection range within the unmasked value.
+    const [unmaskedFrom, unmaskedTo] = applyOverwriteMode(
+      unmaskedElementState,
+      newCharacters,
+      this.maskOptions.overwriteMode
+    ).selection;
+
+    // Create a new unmasked value with the new characters inserted.
+    const newUnmaskedLeadingValuePart = unmaskedElementState.value.slice(0, unmaskedFrom) + newCharacters;
+
+    // Set the new caret index to the end of the new leading value part.
+    const newCaretIndex = newUnmaskedLeadingValuePart.length;
+
+    // Calibrate the new unmasked value by the mask expression to get the new masked value and selection.
+    const maskedElementState = calibrateValueByMask(
+      {
+        value: newUnmaskedLeadingValuePart + unmaskedElementState.value.slice(unmaskedTo),
+        selection: [newCaretIndex, newCaretIndex],
+      },
+      maskExpression,
+      initialElementState
+    );
+
+    // Check if the insertion of new characters is invalid.
+    const isInvalidCharsInsertion =
+      value.slice(0, unmaskedFrom) ===
+      calibrateValueByMask(
+        {
+          value: newUnmaskedLeadingValuePart,
+          selection: [newCaretIndex, newCaretIndex],
+        },
+        maskExpression,
+        initialElementState
+      ).value;
+
+    // Throw an error if the insertion is invalid or the new characters do not change the value.
+    if (isInvalidCharsInsertion || areElementStatesEqual(this, maskedElementState)) {
+      throw new Error('Invalid mask value');
+    }
+
+    // Set the component's value and selection to the masked value and selection.
+    this.value = maskedElementState.value;
+    this.selection = maskedElementState.selection;
+  }
+
+  /**
+   * Deletes characters from the input value within the given selection range.
+   * The characters to be deleted are replaced with empty space characters.
+   *
+   * @param selectionRange - An array containing the start and end indices of the text to delete.
+   */
+  deleteCharacters([from, to]: SelectionRange): void {
+    // If the selection range is empty or undefined, do nothing.
+    if (from === to || to === undefined) {
+      return;
+    }
+
+    const { value } = this;
+
+    // Get the mask expression for the updated value with the selected text deleted.
+    const maskExpression = this.getMaskExpression({
+      value: value.slice(0, from) + value.slice(to),
+      selection: [from, from],
+    });
+
+    // Create an initial element state with the original value and selection.
+    const initialElementState = { value, selection: [from, to] } as ElementState;
+
+    // Remove fixed mask characters from the value within the selection range.
+    const unmaskedElementState = removeFixedMaskCharacters(initialElementState, maskExpression);
+
+    // Get the new selection range within the unmasked value.
+    const [unmaskedFrom, unmaskedTo] = unmaskedElementState.selection;
+
+    // Create a new unmasked value within selected text deleted.
+    const newUnmaskedValue =
+      unmaskedElementState.value.slice(0, unmaskedFrom) + unmaskedElementState.value.slice(unmaskedTo);
+
+    // Calibrate the unmasked value by the mask expression to get the final masked value.
+    const maskedElementState = calibrateValueByMask(
+      { value: newUnmaskedValue, selection: [unmaskedFrom, unmaskedFrom] },
+      maskExpression,
+      initialElementState
+    );
+
+    // Set the component's value and selection to the masked value and selection.
+    this.value = maskedElementState.value;
+    this.selection = maskedElementState.selection;
+  }
+
+  private getMaskExpression(elementState: ElementState): MaskExpression {
+    const { mask } = this.maskOptions;
+    /**
+     * Ionic Framework does not currently allow developers to use
+     * a function as a mask, e.g.: (elementState) => maskExpression.
+     *
+     * However, we are keeping this code here for future reference.
+     */
+    return typeof mask === 'function' ? mask(elementState) : mask;
+  }
+}

--- a/core/src/utils/input-masking/classes/mask-model/utils/apply-overwrite-mode.ts
+++ b/core/src/utils/input-masking/classes/mask-model/utils/apply-overwrite-mode.ts
@@ -1,0 +1,29 @@
+import type { ElementState, MaskOptions, SelectionRange } from '../../../types/mask-interface';
+
+/**
+ * Applies the specified overwrite mode to the selection range within the given element state.
+ *
+ * @param elementState - An object containing the current input value and selection range.
+ * @param newCharacters - The string of new characters to insert into the input value.
+ * @param mode - The overwrite mode to apply. This can be either a string ('replace' or 'preserve'), or a function that takes the element state as input and returns a string.
+ * @returns A new element state object with the updated selection range based on the overwrite mode.
+ */
+export function applyOverwriteMode(
+  { value, selection }: ElementState,
+  newCharacters: string,
+  mode: MaskOptions['overwriteMode']
+): ElementState {
+  const [from, to] = selection;
+
+  // Compute the overwrite mode based on the mode argument
+  const computedMode = typeof mode === 'function' ? mode({ value, selection }) : mode;
+
+  // Determine the updated selection range based on the overwrite mode.
+  const newSelection: SelectionRange = computedMode === 'replace' ? [from, from + newCharacters.length] : [from, to];
+
+  // Return a new element state object with the updated selection range
+  return {
+    value,
+    selection: newSelection,
+  };
+}

--- a/core/src/utils/input-masking/classes/mask-model/utils/calibrate-value-by-mask.ts
+++ b/core/src/utils/input-masking/classes/mask-model/utils/calibrate-value-by-mask.ts
@@ -1,0 +1,25 @@
+import type { ElementState, MaskExpression } from '../../../types/mask-interface';
+
+import { guessValidValueByPattern } from './guess-valid-value-by-pattern';
+import { guessValidValueByRegExp } from './guess-valid-value-by-reg-exp';
+import { validateValueWithMask } from './validate-value-with-mask';
+
+export function calibrateValueByMask(
+  elementState: ElementState,
+  mask: MaskExpression,
+  initialElementState: ElementState | null = null
+): ElementState {
+  if (validateValueWithMask(elementState.value, mask)) {
+    // If the value is valid with the mask, then we don't need to calibrate it.
+    return elementState;
+  }
+
+  const { value, selection } = Array.isArray(mask)
+    ? guessValidValueByPattern(elementState, mask, initialElementState)
+    : guessValidValueByRegExp(elementState, mask);
+
+  return {
+    selection,
+    value: Array.isArray(mask) ? value.slice(0, mask.length) : value,
+  };
+}

--- a/core/src/utils/input-masking/classes/mask-model/utils/get-leading-fixed-characters.ts
+++ b/core/src/utils/input-masking/classes/mask-model/utils/get-leading-fixed-characters.ts
@@ -1,0 +1,35 @@
+import type { ElementState } from '../../../types/mask-interface';
+
+import { isFixedCharacter } from './is-fixed-character';
+
+/**
+ * Returns a string of fixed characters from the beginning of the mask.
+ *
+ * @param mask - An array of mask constraints, where each constraint can be either a string or a regular expression.
+ * @param validatedValuePart - The part of the input value that has already been validated against the mask.
+ * @param newCharacter - The new character being added to the input value.
+ * @param initialElementState - The initial state of the input element, containing the original value and selection range.
+ * @returns A string of fixed characters from the beginning of the mask.
+ */
+export function getLeadingFixedCharacters(
+  mask: (RegExp | string)[],
+  validatedValuePart: string,
+  newCharacter: string,
+  initialElementState: ElementState | null
+): string {
+  let leadingFixedCharacters = '';
+
+  for (let i = validatedValuePart.length; i < mask.length; i++) {
+    const charConstraint = mask[i];
+    // Check if the character constraint exists in the initial element state.
+    const isInitiallyExisted = initialElementState?.value[i] === charConstraint;
+
+    if (!isFixedCharacter(charConstraint) || (charConstraint === newCharacter && !isInitiallyExisted)) {
+      return leadingFixedCharacters;
+    }
+
+    leadingFixedCharacters += charConstraint;
+  }
+
+  return leadingFixedCharacters;
+}

--- a/core/src/utils/input-masking/classes/mask-model/utils/guess-valid-value-by-pattern.ts
+++ b/core/src/utils/input-masking/classes/mask-model/utils/guess-valid-value-by-pattern.ts
@@ -1,0 +1,59 @@
+import type { ElementState } from '../../../types/mask-interface';
+
+import { getLeadingFixedCharacters } from './get-leading-fixed-characters';
+import { isFixedCharacter } from './is-fixed-character';
+import { validateValueWithMask } from './validate-value-with-mask';
+
+/**
+ * Attempts to guess a valid input value by matching the input against a mask pattern.
+ *
+ * @param elementState - An object containing the current input value and selection range.
+ * @param mask - An array of mask constraints, where each constraint can be either a string or a regular expression.
+ * @param initialElementState - The initial state of the input element, containing the original value and selection range.
+ * @returns An element state object containing a potentially valid input value and updated selection range.
+ */
+export function guessValidValueByPattern(
+  elementState: ElementState,
+  mask: (RegExp | string)[],
+  initialElementState: ElementState | null
+): ElementState {
+  let maskedFrom: number | null = null;
+  let maskedTo: number | null = null;
+
+  const maskedValue = Array.from(elementState.value).reduce((validatedCharacters, char, charIndex) => {
+    // Leading fixed characters may be a + or - sign, or a prefix like $.
+    const leadingFixedCharacters = getLeadingFixedCharacters(mask, validatedCharacters, char, initialElementState);
+    const newValidatedChars = validatedCharacters + leadingFixedCharacters;
+    const charConstraint = mask[newValidatedChars.length];
+
+    if (isFixedCharacter(charConstraint)) {
+      // If the character constraint is a fixed character, then we don't need to check it.
+      return newValidatedChars + charConstraint;
+    }
+
+    if (!char.match(charConstraint)) {
+      return newValidatedChars;
+    }
+
+    if (maskedFrom === null && charIndex >= elementState.selection[0]) {
+      maskedFrom = newValidatedChars.length;
+    }
+
+    if (maskedTo === null && charIndex >= elementState.selection[1]) {
+      maskedTo = newValidatedChars.length;
+    }
+
+    return newValidatedChars + char;
+  }, '');
+
+  // Get the trailing fixed characters to add to the potentially valid value.
+  const trailingFixedCharacters = getLeadingFixedCharacters(mask, maskedValue, '', initialElementState);
+
+  // Return a new element state with the updated value and selection.
+  return {
+    value: validateValueWithMask(maskedValue + trailingFixedCharacters, mask)
+      ? maskedValue + trailingFixedCharacters
+      : maskedValue,
+    selection: [maskedFrom ?? maskedValue.length, maskedTo ?? maskedValue.length],
+  };
+}

--- a/core/src/utils/input-masking/classes/mask-model/utils/guess-valid-value-by-reg-exp.ts
+++ b/core/src/utils/input-masking/classes/mask-model/utils/guess-valid-value-by-reg-exp.ts
@@ -1,0 +1,36 @@
+import type { ElementState } from '../../../types/mask-interface';
+
+/**
+ * Attempts to guess a valid input value by matching the value against a mask regular expression.
+ *
+ * @param elementState - An object containing the current input value and selection range.
+ * @param maskRegExp - A regular expression used to validate the input value.
+ * @returns An element state object containing a potentially valid input value and updated selection range.
+ */
+export function guessValidValueByRegExp({ value, selection }: ElementState, maskRegExp: RegExp): ElementState {
+  const [from, to] = selection;
+  let newFrom = from;
+  let newTo = to;
+
+  // Checks the value one character at a time against the mask regular expression.
+  const validatedValue = Array.from(value).reduce((validatedValuePart, char, i) => {
+    const newPossibleValue = validatedValuePart + char;
+
+    if (from === i) {
+      newFrom = validatedValuePart.length;
+    }
+
+    if (to === i) {
+      newTo = validatedValuePart.length;
+    }
+
+    return newPossibleValue.match(maskRegExp)
+      ? // If the new possible value matches the mask regular expression, then we return it.
+        newPossibleValue
+      : // Otherwise, we return the previous validated value part.
+        validatedValuePart;
+  }, '');
+
+  // Return a new element state with the valid value and updated selection range.
+  return { value: validatedValue, selection: [newFrom, newTo] };
+}

--- a/core/src/utils/input-masking/classes/mask-model/utils/is-fixed-character.spec.ts
+++ b/core/src/utils/input-masking/classes/mask-model/utils/is-fixed-character.spec.ts
@@ -1,0 +1,11 @@
+import { isFixedCharacter } from './is-fixed-character';
+
+describe('isFixedCharacter()', () => {
+  it('should return true if the given character is a string', () => {
+    expect(isFixedCharacter('a')).toBe(true);
+  });
+
+  it('should return false if the given character is a RegExp', () => {
+    expect(isFixedCharacter(/[a-z]/)).toBe(false);
+  });
+});

--- a/core/src/utils/input-masking/classes/mask-model/utils/is-fixed-character.ts
+++ b/core/src/utils/input-masking/classes/mask-model/utils/is-fixed-character.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks if the given character is a fixed character.
+ * @param char The character to check.
+ * @returns `true` if the given character is a fixed character, `false` otherwise.
+ */
+export function isFixedCharacter(char: RegExp | string): char is string {
+  return typeof char === 'string';
+}

--- a/core/src/utils/input-masking/classes/mask-model/utils/remove-fixed-mask-characters.ts
+++ b/core/src/utils/input-masking/classes/mask-model/utils/remove-fixed-mask-characters.ts
@@ -1,0 +1,49 @@
+import type { ElementState, MaskExpression } from '../../../types/mask-interface';
+
+import { isFixedCharacter } from './is-fixed-character';
+
+/**
+ * Removes all fixed characters from the value of the given element state.
+ * A fixed character is a character in the mask that is not allowed to change.
+ * @param initialElementState The initial element state containing the value and the selection.
+ * @param mask The mask expression defining the fixed and variable characters allowed at each position of the value.
+ * @returns A new element state with the unmasked value and updated selection indices.
+ */
+export function removeFixedMaskCharacters(initialElementState: ElementState, mask: MaskExpression): ElementState {
+  // If a mask is not an array, it cannot contain fixed characters.
+  if (!Array.isArray(mask)) {
+    return initialElementState;
+  }
+
+  // Get the start and end indices of the selection.
+  const [from, to] = initialElementState.selection;
+  const selection: number[] = [];
+
+  // Loop over each character in the initial value and remove all fixed characters.
+  const unmaskedValue = Array.from(initialElementState.value).reduce((rawValue, char, i) => {
+    const charConstraint = mask[i];
+
+    // Add selection index to array if the character is at the start or end of the selection.
+    if (i === from) {
+      selection.push(rawValue.length);
+    }
+
+    if (i === to) {
+      selection.push(rawValue.length);
+    }
+
+    // Add character to the unmasked value if it is not a fixed character or does not match a mask constraint.
+    return isFixedCharacter(charConstraint) && charConstraint === char ? rawValue : rawValue + char;
+  }, '');
+
+  // Append the length of the unmasked value to the selection array if it has less than two values.
+  if (selection.length < 2) {
+    selection.push(...Array(2 - selection.length).fill(unmaskedValue.length));
+  }
+
+  // Return the new element state with the unmasked value and updated selection indices.
+  return {
+    value: unmaskedValue,
+    selection: [selection[0], selection[1]],
+  };
+}

--- a/core/src/utils/input-masking/classes/mask-model/utils/validate-value-with-mask.ts
+++ b/core/src/utils/input-masking/classes/mask-model/utils/validate-value-with-mask.ts
@@ -1,0 +1,28 @@
+import type { MaskExpression } from '../../../types/mask-interface';
+
+import { isFixedCharacter } from './is-fixed-character';
+
+/**
+ * Validates the given value with the given mask expression.
+ * @param value The value to validate.
+ * @param maskExpression The mask expression to validate the value with.
+ * @returns `true` if the given value is valid with the given mask expression, `false` otherwise.
+ */
+export function validateValueWithMask(value: string, maskExpression: MaskExpression): boolean {
+  if (Array.isArray(maskExpression)) {
+    /**
+     * If the mask expression is an array, check if the the length of the value matches the length of the mask,
+     * and if each character in the values matches the corresponding mask constraint.
+     */
+    return (
+      value.length === maskExpression.length &&
+      Array.from(value).every((char, i) => {
+        const charConstraint = maskExpression[i];
+
+        return isFixedCharacter(charConstraint) ? char === charConstraint : char.match(charConstraint);
+      })
+    );
+  }
+  // If the mask expression is a regular expression, test whether the value matches the expression.
+  return maskExpression.test(value);
+}

--- a/core/src/utils/input-masking/index.ts
+++ b/core/src/utils/input-masking/index.ts
@@ -1,1 +1,2 @@
 export { MaskController } from './mask-controller';
+export { formatMask } from './utils';

--- a/core/src/utils/input-masking/mask-controller.ts
+++ b/core/src/utils/input-masking/mask-controller.ts
@@ -33,7 +33,7 @@ export class MaskController extends MaskHistory {
 
     if (isBeforeInputEventSupported(element)) {
       this.eventListener.listen('beforeinput', (event) => {
-        switch (event.type) {
+        switch (event.inputType) {
           case 'insertText':
           default:
             return this.handleInsert(event, event.data || '');

--- a/core/src/utils/input-masking/types/mask-interface.ts
+++ b/core/src/utils/input-masking/types/mask-interface.ts
@@ -43,8 +43,17 @@ export type MaskPostprocessor = (elementState: ElementState, initialElementState
 
 export interface MaskOptions {
   readonly mask: MaskExpression | ((elementState: ElementState) => MaskExpression);
+  /**
+   * @internal
+   */
   readonly preprocessor?: MaskPreprocessor;
+  /**
+   * @internal
+   */
   readonly postprocessor?: MaskPostprocessor;
+  /**
+   * @internal
+   */
   readonly overwriteMode?: 'replace' | 'shift' | ((elementState: ElementState) => 'replace' | 'shift');
 }
 

--- a/core/src/utils/input-masking/utils/element-states-equality.spec.ts
+++ b/core/src/utils/input-masking/utils/element-states-equality.spec.ts
@@ -1,0 +1,42 @@
+import type { ElementState } from '../types/mask-interface';
+
+import { areElementStatesEqual, areElementValuesEqual } from './element-states-equality';
+
+describe('areElementValuesEqual', () => {
+  it('should return true if the values of the given states are equal', () => {
+    const sampleState = { value: 'a', selection: [0, 0] } as ElementState;
+    const states = [{ value: 'a', selection: [0, 0] }] as ElementState[];
+
+    expect(areElementValuesEqual(sampleState, ...states)).toBe(true);
+  });
+
+  it('should return false if the values of the given states are not equal', () => {
+    const sampleState = { value: 'a', selection: [0, 0] } as ElementState;
+    const states = [{ value: 'b', selection: [0, 0] }] as ElementState[];
+
+    expect(areElementValuesEqual(sampleState, ...states)).toBe(false);
+  });
+});
+
+describe('areElementStatesEqual', () => {
+  it('should return true if the states are equal', () => {
+    const sampleState = { value: 'a', selection: [0, 0] } as ElementState;
+    const states = [{ value: 'a', selection: [0, 0] }] as ElementState[];
+
+    expect(areElementStatesEqual(sampleState, ...states)).toBe(true);
+  });
+
+  it('should return false if the state values are not equal', () => {
+    const sampleState = { value: 'a', selection: [0, 0] } as ElementState;
+    const states = [{ value: 'b', selection: [0, 0] }] as ElementState[];
+
+    expect(areElementStatesEqual(sampleState, ...states)).toBe(false);
+  });
+
+  it('should return false if the state selections are not equal', () => {
+    const sampleState = { value: 'a', selection: [0, 0] } as ElementState;
+    const states = [{ value: 'a', selection: [0, 1] }] as ElementState[];
+
+    expect(areElementStatesEqual(sampleState, ...states)).toBe(false);
+  });
+});

--- a/core/src/utils/input-masking/utils/element-states-equality.ts
+++ b/core/src/utils/input-masking/utils/element-states-equality.ts
@@ -1,0 +1,26 @@
+import type { ElementState } from '../types/mask-interface';
+
+/**
+ * Checks if the values of the given states are equal.
+ * @param sampleState The state to compare with.
+ * @param states The states to compare.
+ * @returns `true` if the values of the given states are equal, `false` otherwise.
+ */
+export function areElementValuesEqual(sampleState: ElementState, ...states: ElementState[]): boolean {
+  return states.every(({ value }) => value === sampleState.value);
+}
+
+/**
+ * Checks if the states are equal (value and selection).
+ * @param sampleState The state to compare with.
+ * @param states The states to compare.
+ * @returns `true` if the states are equal, `false` otherwise.
+ */
+export function areElementStatesEqual(sampleState: ElementState, ...states: ElementState[]): boolean {
+  return states.every(
+    ({ value, selection }) =>
+      value === sampleState.value &&
+      selection[0] === sampleState.selection[0] &&
+      selection[1] === sampleState.selection[1]
+  );
+}

--- a/core/src/utils/input-masking/utils/format-mask.spec.ts
+++ b/core/src/utils/input-masking/utils/format-mask.spec.ts
@@ -1,0 +1,17 @@
+import { formatMask } from './format-mask';
+
+describe('formatMask', () => {
+  it('should return a RegExp if the given mask is a string', () => {
+    expect(formatMask('a')).toBeInstanceOf(RegExp);
+    expect(formatMask('a')).toEqual(/a/);
+  });
+
+  it('should return null if the given mask is an invalid regular expression', () => {
+    const originalError = console.error;
+    console.error = jest.fn();
+
+    expect(formatMask('[')).toBeNull();
+
+    console.error = originalError;
+  });
+});

--- a/core/src/utils/input-masking/utils/format-mask.ts
+++ b/core/src/utils/input-masking/utils/format-mask.ts
@@ -1,0 +1,26 @@
+import { printIonError } from '@utils/logging';
+
+import type { MaskExpression } from '../public-api';
+
+/**
+ * Formats a mask expression into a supported format.
+ * @param mask The mask to format.
+ * @returns The formatted mask.
+ */
+export function formatMask(mask: string | MaskExpression): MaskExpression | null {
+  if (typeof mask === 'string') {
+    try {
+      /**
+       * Incoming masks can be a string, representing a regular expression.
+       * If it is, we need to convert it to a RegExp object.
+       *
+       * e.g.: 'a' => /a/
+       */
+      return new RegExp(mask);
+    } catch (error) {
+      printIonError('Failed to format mask.', error);
+      return null;
+    }
+  }
+  return mask;
+}

--- a/core/src/utils/input-masking/utils/index.ts
+++ b/core/src/utils/input-masking/utils/index.ts
@@ -1,2 +1,4 @@
 export * from './get-not-empty-selection';
 export * from './identity';
+export * from './element-states-equality';
+export * from './format-mask';

--- a/core/src/utils/input-masking/utils/transform.ts
+++ b/core/src/utils/input-masking/utils/transform.ts
@@ -1,0 +1,21 @@
+import { MaskModel } from '../classes';
+import { MASK_DEFAULT_OPTIONS } from '../constants';
+import type { ElementState, MaskOptions } from '../types/mask-interface';
+
+export function maskTransform(value: string, maskOptions: MaskOptions): string;
+export function maskTransform(state: ElementState, maskOptions: MaskOptions): ElementState;
+
+export function maskTransform(valueOrState: ElementState | string, maskOptions: MaskOptions): ElementState | string {
+  const options: Required<MaskOptions> = {
+    ...MASK_DEFAULT_OPTIONS,
+    ...maskOptions,
+  };
+  const initialElementState: ElementState =
+    typeof valueOrState === 'string' ? { value: valueOrState, selection: [0, 0] } : valueOrState;
+
+  const { elementState } = options.preprocessor({ elementState: initialElementState, data: '' }, 'validation');
+  const maskModel = new MaskModel(elementState, options);
+  const { value, selection } = options.postprocessor(maskModel, initialElementState);
+
+  return typeof valueOrState === 'string' ? value : { value, selection };
+}


### PR DESCRIPTION
Issue number: Internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Introduces the ability to type into a mask through insertion (entering new characters consecutively) to conform to a defined mask expression. 
  - This PR __does not__ support deletion/backspace

In order to support a developer friendly syntax with string-based attributes:
```html
<ion-input mask="^\d{0,4}$"></ion-input>
```

We are supporting a "string" value and converting it into a regular expression with `new RegExp(mask)`. `el.getAttribute` does not support resolving an attribute with an assigned `RegExp` instance. As a result, having a property in Stencil that is type of `RegExp`, cannot accept a string value and will resolve `undefined`. 

### Testing

You can open `/src/components/input/test/mask` to interact and experiment with the mask behavior. Fixed characters (such as `(`, `+`, etc.) accept any key as an input. For example, typing `a` in the US Phone Number mask will pre-fill `+1 ` portion of the mask, but not accept the `a` input key. This behavior we may adjust as the mask placeholder behavior is introduced on top of the maskito implementation style. Contrasting with [react-input-mask](http://sanniassin.github.io/react-input-mask/demo.html) where fixed characters are part of the mask placeholder and do not advance the cursor selection when entering an unaccepted mask value on a fixed character. I don't have strong opinions at this time as both accomplish "masking" the input. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
