### PR TITLE
chore(ci): account for new screenshots in error logging

### DIFF
--- a/.github/workflows/actions/update-reference-screenshots/action.yml
+++ b/.github/workflows/actions/update-reference-screenshots/action.yml
@@ -34,7 +34,7 @@ runs:
       run: |
         git config user.name ionitron
         git config user.email hi@ionicframework.com
-        git add src/\*.png --force
+        git add src/\*.png --force -N
 
         if git diff --exit-code; then
           echo -e "\033[1;31m⚠️ Error: No new screenshots generated ⚠️\033[0m"

--- a/.github/workflows/actions/update-reference-screenshots/action.yml
+++ b/.github/workflows/actions/update-reference-screenshots/action.yml
@@ -34,6 +34,10 @@ runs:
       run: |
         git config user.name ionitron
         git config user.email hi@ionicframework.com
+
+        # This adds an empty entry for new
+        # screenshot files so we can track them with
+        # git diff
         git add src/\*.png --force -N
 
         if git diff --exit-code; then
@@ -42,6 +46,9 @@ runs:
           echo -e "\033[1;31mMake sure you have pushed any code changes that would result in visual diffs.\033[0m"
           exit 1
         else
+          # This actually adds the contents
+          # of the screenshots (including new ones)
+          git add src/\*.png --force
           git commit -m "chore(): add updated snapshots"
           git push
         fi


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

We checked `git diff` to see if new screenshots were generated. If no new screenshots were generated then we print a user-friendly message informing the dev what happened. However, `git diff` does not account for untracked changes (i.e. new screenshots).

As a result, this prevented new screenshots from being committed.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- To fix this we use the `-N` flag which is short for `--intent-to-add`. This adds an entry with no content which causes the new screenshots to show up when running `git diff`. We later add the contents of the image.

Example test run of this working: https://github.com/ionic-team/ionic-framework/actions/runs/6174263712/job/16759260534

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
