### PR TITLE
refactor: use capacitor types for native plugins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
       - dependency-name: "@stencil/sass"
       - dependency-name: "@stencil/vue-output-target"
       - dependency-name: "ionicons"
+      - dependency-name: "@capacitor/core"
+      - dependency-name: "@capacitor/keyboard"
+      - dependency-name: "@capacitor/haptics"
+      - dependency-name: "@capacitor/status-bar"

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -15,6 +15,10 @@
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.7.3",
+        "@capacitor/core": "^5.1.1",
+        "@capacitor/haptics": "^5.0.5",
+        "@capacitor/keyboard": "^5.0.5",
+        "@capacitor/status-bar": "^5.0.5",
         "@ionic/eslint-config": "^0.3.0",
         "@ionic/prettier-config": "^2.0.0",
         "@jest/core": "^27.5.1",
@@ -601,6 +605,42 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@capacitor/core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-5.1.1.tgz",
+      "integrity": "sha512-17rZMGpZYQgBAmUS1uAS1GrRkPAQiUfpTfvd2wWS9z87GoTL/5vtpPAtI0/XLtr4eve2TsATY2r8BaW2NfEO6Q==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/haptics": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/haptics/-/haptics-5.0.5.tgz",
+      "integrity": "sha512-iDgmCehrdc0Sdob/y3KjAX0sll/y9PTP6hJubwTpIpRt3kOKGDhMMNkUGRKm6myTIRPpa2Mm8jWCSYaA4pPq4g==",
+      "dev": true,
+      "peerDependencies": {
+        "@capacitor/core": "^5.0.0"
+      }
+    },
+    "node_modules/@capacitor/keyboard": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-5.0.5.tgz",
+      "integrity": "sha512-pB2o15C8Cz3QqDcToU4H0B/i+LLXYPQVtShukywMlVEJZ6UUy+KSK8XCg/YPDZBY9E0lSprHw4+NBqH0HTYRKQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@capacitor/core": "^5.0.0"
+      }
+    },
+    "node_modules/@capacitor/status-bar": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-5.0.5.tgz",
+      "integrity": "sha512-8ykkIbndeAaATrAYcr4CLSplTeR6CU15h8trXV3DgLXlFQAC6E/WJnoMy1QL61n5rHh725nixqwCTepcgGx/rw==",
+      "dev": true,
+      "peerDependencies": {
+        "@capacitor/core": "^5.0.0"
+      }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
@@ -10742,6 +10782,36 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@capacitor/core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-5.1.1.tgz",
+      "integrity": "sha512-17rZMGpZYQgBAmUS1uAS1GrRkPAQiUfpTfvd2wWS9z87GoTL/5vtpPAtI0/XLtr4eve2TsATY2r8BaW2NfEO6Q==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "@capacitor/haptics": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/haptics/-/haptics-5.0.5.tgz",
+      "integrity": "sha512-iDgmCehrdc0Sdob/y3KjAX0sll/y9PTP6hJubwTpIpRt3kOKGDhMMNkUGRKm6myTIRPpa2Mm8jWCSYaA4pPq4g==",
+      "dev": true,
+      "requires": {}
+    },
+    "@capacitor/keyboard": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-5.0.5.tgz",
+      "integrity": "sha512-pB2o15C8Cz3QqDcToU4H0B/i+LLXYPQVtShukywMlVEJZ6UUy+KSK8XCg/YPDZBY9E0lSprHw4+NBqH0HTYRKQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "@capacitor/status-bar": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-5.0.5.tgz",
+      "integrity": "sha512-8ykkIbndeAaATrAYcr4CLSplTeR6CU15h8trXV3DgLXlFQAC6E/WJnoMy1QL61n5rHh725nixqwCTepcgGx/rw==",
+      "dev": true,
+      "requires": {}
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",

--- a/core/package.json
+++ b/core/package.json
@@ -37,6 +37,10 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.7.3",
+    "@capacitor/core": "^5.1.1",
+    "@capacitor/haptics": "^5.0.5",
+    "@capacitor/keyboard": "^5.0.5",
+    "@capacitor/status-bar": "^5.0.5",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "^2.0.0",
     "@jest/core": "^27.5.1",

