### PR TITLE
fix(keyboard): listen on correct events for keyboard lifecycle

### DIFF
--- a/core/src/utils/keyboard/keyboard.ts
+++ b/core/src/utils/keyboard/keyboard.ts
@@ -25,7 +25,7 @@ export const startKeyboardAssist = (win: Window) => {
 
   /**
    * If the native keyboard plugin is available
-   * then we are running in Capacitor/Cordova. As a result
+   * then we are running in a native environment. As a result
    * we should only listen on the native events instead of
    * using the Visual Viewport as the Ionic webview manipulates
    * how it resizes such that the Visual Viewport API is not


### PR DESCRIPTION
Issue number: resolves #27558

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The keyboard lifecycle util was always listening on visual viewport events even when in native environments. The visual viewport API is not reliable due to how the Ionic webview customizes how it resizes. We should only be listening on the native keyboard events in native environments.

https://github.com/ionic-team/capacitor/issues/3730

https://github.com/ionic-team/capacitor-plugins/blob/2e883f39329626062bcf876fe7d424432617229d/keyboard/ios/Plugin/Keyboard.m#L90-L98

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Keyboard lifecycle util listens on native keyboard events only when in native environment

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
