### PR TITLE
chore(global): remove unused context references

### DIFF
--- a/core/src/global/ionic-global.ts
+++ b/core/src/global/ionic-global.ts
@@ -7,8 +7,6 @@ import { config, configFromSession, configFromURL, saveConfig } from './config';
 
 // TODO(FW-2832): types
 
-declare const Context: any;
-
 let defaultMode: Mode;
 
 export const getIonMode = (ref?: any): Mode => {
@@ -22,7 +20,6 @@ export const initialize = (userConfig: IonicConfig = {}) => {
 
   const doc = window.document;
   const win = window;
-  Context.config = config;
   const Ionic = ((win as any).Ionic = (win as any).Ionic || {});
 
   const platformHelpers: any = {};


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Ionic Framework references a deprecated object,`Context`, exposed by Stencil

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

starting with stencil v4, the deprecated `Context` object will no longer be exposed by stencil. this change was introduced in https://github.com/ionic-team/stencil/pull/4437, and will be present in the first v4 prerelease following v4.0.0-beta.2. in anticipation for this change, we seek to remove references to `Context` early.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No - To the best of my knowledge

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

ATM, the Stencil v4 nightly build is passing, as it's grabbing `@stencil/core@4.0.0-beta.2`. The change in which we remove the `Context` object will occur in the _next_ pre-release. I'm removing `Context` here to try to get a jump on things. 


The current iteration of the code that I'm deleting was added in https://github.com/ionic-team/ionic-framework/commit/c415bbe1d712a609ac565ef42640bcb16bea02c8#diff-ce62e75f0c31a76aac491f13a64e9c7771a6cbae8ca6635541164b69f0479bf1
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
