### PR TITLE
chore(ci): fix npm package provenance

### DIFF
--- a/.github/workflows/actions/publish-npm/action.yml
+++ b/.github/workflows/actions/publish-npm/action.yml
@@ -25,6 +25,7 @@ runs:
     # Provenance requires npm 9.5.0+
     - name: Install latest npm
       run: npm install -g npm@latest
+      shell: bash
     # This ensures the local version of Lerna is installed
     # and that we do not use the global Lerna version
     - name: Install root dependencies


### PR DESCRIPTION
Issue number: N/A

---------

## What is the current behavior?

Nightly build and release broken in #27711 due to missing shell property in GitHub Actions workflow.

## What is the new behavior?

- Nightly build and release works.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
