### PR TITLE
fix(datetime-button): log error if non-datetime instance is passed

### DIFF
--- a/core/src/components/datetime-button/datetime-button.tsx
+++ b/core/src/components/datetime-button/datetime-button.tsx
@@ -76,6 +76,18 @@ export class DatetimeButton implements ComponentInterface {
     }
 
     /**
+     * The element reference must be an ion-datetime. Print an error
+     * if a non-datetime element was provided.
+     */
+    if (datetimeEl.tagName !== 'ION-DATETIME') {
+      printIonError(
+        `Expected an ion-datetime instance for ID '${datetime}' but received '${datetimeEl.tagName.toLowerCase()}' instead.`,
+        datetimeEl
+      );
+      return;
+    }
+
+    /**
      * Since the datetime can be used in any context (overlays, accordion, etc)
      * we track when it is visible to determine when it is active.
      * This informs which button is highlighted as well as the


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

An issue was filed in https://github.com/ionic-team/ionic-framework/issues/27452 where the `presentation` property was not being respected. The problem ended up being that the ID passed to `ion-datetime-button` was not associated with an `ion-datetime` instance, so it did not pick up on the `presentation` property. I think we can handle this better by logging an error if the ID passed does not belong to an `ion-datetime`.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Log an error if the ID passed to `ion-datetime-button` exists but does not belong to an `ion-datetime` instance.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
