### PR TITLE
chore(ci): restore npm package provenance

### DIFF
--- a/.github/workflows/actions/publish-npm/action.yml
+++ b/.github/workflows/actions/publish-npm/action.yml
@@ -22,6 +22,9 @@ runs:
     - uses: actions/setup-node@v3
       with:
         node-version: 16.x
+    # Provenance requires npm 9.5.0+
+    - name: Install latest npm
+      run: npm install -g npm@latest
     # This ensures the local version of Lerna is installed
     # and that we do not use the global Lerna version
     - name: Install root dependencies


### PR DESCRIPTION
Issue number: #

---------

## What is the current behavior?

Package provenance was disabled in #27656.

## What is the new behavior?

- Package provenance is enabled.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
