### PR TITLE
chore: add error when no new diffs generated

### DIFF
--- a/.github/workflows/actions/update-reference-screenshots/action.yml
+++ b/.github/workflows/actions/update-reference-screenshots/action.yml
@@ -35,7 +35,16 @@ runs:
         git config user.name ionitron
         git config user.email hi@ionicframework.com
         git add src/\*.png --force
-        git commit -m "chore(): add updated snapshots"
-        git push
+
+        if git diff --exit-code; then
+          echo -e "\033[1;31m⚠️ Error: No new screenshots generated ⚠️\033[0m"
+          echo -e "\033[1;31mThis means that there were zero visual diffs when running screenshot tests.\033[0m"
+          echo -e "\033[1;31mMake sure you have pushed any code changes that would result in visual diffs.\033[0m"
+          exit 1
+        else
+          git commit -m "chore(): add updated snapshots"
+          git push
+        fi
+
       shell: bash
       working-directory: ./core


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When the "Update Reference Screenshot" job is run but no new screenshots are generated, the following error is logged:

```
nothing added to commit but untracked files present (use "git add" to track)
Error: Process completed with exit code 1.
```

This is happening because there are no files to commit when running `git commit`. Brandy noted that this was confusing since it doesn't actually tell you why there are no files to commit.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- If there are no diffs to commit then the update screenshot script will log a message saying that no screenshot diffs were generated.

Example:

```
⚠️ Error: No new screenshots generated ⚠️
This means that there were zero visual diffs when running screenshot tests.
Make sure you have pushed any code changes that would result in visual diffs.
```

https://github.com/ionic-team/ionic-framework/actions/runs/6099399582/job/16552017414

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
