### PR TITLE
fix(overlays): prevent overlays from getting stuck open

### DIFF
--- a/core/src/components/action-sheet/action-sheet.tsx
+++ b/core/src/components/action-sheet/action-sheet.tsx
@@ -230,6 +230,18 @@ export class ActionSheet implements ComponentInterface, OverlayInterface {
    */
   @Method()
   async dismiss(data?: any, role?: string): Promise<boolean> {
+    /**
+     * When using an inline action sheet
+     * and presenting an action sheet it is possible to
+     * quickly dismiss the action sheet while it is
+     * presenting. We need to await any current
+     * transition to allow the present to finish
+     * before dismissing again.
+     */
+    if (this.currentTransition !== undefined) {
+      await this.currentTransition;
+    }
+
     this.currentTransition = dismiss(this, data, role, 'actionSheetLeave', iosLeaveAnimation, mdLeaveAnimation);
     const dismissed = await this.currentTransition;
 

--- a/core/src/components/action-sheet/test/is-open/index.html
+++ b/core/src/components/action-sheet/test/is-open/index.html
@@ -14,7 +14,7 @@
     <style>
       .grid {
         display: grid;
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(3, 1fr);
         grid-row-gap: 20px;
         grid-column-gap: 20px;
       }
@@ -52,6 +52,10 @@
           <div class="grid-item">
             <h2>Open, then close after 500ms</h2>
             <ion-button id="timeout" onclick="openActionSheet(500)">Open ActionSheet</ion-button>
+          </div>
+          <div class="grid-item">
+            <h2>Open, then close after 50ms</h2>
+            <ion-button id="immediate" onclick="openActionSheet(50)">Open ActionSheet</ion-button>
           </div>
         </div>
 

--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -403,6 +403,18 @@ export class Alert implements ComponentInterface, OverlayInterface {
    */
   @Method()
   async dismiss(data?: any, role?: string): Promise<boolean> {
+    /**
+     * When using an inline alert
+     * and presenting an alert it is possible to
+     * quickly dismiss the alert while it is
+     * presenting. We need to await any current
+     * transition to allow the present to finish
+     * before dismissing again.
+     */
+    if (this.currentTransition !== undefined) {
+      await this.currentTransition;
+    }
+
     this.currentTransition = dismiss(this, data, role, 'alertLeave', iosLeaveAnimation, mdLeaveAnimation);
     const dismissed = await this.currentTransition;
 

--- a/core/src/components/alert/test/is-open/index.html
+++ b/core/src/components/alert/test/is-open/index.html
@@ -24,6 +24,7 @@
       <ion-content class="ion-padding">
         <ion-button id="default" onclick="openAlert()">Open Alert</ion-button>
         <ion-button id="timeout" onclick="openAlert(500)">Open Alert, Close After 500ms</ion-button>
+        <ion-button id="immediate" onclick="openAlert(50)">Open Alert, Close After 50ms</ion-button>
 
         <ion-alert header="Alert" message="Hello World!"></ion-alert>
       </ion-content>

--- a/core/src/components/loading/loading.tsx
+++ b/core/src/components/loading/loading.tsx
@@ -271,6 +271,18 @@ export class Loading implements ComponentInterface, OverlayInterface {
    */
   @Method()
   async dismiss(data?: any, role?: string): Promise<boolean> {
+    /**
+     * When using an inline loading indicator
+     * and presenting a loading indicator it is possible to
+     * quickly dismiss the loading indicator while it is
+     * presenting. We need to await any current
+     * transition to allow the present to finish
+     * before dismissing again.
+     */
+    if (this.currentTransition !== undefined) {
+      await this.currentTransition;
+    }
+
     if (this.durationTimeout) {
       clearTimeout(this.durationTimeout);
     }

--- a/core/src/components/loading/test/is-open/index.html
+++ b/core/src/components/loading/test/is-open/index.html
@@ -14,7 +14,7 @@
     <style>
       .grid {
         display: grid;
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(3, 1fr);
         grid-row-gap: 20px;
         grid-column-gap: 20px;
       }
@@ -53,6 +53,10 @@
             <h2>Open, then close after 500ms</h2>
             <ion-button id="timeout" onclick="openLoading(500)">Open Loading</ion-button>
           </div>
+          <div class="grid-item">
+            <h2>Open, then close after 50ms</h2>
+            <ion-button id="immediate" onclick="openLoadingWithFastTimeout()">Open Loading</ion-button>
+          </div>
         </div>
 
         <ion-loading message="Hello world"></ion-loading>
@@ -75,6 +79,14 @@
       loading.addEventListener('ionLoadingDidDismiss', () => {
         loading.isOpen = false;
       });
+
+      const openLoadingWithFastTimeout = (timeout) => {
+        loading.isOpen = true;
+
+        setTimeout(() => {
+          loading.isOpen = false;
+        }, 20);
+      };
     </script>
   </body>
 </html>

--- a/core/src/components/loading/test/is-open/index.html
+++ b/core/src/components/loading/test/is-open/index.html
@@ -85,7 +85,7 @@
 
         setTimeout(() => {
           loading.isOpen = false;
-        }, 20);
+        }, 50);
       };
     </script>
   </body>

--- a/core/src/components/modal/test/is-open/index.html
+++ b/core/src/components/modal/test/is-open/index.html
@@ -14,7 +14,7 @@
     <style>
       .grid {
         display: grid;
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(3, 1fr);
         grid-row-gap: 20px;
         grid-column-gap: 20px;
 
@@ -51,6 +51,10 @@
           <div class="grid-item">
             <h2>Open, then close after 500ms</h2>
             <ion-button id="timeout" onclick="openModal(500)">Open Modal</ion-button>
+          </div>
+          <div class="grid-item">
+            <h2>Open, then close after 50ms</h2>
+            <ion-button id="immediate" onclick="openModal(50)">Open Modal</ion-button>
           </div>
         </div>
 

--- a/core/src/components/picker/picker.tsx
+++ b/core/src/components/picker/picker.tsx
@@ -251,6 +251,18 @@ export class Picker implements ComponentInterface, OverlayInterface {
    */
   @Method()
   async dismiss(data?: any, role?: string): Promise<boolean> {
+    /**
+     * When using an inline picker
+     * and presenting a picker it is possible to
+     * quickly dismiss the picker while it is
+     * presenting. We need to await any current
+     * transition to allow the present to finish
+     * before dismissing again.
+     */
+    if (this.currentTransition !== undefined) {
+      await this.currentTransition;
+    }
+
     if (this.durationTimeout) {
       clearTimeout(this.durationTimeout);
     }

--- a/core/src/components/picker/test/is-open/index.html
+++ b/core/src/components/picker/test/is-open/index.html
@@ -24,6 +24,7 @@
       <ion-content class="ion-padding">
         <ion-button id="default" onclick="openPicker()">Open Picker</ion-button>
         <ion-button id="timeout" onclick="openPicker(500)">Open Picker, Close After 500ms</ion-button>
+        <ion-button id="immediate" onclick="openPicker(50)">Open Picker, Close After 50ms</ion-button>
 
         <ion-picker></ion-picker>
       </ion-content>

--- a/core/src/components/popover/test/is-open/index.html
+++ b/core/src/components/popover/test/is-open/index.html
@@ -14,7 +14,7 @@
     <style>
       .grid {
         display: grid;
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(3, 1fr);
         grid-row-gap: 20px;
         grid-column-gap: 20px;
 
@@ -51,6 +51,10 @@
           <div class="grid-item">
             <h2>Open, then close after 500ms</h2>
             <ion-button id="timeout" onclick="openPopover(event, 500)">Open Popover</ion-button>
+          </div>
+          <div class="grid-item">
+            <h2>Open, then close after 50ms</h2>
+            <ion-button id="immediate" onclick="openPopover(event, 50)">Open Popover</ion-button>
           </div>
         </div>
 

--- a/core/src/components/toast/test/is-open/index.html
+++ b/core/src/components/toast/test/is-open/index.html
@@ -24,6 +24,7 @@
       <ion-content class="ion-padding">
         <ion-button id="default" onclick="openToast()">Open Toast, 2s Duration</ion-button>
         <ion-button id="timeout" onclick="openToast(500)">Open Toast, Close Manually After 500ms</ion-button>
+        <ion-button id="immediate" onclick="openToast(50)">Open Toast, Close Manually After 50ms</ion-button>
 
         <ion-toast message="Hello World" duration="2000"></ion-toast>
       </ion-content>

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -318,6 +318,18 @@ export class Toast implements ComponentInterface, OverlayInterface {
    */
   @Method()
   async dismiss(data?: any, role?: string): Promise<boolean> {
+    /**
+     * When using an inline toast
+     * and presenting a toast it is possible to
+     * quickly dismiss the toast while it is
+     * presenting. We need to await any current
+     * transition to allow the present to finish
+     * before dismissing again.
+     */
+    if (this.currentTransition !== undefined) {
+      await this.currentTransition;
+    }
+
     if (this.durationTimeout) {
       clearTimeout(this.durationTimeout);
     }


### PR DESCRIPTION
Issue number: #27200 

---------

## Background info

Previous reading:
* https://github.com/ionic-team/ionic-framework/issues/27200
* https://ionic-cloud.atlassian.net/browse/FW-4374
* https://ionic-cloud.atlassian.net/browse/FW-4053

NOTE: This PR contains a different solution than recommended in the tickets. This draft PR is so we can decide if we're ok with this solution instead of the options proposed previously.

## The bug

A bug occurs when you click twice quickly to open an overlay with a small timeout. In some cases, the overlay will present, dismiss, present, then not dismiss the second time, getting stuck open. The bug occurs in action sheet, alert, loading, picker, and toast, but not in modal or popover. You can reproduce manually this by grabbing the test HTML included in this PR and putting it in a branch that doesn't include a fix.

## A potential solution

All the overlays had a check in `present()` for if it was dismissing while presenting. Two of the overlays - modal & popover - weren't experiencing the bug. Those two components also had a similar check in the `dismiss()` method (for if it was presenting while dismissing). The solution presented in this PR is to add this check in the `dismiss()` method of all overlays.

[Maria's notes](https://ionic-cloud.atlassian.net/browse/FW-4374?focusedCommentId=20881) said that we would need to leave this check in `present()` even if we implement another solution. Based on that logic, I think we would also need this check in `dismiss()` even if we did the more fancy lock controller or one of the other proposed solutions. If that assumption is true, I believe this is the simplest solution.

## Misc

Side note: I was unable to find a way to test this bug that consistently failed or was flaky (while the bug was present). I did make manual tests so you can reproduce that the bug is happening without the code changes and not happening after them. I'm not sure if we need to leave those test snippets in the HTML files. They will be useful for debugging for this PR, but not helpful in screenshots, etc. perhaps I should remove them before merging.

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
When an overlay has a short timeout, clicking twice to trigger opening it can result in it getting stuck open. This bug is present in all overlays except modal and popover.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When an overlay with a short timeout is triggered twice quickly, it will open-close-open-close.
- The behavior is the same for all overlay components

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
