### PR TITLE
fix(segment): scroll to active segment-button on first load

### DIFF
--- a/core/src/components/segment/test/scrollable/segment.e2e.ts
+++ b/core/src/components/segment/test/scrollable/segment.e2e.ts
@@ -85,23 +85,7 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
       );
 
       const activeButton = page.locator('#activeButton');
-
-      // wait for segment to scroll, which is done in a raf
-      await page.waitForTimeout(500);
-
-      /**
-       * We can't use toBeVisible() here because it returns true
-       * even if the element is outside the viewport.
-       */
-      const box = await activeButton.boundingBox();
-      const viewport = page.viewportSize();
-      let isInViewport = false;
-      if (box && viewport) {
-        isInViewport =
-          box.x >= 0 && box.y >= 0 && box.x + box.width <= viewport.width && box.y + box.height <= viewport.height;
-      }
-
-      expect(isInViewport).toBe(true);
+      await expect(activeButton).toBeInViewport();
     });
   });
 });

--- a/core/src/components/segment/test/scrollable/segment.e2e.ts
+++ b/core/src/components/segment/test/scrollable/segment.e2e.ts
@@ -46,7 +46,7 @@ configs().forEach(({ title, screenshot, config }) => {
   });
 });
 
-configs({ modes: ['md'], directions: ['ltr']}).forEach(({ title, config }) => {
+configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('segment: scrollable (functionality)'), () => {
     test('should scroll active button into view when value is already set', async ({ page }) => {
       await page.setContent(
@@ -88,7 +88,7 @@ configs({ modes: ['md'], directions: ['ltr']}).forEach(({ title, config }) => {
 
       // wait for segment to scroll, which is done in a raf
       await page.waitForTimeout(500);
-      
+
       /**
        * We can't use toBeVisible() here because it returns true
        * even if the element is outside the viewport.
@@ -97,12 +97,8 @@ configs({ modes: ['md'], directions: ['ltr']}).forEach(({ title, config }) => {
       const viewport = page.viewportSize();
       let isInViewport = false;
       if (box && viewport) {
-        isInViewport = (
-          box.x >= 0 &&
-          box.y >= 0 &&
-          box.x + box.width <= viewport.width &&
-          box.y + box.height <= viewport.height
-        );
+        isInViewport =
+          box.x >= 0 && box.y >= 0 && box.x + box.width <= viewport.width && box.y + box.height <= viewport.height;
       }
 
       expect(isInViewport).toBe(true);

--- a/core/src/components/segment/test/scrollable/segment.e2e.ts
+++ b/core/src/components/segment/test/scrollable/segment.e2e.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import { configs, test } from '@utils/test/playwright';
 
 configs().forEach(({ title, screenshot, config }) => {
-  test.describe(title('segment: scrollable'), () => {
+  test.describe(title('segment: scrollable (rendering)'), () => {
     test('should not have visual regressions', async ({ page }) => {
       await page.setContent(
         `
@@ -42,6 +42,70 @@ configs().forEach(({ title, screenshot, config }) => {
       const segment = page.locator('ion-segment');
 
       await expect(segment).toHaveScreenshot(screenshot(`segment-scrollable`));
+    });
+  });
+});
+
+configs({ modes: ['md'], directions: ['ltr']}).forEach(({ title, config }) => {
+  test.describe(title('segment: scrollable (functionality)'), () => {
+    test.only('should scroll active button into view when value is already set', async ({ page }) => {
+      await page.setContent(
+        `
+          <ion-segment scrollable="true" value="8">
+            <ion-segment-button value="1">
+              <ion-label>First</ion-label>
+            </ion-segment-button>
+            <ion-segment-button value="2">
+              <ion-label>Second</ion-label>
+            </ion-segment-button>
+            <ion-segment-button value="3">
+              <ion-label>Third</ion-label>
+            </ion-segment-button>
+            <ion-segment-button value="4">
+              <ion-label>Fourth</ion-label>
+            </ion-segment-button>
+            <ion-segment-button value="5">
+              <ion-label>Fifth</ion-label>
+            </ion-segment-button>
+            <ion-segment-button value="6">
+              <ion-label>Sixth</ion-label>
+            </ion-segment-button>
+            <ion-segment-button value="7">
+              <ion-label>Seventh</ion-label>
+            </ion-segment-button>
+            <ion-segment-button id="activeButton" value="8">
+              <ion-label>Eighth</ion-label>
+            </ion-segment-button>
+            <ion-segment-button value="9">
+              <ion-label>Ninth</ion-label>
+            </ion-segment-button>
+          </ion-segment>
+        `,
+        config
+      );
+
+      const activeButton = page.locator('#activeButton');
+
+      // wait for segment to scroll, which is done in a raf
+      await page.waitForTimeout(500);
+      
+      /**
+       * We can't use toBeVisible() here because it returns true
+       * even if the element is outside the viewport.
+       */
+      const box = await activeButton.boundingBox();
+      const viewport = page.viewportSize();
+      let isInViewport = false;
+      if (box && viewport) {
+        isInViewport = (
+          box.x >= 0 &&
+          box.y >= 0 &&
+          box.x + box.width <= viewport.width &&
+          box.y + box.height <= viewport.height
+        );
+      }
+
+      expect(isInViewport).toBe(true);
     });
   });
 });

--- a/core/src/components/segment/test/scrollable/segment.e2e.ts
+++ b/core/src/components/segment/test/scrollable/segment.e2e.ts
@@ -48,7 +48,7 @@ configs().forEach(({ title, screenshot, config }) => {
 
 configs({ modes: ['md'], directions: ['ltr']}).forEach(({ title, config }) => {
   test.describe(title('segment: scrollable (functionality)'), () => {
-    test.only('should scroll active button into view when value is already set', async ({ page }) => {
+    test('should scroll active button into view when value is already set', async ({ page }) => {
       await page.setContent(
         `
           <ion-segment scrollable="true" value="8">


### PR DESCRIPTION
Issue number: resolves #28096

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When a segment button is clicked, the segment will auto-scroll to position the newly active button fully in view. However, this behavior does not occur on first load. This means that when a segment is initialized with a `value` corresponding to an off-screen button, the button will remain off-screen.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The same auto-scroll behavior from button click now also occurs on component load.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
