### PR TITLE
test(playwright): enable github reporter, test retries

### DIFF
--- a/core/playwright.config.ts
+++ b/core/playwright.config.ts
@@ -69,7 +69,10 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [
+    ['html'],
+    ['github']
+  ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/core/playwright.config.ts
+++ b/core/playwright.config.ts
@@ -64,8 +64,7 @@ const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   /* Fail fast on CI */
   maxFailures: process.env.CI ? 1 : 0,
-  /* Flaky test should be either addressed or disabled until we can address them */
-  retries: 0,
+  retries: 2,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/core/playwright.config.ts
+++ b/core/playwright.config.ts
@@ -63,7 +63,7 @@ const config: PlaywrightTestConfig = {
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Fail fast on CI */
-  maxFailures: process.env.CI ? 1 : 0,
+  maxFailures: 0,
   retries: 2,
   reportSlowTests: null,
   /* Opt out of parallel tests on CI. */

--- a/core/playwright.config.ts
+++ b/core/playwright.config.ts
@@ -65,6 +65,7 @@ const config: PlaywrightTestConfig = {
   /* Fail fast on CI */
   maxFailures: process.env.CI ? 1 : 0,
   retries: 2,
+  reportSlowTests: null,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/core/src/components/button/test/basic/button.e2e.ts
+++ b/core/src/components/button/test/basic/button.e2e.ts
@@ -3,14 +3,13 @@ import { configs, test } from '@utils/test/playwright';
 
 configs().forEach(({ config, screenshot, title }) => {
   test.describe(title('button: basic'), () => {
-
     test('example flaky test', async () => {
       if (Math.random() > 0.7) {
         expect(false).toBe(true);
       } else {
         expect(true).toBe(true);
       }
-    })
+    });
     test('should not have visual regressions', async ({ page }) => {
       await page.goto(`/src/components/button/test/basic`, config);
 

--- a/core/src/components/button/test/basic/button.e2e.ts
+++ b/core/src/components/button/test/basic/button.e2e.ts
@@ -3,14 +3,6 @@ import { configs, test } from '@utils/test/playwright';
 
 configs().forEach(({ config, screenshot, title }) => {
   test.describe(title('button: basic'), () => {
-    test('example flaky test', async ({ page }, testInfo) => {
-      console.log(page);
-      if (testInfo.retry === 0) {
-        expect(false).toBe(true);
-      } else {
-        expect(true).toBe(true);
-      }
-    });
     test('should not have visual regressions', async ({ page }) => {
       await page.goto(`/src/components/button/test/basic`, config);
 

--- a/core/src/components/button/test/basic/button.e2e.ts
+++ b/core/src/components/button/test/basic/button.e2e.ts
@@ -3,7 +3,8 @@ import { configs, test } from '@utils/test/playwright';
 
 configs().forEach(({ config, screenshot, title }) => {
   test.describe(title('button: basic'), () => {
-    test('example flaky test', async ({}, testInfo) => {
+    test('example flaky test', async ({ page }, testInfo) => {
+      console.log(page);
       if (testInfo.retry === 0) {
         expect(false).toBe(true);
       } else {

--- a/core/src/components/button/test/basic/button.e2e.ts
+++ b/core/src/components/button/test/basic/button.e2e.ts
@@ -3,6 +3,14 @@ import { configs, test } from '@utils/test/playwright';
 
 configs().forEach(({ config, screenshot, title }) => {
   test.describe(title('button: basic'), () => {
+
+    test('example flaky test', async ({ page }) => {
+      if (Math.random() > 0.5) {
+        expect(false).toBe(true);
+      } else {
+        expect(true).toBe(true);
+      }
+    })
     test('should not have visual regressions', async ({ page }) => {
       await page.goto(`/src/components/button/test/basic`, config);
 

--- a/core/src/components/button/test/basic/button.e2e.ts
+++ b/core/src/components/button/test/basic/button.e2e.ts
@@ -4,7 +4,7 @@ import { configs, test } from '@utils/test/playwright';
 configs().forEach(({ config, screenshot, title }) => {
   test.describe(title('button: basic'), () => {
     test('example flaky test', async () => {
-      if (Math.random() > 0.7) {
+      if (Math.random() > 0.3) {
         expect(false).toBe(true);
       } else {
         expect(true).toBe(true);

--- a/core/src/components/button/test/basic/button.e2e.ts
+++ b/core/src/components/button/test/basic/button.e2e.ts
@@ -4,7 +4,7 @@ import { configs, test } from '@utils/test/playwright';
 configs().forEach(({ config, screenshot, title }) => {
   test.describe(title('button: basic'), () => {
 
-    test('example flaky test', async ({ page }) => {
+    test('example flaky test', async () => {
       if (Math.random() > 0.7) {
         expect(false).toBe(true);
       } else {

--- a/core/src/components/button/test/basic/button.e2e.ts
+++ b/core/src/components/button/test/basic/button.e2e.ts
@@ -3,8 +3,8 @@ import { configs, test } from '@utils/test/playwright';
 
 configs().forEach(({ config, screenshot, title }) => {
   test.describe(title('button: basic'), () => {
-    test('example flaky test', async () => {
-      if (Math.random() > 0.3) {
+    test('example flaky test', async ({}, testInfo) => {
+      if (testInfo.retry === 0) {
         expect(false).toBe(true);
       } else {
         expect(true).toBe(true);

--- a/core/src/components/button/test/basic/button.e2e.ts
+++ b/core/src/components/button/test/basic/button.e2e.ts
@@ -5,7 +5,7 @@ configs().forEach(({ config, screenshot, title }) => {
   test.describe(title('button: basic'), () => {
 
     test('example flaky test', async ({ page }) => {
-      if (Math.random() > 0.5) {
+      if (Math.random() > 0.7) {
         expect(false).toBe(true);
       } else {
         expect(true).toBe(true);


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The team would like to explore solutions for being informed of flaky tests in a way that is not disruptive to our workflow. Currently, flaky tests fail immediately which means we have to re-run them every time. We'd like flaky tests to be automatically retried but also reported to us so we can address them in a separate PR.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Enables the Playwright GitHub reporter. This will report about flaky tests on the PR if applicable as well as in the CI results.
- Enables test retries. Tests will be retried up to 2 times before failing.
- Disables reporting slow tests in the GitHub reporter. Some of our tests require gesture interaction which are inherently slow but otherwise working as intended. We don't necessarily need to know about these right now.
- Disables "maxFailures". Tests that can fail at most once are never detected as flaky since they are never retried. As a result, we need to disable this in order to have flaky tests be reported to us.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
