### PR TITLE
feat(alert): add htmlAttributes property for passing attributes to buttons

### DIFF
--- a/core/src/components/alert/alert-interface.ts
+++ b/core/src/components/alert/alert-interface.ts
@@ -48,6 +48,7 @@ export interface AlertButton {
   role?: 'cancel' | 'destructive' | string;
   cssClass?: string | string[];
   id?: string;
+  htmlAttributes?: { [key: string]: any };
   // TODO(FW-2832): type
   handler?: (value: any) => AlertButtonOverlayHandler | Promise<AlertButtonOverlayHandler>;
 }

--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -666,6 +666,7 @@ export class Alert implements ComponentInterface, OverlayInterface {
       <div class={alertButtonGroupClass}>
         {buttons.map((button) => (
           <button
+            {...button.htmlAttributes}
             type="button"
             id={button.id}
             class={buttonClass(button)}

--- a/core/src/components/alert/test/a11y/alert.e2e.ts
+++ b/core/src/components/alert/test/a11y/alert.e2e.ts
@@ -60,5 +60,26 @@ configs({ directions: ['ltr'] }).forEach(({ config, title }) => {
     test('should allow for manually specifying aria attributes', async ({ page }) => {
       await testAria(page, 'customAria', 'Custom title', 'Custom description');
     });
+
+    test('should have aria-labelledby and aria-label added to the button when htmlAttributes is set', async ({ page }) => {
+      const didPresent = await page.spyOnEvent('ionAlertDidPresent');
+
+      const button = page.locator('#ariaLabelButton');
+      await button.click();
+
+      await didPresent.next();
+
+      const alertButton = page.locator('ion-alert .alert-button');
+
+      /**
+       * expect().toHaveAttribute() can't check for a null value, so grab and check
+       * the value manually instead.
+       */
+      const ariaLabelledBy = await alertButton.getAttribute('aria-labelledby');
+      expect(ariaLabelledBy).toBe('close-label');
+
+      const ariaLabel = await alertButton.getAttribute('aria-label');
+      expect(ariaLabel).toBe('close button');
+    });
   });
 });

--- a/core/src/components/alert/test/a11y/alert.e2e.ts
+++ b/core/src/components/alert/test/a11y/alert.e2e.ts
@@ -73,15 +73,8 @@ configs({ directions: ['ltr'] }).forEach(({ config, title }) => {
 
       const alertButton = page.locator('ion-alert .alert-button');
 
-      /**
-       * expect().toHaveAttribute() can't check for a null value, so grab and check
-       * the value manually instead.
-       */
-      const ariaLabelledBy = await alertButton.getAttribute('aria-labelledby');
-      expect(ariaLabelledBy).toBe('close-label');
-
-      const ariaLabel = await alertButton.getAttribute('aria-label');
-      expect(ariaLabel).toBe('close button');
+      await expect(alertButton).toHaveAttribute('aria-labelledby', 'close-label');
+      await expect(alertButton).toHaveAttribute('aria-label', 'close button');
     });
   });
 });

--- a/core/src/components/alert/test/a11y/alert.e2e.ts
+++ b/core/src/components/alert/test/a11y/alert.e2e.ts
@@ -61,7 +61,9 @@ configs({ directions: ['ltr'] }).forEach(({ config, title }) => {
       await testAria(page, 'customAria', 'Custom title', 'Custom description');
     });
 
-    test('should have aria-labelledby and aria-label added to the button when htmlAttributes is set', async ({ page }) => {
+    test('should have aria-labelledby and aria-label added to the button when htmlAttributes is set', async ({
+      page,
+    }) => {
       const didPresent = await page.spyOnEvent('ionAlertDidPresent');
 
       const button = page.locator('#ariaLabelButton');

--- a/core/src/components/alert/test/a11y/index.html
+++ b/core/src/components/alert/test/a11y/index.html
@@ -24,6 +24,7 @@
       <ion-button id="noHeaders" expand="block" onclick="presentNoHeaders()">No Headers</ion-button>
       <ion-button id="noMessage" expand="block" onclick="presentNoMessage()">No Message</ion-button>
       <ion-button id="customAria" expand="block" onclick="presentCustomAria()">Custom Aria</ion-button>
+      <ion-button id="ariaLabelButton" expand="block" onclick="presentAriaLabelButton()">Aria Label Button</ion-button>
     </main>
 
     <script>
@@ -74,6 +75,21 @@
             'aria-labelledby': 'Custom title',
             'aria-describedby': 'Custom description',
           },
+        });
+      }
+
+      function presentAriaLabelButton() {
+        openAlert({
+          header: 'Header',
+          subHeader: 'Subtitle',
+          message: 'This is an alert message with custom aria attributes passed to the button.',
+          buttons: [{
+            text: 'Close',
+            htmlAttributes: {
+              ariaLabel: 'close button',
+              'aria-labelledby': 'close-label',
+            }
+          }],
         });
       }
     </script>

--- a/core/src/components/alert/test/a11y/index.html
+++ b/core/src/components/alert/test/a11y/index.html
@@ -83,13 +83,15 @@
           header: 'Header',
           subHeader: 'Subtitle',
           message: 'This is an alert message with custom aria attributes passed to the button.',
-          buttons: [{
-            text: 'Close',
-            htmlAttributes: {
-              ariaLabel: 'close button',
-              'aria-labelledby': 'close-label',
-            }
-          }],
+          buttons: [
+            {
+              text: 'Close',
+              htmlAttributes: {
+                ariaLabel: 'close button',
+                'aria-labelledby': 'close-label',
+              },
+            },
+          ],
         });
       }
     </script>

--- a/core/src/components/alert/test/a11y/index.html
+++ b/core/src/components/alert/test/a11y/index.html
@@ -87,7 +87,7 @@
             {
               text: 'Close',
               htmlAttributes: {
-                ariaLabel: 'close button',
+                'aria-label': 'close button',
                 'aria-labelledby': 'close-label',
               },
             },


### PR DESCRIPTION
Issue number: N/A

---------

## What is the current behavior?
Buttons containing only icons are not accessible as there is no way to pass an `aria-label` attribute (or any other html attribute). 

## What is the new behavior?
- Adds the `htmlAttributes` property on the `AlertButton` interface 
- Passes the `htmlAttributes` to the buttons
- Adds a test to verify `aria-label` and `aria-labelled-by` are passed to the button

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
