### PR TITLE
feat(toast): add htmlAttributes property for passing attributes to buttons  

### DIFF
--- a/core/src/components/toast/test/a11y/index.html
+++ b/core/src/components/toast/test/a11y/index.html
@@ -56,7 +56,7 @@
           htmlAttributes: {
             ariaLabel: 'close button',
             'aria-labelledby': 'close-label',
-          }
+          },
         },
       ];
 

--- a/core/src/components/toast/test/a11y/index.html
+++ b/core/src/components/toast/test/a11y/index.html
@@ -34,12 +34,31 @@
           Present Controller Toast
         </ion-button>
 
+        <ion-button id="aria-label-toast-trigger">Present Aria Label Toast</ion-button>
+        <ion-toast
+          id="aria-label-toast"
+          trigger="aria-label-toast-trigger"
+          header="Aria Label Toast Header"
+          message="Aria Label Toast Message"
+        ></ion-toast>
+
         <ion-button onclick="updateContent()">Update Inner Content</ion-button>
       </main>
     </ion-app>
     <script>
       const inlineToast = document.querySelector('#inline-toast');
       inlineToast.buttons = ['Ok'];
+
+      const ariaLabelToast = document.querySelector('#aria-label-toast');
+      ariaLabelToast.buttons = [
+        {
+          icon: 'close',
+          htmlAttributes: {
+            ariaLabel: 'close button',
+            'aria-labelledby': 'close-label',
+          }
+        },
+      ];
 
       const presentToast = async (opts) => {
         const toast = await toastController.create(opts);

--- a/core/src/components/toast/test/a11y/index.html
+++ b/core/src/components/toast/test/a11y/index.html
@@ -54,7 +54,7 @@
         {
           icon: 'close',
           htmlAttributes: {
-            ariaLabel: 'close button',
+            'aria-label': 'close button',
             'aria-labelledby': 'close-label',
           },
         },

--- a/core/src/components/toast/test/a11y/toast.e2e.ts
+++ b/core/src/components/toast/test/a11y/toast.e2e.ts
@@ -39,7 +39,9 @@ configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
       expect(results.violations).toEqual([]);
     });
 
-    test('should have aria-labelledby and aria-label added to the button when htmlAttributes is set', async ({ page }) => {
+    test('should have aria-labelledby and aria-label added to the button when htmlAttributes is set', async ({
+      page,
+    }) => {
       const ionToastDidPresent = await page.spyOnEvent('ionToastDidPresent');
 
       await page.click('#aria-label-toast-trigger');

--- a/core/src/components/toast/test/a11y/toast.e2e.ts
+++ b/core/src/components/toast/test/a11y/toast.e2e.ts
@@ -11,10 +11,10 @@ configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
       await page.goto(`/src/components/toast/test/a11y`, config);
     });
     test('should not have any axe violations with inline toasts', async ({ page }) => {
-      const ionToastDidPresent = await page.spyOnEvent('ionToastDidPresent');
+      const didPresent = await page.spyOnEvent('ionToastDidPresent');
 
       await page.click('#inline-toast-trigger');
-      await ionToastDidPresent.next();
+      await didPresent.next();
 
       /**
        * IonToast overlays the entire screen, so
@@ -25,10 +25,10 @@ configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
       expect(results.violations).toEqual([]);
     });
     test('should not have any axe violations with controller toasts', async ({ page }) => {
-      const ionToastDidPresent = await page.spyOnEvent('ionToastDidPresent');
+      const didPresent = await page.spyOnEvent('ionToastDidPresent');
 
       await page.click('#controller-toast-trigger');
-      await ionToastDidPresent.next();
+      await didPresent.next();
 
       /**
        * IonToast overlays the entire screen, so
@@ -42,10 +42,10 @@ configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
     test('should have aria-labelledby and aria-label added to the button when htmlAttributes is set', async ({
       page,
     }) => {
-      const ionToastDidPresent = await page.spyOnEvent('ionToastDidPresent');
+      const didPresent = await page.spyOnEvent('ionToastDidPresent');
 
       await page.click('#aria-label-toast-trigger');
-      await ionToastDidPresent.next();
+      await didPresent.next();
 
       const toastButton = page.locator('#aria-label-toast .toast-button');
 

--- a/core/src/components/toast/test/a11y/toast.e2e.ts
+++ b/core/src/components/toast/test/a11y/toast.e2e.ts
@@ -38,5 +38,24 @@ configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
       const results = await new AxeBuilder({ page }).disableRules('color-contrast').analyze();
       expect(results.violations).toEqual([]);
     });
+
+    test('should have aria-labelledby added to the button when htmlAttributes is set', async ({ page }) => {
+      const ionToastDidPresent = await page.spyOnEvent('ionToastDidPresent');
+
+      await page.click('#aria-label-toast-trigger');
+      await ionToastDidPresent.next();
+
+      const toastButton = page.locator('#aria-label-toast .toast-button');
+
+      /**
+       * expect().toHaveAttribute() can't check for a null value, so grab and check
+       * the value manually instead.
+       */
+      const ariaLabelledBy = await toastButton.getAttribute('aria-labelledby');
+      expect(ariaLabelledBy).toBe('close-label');
+
+      const ariaLabel = await toastButton.getAttribute('aria-label');
+      expect(ariaLabel).toBe('close button');
+    });
   });
 });

