### PR TITLE
test(playwright): only use retries on CI

### DIFF
--- a/core/playwright.config.ts
+++ b/core/playwright.config.ts
@@ -60,7 +60,8 @@ const config: PlaywrightTestConfig = {
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   maxFailures: 0,
-  retries: 2,
+  /* Test retries help catch flaky tests on CI */
+  retries: process.env.CI ? 2 : 0,
   reportSlowTests: null,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

We currently use retries on CI to help catch flaky tests. However, retries are enabled even when testing locally. This is not ideal because a failing test will be re-run multiple times before erroring out which increases the time it takes to run tests locally. I typically write tests before fixes so I can verify my test is checking the correct behavior. In this case I don't need it to be re-run twice -- I already know it's supposed to fail.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Test retries are only enabled on CI

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
