### PR TITLE
fix: avoid unresolved import warning on stencil apps

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.1.2",
       "license": "MIT",
       "dependencies": {
-        "@stencil/core": "^3.4.1",
+        "@stencil/core": "^3.4.0",
         "ionicons": "7.1.0",
         "tslib": "^2.1.0"
       },
@@ -1594,9 +1594,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.1.tgz",
-      "integrity": "sha512-7rjOmM0W9K5op2gtOQRLERGH1155rv2fm6ppxOzYqqG8ISct4m9skp5XgUBYPu+GSPsJFdRuCIQs0IuVsG/7+g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-kEtPtV6QegME8YgMjWrhS7KktItbhqOpAuK9aXypDdI/7bLU9iM/4DtnQGWY/DARBophk+XRBfNXcE62Bmi0dw==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -11450,9 +11450,9 @@
       "requires": {}
     },
     "@stencil/core": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.1.tgz",
-      "integrity": "sha512-7rjOmM0W9K5op2gtOQRLERGH1155rv2fm6ppxOzYqqG8ISct4m9skp5XgUBYPu+GSPsJFdRuCIQs0IuVsG/7+g=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-kEtPtV6QegME8YgMjWrhS7KktItbhqOpAuK9aXypDdI/7bLU9iM/4DtnQGWY/DARBophk+XRBfNXcE62Bmi0dw=="
     },
     "@stencil/react-output-target": {
       "version": "0.5.3",

--- a/core/package.json
+++ b/core/package.json
@@ -31,7 +31,7 @@
     "loader/"
   ],
   "dependencies": {
-    "@stencil/core": "^3.4.1",
+    "@stencil/core": "^3.4.0",
     "ionicons": "7.1.0",
     "tslib": "^2.1.0"
   },


### PR DESCRIPTION
Issue number: resolves #27762

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Stencil 3.4.1 regressed the tsconfig alias path transpilation. This is fixed in 4.0.0 though.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Downgrade to Stencil 3.4.0. Stencil 4.0 has breaking changes, so I'd like to wait on upgrading until we can work through any of the changes that impact Ionic.

This reverts commit 9793b3c0a0828b938b825116f78f616b1550d623.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Stencil issue: https://github.com/ionic-team/stencil/issues/4550