### PR TITLE
add center in justification for select

### DIFF
--- a/core/src/components/select/select.scss
+++ b/core/src/components/select/select.scss
@@ -344,6 +344,10 @@ button {
   justify-content: start;
 }
 
+:host(.select-justify-center) .select-wrapper {
+  justify-content: center;
+}
+
 :host(.select-justify-end) .select-wrapper {
   justify-content: end;
 }

--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -113,12 +113,13 @@ export class Select implements ComponentInterface {
    * `"floating"` or `"stacked"`.
    * `"start"`: The label and select will appear on the left in LTR and
    * on the right in RTL.
+   * `"center"`: The label and select will appear on the center.
    * `"end"`: The label and select will appear on the right in LTR and
    * on the left in RTL.
    * `"space-between"`: The label and select will appear on opposite
    * ends of the line with space between the two elements.
    */
-  @Prop() justify: 'start' | 'end' | 'space-between' = 'space-between';
+  @Prop() justify: 'start' | 'center' | 'end' | 'space-between' = 'space-between';
 
   /**
    * The visible label associated with the select.


### PR DESCRIPTION
Issue number: #27666

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
At the moment we can not justify the label by the center for a select

## What is the new behavior?
- Add the center position 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
