### PR TITLE
fix(modal): body background is reset with inline card modals

### DIFF
--- a/core/src/components/modal/animations/ios.leave.ts
+++ b/core/src/components/modal/animations/ios.leave.ts
@@ -51,9 +51,9 @@ export const iosLeaveAnimation = (baseEl: HTMLElement, opts: ModalAnimationOptio
 
         presentingEl.style.setProperty('overflow', '');
 
-        const numModals = Array.from(bodyEl.querySelectorAll('ion-modal')).filter(
-          (m) => m.presentingElement !== undefined
-        ).length;
+        const numModals = (
+          Array.from(bodyEl.querySelectorAll('ion-modal:not(.overlay-hidden)')) as HTMLIonModalElement[]
+        ).filter((m) => m.presentingElement !== undefined).length;
         if (numModals <= 1) {
           bodyEl.style.setProperty('background-color', '');
         }


### PR DESCRIPTION
Issue number: resolves #27830

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Card modals set the body background to `black` to match iOS. This color should be removed once the final card modal has been closed. When modals were updated to work inline, the code that removed the background color was never updated to account for this. As a result, opening multiple inline card modals never removes the background color because there are always >1 modals in the DOM.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The card modal now queries for _visible_ modals in the DOM to determine if it should remove the background color.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `7.2.1-dev.11689879279.14e28634`
