### PR TITLE
fix(tap-click): do not error in document-less environment

### DIFF
--- a/core/src/utils/tap-click/index.ts
+++ b/core/src/utils/tap-click/index.ts
@@ -1,7 +1,13 @@
+import { doc } from '@utils/browser';
+
 import type { Config } from '../../interface';
 import { now, pointerCoord } from '../helpers';
 
 export const startTapClick = (config: Config) => {
+  if (doc === undefined) {
+    return;
+  }
+
   let lastTouch = -MOUSE_WAIT * 10;
   let lastActivated = 0;
 
@@ -143,7 +149,6 @@ export const startTapClick = (config: Config) => {
     }
   };
 
-  const doc = document;
   doc.addEventListener('ionGestureCaptured', cancelActive);
 
   doc.addEventListener('touchstart', onTouchStart, true);


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

While working on getting our starter app tests running on CI, I ran into the following error:

```
⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
ReferenceError: document is not defined
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
 ❯ Module.startTapClick node_modules/@ionic/core/components/index9.js:133:15
    131|   };
    132|   const doc = document;
    133|   doc.addEventListener('ionGestureCaptured', cancelActive);
       |               ^
    134|   doc.addEventListener('touchstart', onTouchStart, true);
    135|   doc.addEventListener('touchcancel', onTouchEnd, true);
 ❯ node_modules/@ionic/core/components/ion-app.js:21:113

This error originated in "src/App.test.tsx" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
This error was caught after test environment was torn down. Make sure to cancel any running tasks before test finishes:
```

We are referencing `document` without any "document defined" checks.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Tap Click is only enabled if the `document` is available since we set event listeners on the document.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
