### PR TITLE
fix(radio): add icon scaling

### DIFF
--- a/core/src/components/radio/radio.ios.vars.scss
+++ b/core/src/components/radio/radio.ios.vars.scss
@@ -11,10 +11,10 @@ $radio-ios-color-on:                  current-color(base) !default;
 $radio-ios-background-color-focused:  ion-color(primary, tint) !default;
 
 /// @prop - Width of the radio icon
-$radio-ios-icon-width:                15px !default;
+$radio-ios-icon-width:                dynamic-font(15px) !default;
 
 /// @prop - Height of the radio icon
-$radio-ios-icon-height:               24px !default;
+$radio-ios-icon-height:               dynamic-font(24px) !default;
 
 /// @prop - Border width of the radio icon
 $radio-ios-icon-border-width:         2px !default;

--- a/core/src/components/radio/radio.md.vars.scss
+++ b/core/src/components/radio/radio.md.vars.scss
@@ -14,10 +14,10 @@ $radio-md-background-color-focused:  ion-color(primary, tint) !default;
 $radio-md-color-off:                 rgb($text-color-rgb, 0.60) !default;
 
 /// @prop - Width of the radio icon
-$radio-md-icon-width:                20px !default;
+$radio-md-icon-width:                dynamic-font-max(20px, 2.5) !default;
 
 /// @prop - Height of the radio icon
-$radio-md-icon-height:               20px !default;
+$radio-md-icon-height:               dynamic-font-max(20px, 2.5) !default;
 
 /// @prop - Border width of the radio icon
 $radio-md-icon-border-width:         2px !default;

--- a/core/src/components/radio/test/a11y/radio.e2e.ts
+++ b/core/src/components/radio/test/a11y/radio.e2e.ts
@@ -96,7 +96,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
 });
 
 configs({ directions: ['ltr'] }).forEach(({ title, config, screenshot }) => {
-  test.describe.only(title('radio: a11y'), () => {
+  test.describe(title('radio: a11y'), () => {
     test.describe(title('radio: font scaling'), () => {
       test('should scale text on larger font sizes', async ({ page }) => {
         await page.setContent(

--- a/core/src/components/radio/test/a11y/radio.e2e.ts
+++ b/core/src/components/radio/test/a11y/radio.e2e.ts
@@ -94,3 +94,28 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
     });
   });
 });
+
+configs({ directions: ['ltr'] }).forEach(({ title, config, screenshot }) => {
+  test.describe.only(title('radio: a11y'), () => {
+    test.describe(title('radio: font scaling'), () => {
+      test('should scale text on larger font sizes', async ({ page }) => {
+        await page.setContent(
+          `
+            <style>
+              html {
+                font-size: 310%;
+              }
+            </style>
+            <ion-radio-group value="strawberries">
+              <ion-radio value="strawberries">Strawberries</ion-radio><br />
+            </ion-radio-group>
+          `,
+          config
+        );
+
+        const radio = page.locator('ion-radio');
+        await expect(radio).toHaveScreenshot(screenshot('radio-scale'));
+      });
+    });
+  });
+});


### PR DESCRIPTION
Issue number: #

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The icon on `ion-radio` does not scale up when font size changes.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The icon on `ion-radio` does scale up when font size changes.
- Added screenshot test.
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

A native iOS radio can be found at Settings > Language & Region > Calendar
