### PR TITLE
test: opt-in to parallel tests

### DIFF
--- a/core/playwright.config.ts
+++ b/core/playwright.config.ts
@@ -46,6 +46,7 @@ const projects: Project<PlaywrightTestOptions, PlaywrightWorkerOptions>[] = [
  * See https://playwright.dev/docs/test-configuration.
  */
 const config: PlaywrightTestConfig = {
+  fullyParallel: true,
   testMatch: '*.e2e.ts',
   expect: {
     /**
@@ -67,7 +68,7 @@ const config: PlaywrightTestConfig = {
   /* Flaky test should be either addressed or disabled until we can address them */
   retries: 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Playwright distributes tests based on the number of total tests, not on running time. As a result, our test runner 17 happens to get a large number of the slower tests in our E2E test suite. This means the entire test suite run typically has to wait for test runner 17 to finish.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- I'd like to experiment with [Parallelism in Playwright](https://playwright.dev/docs/test-parallel) to see if this can improve our CI test run times. This PR's test run shows that test runner 17, while still taking the longest, does run a bit faster than what is happening in `main`

The 5 most recent test runs took on average 17.37 minutes.

https://github.com/ionic-team/ionic-framework/actions/runs/4930656548
https://github.com/ionic-team/ionic-framework/actions/runs/4928553582
https://github.com/ionic-team/ionic-framework/actions/runs/4928536397
https://github.com/ionic-team/ionic-framework/actions/runs/4928511080
https://github.com/ionic-team/ionic-framework/actions/runs/4928398713

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
