### PR TITLE
fix(item-sliding): account for options added before watcher

### DIFF
--- a/core/src/components/item-sliding/item-sliding.tsx
+++ b/core/src/components/item-sliding/item-sliding.tsx
@@ -244,7 +244,6 @@ export class ItemSliding implements ComponentInterface {
   }
 
   private async updateOptions() {
-    console.log('update');
     const options = this.el.querySelectorAll('ion-item-options');
 
     let sides = 0;

--- a/core/src/components/item-sliding/item-sliding.tsx
+++ b/core/src/components/item-sliding/item-sliding.tsx
@@ -76,11 +76,18 @@ export class ItemSliding implements ComponentInterface {
     this.item = el.querySelector('ion-item');
     this.contentEl = findClosestIonContent(el);
 
-    await this.updateOptions();
-
+    /**
+     * The MutationObserver needs to be added before we
+     * call updateOptions below otherwise we may miss
+     * ion-item-option elements that are added to the DOM
+     * while updateOptions is running and before the MutationObserver
+     * has been initialized.
+     */
     this.mutationObserver = watchForOptions<HTMLIonItemOptionElement>(el, 'ion-item-option', async () => {
       await this.updateOptions();
     });
+
+    await this.updateOptions();
 
     this.gesture = (await import('../../utils/gesture')).createGesture({
       el,
@@ -237,6 +244,7 @@ export class ItemSliding implements ComponentInterface {
   }
 
   private async updateOptions() {
+    console.log('update');
     const options = this.el.querySelectorAll('ion-item-options');
 
     let sides = 0;


### PR DESCRIPTION
Issue number: resolves #27910

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

There is an edge case in our `ion-item-sliding` code where options can be added after the `querySelectorAll` has been run in `updateOptions` but before `watchForOptions` has been called which causes us to miss the newly created options. These options can never be shown as a result.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `watchForOptions` is called before the initial `updateOptions` call so that we can re-run `updateOptions` in the event that options are added while that first call is running.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `7.2.2-dev.11690983626.19a2a8cb`