### PR TITLE
fix(scroll-assist): run when keyboard dimension changes

### DIFF
--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -11,7 +11,6 @@ import { setScrollPadding, setClearScrollPaddingListener } from './scroll-paddin
 let currentPadding = 0;
 
 const SKIP_SCROLL_ASSIST = 'data-ionic-skip-scroll-assist';
-
 export const enableScrollAssist = (
   componentEl: HTMLElement,
   inputEl: HTMLInputElement | HTMLTextAreaElement,
@@ -35,6 +34,81 @@ export const enableScrollAssist = (
     enableScrollPadding && (keyboardResize === undefined || keyboardResize.mode === KeyboardResize.None);
 
   /**
+   * This tracks whether or not the keyboard has been
+   * presented for a single focused text field. Note
+   * that it does not track if the keyboard is open
+   * in general such as if the keyboard is open for
+   * a different focused text field.
+   */
+  let hasKeyboardBeenPresentedForTextField = false;
+
+  /**
+   * Scroll assist is run when a text field
+   * is focused. However, it may need to
+   * re-run when the keyboard size changes
+   * such that the text field is now hidden
+   * underneath the keyboard.
+   * This function re-runs scroll assist
+   * when that happens.
+   *
+   * One limitation of this is on a web browser
+   * where native keyboard APIs do not have cross-browser
+   * support. `ionKeyboardDidShow` relies on the Visual Viewport API.
+   * This means that if the keyboard changes but does not change
+   * geometry, then scroll assist will not re-run even if
+   * the user has scrolled the text field under the keyboard.
+   * This should not be a problem when running in Cordova/Capacitor
+   * because `ionKeyboardDidShow` uses the native events
+   * which fire every time the keyboard changes.
+   */
+  const keyboardShow = (ev: any) => {
+    /**
+     * If the keyboard has not yet been presented
+     * for this text field then the text field has just
+     * received focus. In that case, the focusin listener
+     * will run scroll assist.
+     */
+    if (hasKeyboardBeenPresentedForTextField === false) {
+      hasKeyboardBeenPresentedForTextField = true;
+      return;
+    }
+
+    /**
+     * Otherwise, the keyboard has already been presented
+     * for the focused text field.
+     * This means that the keyboard likely changed
+     * geometry, and we need to re-run scroll assist.
+     * This can happen when the user rotates their device
+     * or when they switch keyboards.
+     *
+     * Make sure we pass in the computed keyboard height
+     * rather than the estimated keyboard height.
+     *
+     * Since the keyboard is already open then we do not
+     * need to wait for the webview to resize, so we pass
+     * "waitForResize: false".
+     */
+    jsSetFocus(
+      componentEl,
+      inputEl,
+      contentEl,
+      footerEl,
+      ev.detail.keyboardHeight,
+      addScrollPadding,
+      disableClonedInput,
+      false
+    );
+  };
+
+  /**
+   * Reset the internal state when the text field loses focus.
+   */
+  const focusOut = () => {
+    hasKeyboardBeenPresentedForTextField = false;
+    window.removeEventListener('ionKeyboardDidShow', keyboardShow);
+  };
+
+  /**
    * When the input is about to receive
    * focus, we need to move it to prevent
    * mobile Safari from adjusting the viewport.
@@ -51,11 +125,25 @@ export const enableScrollAssist = (
       return;
     }
     jsSetFocus(componentEl, inputEl, contentEl, footerEl, keyboardHeight, addScrollPadding, disableClonedInput);
+
+    /**
+     * Listen for any changes to the keyboard
+     * dimensions in case we need to re-run scroll assist.
+     */
+    window.addEventListener('ionKeyboardDidShow', keyboardShow);
+    componentEl.addEventListener('focusout', focusOut, true);
   };
+
   componentEl.addEventListener('focusin', focusIn, true);
 
+  /**
+   * Scroll assist is being destroyed for this
+   * text field instance, so remove any remaining listeners.
+   */
   return () => {
     componentEl.removeEventListener('focusin', focusIn, true);
+    window.removeEventListener('ionKeyboardDidShow', keyboardShow);
+    componentEl.removeEventListener('focusout', focusOut, true);
   };
 };
 
@@ -84,7 +172,8 @@ const jsSetFocus = async (
   footerEl: HTMLIonFooterElement | null,
   keyboardHeight: number,
   enableScrollPadding: boolean,
-  disableClonedInput = false
+  disableClonedInput = false,
+  waitForResize = true
 ) => {
   if (!contentEl && !footerEl) {
     return;
@@ -191,7 +280,7 @@ const jsSetFocus = async (
        * bandwidth to become available.
        */
       const totalScrollAmount = scrollEl.scrollHeight - scrollEl.clientHeight;
-      if (scrollData.scrollAmount > totalScrollAmount - scrollEl.scrollTop) {
+      if (waitForResize && scrollData.scrollAmount > totalScrollAmount - scrollEl.scrollTop) {
         /**
          * On iOS devices, the system will show a "Passwords" bar above the keyboard
          * after the initial keyboard is shown. This prevents the webview from resizing


### PR DESCRIPTION
TODO: On cap apps the scroll adjustment is too large when changing keyboards

Issue number: #

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `7.3.1-dev.11692293668.19f31f09`