### PR TITLE
fix(refresher): scroll styles are reset when using non-native refresher

### DIFF
--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -695,8 +695,11 @@ export class Refresher implements ComponentInterface {
     } else if (this.state === RefresherState.Inactive) {
       /**
        * The pull to refresh gesture was aborted
-       * so we should restore any overflow styles
-       * that have been modified.
+       * so we should immediately restore any overflow styles
+       * that have been modified. Do not call this.cancel
+       * because the styles will only be reset after a timeout.
+       * If the gesture is aborted then scrolling should be
+       * available right away.
        */
       this.restoreOverflowStyle();
     }

--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -686,7 +686,7 @@ export class Refresher implements ComponentInterface {
     if (this.state === RefresherState.Ready) {
       // they pulled down far enough, so it's ready to refresh
       this.beginRefresh();
-    } else if (this.state === RefresherState.Pulling) {
+    } else if ([RefresherState.Pulling, RefresherState.Inactive].includes(this.state)) {
       // they were pulling down, but didn't pull down far enough
       // set the content back to it's original location
       // and close the refresher
@@ -723,6 +723,9 @@ export class Refresher implements ComponentInterface {
     // set that the refresh is actively cancelling/completing
     this.state = state;
     this.setCss(0, this.closeDuration, true, delay);
+    writeTask(() => {
+      this.restoreOverflowStyle();
+    })
   }
 
   private setCss(y: number, duration: string, overflowVisible: boolean, delay: string) {
@@ -740,8 +743,6 @@ export class Refresher implements ComponentInterface {
         scrollStyle.transitionDelay = backgroundStyle.transitionDelay = delay;
         if (overflowVisible) {
           scrollStyle.overflow = 'hidden';
-        } else {
-          this.restoreOverflowStyle();
         }
       }
     });


### PR DESCRIPTION
Issue number: resolves #27601 

---------

## What is the current behavior?
The current behavior restores overflow styles while moving (within the setCSS function).

## What is the new behavior?
Overflow styles are restored when refresher gesture ends.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
Honestly, I don't know exactly. From code perspective I would say 'Yes', but I can't get the impact of the change.

Ionic Team edit: There are no changes to the public API, and this is fixing a behavior that used to work so there are no breaking changes. 

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->