### PR TITLE
chore: update to stencil 4

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
-        "@stencil/core": "^3.4.0",
+        "@stencil/core": "^4.0.2",
         "ionicons": "7.1.0",
         "tslib": "^2.1.0"
       },
@@ -1634,15 +1634,15 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.0.tgz",
-      "integrity": "sha512-kEtPtV6QegME8YgMjWrhS7KktItbhqOpAuK9aXypDdI/7bLU9iM/4DtnQGWY/DARBophk+XRBfNXcE62Bmi0dw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-1AnLpHAQDHB+DbM8VpuZikMMmIAtLrkYHMBm+pXKj+EPQqsTcyiZ3a7MAqajdM0WlOXb9rfTZT4aYbPwvItEJw==",
       "bin": {
         "stencil": "bin/stencil"
       },
       "engines": {
-        "node": ">=14.10.0",
-        "npm": ">=6.0.0"
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
       }
     },
     "node_modules/@stencil/react-output-target": {
@@ -11520,9 +11520,9 @@
       "requires": {}
     },
     "@stencil/core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.0.tgz",
-      "integrity": "sha512-kEtPtV6QegME8YgMjWrhS7KktItbhqOpAuK9aXypDdI/7bLU9iM/4DtnQGWY/DARBophk+XRBfNXcE62Bmi0dw=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-1AnLpHAQDHB+DbM8VpuZikMMmIAtLrkYHMBm+pXKj+EPQqsTcyiZ3a7MAqajdM0WlOXb9rfTZT4aYbPwvItEJw=="
     },
     "@stencil/react-output-target": {
       "version": "0.5.3",

--- a/core/package.json
+++ b/core/package.json
@@ -31,7 +31,7 @@
     "loader/"
   ],
   "dependencies": {
-    "@stencil/core": "^3.4.0",
+    "@stencil/core": "^4.0.2",
     "ionicons": "7.1.0",
     "tslib": "^2.1.0"
   },


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Ionic is using Stencil 3

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Ionic now uses Stencil 4

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


Dev build: `7.2.1-dev.11690318651.186a9ff5`

I tested this dev build on a Stencil app with Ionic and verified that https://github.com/ionic-team/ionic-framework/pull/27767#issuecomment-1625746820 is resolved. No import warnings are logged on build.