### PR TITLE
chore(repo): add `@stencil/*` packages to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,8 @@ updates:
     allow:
       - dependency-name: "@playwright/test"
       - dependency-name: "@axe-core/playwright"
+      - dependency-name: "@stencil/angular-output-target"
       - dependency-name: "@stencil/core"
+      - dependency-name: "@stencil/react-output-target"
+      - dependency-name: "@stencil/sass"
+      - dependency-name: "@stencil/vue-output-target"


### PR DESCRIPTION

Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`@stencil/core` is the only package checked by dependabot

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the allow list for dependabot to allow additional stencil-scoped packages. the motivation for this is to allow the other stencil dependencies used in ionic framework to be automatically bumped by automation, rather than making it a manual process. this is intended to help with the stencil v4 rollout, where new versions on stencil packages (other than core) will be released with early v4 support.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
I arbitrarily alphabetized the `@stencil/*` section of this allow-list. LMK if you'd prefer something different here