### PR TITLE
fix(refresher): scrolling is reset with non-native refresher

### DIFF
--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -693,6 +693,8 @@ export class Refresher implements ComponentInterface {
       // set that the refresh is actively cancelling
       this.cancel();
     }
+
+    this.restoreOverflowStyle();
   }
 
   private beginRefresh() {
@@ -738,11 +740,7 @@ export class Refresher implements ComponentInterface {
         scrollStyle.transform = backgroundStyle.transform = y > 0 ? `translateY(${y}px) translateZ(0px)` : '';
         scrollStyle.transitionDuration = backgroundStyle.transitionDuration = duration;
         scrollStyle.transitionDelay = backgroundStyle.transitionDelay = delay;
-        if (overflowVisible) {
-          scrollStyle.overflow = 'hidden';
-        } else {
-          this.restoreOverflowStyle();
-        }
+        scrollStyle.overflow = overflowVisible ? 'hidden' : '';
       }
     });
   }


### PR DESCRIPTION
Issue number: resolves #27601

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

For non-native refreshers the overflow data is cached on gesture start and cleared mid-gesture. However, if a user swipes up such that the cached data is cleared and then scrolls down again, overflow will not be reset because the cache data was wiped. This causes scrolling to stay disabled.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Overflow data is only cleared once the gesture ends.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
