### PR TITLE
fix(datetime, tests): using slim spaces in unit tests of datetime

### DIFF
--- a/core/src/components/datetime/test/format.spec.ts
+++ b/core/src/components/datetime/test/format.spec.ts
@@ -8,6 +8,12 @@ import {
   getLocalizedTime,
 } from '../utils/format';
 
+/**
+ * IMPORTANT: AM/PM indications should use slim spaces (U+202F) for proper formatting.
+ * Please make sure to replace regular spaces with slim spaces when representing AM/PM.
+ * Slim spaces (U+202F) are used to ensure correct localization and formatting of time values.
+ */
+
 describe('generateDayAriaLabel()', () => {
   it('should return Wednesday, May 12', () => {
     const reference = { month: 5, day: 12, year: 2021 };
@@ -111,7 +117,7 @@ describe('getLocalizedTime', () => {
       minute: 40,
     };
 
-    expect(getLocalizedTime('en-US', datetimeParts, false)).toEqual('1:40 PM');
+    expect(getLocalizedTime('en-US', datetimeParts, false)).toEqual('1:40 PM'); //slim spaces
   });
 
   it('should localize the time to AM', () => {
@@ -123,7 +129,7 @@ describe('getLocalizedTime', () => {
       minute: 40,
     };
 
-    expect(getLocalizedTime('en-US', datetimeParts, false)).toEqual('9:40 AM');
+    expect(getLocalizedTime('en-US', datetimeParts, false)).toEqual('9:40 AM'); //slim spaces
   });
 
   it('should avoid Chromium bug when using 12 hour time in a 24 hour locale', () => {
@@ -135,7 +141,7 @@ describe('getLocalizedTime', () => {
       minute: 0,
     };
 
-    expect(getLocalizedTime('en-GB', datetimeParts, false)).toEqual('12:00 am');
+    expect(getLocalizedTime('en-GB', datetimeParts, false)).toEqual('12:00 am'); //slim spaces
   });
   it('should parse time-only values correctly', () => {
     const datetimeParts = {
@@ -143,7 +149,7 @@ describe('getLocalizedTime', () => {
       minute: 40,
     };
 
-    expect(getLocalizedTime('en-US', datetimeParts, false)).toEqual('10:40 PM');
+    expect(getLocalizedTime('en-US', datetimeParts, false)).toEqual('10:40 PM'); //slim spaces
     expect(getLocalizedTime('en-US', datetimeParts, true)).toEqual('22:40');
   });
 });


### PR DESCRIPTION
Issue number: #27516

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The unit tests for AM/PM indications are failing due to the use of regular spaces instead of slim spaces (U+202F). The assertions in the unit tests compare the expected values, which contain regular spaces, with the received values that include slim spaces. This mismatch leads to assertion failures and inaccurate test results.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

I changed the occurences of all spaces with AM/PM to slim spaces. Now the tests are accepted.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Furthermore I left a comment in the respective file with an info about the space-topic so that other contributors have this topic in their mind if they adjust the file.

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
