### PR TITLE
feat(toast): add part for button cancel

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -1419,6 +1419,7 @@ ion-toast,css-prop,--start
 ion-toast,css-prop,--white-space
 ion-toast,css-prop,--width
 ion-toast,part,button
+ion-toast,part,button-cancel
 ion-toast,part,container
 ion-toast,part,header
 ion-toast,part,icon

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -30,6 +30,7 @@ import type { ToastAttributes, ToastPosition, ToastLayout } from './toast-interf
  * @virtualProp {"ios" | "md"} mode - The mode determines which platform styles to use.
  *
  * @part button - Any button element that is displayed inside of the toast.
+ * @part button-cancel - Any button element with role "cancel" that is displayed inside of the toast.
  * @part container - The element that wraps all child elements.
  * @part header - The header text of the toast.
  * @part message - The body text of the toast.
@@ -283,7 +284,13 @@ export class Toast implements ComponentInterface, OverlayInterface {
     return (
       <div class={buttonGroupsClasses}>
         {buttons.map((b) => (
-          <button type="button" class={buttonClass(b)} tabIndex={0} onClick={() => this.buttonClick(b)} part="button">
+          <button
+            type="button"
+            class={buttonClass(b)}
+            tabIndex={0}
+            onClick={() => this.buttonClick(b)}
+            part={buttonPart(b)}
+          >
             <div class="toast-button-inner">
               {b.icon && (
                 <ion-icon
@@ -394,6 +401,10 @@ const buttonClass = (button: ToastButton): CssClassMap => {
     'ion-activatable': true,
     ...getClassMap(button.cssClass),
   };
+};
+
+const buttonPart = (button: ToastButton): string => {
+  return isCancel(button.role) ? 'button-cancel' : 'button';
 };
 
 type ToastPresentOptions = ToastPosition;


### PR DESCRIPTION
Issue number: [#27920](https://github.com/ionic-team/ionic-framework/issues/27920)

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
It is not possible to style the buttons with the cancel role in a toast since it uses shadow DOM and there are no exposed parts or CSS variables for the cancel buttons.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Exposes the following part of a toast: button with rol cancel
- Update the e2e toast test to check if the button-cancel part is exposed

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
Change the css shadow part for all buttons added to a toast with the cancel role from 'button' to 'button-cancel'.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
