### PR TITLE
refactor(item-options): remove unnecessary font-size styles

### DIFF
--- a/core/src/components/item-options/item-options.scss
+++ b/core/src/components/item-options/item-options.scss
@@ -33,8 +33,6 @@ ion-item-options {
 
   height: 100%;
 
-  font-size: dynamic-font(14px);
-
   user-select: none;
   z-index: $z-index-item-options;
 }


### PR DESCRIPTION
Issue number: N/A

---------

## What is the current behavior?
Item options defines a font-size that is unnecessary because `ion-item-option` also defines it. 

## What is the new behavior?
Remove the font-size from `ion-item-options`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No