### PR TITLE
chore(infra): clean build check will log recommended steps

### DIFF
--- a/.github/workflows/actions/test-core-clean-build/action.yml
+++ b/.github/workflows/actions/test-core-clean-build/action.yml
@@ -15,9 +15,12 @@ runs:
     - name: Check Diff
       run: |
         git diff --exit-code || {
-          echo -e "\033[1;31mWarning: There is a diff between the build output from main and your branch.\033[0m"
-          echo -e "\033[1;31mConfirm that you have run npm run build locally and pushed all expected changes to your branch.\033[0m"
-          echo -e "\033[1;31mGit Diff Output:\033[0m"
+          echo -e "\033[1;31m⚠️ Error: Differences Detected ⚠️\033[0m"
+          echo -e "\033[1;31mThere are uncommitted changes between the build outputs from CI and your branch.\033[0m"
+          echo -e "\033[1;31mPlease ensure you have followed these steps:\033[0m"
+          echo -e "\033[1;31m1. Run 'npm run build' locally to generate the latest build output.\033[0m"
+          echo -e "\033[1;31m2. Commit and push all necessary changes to your branch.\033[0m"
+          echo -e "\033[1;31m3. Compare and validate the differences before proceeding.\033[0m"
           exit 1
         }
       shell: bash

--- a/.github/workflows/actions/test-core-clean-build/action.yml
+++ b/.github/workflows/actions/test-core-clean-build/action.yml
@@ -15,9 +15,9 @@ runs:
     - name: Check Diff
       run: |
         git diff --exit-code || {
-          echo "There is a diff between the build output from main and your branch."
-          echo "Confirm that you have run "npm run build" locally and pushed all expected changes to your branch."
-          git diff
+          echo -e "\033[1;31mWarning: There is a diff between the build output from main and your branch.\033[0m"
+          echo -e "\033[1;31mConfirm that you have run npm run build locally and pushed all expected changes to your branch.\033[0m"
+          echo -e "\033[1;31mGit Diff Output:\033[0m"
           exit 1
         }
       shell: bash

--- a/.github/workflows/actions/test-core-clean-build/action.yml
+++ b/.github/workflows/actions/test-core-clean-build/action.yml
@@ -13,6 +13,12 @@ runs:
         path: ./core
         filename: CoreBuild.zip
     - name: Check Diff
-      run: git diff --exit-code
+      run: |
+        git diff --exit-code || {
+          echo "There is a diff between the build output from main and your branch."
+          echo "Confirm that you have run "npm run build" locally and pushed all expected changes to your branch."
+          git diff
+          exit 1
+        }
       shell: bash
       working-directory: ./core

--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -143,8 +143,6 @@ export class Button implements ComponentInterface, AnchorInterface, ButtonInterf
    */
   @Prop() form?: string | HTMLFormElement;
 
-  @Prop() invalid = false; // testing prop for build output diff
-
   /**
    * Emitted when the button has focus.
    */

--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -143,6 +143,8 @@ export class Button implements ComponentInterface, AnchorInterface, ButtonInterf
    */
   @Prop() form?: string | HTMLFormElement;
 
+  @Prop() invalid = false; // testing prop for build output diff
+
   /**
    * Emitted when the button has focus.
    */


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When the CI process detects a diff between the output in CI after running `npm run build` versus the checked out branch, it will log the diff and exit. It isn't very clear to developers what they need to do or why this job step exists.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Logs a prettier error message to the developer to let them know the steps they can take when a diff is detected in CI

![CleanShot 2023-08-22 at 15 05 03](https://github.com/ionic-team/ionic-framework/assets/13732623/0397523e-5f4d-4ab6-8a2e-d9ecc4d085ba)

Example run: https://github.com/ionic-team/ionic-framework/actions/runs/5942940488/job/16117074372?pr=28044

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
