### PR TITLE
fix(icon): add export interface

### DIFF
--- a/packages/react/src/components/IonIcon.tsx
+++ b/packages/react/src/components/IonIcon.tsx
@@ -6,7 +6,7 @@ import type { IonicReactProps } from './IonicReactProps';
 import { IonIconInner } from './inner-proxies';
 import { createForwardRef, getConfig } from './utils';
 
-interface IonIconProps {
+export interface IonIconProps {
   color?: string;
   flipRtl?: boolean;
   icon?: string;


### PR DESCRIPTION
this type can be useful for passing all the icon props from the parent

Issue number: #28114

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
currently the IonIconProps type is not exported

## What is the new behavior?
- export IonIconProps

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->