### PR TITLE
docs(input, select, textarea): document workaround for large border-radius with fill="outline"

### DIFF
--- a/core/src/components/input/input.scss
+++ b/core/src/components/input/input.scss
@@ -24,7 +24,7 @@
    * @prop --highlight-color-invalid: The color of the highlight on the input when invalid
    *
    * @prop --border-color: Color of the border below the input when using helper text, error text, or counter
-   * @prop --border-radius: Radius of the input
+   * @prop --border-radius: Radius of the input. A large radius may display unevenly when using fill="outline"; if needed, use shape="round" instead or increase --padding-start.
    * @prop --border-style: Style of the border below the input when using helper text, error text, or counter
    * @prop --border-width: Width of the border below the input when using helper text, error text, or counter
    */

--- a/core/src/components/select/select.scss
+++ b/core/src/components/select/select.scss
@@ -19,7 +19,7 @@
    * @prop --highlight-color-valid: The color of the highlight on the select when valid
    *
    * @prop --border-color: Color of the select border
-   * @prop --border-radius: Radius of the select border
+   * @prop --border-radius: Radius of the select border. A large radius may display unevenly when using fill="outline"; if needed, use shape="round" instead or increase --padding-start.
    * @prop --border-style: Style of the select border
    * @prop --border-width: Width of the select border
    *

--- a/core/src/components/textarea/textarea.scss
+++ b/core/src/components/textarea/textarea.scss
@@ -9,7 +9,7 @@
    *
    * @prop --border-radius: Border radius of the textarea
    * @prop --border-color: Color of the border below the textarea when using helper text, error text, or counter
-   * @prop --border-radius: Radius of the textarea border
+   * @prop --border-radius: Radius of the textarea border. A large radius may display unevenly when using fill="outline"; if needed, use shape="round" instead or increase --padding-start.
    * @prop --border-style: Style of the border below the textarea when using helper text, error text, or counter
    * @prop --border-width: Width of the border below the textarea when using helper text, error text, or counter
    *


### PR DESCRIPTION
Issue number: resolves #27116

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

With `ion-input`, `ion-select`, or `ion-textarea` using `fill="outline"`, applying a large value for the `--border-radius` CSS prop causes the radius to render differently on the left and right sides:

![uneven radii](https://user-images.githubusercontent.com/9688384/229952214-6e106879-81bf-4b88-90f4-fbaaea93d293.png)

This is due to the structure of the outline container, which is used to render the empty space in the border when a `stacked` or `floating` label floats upwards. The container has three pieces, which combine to form a seamless-looking border:

![container pieces](https://i.gyazo.com/a2b2041360e2e51b9d04a459ec77f43c.png)

The issue is that the browser will only render a radius that fits within the element's dimensions, and the piece on the left side (or right on RTL) is not wide enough.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

While we could fix this issue by making the left-side piece wider (and there was originally a PR for this at https://github.com/ionic-team/ionic-framework/pull/27459), it was decided to not include this fix in Ionic automatically. This is because the fix does not work for `label-placement="stacked"` or `"floating"`; the notch spacer (the middle piece of the outline) is pushed to the side, leading to broken visuals:

![broken outline](https://i.gyazo.com/b8648aaea0ac6f3f865be5dfcd98724d.png)

We decided that introducing inconsistent behavior across different values for `label-placement` would be confusing for developers. Even if we did restructure the outline container to position the notch spacer correctly, it could easily be made to fall on the curve of the border, creating awkward visuals.

Instead, developers looking to use a large `--border-radius` with `fill="outline"` should either increase `--padding-start` to be at least as high as the `--border-radius` (which will increase the width of the left outline piece while also moving the floating label in step), or use `shape="round"` (which will change both the padding and border radius automatically). This PR documents this workaround in the `--border-radius` description.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
