### PR TITLE
fix: safari no longer adjusts text in landscape

### DIFF
--- a/core/src/css/structure.scss
+++ b/core/src/css/structure.scss
@@ -19,6 +19,7 @@ html {
   height: 100%;
 
   text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
 }
 
 html:not(.hydrated) body {
@@ -82,4 +83,5 @@ body {
   overscroll-behavior-y: none;
 
   text-size-adjust: none;
+  -webkit-text-size-adjust: none;
 }

--- a/core/src/css/structure.scss
+++ b/core/src/css/structure.scss
@@ -17,9 +17,9 @@
 html {
   width: 100%;
   height: 100%;
+  -webkit-text-size-adjust: 100%;
 
   text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
 }
 
 html:not(.hydrated) body {
@@ -81,7 +81,7 @@ body {
   word-wrap: break-word;
 
   overscroll-behavior-y: none;
+  -webkit-text-size-adjust: none;
 
   text-size-adjust: none;
-  -webkit-text-size-adjust: none;
 }


### PR DESCRIPTION
Issue number: resolves #27782

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Ionic uses text-size-adjust to prevent browsers from resizing text in landscape mode in order to match native app behavior. However, WebKit only supports `-webkit-text-size-adjust`, so this fix never applied to iOS devices.

https://caniuse.com/?search=text-size-adjust

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add `-webkit-text-size-adjust` where we use `text-size-adjust`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

**Landscape**

| main | branch |
| - | - |
|  ![IMG_0046](https://github.com/ionic-team/ionic-framework/assets/2721089/d719f495-c051-4f64-a6fa-f17435c68cb5) | ![IMG_0048](https://github.com/ionic-team/ionic-framework/assets/2721089/7a0b5f45-b72a-466d-8e00-846de2572e49) |

**Portrait** (Should be no changes)

| main | branch |
| - | - |
| ![IMG_0045](https://github.com/ionic-team/ionic-framework/assets/2721089/a2324f9f-efcc-4c75-8359-2441f93ceadc) | ![IMG_0047](https://github.com/ionic-team/ionic-framework/assets/2721089/64566645-5778-435f-a511-5fe7234c7f65) |
