### PR TITLE
test(alert): remove unneeded disabled Axe rule

### DIFF
--- a/core/src/components/alert/alert.ios.vars.scss
+++ b/core/src/components/alert/alert.ios.vars.scss
@@ -15,7 +15,7 @@ $alert-ios-max-width:                                   270px !default;
 $alert-ios-border-radius:                               13px !default;
 
 /// @prop - Background color of the alert
-$alert-ios-background-color:                            $overlay-ios-background-color !default;
+$alert-ios-background-color:                            #ffffff !default;
 
 /// @prop - Background color alpha of the alert when translucent
 $alert-ios-translucent-background-color-alpha:          .9 !default;

--- a/core/src/components/alert/test/a11y/alert.e2e.ts
+++ b/core/src/components/alert/test/a11y/alert.e2e.ts
@@ -40,8 +40,7 @@ configs({ directions: ['ltr'] }).forEach(({ config, title }) => {
 
       await didPresent.next();
 
-      // TODO FW-4375
-      const results = await new AxeBuilder({ page }).disableRules('color-contrast').analyze();
+      const results = await new AxeBuilder({ page }).analyze();
       expect(results.violations).toEqual([]);
     });
 


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

One of the Alert a11y tests skips the `color-contrast` rule when checking Axe. This was done in https://github.com/ionic-team/ionic-framework/pull/27351 because the test started failing due to `color-contrast` behavior changes on Axe's end: https://github.com/dequelabs/axe-core/releases/tag/v4.7.0

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Skip removed. It looks like the test failure was due to a problem on Axe's side exclusive to v4.7.0, as I'm not able to reproduce with Axe Core 4.7.1 (using Chrome's dev tools) or Framework's currently used 4.7.3 (by running the a11y test itself).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
