### PR TITLE
fix(overlays): first button is not focused on backdrop tap

### DIFF
--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -240,8 +240,11 @@ const trapKeyboardFocus = (ev: Event, doc: Document) => {
       /**
        * If the target is inside the wrapper, let the browser
        * focus as normal and keep a log of the last focused element.
+       * Additionally, if the backdrop was tapped we should not
+       * move focus back inside the wrapper as that could cause
+       * an interactive elements focus state to activate.
        */
-      if (overlayWrapper.contains(target)) {
+      if (overlayWrapper.contains(target) || target === overlayRoot.querySelector('ion-backdrop')) {
         lastOverlay.lastFocus = target;
       } else {
         /**


### PR DESCRIPTION
Issue number: resolves #27773

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The focus trap util for scoped components moves focus back to the first focusable element inside of `.ion-overlay-wrapper` when clicking the backdrop. The reason for this is it (incorrectly) assumes that all focusable elements will be children of `.ion-overlay-wrapper`. This is true **except** for `ion-backdrop` which overlays the entire screen and therefore cannot be a child of `.ion-overlay-wrapper`.

This does not impact modal and popover as the shadow focus trap utility makes use of the Shadow Root as the parent for all focusable elements, not `.ion-overlay-wrapper`.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Scoped focus trap util no longer moves focus if the `ion-backdrop` was focused.

I opted to explicitly account for `ion-backdrop` rather than come up with some new private API. As far as I can tell `ion-backdrop` is the only exception to this focus trapping rule with `.ion-overlay-wrapper`. Open to alternative ideas though.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `7.1.3-dev.11689085446.181c2143`