### PR TITLE
chore(vue): add missing routerAnimation type

### DIFF
--- a/packages/vue-router/src/types.ts
+++ b/packages/vue-router/src/types.ts
@@ -73,6 +73,7 @@ export interface ViewItem {
   vueComponentRef: Ref;
   params?: { [k: string]: any };
   vueComponentData: VueComponentData;
+  routerAnimation?: AnimationBuilder;
 }
 
 export interface ViewStacks {


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The Vue Router implementation [assigns data to the `routerAnimation` on the view item](https://github.com/ionic-team/ionic-framework/blob/cddefd1548be1f43fd529483e3829d3f5719a753/packages/vue/src/components/IonRouterOutlet.ts#L165-L170), but the [type does not exist on the `ViewItem` interface](https://github.com/ionic-team/ionic-framework/blob/main/packages/vue-router/src/types.ts#L62-L76). The actual routing implementation does not make use of the type, but this is backfilling the information when we wire up the types to the implementation. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds the missing type for `routerAnimation` to the `ViewItem`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
