### PR TITLE
fix(react, vue): custom animations are used when going back

### DIFF
--- a/packages/react-router/src/ReactRouter/IonRouter.tsx
+++ b/packages/react-router/src/ReactRouter/IonRouter.tsx
@@ -270,13 +270,13 @@ class IonRouterInner extends React.PureComponent<IonRouteProps, IonRouteState> {
           const goBack = history.goBack || history.back;
           goBack();
         } else {
-          this.handleNavigate(prevInfo.pathname + (prevInfo.search || ''), 'pop', 'back');
+          this.handleNavigate(prevInfo.pathname + (prevInfo.search || ''), 'pop', 'back', routeAnimation);
         }
       } else {
-        this.handleNavigate(defaultHref as string, 'pop', 'back');
+        this.handleNavigate(defaultHref as string, 'pop', 'back', routeAnimation);
       }
     } else {
-      this.handleNavigate(defaultHref as string, 'pop', 'back');
+      this.handleNavigate(defaultHref as string, 'pop', 'back', routeAnimation);
     }
   }
 

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -186,10 +186,10 @@ export const createIonRouter = (
           router.go(prevInfo.position - routeInfo.position);
         }
       } else {
-        handleNavigate(defaultHref, "pop", "back");
+        handleNavigate(defaultHref, "pop", "back", routerAnimation);
       }
     } else {
-      handleNavigate(defaultHref, "pop", "back");
+      handleNavigate(defaultHref, "pop", "back", routerAnimation);
     }
   };
 


### PR DESCRIPTION
Issue number: resolves #27873

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Custom animations are not always used when the `handleNavigateBack` method is called. This impacts both Ionic React and Ionic Vue.

While we do set the `incomingRouteParams` with the animation: https://github.com/ionic-team/ionic-framework/blob/a08a5894baa862bab58cd19030682e6853dac1d6/packages/react-router/src/ReactRouter/IonRouter.tsx#L247-L252

We do sometimes call `handleNavigate`: https://github.com/ionic-team/ionic-framework/blob/a08a5894baa862bab58cd19030682e6853dac1d6/packages/react-router/src/ReactRouter/IonRouter.tsx#L273-L279

This `handleNavigate` method sets `incomingRouteParams` again: https://github.com/ionic-team/ionic-framework/blob/a08a5894baa862bab58cd19030682e6853dac1d6/packages/react-router/src/ReactRouter/IonRouter.tsx#L225-L230

Since we do not re-pass `routeAnimation`, that field gets set to `undefined` and the custom animation does not get used.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Custom animation is now passed to `handleNavigate`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `7.2.2-dev.11690810887.180000d1`