### PR TITLE
refactor: rename dynamic font variable

### DIFF
--- a/core/scripts/testing/styles.css
+++ b/core/scripts/testing/styles.css
@@ -33,7 +33,7 @@
 }
 
 :root, html {
-  --ion-dynamic-type: var(--ion-default-dynamic-font);
+  --ion-dynamic-font: var(--ion-default-dynamic-font);
 }
 
 :root,

--- a/core/src/css/typography.scss
+++ b/core/src/css/typography.scss
@@ -38,7 +38,7 @@ html {
  */
 @supports (-webkit-touch-callout: none) {
   html {
-    font: var(--ion-dynamic-type);
+    font: var(--ion-dynamic-font);
   }
 }
 


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The team discussed offline that there are a few issues with the current name of `--ion-dynamic-type`:

1. It's not clear what this does. Dynamic Type is an iOS-specific term, but this feature is for all Ionic apps.
2. It's inconsistent with the other Dynamic Font Scaling variable named `--ion-default-dynamic-font`.
3. The naming does not align with how the variable is applied via the `font` CSS property.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Renames `--ion-dynamic-type` to `--ion-dynamic-font`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
(This feature has not shipped yet, so it's not a breaking change)

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
