### PR TITLE
chore: add infrastructure for standalone

### DIFF
--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -52,3 +52,23 @@ $ npx schematics @ionic/angular:ng-add
 
 
 You'll now be able to add ionic components to a vanilla Angular app setup.
+
+## Project Structure
+
+**common**
+
+This is where logic that is shared between lazy loaded and standalone components live. For example, the lazy loaded IonPopover and standalone IonPopover components extend from a base IonPopover implementation that exists in this directory.
+
+**Note:** This directory exposes internal APIs and is only accessed in the `standalone` and `src` submodules. Ionic developers should never import directly from `@ionic/angular/common`. Instead, they should import from `@ionic/angular` or `@ionic/angular/standalone`.
+
+**standalone**
+
+This is where the standalone component implementations live. It was added as a separate entry point to avoid any lazy loaded logic from accidentally being pulled in to the final build. Having a separate directory allows the lazy loaded implementation to remain accessible from `@ionic/angular` for backwards compatibility.
+
+Ionic developers can access this by importing from `@ionic/angular/standalone`.
+
+**src**
+
+This is where the lazy loaded component implementations live.
+
+Ionic developers can access this by importing from `@ionic/angular`.

--- a/packages/angular/common/ng-package.json
+++ b/packages/angular/common/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  },
+}

--- a/packages/angular/common/src/index.ts
+++ b/packages/angular/common/src/index.ts
@@ -1,0 +1,3 @@
+// This is required to get ng-packagr to build.
+// Remove this when you actually have something to export
+export const placeholder = true;

--- a/packages/angular/standalone/ng-package.json
+++ b/packages/angular/standalone/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  },
+}

--- a/packages/angular/standalone/src/index.ts
+++ b/packages/angular/standalone/src/index.ts
@@ -1,0 +1,3 @@
+// This is required to get ng-packagr to build.
+// Remove this when you actually have something to export
+export const placeholder = true;


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

We do not have a way of separating lazy loaded components from standalone components. This is important because developers who wish to use Ionic UI components as standalone components do not want their component implementation to use the lazy loaded component.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR creates two submodules within `@ionic/angular`:

`@ionic/angular/common` located at `packages/angular/common`:

- This is where logic that is shared between lazy loaded and standalone components live. For example, if you want to have a lazy loaded IonPopover and standalone IonPopover, you could put the base component implementation here and then have the lazy loaded/standalone implementations extend from this base implementation.

`@ionic/angular/standalone` located at `packages/angular/standalone`:

- This is where the standalone component implementations live. It was added as a separate entry point to avoid any lazy loaded logic from accidentally being pulled in to the final build.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
