### PR TITLE
fix(nav-link): prevent navigation when clicking disabled button

### DIFF
--- a/core/src/components/nav-link/nav-link.tsx
+++ b/core/src/components/nav-link/nav-link.tsx
@@ -34,7 +34,14 @@ export class NavLink implements ComponentInterface {
   @Prop() routerAnimation?: AnimationBuilder;
 
   private onClick = () => {
-    return navLink(this.el, this.routerDirection, this.component, this.componentProps, this.routerAnimation);
+    const { el } = this;
+    const button = el.querySelector('button,ion-button,a');
+    if (button?.hasAttribute('disabled')) {
+      // Do not navigate if the button is disabled
+      return;
+    }
+
+    return navLink(el, this.routerDirection, this.component, this.componentProps, this.routerAnimation);
   };
 
   render() {

--- a/core/src/components/nav-link/nav-link.tsx
+++ b/core/src/components/nav-link/nav-link.tsx
@@ -35,8 +35,8 @@ export class NavLink implements ComponentInterface {
 
   private onClick = () => {
     const { el } = this;
-    const button = el.querySelector('button,ion-button,a');
-    if (button?.hasAttribute('disabled')) {
+    const button = el.querySelector<HTMLIonButtonElement>('ion-button');
+    if (button?.disabled) {
       // Do not navigate if the button is disabled
       return;
     }

--- a/core/src/components/nav-link/test/nav-link.spec.tsx
+++ b/core/src/components/nav-link/test/nav-link.spec.tsx
@@ -1,0 +1,32 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import { Button } from '../../button/button';
+import { Nav } from '../../nav/nav';
+import { NavLink } from '../nav-link';
+
+describe('NavLink', () => {
+  it('should not navigate when button is disabled', async () => {
+    const page = await newSpecPage({
+      components: [Nav, NavLink, Button],
+      template: () => (
+        <ion-nav>
+          <ion-nav-link component="div">
+            <ion-button disabled>Disabled</ion-button>
+          </ion-nav-link>
+        </ion-nav>
+      ),
+    });
+
+    const mock = jest.fn();
+
+    const nav = page.body.querySelector('ion-nav')!;
+    const ionButton = page.body.querySelector('ion-button')!;
+
+    nav.addEventListener('ionNavWillChange', mock);
+
+    await ionButton.click();
+
+    expect(mock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Issue number: Resolves #26541

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When a disabled `ion-button` is clicked within `ion-nav-link`, the navigation stack will navigate. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When a disabled`ion-button` is clicked within `ion-nav-link`, it will not navigate.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
