### PR TITLE
fix(header): collapsible large title main header does not flicker on load

### DIFF
--- a/core/src/components/header/header.ios.scss
+++ b/core/src/components/header/header.ios.scss
@@ -122,6 +122,11 @@
  * header will have the ".header-collapse-main" class, and
  * this selector will no longer apply.
  *
+ * The :has(...) part of the selector ensures a couple things:
+ * 1. This will only apply within a page view since the content
+ * must be a subsequent-sibling of the header (~ ion-content).
+ * 2. This will only apply when that content has a collapse header (ion-header[collapse="condense"])
+ *
  * We use opacity: 0 to avoid a layout shift.
  */
 ion-header:not(.header-collapse-main):has(~ ion-content ion-header[collapse="condense"]) {

--- a/core/src/components/header/header.ios.scss
+++ b/core/src/components/header/header.ios.scss
@@ -107,3 +107,21 @@
 .header-collapse-condense-inactive.header-collapse-condense ion-toolbar.in-toolbar ion-buttons.buttons-collapse {
   visibility: hidden;
 }
+
+/**
+ * The main header is only hidden once the collapsible large
+ * title is configured. As a result, if the main header loads
+ * before the collapsible large title is configured then the
+ * main header will be visible briefly before being hidden
+ * by the collapsible large title.
+ *
+ * The following selector ensures that any main header
+ * on a page with a collapsible large title is hidden
+ * before the collapsible large title is configured.
+ * Once the collapsible large title is configured the main
+ * header will have the ".header-collapse-main" class, and
+ * this selector will no longer apply.
+ */
+ion-header:not(.header-collapse-main):has(~ ion-content ion-header[collapse="condense"]) {
+  opacity: 0;
+}

--- a/core/src/components/header/header.ios.scss
+++ b/core/src/components/header/header.ios.scss
@@ -121,6 +121,8 @@
  * Once the collapsible large title is configured the main
  * header will have the ".header-collapse-main" class, and
  * this selector will no longer apply.
+ *
+ * We use opacity: 0 to avoid a layout shift.
  */
 ion-header:not(.header-collapse-main):has(~ ion-content ion-header[collapse="condense"]) {
   opacity: 0;


### PR DESCRIPTION
Issue number: resolves #27060

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The main header is controlled by the header with `collapse="condense"` set: https://github.com/ionic-team/ionic-framework/blob/a04a11be3571faa99c751edc034462e94a977e95/core/src/components/header/header.tsx#L144

The collapse header will hide the main header and then show it once the user has scrolled enough. However, if the main header is rendered before the collapse header is rendered, then the main header will be visible for a brief moment before being hidden by the collapse header. This gives the perception of flicker that is reported on the linked issue.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The main header will be hidden on load if it loads before the collapse header

The selector was written in a way such that once the collapse header loads, this CSS no longer applies (since the collapse header will add `.header-collapse-main` to the main header)

| `main` | branch |
| - | - |
| <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/3cb11a57-e084-435a-89c2-e1c2afba04b1"></video> | <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/c5caeb5e-3b33-4598-986f-bf097c46251c"></video> |

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Note: `:has` browser compat is still fairly new. However, it is available on both Chromium and WebKit browsers (and has been for at least a year): https://caniuse.com/?search=%3Ahas

Given that this bug is a fairly minor UI glitch (as opposed to something that would cause an app to crash or otherwise malfunction), I think this is an acceptable tradeoff. As time goes on this will become less of a concern as more users update their devices.

Dev build: `7.4.3-dev.11696365694.156f41d3`