### PR TITLE
fix(footer, tab-bar): do not hide when webview resizing disabled

### DIFF
--- a/core/src/components/footer/footer.tsx
+++ b/core/src/components/footer/footer.tsx
@@ -3,6 +3,7 @@ import { Component, Element, Host, Prop, State, h } from '@stencil/core';
 import { findIonContent, getScrollElement, printIonContentErrorMsg } from '@utils/content';
 import type { KeyboardController } from '@utils/keyboard/keyboard-controller';
 import { createKeyboardController } from '@utils/keyboard/keyboard-controller';
+import { Keyboard, KeyboardResize } from '@utils/native/keyboard';
 
 import { getIonMode } from '../../global/ionic-global';
 
@@ -52,18 +53,28 @@ export class Footer implements ComponentInterface {
   }
 
   async connectedCallback() {
-    this.keyboardCtrl = await createKeyboardController(async (keyboardOpen, waitForResize) => {
-      /**
-       * If the keyboard is hiding, then we need to wait
-       * for the webview to resize. Otherwise, the footer
-       * will flicker before the webview resizes.
-       */
-      if (keyboardOpen === false && waitForResize !== undefined) {
-        await waitForResize;
-      }
+    const resizeMode = await Keyboard.getResizeMode();
 
-      this.keyboardVisible = keyboardOpen; // trigger re-render by updating state
-    });
+    /**
+     * If the resize mode is set to None then we don't want to
+     * hide the tab bar here since it will never sit on top
+     * of the keyboard. Hiding the tab bar will cause a layout shift
+     * in apps that have resize set to None.
+     */
+    if (resizeMode === undefined || resizeMode.mode !== KeyboardResize.None) {
+      this.keyboardCtrl = await createKeyboardController(async (keyboardOpen, waitForResize) => {
+        /**
+         * If the keyboard is hiding, then we need to wait
+         * for the webview to resize. Otherwise, the footer
+         * will flicker before the webview resizes.
+         */
+        if (keyboardOpen === false && waitForResize !== undefined) {
+          await waitForResize;
+        }
+
+        this.keyboardVisible = keyboardOpen; // trigger re-render by updating state
+      });
+    }
   }
 
   disconnectedCallback() {

--- a/core/src/utils/keyboard/keyboard-controller.ts
+++ b/core/src/utils/keyboard/keyboard-controller.ts
@@ -1,6 +1,5 @@
 import { doc, win } from '@utils/browser';
-
-import { Keyboard, KeyboardResize } from '../native/keyboard';
+import { Keyboard, KeyboardResize } from '@utils/native/keyboard';
 
 /**
  * The element that resizes when the keyboard opens


### PR DESCRIPTION
Issue number: resolves #28226

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

In https://github.com/ionic-team/ionic-framework/pull/27417, we introduced the keyboard controller which allows the footer and tab bar to hide when the keyboard is opened. This prevents those elements from sitting on top of the keyboard.

However, we did not account for when webview resizing is disabled. In that scenario, these elements do not need to hide since they will never sit on top of the keyboard. Since these elements are hidden, the size of the content increases which causes a layout shift whenever the keyboard opens.

| main | branch |
| - | - |
| <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/3e12d29d-756e-446c-92d0-41c2640c75e1"></video> | <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/77f3cdfd-c844-43d5-ba6e-1884b61ff031"></video> |

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The tab bar and footer elements do not hide when webview resizing is set to "NONE".

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