--- a/core/src/components/modal/utils.ts
+++ b/core/src/components/modal/utils.ts
@@ -74,6 +74,7 @@ export const getBackdropValueForSheet = (x: number, backdropBreakpoint: number) 
  * support for Style.Default.
  */
 export const setCardStatusBarDark = () => {
+  // TODO FW-4696 Remove supportDefaultStatusBarStyle in Ionic v8
   if (!win || win.innerWidth >= 768 || !StatusBar.supportsDefaultStatusBarStyle()) {
     return;
   }
@@ -82,6 +83,7 @@ export const setCardStatusBarDark = () => {
 };
 
 export const setCardStatusBarDefault = (defaultStyle = Style.Default) => {
+  // TODO FW-4696 Remove supportDefaultStatusBarStyle in Ionic v8
   if (!win || win.innerWidth >= 768 || !StatusBar.supportsDefaultStatusBarStyle()) {
     return;
   }

--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -8,7 +8,7 @@ import {
   printIonContentErrorMsg,
 } from '@utils/content';
 import { clamp, componentOnReady, getElementRoot, raf, transitionEndAsync } from '@utils/helpers';
-import { hapticImpact } from '@utils/native/haptic';
+import { ImpactStyle, hapticImpact } from '@utils/native/haptic';
 
 import { getIonMode } from '../../global/ionic-global';
 import type { Animation, Gesture, GestureDetail } from '../../interface';
@@ -246,7 +246,7 @@ export class Refresher implements ComponentInterface {
           if (!this.didRefresh) {
             this.beginRefresh();
             this.didRefresh = true;
-            hapticImpact({ style: 'light' });
+            hapticImpact({ style: ImpactStyle.Light });
 
             /**
              * Translate the content element otherwise when pointer is removed

--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -1,6 +1,7 @@
+import type { KeyboardResizeOptions } from '@capacitor/keyboard';
+
 import { getScrollElement, scrollByPoint } from '../../content';
 import { raf } from '../../helpers';
-import type { KeyboardResizeOptions } from '../../native/keyboard';
 import { KeyboardResize } from '../../native/keyboard';
 
 import { relocateInput, SCROLL_AMOUNT_PADDING } from './common';

--- a/core/src/utils/keyboard/keyboard-controller.ts
+++ b/core/src/utils/keyboard/keyboard-controller.ts
@@ -1,6 +1,6 @@
 import { doc, win } from '@utils/browser';
 
-import { KeyboardResize, Keyboard } from '../native/keyboard';
+import { Keyboard, KeyboardResize } from '../native/keyboard';
 
 /**
  * The element that resizes when the keyboard opens

--- a/core/src/utils/native/capacitor.ts
+++ b/core/src/utils/native/capacitor.ts
@@ -1,13 +1,13 @@
-import type { CapacitorInstance } from '@capacitor/core/types/definitions-internal';
+import type { CapacitorGlobal } from '@capacitor/core';
 
-let capacitor: CapacitorInstance | undefined;
+let capacitor: CapacitorGlobal | undefined;
 
 export const getCapacitor = () => {
   if (capacitor !== undefined) {
     return capacitor;
   }
   if (window !== undefined) {
-    return (window as any)?.Capacitor as CapacitorInstance;
+    return (window as any)?.Capacitor as CapacitorGlobal;
   }
   return undefined;
 };

--- a/core/src/utils/native/capacitor.ts
+++ b/core/src/utils/native/capacitor.ts
@@ -1,12 +1,7 @@
 import type { CapacitorGlobal } from '@capacitor/core';
 import { win } from '@utils/browser';
 
-let capacitor: CapacitorGlobal | undefined;
-
 export const getCapacitor = () => {
-  if (capacitor !== undefined) {
-    return capacitor;
-  }
   if (win !== undefined) {
     return (win as any).Capacitor as CapacitorGlobal;
   }

--- a/core/src/utils/native/capacitor.ts
+++ b/core/src/utils/native/capacitor.ts
@@ -1,3 +1,3 @@
-import type { CapacitorGlobal } from '@capacitor/core';
+import type { CapacitorInstance } from '@capacitor/core/types/definitions-internal'
 
-export const capacitor = (window as any).capacitor as CapacitorGlobal;
+export const capacitor = (window as any)?.Capacitor as CapacitorInstance;

--- a/core/src/utils/native/capacitor.ts
+++ b/core/src/utils/native/capacitor.ts
@@ -1,0 +1,3 @@
+import type { CapacitorGlobal } from '@capacitor/core';
+
+export const capacitor = (window as any).capacitor as CapacitorGlobal;

--- a/core/src/utils/native/capacitor.ts
+++ b/core/src/utils/native/capacitor.ts
@@ -1,4 +1,5 @@
 import type { CapacitorGlobal } from '@capacitor/core';
+import { win } from '@utils/browser';
 
 let capacitor: CapacitorGlobal | undefined;
 
@@ -6,8 +7,8 @@ export const getCapacitor = () => {
   if (capacitor !== undefined) {
     return capacitor;
   }
-  if (window !== undefined) {
-    return (window as any)?.Capacitor as CapacitorGlobal;
+  if (win !== undefined) {
+    return (win as any).Capacitor as CapacitorGlobal;
   }
   return undefined;
 };

--- a/core/src/utils/native/capacitor.ts
+++ b/core/src/utils/native/capacitor.ts
@@ -1,3 +1,13 @@
-import type { CapacitorInstance } from '@capacitor/core/types/definitions-internal'
+import type { CapacitorInstance } from '@capacitor/core/types/definitions-internal';
 
-export const capacitor = (window as any)?.Capacitor as CapacitorInstance;
+let capacitor: CapacitorInstance | undefined;
+
+export const getCapacitor = () => {
+  if (capacitor !== undefined) {
+    return capacitor;
+  }
+  if (window !== undefined) {
+    return (window as any)?.Capacitor as CapacitorInstance;
+  }
+  return undefined;
+};

--- a/core/src/utils/native/haptic.ts
+++ b/core/src/utils/native/haptic.ts
@@ -1,4 +1,8 @@
-import type { HapticsPlugin, NotificationType as CapacitorNotificationType, ImpactStyle as CapacitorImpactStyle } from '@capacitor/haptics';
+import type {
+  HapticsPlugin,
+  NotificationType as CapacitorNotificationType,
+  ImpactStyle as CapacitorImpactStyle,
+} from '@capacitor/haptics';
 
 import { capacitor } from './capacitor';
 
@@ -8,19 +12,19 @@ export enum ImpactStyle {
    *
    * @since 1.0.0
    */
-  Heavy = "HEAVY",
+  Heavy = 'HEAVY',
   /**
    * A collision between moderately sized user interface elements
    *
    * @since 1.0.0
    */
-  Medium = "MEDIUM",
+  Medium = 'MEDIUM',
   /**
    * A collision between small, light user interface elements
    *
    * @since 1.0.0
    */
-  Light = "LIGHT"
+  Light = 'LIGHT',
 }
 
 interface HapticImpactOptions {
@@ -33,25 +37,24 @@ export enum NotificationType {
    *
    * @since 1.0.0
    */
-  Success = "SUCCESS",
+  Success = 'SUCCESS',
   /**
    * A notification feedback type indicating that a task has produced a warning
    *
    * @since 1.0.0
    */
-  Warning = "WARNING",
+  Warning = 'WARNING',
   /**
    * A notification feedback type indicating that a task has failed
    *
    * @since 1.0.0
    */
-  Error = "ERROR"
+  Error = 'ERROR',
 }
 
 interface HapticNotificationOptions {
   type: CapacitorNotificationType;
 }
-
 
 interface TapticEngine {
   gestureSelectionStart: () => void;

--- a/core/src/utils/native/haptic.ts
+++ b/core/src/utils/native/haptic.ts
@@ -67,6 +67,7 @@ const HapticEngine = {
     const tapticEngine = (window as any).TapticEngine;
     if (tapticEngine) {
       // Cordova
+      // TODO FW-4707 - Remove this in Ionic 8
       return tapticEngine;
     }
     const capacitor = getCapacitor();
@@ -111,17 +112,38 @@ const HapticEngine = {
     if (!engine) {
       return;
     }
-    engine.impact({ style: options.style });
+    /**
+     * To provide backwards compatibility with Cordova apps,
+     * we convert the style to lowercase.
+     *
+     * TODO: FW-4707 - Remove this in Ionic 8
+     */
+    const style = this.isCapacitor() ? options.style : options.style.toLowerCase() as ImpactStyle;
+    engine.impact({ style });
   },
   notification(options: HapticNotificationOptions) {
     const engine = this.getEngine();
     if (!engine) {
       return;
     }
-    engine.notification({ type: options.type });
+    /**
+     * To provide backwards compatibility with Cordova apps,
+     * we convert the style to lowercase.
+     *
+     * TODO: FW-4707 - Remove this in Ionic 8
+     */
+    const type = this.isCapacitor() ? options.type : options.type.toLowerCase() as NotificationType;
+    engine.notification({ type });
   },
   selection() {
-    this.impact({ style: ImpactStyle.Light });
+    /**
+     * To provide backwards compatibility with Cordova apps,
+     * we convert the style to lowercase.
+     *
+     * TODO: FW-4707 - Remove this in Ionic 8
+     */
+    const style = this.isCapacitor() ? ImpactStyle.Light : 'light' as ImpactStyle;
+    this.impact({ style });
   },
   selectionStart() {
     const engine = this.getEngine();

--- a/core/src/utils/native/haptic.ts
+++ b/core/src/utils/native/haptic.ts
@@ -4,7 +4,7 @@ import type {
   ImpactStyle as CapacitorImpactStyle,
 } from '@capacitor/haptics';
 
-import { capacitor } from './capacitor';
+import { getCapacitor } from './capacitor';
 
 export enum ImpactStyle {
   /**
@@ -69,6 +69,8 @@ const HapticEngine = {
       // Cordova
       return tapticEngine;
     }
+    const capacitor = getCapacitor();
+
     if (capacitor?.isPluginAvailable('Haptics')) {
       // Capacitor
       return capacitor.Plugins.Haptics as HapticsPlugin;
@@ -80,6 +82,8 @@ const HapticEngine = {
     if (!engine) {
       return false;
     }
+
+    const capacitor = getCapacitor();
 
     /**
      * Developers can manually import the
@@ -100,7 +104,7 @@ const HapticEngine = {
     return (window as any).TapticEngine !== undefined;
   },
   isCapacitor() {
-    return capacitor !== undefined;
+    return getCapacitor() !== undefined;
   },
   impact(options: HapticImpactOptions) {
     const engine = this.getEngine();

--- a/core/src/utils/native/haptic.ts
+++ b/core/src/utils/native/haptic.ts
@@ -118,7 +118,7 @@ const HapticEngine = {
      *
      * TODO: FW-4707 - Remove this in Ionic 8
      */
-    const style = this.isCapacitor() ? options.style : options.style.toLowerCase() as ImpactStyle;
+    const style = this.isCapacitor() ? options.style : (options.style.toLowerCase() as ImpactStyle);
     engine.impact({ style });
   },
   notification(options: HapticNotificationOptions) {
@@ -132,7 +132,7 @@ const HapticEngine = {
      *
      * TODO: FW-4707 - Remove this in Ionic 8
      */
-    const type = this.isCapacitor() ? options.type : options.type.toLowerCase() as NotificationType;
+    const type = this.isCapacitor() ? options.type : (options.type.toLowerCase() as NotificationType);
     engine.notification({ type });
   },
   selection() {
@@ -142,7 +142,7 @@ const HapticEngine = {
      *
      * TODO: FW-4707 - Remove this in Ionic 8
      */
-    const style = this.isCapacitor() ? ImpactStyle.Light : 'light' as ImpactStyle;
+    const style = this.isCapacitor() ? ImpactStyle.Light : ('light' as ImpactStyle);
     this.impact({ style });
   },
   selectionStart() {

--- a/core/src/utils/native/keyboard.ts
+++ b/core/src/utils/native/keyboard.ts
@@ -1,7 +1,7 @@
 import type { CapacitorException } from '@capacitor/core';
 import type { KeyboardPlugin, KeyboardResize as CapacitorKeyboardResize } from '@capacitor/keyboard';
 
-import { capacitor } from './capacitor';
+import { getCapacitor } from './capacitor';
 import { ExceptionCode } from './native-interface';
 
 export enum KeyboardResize {
@@ -41,6 +41,8 @@ export interface KeyboardResizeOptions {
 
 export const Keyboard = {
   getEngine(): KeyboardPlugin | undefined {
+    const capacitor = getCapacitor();
+
     if (capacitor?.isPluginAvailable('Keyboard')) {
       return capacitor.Plugins.Keyboard as KeyboardPlugin;
     }

--- a/core/src/utils/native/keyboard.ts
+++ b/core/src/utils/native/keyboard.ts
@@ -41,7 +41,7 @@ export interface KeyboardResizeOptions {
 
 export const Keyboard = {
   getEngine(): KeyboardPlugin | undefined {
-    if (capacitor.isPluginAvailable('Keyboard')) {
+    if (capacitor?.isPluginAvailable('Keyboard')) {
       return capacitor.Plugins.Keyboard as KeyboardPlugin;
     }
     return undefined;

--- a/core/src/utils/native/keyboard.ts
+++ b/core/src/utils/native/keyboard.ts
@@ -1,30 +1,59 @@
-import { win } from '../browser';
+import type { CapacitorException } from '@capacitor/core';
+import type { KeyboardPlugin, KeyboardResize as CapacitorKeyboardResize } from '@capacitor/keyboard';
 
-import type { NativePluginError } from './native-interface';
+import { capacitor } from './capacitor';
+import { ExceptionCode } from './native-interface';
+
+export enum KeyboardResize {
+  /**
+   * Only the `body` HTML element will be resized.
+   * Relative units are not affected, because the viewport does not change.
+   *
+   * @since 1.0.0
+   */
+  Body = "body",
+  /**
+   * Only the `ion-app` HTML element will be resized.
+   * Use it only for Ionic Framework apps.
+   *
+   * @since 1.0.0
+   */
+  Ionic = "ionic",
+  /**
+   * The whole native Web View will be resized when the keyboard shows/hides.
+   * This affects the `vh` relative unit.
+   *
+   * @since 1.0.0
+   */
+  Native = "native",
+  /**
+   * Neither the app nor the Web View are resized.
+   *
+   * @since 1.0.0
+   */
+  None = "none"
+}
 
 // Interfaces source: https://capacitorjs.com/docs/apis/keyboard#interfaces
 export interface KeyboardResizeOptions {
-  mode: KeyboardResize;
+  mode: CapacitorKeyboardResize;
 }
 
-export enum KeyboardResize {
-  Body = 'body',
-  Ionic = 'ionic',
-  Native = 'native',
-  None = 'none',
-}
 
 export const Keyboard = {
-  getEngine() {
-    return (win as any)?.Capacitor?.isPluginAvailable('Keyboard') && (win as any)?.Capacitor.Plugins.Keyboard;
+  getEngine(): KeyboardPlugin | undefined {
+    if (capacitor.isPluginAvailable('Keyboard')) {
+      return capacitor.Plugins.Keyboard as KeyboardPlugin;
+    }
+    return undefined;
   },
   getResizeMode(): Promise<KeyboardResizeOptions | undefined> {
     const engine = this.getEngine();
     if (!engine?.getResizeMode) {
       return Promise.resolve(undefined);
     }
-    return engine.getResizeMode().catch((e: NativePluginError) => {
-      if (e.code === 'UNIMPLEMENTED') {
+    return engine.getResizeMode().catch((e: CapacitorException) => {
+      if (e.code === ExceptionCode.Unimplemented) {
         // If the native implementation is not available
         // we treat it the same as if the plugin is not available.
         return undefined;

--- a/core/src/utils/native/keyboard.ts
+++ b/core/src/utils/native/keyboard.ts
@@ -11,34 +11,33 @@ export enum KeyboardResize {
    *
    * @since 1.0.0
    */
-  Body = "body",
+  Body = 'body',
   /**
    * Only the `ion-app` HTML element will be resized.
    * Use it only for Ionic Framework apps.
    *
    * @since 1.0.0
    */
-  Ionic = "ionic",
+  Ionic = 'ionic',
   /**
    * The whole native Web View will be resized when the keyboard shows/hides.
    * This affects the `vh` relative unit.
    *
    * @since 1.0.0
    */
-  Native = "native",
+  Native = 'native',
   /**
    * Neither the app nor the Web View are resized.
    *
    * @since 1.0.0
    */
-  None = "none"
+  None = 'none',
 }
 
 // Interfaces source: https://capacitorjs.com/docs/apis/keyboard#interfaces
 export interface KeyboardResizeOptions {
   mode: CapacitorKeyboardResize;
 }
-
 
 export const Keyboard = {
   getEngine(): KeyboardPlugin | undefined {

--- a/core/src/utils/native/keyboard.ts
+++ b/core/src/utils/native/keyboard.ts
@@ -1,5 +1,5 @@
 import type { CapacitorException } from '@capacitor/core';
-import type { KeyboardPlugin, KeyboardResize as CapacitorKeyboardResize } from '@capacitor/keyboard';
+import type { KeyboardPlugin, KeyboardResizeOptions } from '@capacitor/keyboard';
 
 import { getCapacitor } from './capacitor';
 import { ExceptionCode } from './native-interface';
@@ -32,11 +32,6 @@ export enum KeyboardResize {
    * @since 1.0.0
    */
   None = 'none',
-}
-
-// Interfaces source: https://capacitorjs.com/docs/apis/keyboard#interfaces
-export interface KeyboardResizeOptions {
-  mode: CapacitorKeyboardResize;
 }
 
 export const Keyboard = {

--- a/core/src/utils/native/native-interface.ts
+++ b/core/src/utils/native/native-interface.ts
@@ -1,13 +1,17 @@
-/**
- * Used to represent a generic error from a native plugin call.
- */
-export interface NativePluginError {
+export enum ExceptionCode {
   /**
-   * The error code.
+   * API is not implemented.
+   *
+   * This usually means the API can't be used because it is not implemented for
+   * the current platform.
    */
-  code?: string;
+  Unimplemented = "UNIMPLEMENTED",
   /**
-   * The error message.
+   * API is not available.
+   *
+   * This means the API can't be used right now because:
+   *   - it is currently missing a prerequisite, such as network connectivity
+   *   - it requires a particular platform or browser version
    */
-  message?: string;
+  Unavailable = "UNAVAILABLE"
 }

--- a/core/src/utils/native/native-interface.ts
+++ b/core/src/utils/native/native-interface.ts
@@ -5,7 +5,7 @@ export enum ExceptionCode {
    * This usually means the API can't be used because it is not implemented for
    * the current platform.
    */
-  Unimplemented = "UNIMPLEMENTED",
+  Unimplemented = 'UNIMPLEMENTED',
   /**
    * API is not available.
    *
@@ -13,5 +13,5 @@ export enum ExceptionCode {
    *   - it is currently missing a prerequisite, such as network connectivity
    *   - it requires a particular platform or browser version
    */
-  Unavailable = "UNAVAILABLE"
+  Unavailable = 'UNAVAILABLE',
 }

--- a/core/src/utils/native/status-bar.ts
+++ b/core/src/utils/native/status-bar.ts
@@ -1,6 +1,6 @@
 import type { StatusBarPlugin, Style as StatusBarStyle } from '@capacitor/status-bar';
 
-import { capacitor } from './capacitor';
+import { getCapacitor } from './capacitor';
 
 interface StyleOptions {
   style: StatusBarStyle;
@@ -14,12 +14,15 @@ export enum Style {
 
 export const StatusBar = {
   getEngine(): StatusBarPlugin | undefined {
+    const capacitor = getCapacitor();
+
     if (capacitor?.isPluginAvailable('StatusBar')) {
       return capacitor.Plugins.StatusBar as StatusBarPlugin;
     }
     return undefined;
   },
   supportsDefaultStatusBarStyle() {
+    const capacitor = getCapacitor();
     /**
      * The 'DEFAULT' status bar style was added
      * to the @capacitor/status-bar plugin in Capacitor 3.

--- a/core/src/utils/native/status-bar.ts
+++ b/core/src/utils/native/status-bar.ts
@@ -1,7 +1,5 @@
 import type { StatusBarPlugin, Style as StatusBarStyle } from '@capacitor/status-bar';
 
-import { win } from '../browser';
-
 import { capacitor } from './capacitor';
 
 interface StyleOptions {
@@ -28,7 +26,7 @@ export const StatusBar = {
      * PluginHeaders is only supported in Capacitor 3+,
      * so we can use this to detect Capacitor 3.
      */
-    return !!(win as any)?.Capacitor?.PluginHeaders;
+    return !!capacitor?.PluginHeaders;
   },
   setStyle(options: StyleOptions) {
     const engine = this.getEngine();

--- a/core/src/utils/native/status-bar.ts
+++ b/core/src/utils/native/status-bar.ts
@@ -4,7 +4,6 @@ import { win } from '../browser';
 
 import { capacitor } from './capacitor';
 
-
 interface StyleOptions {
   style: StatusBarStyle;
 }

--- a/core/src/utils/native/status-bar.ts
+++ b/core/src/utils/native/status-bar.ts
@@ -1,7 +1,12 @@
+import type { StatusBarPlugin, Style as StatusBarStyle } from '@capacitor/status-bar';
+
 import { win } from '../browser';
 
+import { capacitor } from './capacitor';
+
+
 interface StyleOptions {
-  style: Style;
+  style: StatusBarStyle;
 }
 
 export enum Style {
@@ -11,8 +16,11 @@ export enum Style {
 }
 
 export const StatusBar = {
-  getEngine() {
-    return (win as any)?.Capacitor?.isPluginAvailable('StatusBar') && (win as any)?.Capacitor.Plugins.StatusBar;
+  getEngine(): StatusBarPlugin | undefined {
+    if (capacitor?.isPluginAvailable('StatusBar')) {
+      return capacitor.Plugins.StatusBar as StatusBarPlugin;
+    }
+    return undefined;
   },
   supportsDefaultStatusBarStyle() {
     /**
@@ -31,7 +39,7 @@ export const StatusBar = {
 
     engine.setStyle(options);
   },
-  getStyle: async function (): Promise<Style> {
+  getStyle: async function (): Promise<StatusBarStyle> {
     const engine = this.getEngine();
     if (!engine) {
       return Style.Default;

--- a/core/src/utils/native/status-bar.ts
+++ b/core/src/utils/native/status-bar.ts
@@ -21,8 +21,9 @@ export const StatusBar = {
     }
     return undefined;
   },
+  // TODO FW-4696 Remove supportDefaultStatusBarStyle in Ionic v8
   supportsDefaultStatusBarStyle() {
-    const capacitor = getCapacitor();
+    const capacitor = getCapacitor() as any;
     /**
      * The 'DEFAULT' status bar style was added
      * to the @capacitor/status-bar plugin in Capacitor 3.


### PR DESCRIPTION
Issue number: Internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Ionic currently detects and uses Capacitor APIs for different plugins (haptics, status bar and keyboard). This implementation does not have type safety and can result in unexpected behaviors. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds `@capacitor/core`, `@capacitor/keyboard`, `@capacitor/haptics` and `@capacitor/status-bar` as dev dependencies. These should _only_ be used with `import type { }`. 
- Refactors the plugin usages to be typed against the plugin packages, while using a duplicate enum when needing a value. This allows us to not bundle the capacitor plugins with Ionic Framework.
- Introduces a `getCapacitor()` function for interacting with the `window.Capacitor` object through a typed object. 

**How does it work?**

The idea is we want the type safety from the Capacitor packages, without directly bundling that source code within Ionic Framework. This means we use the Capacitor deps where a type is needed, but clone any enums where a value is referenced. If a Capacitor dep changes the supported values, Typescript will fail to compile and that will signal to use to update our enum values to match any changes. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `7.1.2-dev.11688696027.1c4d4ad1`

Tested against a demo app for some of the core behavior: https://github.com/sean-perkins/capacitor-ionic-plugins-demo