### PR TITLE
chore(ci): use correct tag for stencil v4

### DIFF
--- a/.github/workflows/stencil-v4.yml
+++ b/.github/workflows/stencil-v4.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/workflows/actions/build-core-stencil-prerelease
         with:
-          stencil-version: nightly
+          stencil-version: v4-next
 
   test-core-clean-build:
     needs: [build-core-with-stencil-v4]


### PR DESCRIPTION


Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
In https://github.com/ionic-team/ionic-framework/pull/27598, I failed to push a change that used the correct tag in the new Stencil v4 tag
## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the stencil-version field for the Stencil v4 workflow to use the correct tag

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

[This log](https://github.com/ionic-team/ionic-framework/actions/runs/5190015779) shows it being used properly:
<img width="579" alt="Screenshot 2023-06-06 at 10 53 18 AM" src="https://github.com/ionic-team/ionic-framework/assets/1930213/eca96936-a114-4fb5-b473-cbd6bfc71b3a">

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
