### PR TITLE
feat(angular, react, vue, core): export openURL utility

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -11,7 +11,7 @@ export { componentOnReady } from './utils/helpers';
 export { isPlatform, Platforms, PlatformConfig, getPlatforms } from './utils/platform';
 export { IonicSafeString } from './utils/sanitization';
 export { IonicConfig, getMode, setupConfig } from './utils/config';
-export { openURL } from "./utils/theme";
+export { openURL } from './utils/theme';
 export {
   LIFECYCLE_WILL_ENTER,
   LIFECYCLE_DID_ENTER,

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -11,6 +11,7 @@ export { componentOnReady } from './utils/helpers';
 export { isPlatform, Platforms, PlatformConfig, getPlatforms } from './utils/platform';
 export { IonicSafeString } from './utils/sanitization';
 export { IonicConfig, getMode, setupConfig } from './utils/config';
+export { openURL } from "./utils/theme";
 export {
   LIFECYCLE_WILL_ENTER,
   LIFECYCLE_DID_ENTER,

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -131,4 +131,5 @@ export {
   ToggleChangeEventDetail,
   ToggleCustomEvent,
   TransitionOptions,
+  openURL,
 } from '@ionic/core';

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -10,6 +10,7 @@ export {
   IonicSlides,
   getTimeGivenProgression,
   getIonPageElement,
+  openURL,
 
   // TYPES
   Animation,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -48,6 +48,7 @@ export {
   menuController,
   getTimeGivenProgression,
   getIonPageElement,
+  openURL,
 
   // TYPES
   Animation,


### PR DESCRIPTION
Issue number: resolves #27911 

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The `openURL` utility is not available to developers. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Export `openURL` utilities from `@ionic/core`, `@ionic/angular`, `@ionic/react` and `@ionic/vue`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
