### PR TITLE
fix(core): swipe to go back gesture has priority over other horizontal swipe gestures

### DIFF
--- a/core/src/utils/gesture/swipe-back.ts
+++ b/core/src/utils/gesture/swipe-back.ts
@@ -79,6 +79,10 @@ export const createSwipeBackGesture = (
   return createGesture({
     el,
     gestureName: 'goback-swipe',
+    /**
+     * Swipe to go back should have priority over other horizontal swipe
+     * gestures. These gestures have a priority of 100 which is why 101 was chosen here.
+     */
     gesturePriority: 101,
     threshold: 10,
     canStart,

--- a/core/src/utils/gesture/swipe-back.ts
+++ b/core/src/utils/gesture/swipe-back.ts
@@ -79,7 +79,7 @@ export const createSwipeBackGesture = (
   return createGesture({
     el,
     gestureName: 'goback-swipe',
-    gesturePriority: 40,
+    gesturePriority: 101,
     threshold: 10,
     canStart,
     onStart: onStartHandler,


### PR DESCRIPTION
Issue number: resolves #28303

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?

- Swipe back gesture is inconsistently clobbered by ion-item-sliding's gesture.

## What is the new behavior?

- Swipe back gesture now has a higher priority than ion-item-sliding
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This patch has been in use in [Voyager](https://github.com/aeharding/voyager) for the past couple months to great success!