### PR TITLE
fix(scroll-assist): improve input scroll accuracy with native resizing

### DIFF
--- a/core/src/utils/input-shims/hacks/scroll-data.ts
+++ b/core/src/utils/input-shims/hacks/scroll-data.ts
@@ -9,13 +9,18 @@ export interface ScrollData {
   inputSafeY: number;
 }
 
-export const getScrollData = (componentEl: HTMLElement, contentEl: HTMLElement, keyboardHeight: number): ScrollData => {
+export const getScrollData = (
+  componentEl: HTMLElement,
+  contentEl: HTMLElement,
+  keyboardHeight: number,
+  platformHeight: number
+): ScrollData => {
   const itemEl = (componentEl.closest('ion-item,[ion-item]') as HTMLElement) ?? componentEl;
   return calcScrollData(
     itemEl.getBoundingClientRect(),
     contentEl.getBoundingClientRect(),
     keyboardHeight,
-    (componentEl as any).ownerDocument.defaultView.innerHeight // TODO(FW-2832): type
+    platformHeight
   );
 };
 


### PR DESCRIPTION
Issue number: Part of #22940

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

While working on a fix for #22940, I discovered another bug that impacted the reliability of my proposed fix for #22940. When we compute the scroll data (i.e. how much the input needs to be scrolled by), we subtract the `keyboardHeight` from the `platformHeight` (i.e. the viewport height): https://github.com/ionic-team/ionic-framework/blob/1015c06cbef4ceb10d43e722157c04844d984509/core/src/utils/input-shims/hacks/scroll-data.ts#L34

Every time we tap between inputs (even if the keyboard is already open) we re-run scroll assist because the newly focused input could be partially obscured by the keyboard. However, in this case we scroll by too much because we effectively subtract the keyboard height twice. This is because by the time we compute `platformHeight`, the platform dimensions have already shrunk to account for the keyboard (when the webview resizes).

As a result, when we subtract `keyboardHeight` we get a visible area that is much smaller than the actual visible area.

Examples below with different resize modes. Notice that with the "Native" resize mode (entire webview resizes when keyboard is open) tapping into other inputs scrolls the content by much more than it needs to.

| Body | Native | Ionic | None |
| - | - | - | - |
| <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/06d1cd20-0349-4a59-ad85-c1c8a8a03caa"></video> | <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/1d4e8363-a69b-45c4-931c-d6227e548ec9"></video> | <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/7e4304c1-7d56-48c8-aed8-16fc7e51641a"></video> | <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/7869c5e0-b202-46e1-af82-49e41b3b067e"></video> |

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- We now compute the viewport height on load rather than on focus. This ensures that we always use the full viewport height when computing the visible area.

| Body | Native | Ionic | None |
| - | - | - | - |
| <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/c5a66287-0cad-42db-bece-da16edad60e3"></video> | <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/372a45c8-e8bd-43d2-bf50-d87b7250e9b3"></video> | <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/3d656467-8e2e-48cc-8d72-dc89a67ef8b1"></video> | <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/19969535-7d06-404c-98e4-ae49957e0ffe"></video> |



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `7.3.4-dev.11694548895.1578981b`