### PR TITLE
chore: use ionicons 7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center">
+1<p align="center">
   <a href="#">
     <img alt="Ionic" src="https://github.com/ionic-team/ionic-framework/blob/main/.github/assets/logo.png?raw=true" width="60" />
   </a>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-1<p align="center">
+<p align="center">
   <a href="#">
     <img alt="Ionic" src="https://github.com/ionic-team/ionic-framework/blob/main/.github/assets/logo.png?raw=true" width="60" />
   </a>

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^4.4.0",
-        "ionicons": "7.1.0",
+        "ionicons": "^7.2.1",
         "tslib": "^2.1.0"
       },
       "devDependencies": {
@@ -5328,23 +5328,11 @@
       }
     },
     "node_modules/ionicons": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.1.0.tgz",
-      "integrity": "sha512-iE4GuEdEHARJpp0sWL7WJZCzNCf5VxpNRhAjW0fLnZPnNL5qZOJUcfup2Z2Ty7Jk8Q5hacrHfGEB1lCwOdXqGg==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.2.1.tgz",
+      "integrity": "sha512-2pvCM7DGVEtbbj48PJzQrCADCQrqjU1nUYX9l9PyEWz3ZfdnLdAouqwPxLdl8tbaF9cE7OZRSlyQD7oLOLnGoQ==",
       "dependencies": {
-        "@stencil/core": "^2.18.0"
-      }
-    },
-    "node_modules/ionicons/node_modules/@stencil/core": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.2.tgz",
-      "integrity": "sha512-r+vbxsGNcBaV1VDOYW25lv4QfXTlNoIb5GpUX7rZ+cr59yqYCZC5tlV+IzX6YgHKW62ulCc9M3RYtTfHtNbNNw==",
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
+        "@stencil/core": "^4.0.3"
       }
     },
     "node_modules/is-alphabetical": {
@@ -14297,18 +14285,11 @@
       }
     },
     "ionicons": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.1.0.tgz",
-      "integrity": "sha512-iE4GuEdEHARJpp0sWL7WJZCzNCf5VxpNRhAjW0fLnZPnNL5qZOJUcfup2Z2Ty7Jk8Q5hacrHfGEB1lCwOdXqGg==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.2.1.tgz",
+      "integrity": "sha512-2pvCM7DGVEtbbj48PJzQrCADCQrqjU1nUYX9l9PyEWz3ZfdnLdAouqwPxLdl8tbaF9cE7OZRSlyQD7oLOLnGoQ==",
       "requires": {
-        "@stencil/core": "^2.18.0"
-      },
-      "dependencies": {
-        "@stencil/core": {
-          "version": "2.22.2",
-          "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.2.tgz",
-          "integrity": "sha512-r+vbxsGNcBaV1VDOYW25lv4QfXTlNoIb5GpUX7rZ+cr59yqYCZC5tlV+IzX6YgHKW62ulCc9M3RYtTfHtNbNNw=="
-        }
+        "@stencil/core": "^4.0.3"
       }
     },
     "is-alphabetical": {

--- a/core/package.json
+++ b/core/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "@stencil/core": "^4.4.0",
-    "ionicons": "7.1.0",
+    "ionicons": "^7.2.1",
     "tslib": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The Dynamic Font Scaling branch was using an outdated version of Ionicons which did not support Dynamic Font Scaling. There were no visual diffs because we typically override the size of the icon internally, but still good to be on the latest version.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Ionic Core uses Ionicons 7.2 internally

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
