### PR TITLE
fix(back-button): show correct background on focus + hover with ios

### DIFF
--- a/core/src/components/back-button/back-button.ios.scss
+++ b/core/src/components/back-button/back-button.ios.scss
@@ -38,11 +38,3 @@
     opacity: .6;
   }
 }
-
-
-// Back Button Color: Focused
-// --------------------------------------------------
-
-:host(.ion-color.ion-focused) .button-native::after {
-  background: #{current-color(base)};
-}


### PR DESCRIPTION
Issue number: resolves #27722

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The back button on iOS uses the same background and foreground colors on hover + focus making it impossible to read

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Back button uses a transparent background color on hover + focus to match the behavior of `ion-button`

| `main` | branch |
| - | - |
| <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/e8bed785-66d7-40cd-beb3-54636c7fc59a"></video> | <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/2c4a9a5c-f1a9-4a83-879f-8b0e9ce18558"></video> |

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
