### PR TITLE
fix(segment): remove duplicate ripple effect on pointerup

### DIFF
--- a/core/src/components/segment/segment.tsx
+++ b/core/src/components/segment/segment.tsx
@@ -1,11 +1,9 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Listen, Prop, State, Watch, h, writeTask } from '@stencil/core';
 
-import { config } from '../../global/config';
 import { getIonMode } from '../../global/ionic-global';
 import type { Color, StyleEventDetail } from '../../interface';
 import type { Gesture, GestureDetail } from '../../utils/gesture';
-import { pointerCoord } from '../../utils/helpers';
 import { isRTL } from '../../utils/rtl';
 import { createColorClasses, hostContext } from '../../utils/theme';
 
@@ -194,13 +192,7 @@ export class Segment implements ComponentInterface {
   onEnd(detail: GestureDetail) {
     this.setActivated(false);
 
-    const checkedValidButton = this.setNextIndex(detail, true);
-
     detail.event.stopImmediatePropagation();
-
-    if (checkedValidButton) {
-      this.addRipple(detail);
-    }
 
     const value = this.value;
     if (value !== undefined) {
@@ -228,32 +220,6 @@ export class Segment implements ComponentInterface {
 
   private get checked() {
     return this.getButtons().find((button) => button.value === this.value);
-  }
-
-  /**
-   * The gesture blocks the segment button ripple. This
-   * function adds the ripple based on the checked segment
-   * and where the cursor ended.
-   */
-  private addRipple(detail: GestureDetail) {
-    const useRippleEffect = config.getBoolean('animated', true) && config.getBoolean('rippleEffect', true);
-    if (!useRippleEffect) {
-      return;
-    }
-
-    const buttons = this.getButtons();
-    const checked = buttons.find((button) => button.value === this.value)!;
-
-    const root = checked.shadowRoot || checked;
-    const ripple = root.querySelector('ion-ripple-effect');
-
-    if (!ripple) {
-      return;
-    }
-
-    const { x, y } = pointerCoord(detail.event);
-
-    ripple.addRipple(x, y).then((remove) => remove());
   }
 
   /*


### PR DESCRIPTION
closes #27338

Issue number: #

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
ion-segment-button md theme shows ripples on mouse-up & touch-up.

## What is the new behavior?
ion-segment-button md theme doesn't show ripples on mouse-up & touch-up.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
