### PR TITLE
fix(alert): does not match MD spec for tablet dimensions

### DIFF
--- a/core/src/components/alert/alert.md.scss
+++ b/core/src/components/alert/alert.md.scss
@@ -8,6 +8,8 @@
   --background: #{$alert-md-background-color};
   --max-width: #{$alert-md-max-width};
   --backdrop-opacity: var(--ion-backdrop-opacity, 0.32);
+  padding-inline-start: #{$alert-md-padding-start};
+  padding-inline-end: #{$alert-md-padding-end};
 
   font-size: $alert-md-font-size;
 }

--- a/core/src/components/alert/alert.md.vars.scss
+++ b/core/src/components/alert/alert.md.vars.scss
@@ -8,7 +8,13 @@
 $alert-md-font-size:                          14px !default;
 
 /// @prop - Max width of the alert
-$alert-md-max-width:                          280px !default;
+$alert-md-max-width:                          560px !default;
+
+/// @prop - Padding end of the alert head
+$alert-md-padding-end:                        16px !default;
+
+/// @prop - Padding start of the alert
+$alert-md-padding-start:                      $alert-md-padding-end !default;
 
 /// @prop - Border radius of the alert
 $alert-md-border-radius:                      4px !default;


### PR DESCRIPTION
closes #23977

Issue number: #23977

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
All ion-alerts in md mode have a max width of 280px, and the alert content has a max height of 240px.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
ion-alert max width is now 560px, per MD spec

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
