### PR TITLE
fix(ion-tab-button): update event type interface

### DIFF
--- a/packages/react/src/components/navigation/IonTabButton.tsx
+++ b/packages/react/src/components/navigation/IonTabButton.tsx
@@ -9,7 +9,7 @@ type Props = LocalJSX.IonTabButton &
   IonicReactProps & {
     routerOptions?: RouterOptions;
     ref?: React.Ref<HTMLIonTabButtonElement>;
-    onClick?: (e: Event) => void;
+    onClick?: (e: CustomEvent) => void;
   };
 
 export const IonTabButton = /*@__PURE__*/ (() =>


### PR DESCRIPTION
closes #27949

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

- Typescript is complaining about the `onClick` event type of the `IonTabButton`

```ts
const App: React.FC = () => {
  async function handleTabClick(e: CustomEvent<HTMLIonTabButtonElement>) {
    alert(e.detail.tab);
  }

  return (
    <IonTabButton tab="myTab" onClick={handleTabClick}>
  );
};
```

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Typescript does not complain anymore

## Does this introduce a breaking change?

- [] Yes
- [] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->




## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
