### PR TITLE
refactor(router-outlet): reuse lock controller

### DIFF
--- a/core/src/components/router-outlet/router-outlet.tsx
+++ b/core/src/components/router-outlet/router-outlet.tsx
@@ -30,7 +30,6 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
   // TODO(FW-2832): types
   private activeComponent: any;
   private activeParams: any;
-  private waitPromise?: Promise<void>;
   private gesture?: Gesture;
   private ani?: Animation;
   private gestureOrAnimationInProgress = false;


### PR DESCRIPTION
Issue number: Internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Code is duplicated between the router outlet and the overlays

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Code is reused between the router outlet and the overlays

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
