### PR TITLE
fix(datetime): ascending order for selectable years

### DIFF
--- a/core/src/components/datetime/utils/data.ts
+++ b/core/src/components/datetime/utils/data.ts
@@ -411,7 +411,7 @@ export const getYearColumnData = (
     const maxYear = maxParts?.year ?? year;
     const minYear = minParts?.year ?? year - 100;
 
-    for (let i = maxYear; i >= minYear; i--) {
+    for (let i = minYear; i <= maxYear; i++) {
       processedYears.push(i);
     }
   }


### PR DESCRIPTION
Issue number: #27422

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
- When you select a year via the datetime component, the years are in descending order, whereas days and months are in ascending order.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The years are now in ascending order too.
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Before:
<img width="384" alt="datetime-before-changes" src="https://github.com/ionic-team/ionic-framework/assets/83428138/04d5ec9d-c96f-40af-9ae9-b90a7a7e56e9">

After:
<img width="375" alt="datetime-after-changes" src="https://github.com/ionic-team/ionic-framework/assets/83428138/32104ba6-c46b-43a8-b30b-477eeef0d98f">


