### PR TITLE
chore: add ionicons to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,4 @@ updates:
       - dependency-name: "@stencil/react-output-target"
       - dependency-name: "@stencil/sass"
       - dependency-name: "@stencil/vue-output-target"
+      - dependency-name: "ionicons"


### PR DESCRIPTION
Issue number: N/A

---------

This change ensures that Ionicons always stays up to date in Ionic Framework with Dependabot.