### PR TITLE
refactor(accordion): remove duplicate selector

### DIFF
--- a/core/src/components/accordion-group/accordion-group.md.scss
+++ b/core/src/components/accordion-group/accordion-group.md.scss
@@ -21,7 +21,7 @@
 :host(.accordion-group-expand-inset) ::slotted(ion-accordion.accordion-next) {
   @include border-radius($accordion-md-border-radius, $accordion-md-border-radius, null, null);
 }
-:host(.accordion-group-expand-inset) ::slotted(ion-accordion):first-of-type,
+
 :host(.accordion-group-expand-inset) ::slotted(ion-accordion):first-of-type {
   @include margin(0, 0, 0, 0);
 }


### PR DESCRIPTION
Hey guys, I've found a minor issue.

There is a duplicate selector for the same rules. The lines `:24` and `:25` are the same.