### PR TITLE
chore(ci): add workflow for testing ionicons dev build

### DIFF
--- a/.github/workflows/actions/build-core/action.yml
+++ b/.github/workflows/actions/build-core/action.yml
@@ -1,5 +1,10 @@
 name: 'Build Ionic Core'
 description: 'Build Ionic Core'
+inputs:
+  ionicons-version:
+    description: 'The NPM tag of ionicons to install.'
+    type: string
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -9,6 +14,13 @@ runs:
         node-version: 18.x
     - name: Install Dependencies
       run: npm install
+      working-directory: ./core
+      shell: bash
+    # If an Ionicons version was specified install that.
+    # Otherwise just use the version defined in the package.json.
+    - name: Install Ionicons Version
+      if: inputs.ionicons-version != ''
+      run: npm install ionicons@${{ inputs.ionicons-version }}
       working-directory: ./core
       shell: bash
     - name: Build Core

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches: [ '**' ]
   merge_group:
+  workflow_dispatch:
+    inputs:
+      ionicons_npm_release_tag:
+        required: false
+        type: string
+        description: What version of ionicons should be pulled from NPM? Use this if you want to test a custom version of Ionicons with Ionic.
 
 # When pushing a new commit we should
 # cancel the previous test run to not
@@ -18,6 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/workflows/actions/build-core
+        with:
+          ionicons-version: ${{ inputs.ionicons_npm_release_tag }}
 
   test-core-clean-build:
     needs: [build-core]


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Testing Ionicons in Ionic is currently difficult. Developers need to a) create a dev build of Ionicons, b) create a branch in Ionic, c) install the dev build in Ionic core, d) push the branch, and e) create a draft PR to watch the CI process run.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Introduces a workflow dispatch option for our CI process. This allows developers to run the CI process for any branch without creating PR.
- I also added an optional input so devs can specify the ionicons version if they want to pass a special version.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
