### PR TITLE
chore: re-land stencil 3.4.1

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.1.2",
       "license": "MIT",
       "dependencies": {
-        "@stencil/core": "^3.4.0",
+        "@stencil/core": "^3.4.1",
         "ionicons": "7.1.0",
         "tslib": "^2.1.0"
       },
@@ -1594,9 +1594,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.0.tgz",
-      "integrity": "sha512-kEtPtV6QegME8YgMjWrhS7KktItbhqOpAuK9aXypDdI/7bLU9iM/4DtnQGWY/DARBophk+XRBfNXcE62Bmi0dw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.1.tgz",
+      "integrity": "sha512-7rjOmM0W9K5op2gtOQRLERGH1155rv2fm6ppxOzYqqG8ISct4m9skp5XgUBYPu+GSPsJFdRuCIQs0IuVsG/7+g==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -11450,9 +11450,9 @@
       "requires": {}
     },
     "@stencil/core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.0.tgz",
-      "integrity": "sha512-kEtPtV6QegME8YgMjWrhS7KktItbhqOpAuK9aXypDdI/7bLU9iM/4DtnQGWY/DARBophk+XRBfNXcE62Bmi0dw=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.1.tgz",
+      "integrity": "sha512-7rjOmM0W9K5op2gtOQRLERGH1155rv2fm6ppxOzYqqG8ISct4m9skp5XgUBYPu+GSPsJFdRuCIQs0IuVsG/7+g=="
     },
     "@stencil/react-output-target": {
       "version": "0.5.3",

--- a/core/package.json
+++ b/core/package.json
@@ -31,7 +31,7 @@
     "loader/"
   ],
   "dependencies": {
-    "@stencil/core": "^3.4.0",
+    "@stencil/core": "^3.4.1",
     "ionicons": "7.1.0",
     "tslib": "^2.1.0"
   },

--- a/core/stencil.config.ts
+++ b/core/stencil.config.ts
@@ -156,7 +156,8 @@ export const config: Config = {
     },
     {
       type: 'dist',
-      esmLoaderPath: '../loader'
+      esmLoaderPath: '../loader',
+      transformAliasedImportPathsInCollection: true
     },
     {
       type: 'dist-custom-elements',


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

In https://github.com/ionic-team/ionic-framework/issues/27762 it was discovered that Stencil 3.4.1 caused aliased paths in `dist/collection` to no longer be transpiled on build. As part of https://github.com/ionic-team/stencil/pull/4501 the Stencil team fixed a bug which caused paths in dist-collection to (correctly) no longer be transpiled unless `transformAliasedImportPathsInCollection` is set to `true`. This flag is `false` by default, so upon upgrade our the paths in dist-collection stopped being transpiled.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds `transformAliasedImportPathsInCollection: true` to the `dist` output target in the stencil config. (dist-collection is part of dist in this case)
- Re-upgrades Ionic to Stencil 3.4.1

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev Build: `7.1.3-dev.11688751672.167a6cdd`

Reviewers can manually verify the built changes by looking in `core/dist/collection/components/` and then looking at a JS file for a component that uses aliased paths (such as datetime-button)