### PR TITLE
Added img direct sibling

### DIFF
--- a/core/src/css/ionic-swiper.scss
+++ b/core/src/css/ionic-swiper.scss
@@ -93,7 +93,7 @@
   box-sizing: border-box;
 }
 
-.swiper .swiper-slide img {
+.swiper .swiper-slide > img {
   width: auto;
   max-width: 100%;
   height: auto;


### PR DESCRIPTION
Since there is no encapsulation, the current behavior is really annoying, forcing img style for any img in a slide, whatever the deepness.

Issue number: #27744

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
Slide `img` style is overriding any deep image style.

## What is the new behavior?

- Default CSS only target first children
- Deeper images will keep their layout
- User can style set its deep image style to full width manually on his own

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
