### PR TITLE
chore(repo): parameterize stencil nightly

### DIFF
--- a/.github/workflows/stencil-nightly.yml
+++ b/.github/workflows/stencil-nightly.yml
@@ -8,7 +8,12 @@ on:
     # at 6:00 UTC (6:00 am UTC)
     - cron: '00 06 * * 1-5'
   workflow_dispatch:
-    # allows for manual invocations in the GitHub UI
+    inputs:
+      npm_release_tag:
+        required: true
+        type: string
+        description: What version should be pulled from NPM?
+        default: nightly
 
 # When pushing a new commit we should
 # cancel the previous test run to not
@@ -24,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/workflows/actions/build-core-stencil-prerelease
         with:
-          stencil-version: nightly
+          stencil-version: ${{ inputs.npm_release_tag || 'nightly' }}
 
   test-core-clean-build:
     needs: [build-core-with-stencil-nightly]
@@ -47,7 +52,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/workflows/actions/test-core-spec
         with:
-          stencil-version: nightly
+          stencil-version: ${{ inputs.npm_release_tag || 'nightly' }}
 
   test-core-screenshot:
     strategy:


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

when the stencil team wants to test a dev build of stencil against the framework team's ci, they  push a branch to this repo that overrides the stencil nightly job's npm tag (replacing 'nightly' with the dev build version) and manually kick off the nightly workflow. this commit would eliminate the need for that first step there

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

update the stencil nightly job to accept any npm release tag, rather than always default to 'nightly'. doing so allows the stencil team to reuse this workflow for cases where we'd like to test a _dev_ build of stencil by running it through the framework's ci process, without landing the feature in stencil first.

I was able to test that `nightly` gets set by default (and the field is required) by running the workflow from this branch.

I then also tested this against a dev build of Stencil:
![Screenshot 2023-10-09 at 9 45 41 AM](https://github.com/ionic-team/ionic-framework/assets/1930213/65613327-e5b6-475d-9bcd-b3c0d27019d9)

Interestingly enough, it helped me catch something to consider if we were to accept the PR this dev build is accepted!


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I considered making a separate workflow for this (rather than override/use nightly) - it didn't quite seem worth the maintenance effort 🤷 
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
