### PR TITLE
fix(react): remove incorrect class key from IonicReactProps

### DIFF
--- a/packages/react/src/components/IonicReactProps.ts
+++ b/packages/react/src/components/IonicReactProps.ts
@@ -1,5 +1,4 @@
 export interface IonicReactProps {
-  class?: string;
   className?: string;
   style?: { [key: string]: any };
 }


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

As noted in https://github.com/ionic-team/ionic-framework/issues/27415, `IonicReactProps` still has `class` as an exposed attribute on Ionic React components. React components should use the `className` property instead. It looks like this was left over code from the Ionic React beta that never got removed.

`class` was originally added in https://github.com/ionic-team/ionic-framework/commit/c79e74b91fdfd931f7ae082cfc374b2e55ee6d06#diff-065219c56a8c5dfc32564fac317b8cc9c03f1fbcb7f9cc2de0c5581970f21b51

And `className` was added in https://github.com/ionic-team/ionic-framework/commit/ab0f92e01f892c1c5f0db6e1e8467fe553e48bdd#diff-065219c56a8c5dfc32564fac317b8cc9c03f1fbcb7f9cc2de0c5581970f21b51

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removes the `class` key

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
