### PR TITLE
docs(picker): describe how to set the initial value of a picker column

### DIFF
--- a/core/src/components/picker/picker-interface.ts
+++ b/core/src/components/picker/picker-interface.ts
@@ -28,7 +28,7 @@ export interface PickerColumn {
   name: string;
   align?: string;
   /**
-   * Changing this value allows the initial value of a picker column to be set
+   * Changing this value allows the initial value of a picker column to be set.
    */
   selectedIndex?: number;
   prevSelected?: number;

--- a/core/src/components/picker/picker-interface.ts
+++ b/core/src/components/picker/picker-interface.ts
@@ -27,6 +27,9 @@ export interface PickerButton {
 export interface PickerColumn {
   name: string;
   align?: string;
+  /**
+   * Changing this value allows the initial value of a picker column to be set
+   */
   selectedIndex?: number;
   prevSelected?: number;
   prefix?: string;


### PR DESCRIPTION
## What is the current behavior?
There is no description of how to set the value of a picker.

## What is the new behavior?
Readers can find this description in the documentation.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No



