### PR TITLE
investigation(datetime): using a button wrapper to combine calendar day and highlight

### DIFF
--- a/core/src/components/datetime/datetime.ios.scss
+++ b/core/src/components/datetime/datetime.ios.scss
@@ -20,7 +20,7 @@
   @include padding($datetime-ios-padding, $datetime-ios-padding, $datetime-ios-padding, $datetime-ios-padding);
 
   border-bottom: $datetime-ios-border-color;
-  
+
   font-size: 14px;
 }
 
@@ -89,27 +89,21 @@
 }
 
 :host .calendar-day {
+  @include padding(4px);
+
+  width: 40px;
+  height: 40px;
+
   font-size: 20px;
 }
 
-.calendar-day:focus .calendar-day-highlight,
-.calendar-day.calendar-day-active .calendar-day-highlight {
-  opacity: 0.2;
-}
-
-.calendar-day.calendar-day-active .calendar-day-highlight {
-  background: current-color(base);
-}
-
-// !important is needed here to overwrite custom highlight background, which is inline.
-// Does not apply to the active state because highlights aren't applied at all there.
-.calendar-day:focus .calendar-day-highlight {
-  /* stylelint-disable-next-line declaration-no-important */
-  background: current-color(base) !important;
+.calendar-day:focus,
+.calendar-day.calendar-day-active {
+  background: current-color(base, 0.2);
 }
 
 /**
- * Day that today but not selected
+ * Day that is today but not selected
  * should have ion-color for text color.
  */
 :host .calendar-day.calendar-day-today {
@@ -135,10 +129,8 @@
   color: current-color(contrast);
 }
 
-.calendar-day.calendar-day-today.calendar-day-active .calendar-day-highlight {
+.calendar-day.calendar-day-today.calendar-day-active {
   background: current-color(base);
-
-  opacity: 1;
 }
 
 // Time / Header

--- a/core/src/components/datetime/datetime.md.scss
+++ b/core/src/components/datetime/datetime.md.scss
@@ -71,6 +71,9 @@
 :host .calendar-day {
   @include padding(13px, 0, 13px, 0px);
 
+  width: 32px;
+  height: 32px;
+
   font-size: $datetime-md-calendar-item-font-size;
 }
 

--- a/core/src/components/datetime/datetime.scss
+++ b/core/src/components/datetime/datetime.scss
@@ -329,9 +329,9 @@ ion-picker-column-internal {
  * Center the day text vertically
  * and horizontally within its grid cell.
  */
-:host .calendar-day {
-  @include padding(0px, 0px, 0px, 0px);
-  @include margin(0px, 0px, 0px, 0px);
+:host .calendar-day-wrapper {
+  @include padding(0);
+  @include margin(0);
 
   display: flex;
 
@@ -339,6 +339,12 @@ ion-picker-column-internal {
 
   align-items: center;
   justify-content: center;
+}
+
+:host .calendar-day {
+  @include border-radius(50%);
+
+  position: absolute;
 
   border: none;
 
@@ -362,17 +368,6 @@ ion-picker-column-internal {
   opacity: 0.4;
 }
 
-.calendar-day-highlight {
-  @include border-radius(32px, 32px, 32px, 32px);
-  @include padding(4px, 4px, 4px, 4px);
-
-  position: absolute;
-
-  width: 32px;
-  height: 32px;
-
-  z-index: -1;
-}
 
 // Time / Header
 // -----------------------------------

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -2084,68 +2084,70 @@ export class Datetime implements ComponentInterface {
             }
 
             return (
-              <button
-                tabindex="-1"
-                data-day={day}
-                data-month={month}
-                data-year={year}
-                data-index={index}
-                data-day-of-week={dayOfWeek}
-                disabled={isCalDayDisabled}
-                class={{
-                  'calendar-day-padding': isCalendarPadding,
-                  'calendar-day': true,
-                  'calendar-day-active': isActive,
-                  'calendar-day-today': isToday,
-                }}
-                style={
-                  dateStyle && {
-                    color: dateStyle.textColor,
+              <div class="calendar-day-wrapper">
+                <button
+                  tabindex="-1"
+                  data-day={day}
+                  data-month={month}
+                  data-year={year}
+                  data-index={index}
+                  data-day-of-week={dayOfWeek}
+                  disabled={isCalDayDisabled}
+                  class={{
+                    'calendar-day-padding': isCalendarPadding,
+                    'calendar-day': true,
+                    'calendar-day-active': isActive,
+                    'calendar-day-today': isToday,
+                  }}
+                  style={
+                    dateStyle && {
+                      color: dateStyle.textColor,
+                    }
                   }
-                }
-                aria-hidden={isCalendarPadding ? 'true' : null}
-                aria-selected={ariaSelected}
-                aria-label={ariaLabel}
-                onClick={() => {
-                  if (isCalendarPadding) {
-                    return;
-                  }
+                  aria-hidden={isCalendarPadding ? 'true' : null}
+                  aria-selected={ariaSelected}
+                  aria-label={ariaLabel}
+                  onClick={() => {
+                    if (isCalendarPadding) {
+                      return;
+                    }
 
-                  this.setWorkingParts({
-                    ...this.workingParts,
-                    month,
-                    day,
-                    year,
-                  });
-
-                  // multiple only needs date info, so we can wipe out other fields like time
-                  if (multiple) {
-                    this.setActiveParts(
-                      {
-                        month,
-                        day,
-                        year,
-                      },
-                      isActive
-                    );
-                  } else {
-                    this.setActiveParts({
-                      ...activePart,
+                    this.setWorkingParts({
+                      ...this.workingParts,
                       month,
                       day,
                       year,
                     });
-                  }
-                }}
-              >
-                <div
-                  class="calendar-day-highlight"
-                  style={{
-                    backgroundColor: dateStyle?.backgroundColor,
+
+                    // multiple only needs date info, so we can wipe out other fields like time
+                    if (multiple) {
+                      this.setActiveParts(
+                        {
+                          month,
+                          day,
+                          year,
+                        },
+                        isActive
+                      );
+                    } else {
+                      this.setActiveParts({
+                        ...activePart,
+                        month,
+                        day,
+                        year,
+                      });
+                    }
                   }}
-                ></div>
-                {text}
-              </button>
+                >
+                  {/* <div
+                    class="calendar-day-highlight"
+                    style={{
+                      backgroundColor: dateStyle?.backgroundColor,
+                    }}
+                  ></div> */}
+                  {text}
+                </button>
+              </div>
             );
           })}
         </div>


### PR DESCRIPTION
This is a proof of concept for adding a button wrapper around `.calendar-day` in datetime in order to combine it with `.calendar-day-highlight`.