### PR TITLE
feat(breadcrumb): support dynamic type

### DIFF
--- a/core/src/components/breadcrumb/breadcrumb.ios.scss
+++ b/core/src/components/breadcrumb/breadcrumb.ios.scss
@@ -14,6 +14,8 @@
   /**
    * Main content should be prioritized
    * on iOS, so we set max font size for breadcrumbs.
+   * Breadcrumbs can be placed in the content too, so
+   * we add a min font size to keep the text legible.
    */
   font-size: clamp(16px, #{$breadcrumb-font-size}, 22px);
 }

--- a/core/src/components/breadcrumb/breadcrumb.ios.scss
+++ b/core/src/components/breadcrumb/breadcrumb.ios.scss
@@ -10,6 +10,12 @@
   --color-hover: #{$breadcrumb-ios-color-active};
   --color-focused: var(--color-active);
   --background-focused: #{$breadcrumb-ios-background-focused};
+
+  /**
+   * Main content should be prioritized
+   * on iOS, so we set max font size for breadcrumbs.
+   */
+  font-size: min(#{$breadcrumb-font-size}, 22px);
 }
 
 :host(.breadcrumb-active) {
@@ -58,7 +64,7 @@
 ::slotted(ion-icon) {
   color: $breadcrumb-ios-icon-color;
 
-  font-size: 18px;
+  font-size: min(1.125rem, 22px);
 }
 
 ::slotted(ion-icon[slot="start"]) {
@@ -91,4 +97,8 @@
 
 .breadcrumbs-collapsed-indicator:focus {
   background: $breadcrumb-ios-indicator-background-focused;
+}
+
+.breadcrumbs-collapsed-indicator ion-icon {
+  font-size: min(1.375rem, 22px);
 }

--- a/core/src/components/breadcrumb/breadcrumb.ios.scss
+++ b/core/src/components/breadcrumb/breadcrumb.ios.scss
@@ -15,7 +15,7 @@
    * Main content should be prioritized
    * on iOS, so we set max font size for breadcrumbs.
    */
-  font-size: min(#{$breadcrumb-font-size}, 22px);
+  font-size: clamp(16px, #{$breadcrumb-font-size}, 22px);
 }
 
 :host(.breadcrumb-active) {

--- a/core/src/components/breadcrumb/breadcrumb.md.scss
+++ b/core/src/components/breadcrumb/breadcrumb.md.scss
@@ -53,7 +53,7 @@
 ::slotted(ion-icon) {
   color: $breadcrumb-md-icon-color;
 
-  font-size: 18px;
+  font-size: 1.125rem;
 }
 
 ::slotted(ion-icon[slot="start"]) {

--- a/core/src/components/breadcrumb/breadcrumb.scss
+++ b/core/src/components/breadcrumb/breadcrumb.scss
@@ -156,5 +156,5 @@
 .breadcrumbs-collapsed-indicator ion-icon {
   margin-top: 1px;
 
-  font-size: 22px;
+  font-size: 1.375rem;
 }

--- a/core/src/components/breadcrumb/breadcrumb.vars.scss
+++ b/core/src/components/breadcrumb/breadcrumb.vars.scss
@@ -7,7 +7,7 @@
 $breadcrumb-font-weight:         400 !default;
 
 /// @prop - Font size of the breadcrumb
-$breadcrumb-font-size:           16px !default;
+$breadcrumb-font-size:           1rem !default;
 
 /// @prop - Color of the breadcrumb separator
 $breadcrumb-separator-color:     var(--ion-color-step-550, #73849a) !default;


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Breadcrumb does not support dynamic type

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Convert fonts to rem
- Add maximum font size for iOS to prioritize main content. Note that 22px was chosen to match the [back button max font size](https://github.com/ionic-team/ionic-framework/pull/27750) since breadcrumbs can be used in a toolbar.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Demo Video: https://github.com/ionic-team/ionic-framework/assets/2721089/3e59160b-e18e-4f96-975d-f9dc7f8a49d4