### PR TITLE
fix(gesture): gestures activate on user-generated events

### DIFF
--- a/core/src/utils/gesture/index.ts
+++ b/core/src/utils/gesture/index.ts
@@ -88,6 +88,14 @@ export const createGesture = (config: GestureConfig): Gesture => {
   };
 
   const pointerMove = (ev: UIEvent) => {
+    /**
+     * Gestures should only activate
+     * on user-generated events.
+     */
+    if (!ev.isTrusted) {
+      return;
+    }
+
     // fast path, if gesture is currently captured
     // do minimum job to get user-land even dispatched
     if (hasCapturedPan) {

--- a/core/src/utils/gesture/pointer-events.ts
+++ b/core/src/utils/gesture/pointer-events.ts
@@ -23,7 +23,6 @@ export const createPointerEvents = (
   let lastTouchEvent = 0;
 
   const handleTouchStart = (ev: any) => {
-    console.log('touch start!!',ev)
     /**
      * Gestures should only activate
      * on user-generated events.

--- a/core/src/utils/gesture/pointer-events.ts
+++ b/core/src/utils/gesture/pointer-events.ts
@@ -23,6 +23,14 @@ export const createPointerEvents = (
   let lastTouchEvent = 0;
 
   const handleTouchStart = (ev: any) => {
+    /**
+     * Gestures should only activate
+     * on user-generated events.
+     */
+    if (!ev.isTrusted) {
+      return;
+    }
+
     lastTouchEvent = Date.now() + MOUSE_WAIT;
     if (!pointerDown(ev)) {
       return;

--- a/core/src/utils/gesture/pointer-events.ts
+++ b/core/src/utils/gesture/pointer-events.ts
@@ -23,6 +23,7 @@ export const createPointerEvents = (
   let lastTouchEvent = 0;
 
   const handleTouchStart = (ev: any) => {
+    console.log('touch start!!',ev)
     /**
      * Gestures should only activate
      * on user-generated events.
@@ -57,6 +58,14 @@ export const createPointerEvents = (
   };
 
   const handleMouseDown = (ev: any) => {
+    /**
+     * Gestures should only activate
+     * on user-generated events.
+     */
+    if (!ev.isTrusted) {
+      return;
+    }
+
     if (lastTouchEvent > Date.now()) {
       return;
     }

--- a/core/src/utils/gesture/pointer-events.ts
+++ b/core/src/utils/gesture/pointer-events.ts
@@ -64,6 +64,14 @@ export const createPointerEvents = (
   };
 
   const handleTouchEnd = (ev: any) => {
+    /**
+     * Gestures should only activate
+     * on user-generated events.
+     */
+    if (!ev.isTrusted) {
+      return;
+    }
+
     stopTouch();
     if (pointerUp) {
       pointerUp(ev);
@@ -71,6 +79,14 @@ export const createPointerEvents = (
   };
 
   const handleMouseUp = (ev: any) => {
+    /**
+     * Gestures should only activate
+     * on user-generated events.
+     */
+    if (!ev.isTrusted) {
+      return;
+    }
+
     stopMouse();
     if (pointerUp) {
       pointerUp(ev);


### PR DESCRIPTION
Issue number: resolves #27819

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Ionic's gesture utility listens for many types of mouse/touch events (`touchstart`, `mousedown`, etc). However, it also listens for script-generated events of the same name. Swiper generates custom touch events that collide with the native touch event names. However, it does not include the same payload as the native events. As a result, Ionic's gesture utility responds to these custom events. Since the payload info does not include pointer coordinates, Ionic assumes the coordinates are 0x0 every time causing the gesture to never activate.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Gesture utility now only responds to events generated  by a user using `event.isTrusted`. Note that this should not impact our ability to test gestures as tools such as Puppeteer and Playwright will generate trusted events when manually dispatching mouse events while testing.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