--- a/core/src/components/toast/test/a11y/toast.e2e.ts
+++ b/core/src/components/toast/test/a11y/toast.e2e.ts
@@ -39,7 +39,7 @@ configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
       expect(results.violations).toEqual([]);
     });
 
-    test('should have aria-labelledby added to the button when htmlAttributes is set', async ({ page }) => {
+    test('should have aria-labelledby and aria-label added to the button when htmlAttributes is set', async ({ page }) => {
       const ionToastDidPresent = await page.spyOnEvent('ionToastDidPresent');
 
       await page.click('#aria-label-toast-trigger');

--- a/core/src/components/toast/test/a11y/toast.e2e.ts
+++ b/core/src/components/toast/test/a11y/toast.e2e.ts
@@ -49,15 +49,8 @@ configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
 
       const toastButton = page.locator('#aria-label-toast .toast-button');
 
-      /**
-       * expect().toHaveAttribute() can't check for a null value, so grab and check
-       * the value manually instead.
-       */
-      const ariaLabelledBy = await toastButton.getAttribute('aria-labelledby');
-      expect(ariaLabelledBy).toBe('close-label');
-
-      const ariaLabel = await toastButton.getAttribute('aria-label');
-      expect(ariaLabel).toBe('close button');
+      await expect(toastButton).toHaveAttribute('aria-labelledby', 'close-label');
+      await expect(toastButton).toHaveAttribute('aria-label', 'close button');
     });
   });
 });

--- a/core/src/components/toast/toast-interface.ts
+++ b/core/src/components/toast/toast-interface.ts
@@ -31,6 +31,7 @@ export interface ToastButton {
   side?: 'start' | 'end';
   role?: 'cancel' | string;
   cssClass?: string | string[];
+  htmlAttributes?: { [key: string]: any };
   handler?: () => boolean | void | Promise<boolean | void>;
 }
 

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -406,7 +406,7 @@ export class Toast implements ComponentInterface, OverlayInterface {
       <div class={buttonGroupsClasses}>
         {buttons.map((b) => (
           <button
-            {...(b.htmlAttributes as any)}
+            {...b.htmlAttributes}
             type="button"
             class={buttonClass(b)}
             tabIndex={0}

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -405,7 +405,14 @@ export class Toast implements ComponentInterface, OverlayInterface {
     return (
       <div class={buttonGroupsClasses}>
         {buttons.map((b) => (
-          <button type="button" class={buttonClass(b)} tabIndex={0} onClick={() => this.buttonClick(b)} part="button">
+          <button
+            {...(b.htmlAttributes as any)}
+            type="button"
+            class={buttonClass(b)}
+            tabIndex={0}
+            onClick={() => this.buttonClick(b)}
+            part="button"
+          >
             <div class="toast-button-inner">
               {b.icon && (
                 <ion-icon


### PR DESCRIPTION
Issue number: N/A

---------

## What is the current behavior?
Buttons containing only icons are not accessible as there is no way to pass an `aria-label` attribute (or any other html attribute). 

## What is the new behavior?
- Adds the `htmlAttributes` property on the `ToastButton` interface 
- Passes the `htmlAttributes` to the buttons
- Adds a test to verify `aria-label` and `aria-labelled-by` are passed to the button

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
