### PR TITLE
chore: remove deprecated attribute selectors

### DIFF
--- a/core/src/components/label/label.ios.scss
+++ b/core/src/components/label/label.ios.scss
@@ -4,8 +4,7 @@
 // iOS Label
 // --------------------------------------------------
 
-:host(.ion-text-wrap),
-:host([text-wrap]) {
+:host(.ion-text-wrap) {
   font-size: $label-ios-text-wrap-font-size;
 
   line-height: $label-ios-text-wrap-line-height;

--- a/core/src/components/label/label.md.scss
+++ b/core/src/components/label/label.md.scss
@@ -4,8 +4,7 @@
 // Material Design Label
 // --------------------------------------------------
 
-:host(.ion-text-wrap),
-:host([text-wrap]) {
+:host(.ion-text-wrap) {
   line-height: $label-md-text-wrap-line-height;
 }
 

--- a/core/src/components/label/label.scss
+++ b/core/src/components/label/label.scss
@@ -29,8 +29,7 @@
   color: current-color(base);
 }
 
-:host(.ion-text-wrap),
-:host([text-wrap]) {
+:host(.ion-text-wrap) {
   white-space: normal;
 }
 


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The `text-wrap` attribute was removed in Ionic v5, but references to it still exist in the `ion-label` stylesheets.

https://github.com/ionic-team/ionic-framework/blob/main/BREAKING_ARCHIVE/v5.md#css-utilities

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed references to the unsupported `text-wrap` attributed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Note: This is not a breaking change because support for `text-wrap` was removed in Ionic v5.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->