### PR TITLE
chore: typescript resolves @ionic/angular/common import paths

### DIFF
--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -35,8 +35,11 @@
       {
         "name": "typescript-eslint-language-service"
       }
-    ]
+    ],
+    "paths": {
+      "@ionic/angular/common": ["common/src/index.ts"]
+    }
   },
   "exclude": ["node_modules", "src/schematics"],
-  "files": ["src/index.ts"]
+  "files": ["src/index.ts", "common/src/index.ts"]
 }


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

IDEs that perform type checking/include a language service will error on the `@ionic/angular/common` import paths and not provide intelisense or auto import detection.

![CleanShot 2023-08-15 at 09 49 34](https://github.com/ionic-team/ionic-framework/assets/13732623/2e9913b2-5b44-4dd7-8cf7-8fa0d6aaac69)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `@ionic/angular/common` import paths are detected by IDEs such as VSCode

![CleanShot 2023-08-15 at 09 48 40](https://github.com/ionic-team/ionic-framework/assets/13732623/cd502093-b095-47a8-b5f7-b28a0fc9fe27)


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
