### PR TITLE
fix(select): hide notch cutout if no visible label provided

### DIFF
--- a/core/src/components/select/select.scss
+++ b/core/src/components/select/select.scss
@@ -316,7 +316,8 @@ button {
  * then the element should be hidden otherwise
  * there will be additional margins added.
  */
-.label-text-wrapper-hidden {
+.label-text-wrapper-hidden,
+.select-outline-notch-hidden {
   display: none;
 }
 

--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -910,7 +910,12 @@ export class Select implements ComponentInterface {
       return [
         <div class="select-outline-container">
           <div class="select-outline-start"></div>
-          <div class="select-outline-notch">
+          <div
+            class={{
+              'select-outline-notch': true,
+              'select-outline-notch-hidden': !this.hasLabel,
+            }}
+          >
             <div class="notch-spacer" aria-hidden="true" ref={(el) => (this.notchSpacerEl = el)}>
               {this.label}
             </div>

--- a/core/src/components/select/test/fill/select.e2e.ts
+++ b/core/src/components/select/test/fill/select.e2e.ts
@@ -224,4 +224,17 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, screenshot, co
       expect(await select.screenshot()).toMatchSnapshot(screenshot(`select-fill-outline-hidden-slotted-label`));
     });
   });
+  test.describe(title('select: notch cutout'), () => {
+    test('notch cutout should be hidden when no label is passed', async ({ page }) => {
+      await page.setContent(
+        `
+        <ion-select fill="outline" label-placement="stacked" aria-label="my select"></ion-select>
+      `,
+        config
+      );
+
+      const notchCutout = page.locator('ion-select .select-outline-notch');
+      await expect(notchCutout).toBeHidden();
+    });
+  });
 });


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Brandy discovered a bug in input, textarea, and select where the notch cutout remains visible even when no visible label is provided. I fixed this for input in https://github.com/ionic-team/ionic-framework/pull/27636 and for textarea in https://github.com/ionic-team/ionic-framework/pull/27647.

```html
<ion-select fill="outline" label-placement="stacked" value="select" aria-label="my select"></ion-select>
```

![image](https://github.com/ionic-team/ionic-framework/assets/2721089/2d79a5d6-a349-4458-b9bd-d7e5b8004c07)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The notch cut out is hidden if no visible label is provided

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
