### PR TITLE
Fix transition speed on swipe back

### DIFF
--- a/core/src/components/router-outlet/router-outlet.tsx
+++ b/core/src/components/router-outlet/router-outlet.tsx
@@ -111,7 +111,9 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
             this.ani.easing('cubic-bezier(1, 0, 0.68, 0.28)');
             newStepValue += getTimeGivenProgression([0, 0], [1, 0], [0.68, 0.28], [1, 1], step)[0];
           } else {
-            newStepValue += getTimeGivenProgression([0, 0], [0.32, 0.72], [0, 1], [1, 1], step)[0];
+            this.ani.easing('linear');
+
+            newStepValue += step;
           }
 
           this.ani.progressEnd(shouldComplete ? 1 : 0, newStepValue, dur);

--- a/core/src/utils/gesture/swipe-back.ts
+++ b/core/src/utils/gesture/swipe-back.ts
@@ -70,7 +70,7 @@ export const createSwipeBackGesture = (
     let realDur = 0;
     if (missingDistance > 5) {
       const dur = missingDistance / Math.abs(velocity);
-      realDur = Math.min(dur, 540);
+      realDur = Math.min(dur, 200);
     }
 
     onEndHandler(shouldComplete, stepValue <= 0 ? 0.01 : clamp(0, stepValue, 0.9999), realDur);


### PR DESCRIPTION
Issue number: #27748

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?

Swipe back can take too long. On the iOS settings app, swipe back is always shorter than tapping to go to a new page (even if you swipe back slowly). This is accomplished without making it visually seem "faster" by using a linear transition function for the back swipe.

A slow swipe back transition can make the app see laggy and slow when swiping back and then scrolling down in the page you swiped back to.

## What is the new behavior?

- Swipe back function is linear
- Maximum of 200ms to complete swipe back animation

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This patch has been in use in [Voyager](https://github.com/aeharding/voyager) for the past couple months with great results. 
