### PR TITLE
fix(modalSheet): change gesture to allow draging when content scrolle…

### DIFF
--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -602,7 +602,6 @@ export class Modal implements ComponentInterface, OverlayInterface {
       backdropBreakpoint,
       ani,
       this.sortedBreakpoints,
-      () => this.currentBreakpoint ?? 0,
       () => this.sheetOnDismiss(),
       (breakpoint: number) => {
         if (this.currentBreakpoint !== breakpoint) {


### PR DESCRIPTION
Change gesture to allow draging when user overscroll

Issue number: #24583

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
As mentionned in [this comment](https://github.com/ionic-team/ionic-framework/issues/24583#issuecomment-1020197730) on the issue [#24583](https://github.com/ionic-team/ionic-framework/issues/24583). Once you can scroll, dragging down on anywhere but the handle when the content is scrolled to the top doesn't do anything, when it should move the modal.

## What is the new behavior?
- When their is a ion-content tag inside a modal and the modal is fully opened (max breakpoint) ion-content is scrollable and scrolling at the top now drag the modal instead of doing nothing.
- Ion-content only scroll when you drag the content and not the ion-toolbar at the top of the modal

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Apart from scrolling and dragging modal everything stay unchanged.
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
