### PR TITLE
fix(searchbar): searchbar in collapsible header has correct height

### DIFF
--- a/core/src/components/header/header.ios.scss
+++ b/core/src/components/header/header.ios.scss
@@ -69,8 +69,6 @@
 }
 
 .header-collapse-condense ion-toolbar ion-searchbar {
-  height: 48px;
-
   padding-top: 0px;
   padding-bottom: 13px;
 }


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When testing Dynamic Type I discovered that the searchbar has the wrong height when placed inside of a toolbar inside of a collapsible header.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed the additional CSS. This is no longer needed because `ion-searchbar` has `min-height: 52px`


| `FW-4146` | branch |
| - | - |
| ![IMG_0148](https://github.com/ionic-team/ionic-framework/assets/2721089/d9e5c0ce-98a1-4e5e-9365-9487b00bb602) | ![IMG_0147](https://github.com/ionic-team/ionic-framework/assets/2721089/7ac1b08f-809e-4c2b-868f-3294f6448555) |

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
