### PR TITLE
fix(core): handle uncaught native keyboard exceptions

### DIFF
--- a/core/src/utils/native/keyboard.ts
+++ b/core/src/utils/native/keyboard.ts
@@ -20,7 +20,7 @@ export const Keyboard = {
   },
   getResizeMode(): Promise<KeyboardResizeOptions | undefined> {
     const engine = this.getEngine();
-    if (!engine || !isPlatform('ios') || !engine.getResizeMode) {
+    if (!isPlatform('ios') || !engine?.getResizeMode) {
       // getResizeMode is only available on iOS
       // see: https://ionicframework.com/docs/native/keyboard#getresizemode
       return Promise.resolve(undefined);

--- a/core/src/utils/native/keyboard.ts
+++ b/core/src/utils/native/keyboard.ts
@@ -1,3 +1,5 @@
+import { isPlatform } from '@utils/platform';
+
 import { win } from '../browser';
 
 // Interfaces source: https://capacitorjs.com/docs/apis/keyboard#interfaces
@@ -18,7 +20,9 @@ export const Keyboard = {
   },
   getResizeMode(): Promise<KeyboardResizeOptions | undefined> {
     const engine = this.getEngine();
-    if (!engine || !engine.getResizeMode) {
+    if (!engine || !isPlatform('ios') || !engine.getResizeMode) {
+      // getResizeMode is only available on iOS
+      // see: https://ionicframework.com/docs/native/keyboard#getresizemode
       return Promise.resolve(undefined);
     }
 

--- a/core/src/utils/native/keyboard.ts
+++ b/core/src/utils/native/keyboard.ts
@@ -1,5 +1,7 @@
 import { win } from '../browser';
 
+import type { NativePluginError } from './native-interface';
+
 // Interfaces source: https://capacitorjs.com/docs/apis/keyboard#interfaces
 export interface KeyboardResizeOptions {
   mode: KeyboardResize;
@@ -21,7 +23,7 @@ export const Keyboard = {
     if (!engine?.getResizeMode) {
       return Promise.resolve(undefined);
     }
-    return engine.getResizeMode().catch((e: any) => {
+    return engine.getResizeMode().catch((e: NativePluginError) => {
       if (e.code === 'UNIMPLEMENTED') {
         // If the native implementation is not available
         // we treat it the same as if the plugin is not available.

--- a/core/src/utils/native/keyboard.ts
+++ b/core/src/utils/native/keyboard.ts
@@ -1,5 +1,3 @@
-import { isPlatform } from '@utils/platform';
-
 import { win } from '../browser';
 
 // Interfaces source: https://capacitorjs.com/docs/apis/keyboard#interfaces
@@ -20,12 +18,16 @@ export const Keyboard = {
   },
   getResizeMode(): Promise<KeyboardResizeOptions | undefined> {
     const engine = this.getEngine();
-    if (!isPlatform('ios') || !engine?.getResizeMode) {
-      // getResizeMode is only available on iOS
-      // see: https://ionicframework.com/docs/native/keyboard#getresizemode
+    if (!engine?.getResizeMode) {
       return Promise.resolve(undefined);
     }
-
-    return engine.getResizeMode();
+    return engine.getResizeMode().catch((e: any) => {
+      if (e.code === 'UNIMPLEMENTED') {
+        // If the native implementation is not available
+        // we treat it the same as if the plugin is not available.
+        return undefined;
+      }
+      throw e;
+    });
   },
 };

--- a/core/src/utils/native/native-interface.ts
+++ b/core/src/utils/native/native-interface.ts
@@ -1,0 +1,13 @@
+/**
+ * Used to represent a generic error from a native plugin call.
+ */
+export interface NativePluginError {
+  /**
+   * The error code.
+   */
+  code?: string;
+  /**
+   * The error message.
+   */
+  message?: string;
+}


### PR DESCRIPTION
Issue number: Resolves #27503

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Ionic Framework wraps the implementation around Capacitor's Keyboard plugin API, to provide additional functionality and behavior "automatically" in Ionic, when the plugin is installed.

Certain methods such as `getResizeMode()` are only available for certain platforms and will cause an error when running in the unsupported platform. 

Ionic Framework does not check to see if that platform is active before calling potentially unsupported methods, which leads to an exception for scenarios such as this - calling `getResizeMode()` on Android. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Handles the uncaught exception by returning `undefined` if the plugin method is unavailable.
- Developers do not receive an uncaught exception on Android when using the Capacitor Keyboard plugin with Ionic Framework

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `7.0.8-dev.11684444351.1b1ab142` (outdated)
