### PR TITLE
chore(item): add deprecated flag to fill prop

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -1336,6 +1336,7 @@ export namespace Components {
         "download": string | undefined;
         /**
           * The fill for the item. If `"solid"` the item will have a background. If `"outline"` the item will be transparent with a border. Only available in `md` mode.
+          * @deprecated Use the `fill` property on `ion-input` or `ion-textarea` instead.
          */
         "fill"?: 'outline' | 'solid';
         /**
@@ -5407,6 +5408,7 @@ declare namespace LocalJSX {
         "download"?: string | undefined;
         /**
           * The fill for the item. If `"solid"` the item will have a background. If `"outline"` the item will be transparent with a border. Only available in `md` mode.
+          * @deprecated Use the `fill` property on `ion-input` or `ion-textarea` instead.
          */
         "fill"?: 'outline' | 'solid';
         /**

--- a/core/src/components/item/item.tsx
+++ b/core/src/components/item/item.tsx
@@ -85,6 +85,7 @@ export class Item implements ComponentInterface, AnchorInterface, ButtonInterfac
   /**
    * The fill for the item. If `"solid"` the item will have a background. If
    * `"outline"` the item will be transparent with a border. Only available in `md` mode.
+   * @deprecated Use the `fill` property on `ion-input` or `ion-textarea` instead.
    */
   @Prop() fill?: 'outline' | 'solid';
 


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The `fill` prop on `ion-item` is currently deprecated (see warning [here](https://github.com/ionic-team/ionic-framework/blob/main/core/src/components/item/item.tsx#L248-L253)) but the docs have not been updated to reflect this.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

`@deprecated` flag added to the `fill` prop.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
