### PR TITLE
fix(angular): remove form control side effects

### DIFF
--- a/packages/angular/standalone/src/directives/checkbox.ts
+++ b/packages/angular/standalone/src/directives/checkbox.ts
@@ -8,6 +8,7 @@ import {
   Injector,
   NgZone,
 } from '@angular/core';
+import type { OnInit } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ValueAccessor, setIonicClasses } from '@ionic/angular/common';
 import type { CheckboxChangeEventDetail, Components } from '@ionic/core/components';
@@ -55,15 +56,23 @@ const CHECKBOX_INPUTS = [
   ],
   standalone: true,
 })
-export class IonCheckbox extends ValueAccessor {
+export class IonCheckbox extends ValueAccessor implements OnInit {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
     defineCustomElement();
-    proxyInputs(IonCheckbox, CHECKBOX_INPUTS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionChange', 'ionFocus', 'ionBlur']);
+  }
+
+  ngOnInit(): void {
+    /**
+     * Data-bound input properties are set
+     * by Angular after the constructor, so
+     * we need to run the proxy in ngOnInit.
+     */
+    proxyInputs(IonCheckbox, CHECKBOX_INPUTS);
   }
 
   writeValue(value: boolean): void {

--- a/packages/angular/standalone/src/directives/checkbox.ts
+++ b/packages/angular/standalone/src/directives/checkbox.ts
@@ -13,7 +13,19 @@ import { ValueAccessor, setIonicClasses } from '@ionic/angular/common';
 import type { CheckboxChangeEventDetail, Components } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-checkbox.js';
 
-import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
+/**
+ * Value accessor components should not use ProxyCmp
+ * and should call defineCustomElement and proxyInputs
+ * manually instead. Using both the @ProxyCmp and @Component
+ * decorators and useExisting (where useExisting refers to the
+ * class) causes ng-packagr to output multiple component variables
+ * which breaks treeshaking.
+ * For example, the following would be generated:
+ * let IonCheckbox = IonCheckbox_1 = class IonCheckbox extends ValueAccessor {
+ * Instead, we want only want the class generated:
+ * class IonCheckbox extends ValueAccessor {
+ */
+import { proxyInputs, proxyOutputs } from './angular-component-lib/utils';
 
 const CHECKBOX_INPUTS = [
   'checked',
@@ -28,10 +40,6 @@ const CHECKBOX_INPUTS = [
   'value',
 ];
 
-@ProxyCmp({
-  defineCustomElementFn: defineCustomElement,
-  inputs: CHECKBOX_INPUTS,
-})
 @Component({
   selector: 'ion-checkbox',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -51,6 +59,8 @@ export class IonCheckbox extends ValueAccessor {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
+    defineCustomElement();
+    proxyInputs(IonCheckbox, CHECKBOX_INPUTS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionChange', 'ionFocus', 'ionBlur']);

--- a/packages/angular/standalone/src/directives/datetime.ts
+++ b/packages/angular/standalone/src/directives/datetime.ts
@@ -8,6 +8,7 @@ import {
   Injector,
   NgZone,
 } from '@angular/core';
+import type { OnInit } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ValueAccessor } from '@ionic/angular/common';
 import type { DatetimeChangeEventDetail, Components } from '@ionic/core/components';
@@ -77,16 +78,24 @@ const DATETIME_METHODS = ['confirm', 'reset', 'cancel'];
   ],
   standalone: true,
 })
-export class IonDatetime extends ValueAccessor {
+export class IonDatetime extends ValueAccessor implements OnInit {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
     defineCustomElement();
-    proxyInputs(IonDatetime, DATETIME_INPUTS);
-    proxyMethods(IonDatetime, DATETIME_METHODS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionCancel', 'ionChange', 'ionFocus', 'ionBlur']);
+  }
+
+  ngOnInit(): void {
+    /**
+     * Data-bound input properties are set
+     * by Angular after the constructor, so
+     * we need to run the proxy in ngOnInit.
+     */
+    proxyInputs(IonDatetime, DATETIME_INPUTS);
+    proxyMethods(IonDatetime, DATETIME_METHODS);
   }
 
   @HostListener('ionChange', ['$event.target'])

--- a/packages/angular/standalone/src/directives/datetime.ts
+++ b/packages/angular/standalone/src/directives/datetime.ts
@@ -13,7 +13,19 @@ import { ValueAccessor } from '@ionic/angular/common';
 import type { DatetimeChangeEventDetail, Components } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-datetime.js';
 
-import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
+/**
+ * Value accessor components should not use ProxyCmp
+ * and should call defineCustomElement and proxyInputs
+ * manually instead. Using both the @ProxyCmp and @Component
+ * decorators and useExisting (where useExisting refers to the
+ * class) causes ng-packagr to output multiple component variables
+ * which breaks treeshaking.
+ * For example, the following would be generated:
+ * let IonDatetime = IonDatetime_1 = class IonDatetime extends ValueAccessor {
+ * Instead, we want only want the class generated:
+ * class IonDatetime extends ValueAccessor {
+ */
+import { proxyInputs, proxyMethods, proxyOutputs } from './angular-component-lib/utils';
 
 const DATETIME_INPUTS = [
   'cancelText',
@@ -48,11 +60,8 @@ const DATETIME_INPUTS = [
   'yearValues',
 ];
 
-@ProxyCmp({
-  defineCustomElementFn: defineCustomElement,
-  inputs: DATETIME_INPUTS,
-  methods: ['confirm', 'reset', 'cancel'],
-})
+const DATETIME_METHODS = ['confirm', 'reset', 'cancel'];
+
 @Component({
   selector: 'ion-datetime',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -72,6 +81,9 @@ export class IonDatetime extends ValueAccessor {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
+    defineCustomElement();
+    proxyInputs(IonDatetime, DATETIME_INPUTS);
+    proxyMethods(IonDatetime, DATETIME_METHODS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionCancel', 'ionChange', 'ionFocus', 'ionBlur']);

--- a/packages/angular/standalone/src/directives/input.ts
+++ b/packages/angular/standalone/src/directives/input.ts
@@ -8,6 +8,7 @@ import {
   Injector,
   NgZone,
 } from '@angular/core';
+import type { OnInit } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ValueAccessor } from '@ionic/angular/common';
 import type {
@@ -88,16 +89,24 @@ const INPUT_METHODS = ['setFocus', 'getInputElement'];
   ],
   standalone: true,
 })
-export class IonInput extends ValueAccessor {
+export class IonInput extends ValueAccessor implements OnInit {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
     defineCustomElement();
-    proxyInputs(IonInput, INPUT_INPUTS);
-    proxyMethods(IonInput, INPUT_METHODS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionInput', 'ionChange', 'ionBlur', 'ionFocus']);
+  }
+
+  ngOnInit(): void {
+    /**
+     * Data-bound input properties are set
+     * by Angular after the constructor, so
+     * we need to run the proxy in ngOnInit.
+     */
+    proxyInputs(IonInput, INPUT_INPUTS);
+    proxyMethods(IonInput, INPUT_METHODS);
   }
 
   @HostListener('ionInput', ['$event.target'])

--- a/packages/angular/standalone/src/directives/input.ts
+++ b/packages/angular/standalone/src/directives/input.ts
@@ -17,7 +17,19 @@ import type {
 } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-input.js';
 
-import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
+/**
+ * Value accessor components should not use ProxyCmp
+ * and should call defineCustomElement and proxyInputs
+ * manually instead. Using both the @ProxyCmp and @Component
+ * decorators and useExisting (where useExisting refers to the
+ * class) causes ng-packagr to output multiple component variables
+ * which breaks treeshaking.
+ * For example, the following would be generated:
+ * let IonInput = IonInput_1 = class IonInput extends ValueAccessor {
+ * Instead, we want only want the class generated:
+ * class IonInput extends ValueAccessor {
+ */
+import { proxyInputs, proxyMethods, proxyOutputs } from './angular-component-lib/utils';
 
 const INPUT_INPUTS = [
   'accept',
@@ -59,11 +71,8 @@ const INPUT_INPUTS = [
   'value',
 ];
 
-@ProxyCmp({
-  defineCustomElementFn: defineCustomElement,
-  inputs: INPUT_INPUTS,
-  methods: ['setFocus', 'getInputElement'],
-})
+const INPUT_METHODS = ['setFocus', 'getInputElement'];
+
 @Component({
   selector: 'ion-input',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -83,6 +92,9 @@ export class IonInput extends ValueAccessor {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
+    defineCustomElement();
+    proxyInputs(IonInput, INPUT_INPUTS);
+    proxyMethods(IonInput, INPUT_METHODS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionInput', 'ionChange', 'ionBlur', 'ionFocus']);

--- a/packages/angular/standalone/src/directives/radio-group.ts
+++ b/packages/angular/standalone/src/directives/radio-group.ts
@@ -13,14 +13,22 @@ import { ValueAccessor } from '@ionic/angular/common';
 import type { RadioGroupChangeEventDetail, Components } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-radio-group.js';
 
-import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
+/**
+ * Value accessor components should not use ProxyCmp
+ * and should call defineCustomElement and proxyInputs
+ * manually instead. Using both the @ProxyCmp and @Component
+ * decorators and useExisting (where useExisting refers to the
+ * class) causes ng-packagr to output multiple component variables
+ * which breaks treeshaking.
+ * For example, the following would be generated:
+ * let IonRadioGroup = IonRadioGroup_1 = class IonRadioGroup extends ValueAccessor {
+ * Instead, we want only want the class generated:
+ * class IonRadioGroup extends ValueAccessor {
+ */
+import { proxyInputs, proxyOutputs } from './angular-component-lib/utils';
 
 const RADIO_GROUP_INPUTS = ['allowEmptySelection', 'name', 'value'];
 
-@ProxyCmp({
-  defineCustomElementFn: defineCustomElement,
-  inputs: RADIO_GROUP_INPUTS,
-})
 @Component({
   selector: 'ion-radio-group',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -40,6 +48,8 @@ export class IonRadioGroup extends ValueAccessor {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
+    defineCustomElement();
+    proxyInputs(IonRadioGroup, RADIO_GROUP_INPUTS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionChange']);

--- a/packages/angular/standalone/src/directives/radio-group.ts
+++ b/packages/angular/standalone/src/directives/radio-group.ts
@@ -8,6 +8,7 @@ import {
   Injector,
   NgZone,
 } from '@angular/core';
+import type { OnInit } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ValueAccessor } from '@ionic/angular/common';
 import type { RadioGroupChangeEventDetail, Components } from '@ionic/core/components';
@@ -44,15 +45,23 @@ const RADIO_GROUP_INPUTS = ['allowEmptySelection', 'name', 'value'];
   ],
   standalone: true,
 })
-export class IonRadioGroup extends ValueAccessor {
+export class IonRadioGroup extends ValueAccessor implements OnInit {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
     defineCustomElement();
-    proxyInputs(IonRadioGroup, RADIO_GROUP_INPUTS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionChange']);
+  }
+
+  ngOnInit(): void {
+    /**
+     * Data-bound input properties are set
+     * by Angular after the constructor, so
+     * we need to run the proxy in ngOnInit.
+     */
+    proxyInputs(IonRadioGroup, RADIO_GROUP_INPUTS);
   }
 
   @HostListener('ionChange', ['$event.target'])

--- a/packages/angular/standalone/src/directives/radio.ts
+++ b/packages/angular/standalone/src/directives/radio.ts
@@ -13,14 +13,22 @@ import { ValueAccessor } from '@ionic/angular/common';
 import type { Components } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-radio.js';
 
-import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
+/**
+ * Value accessor components should not use ProxyCmp
+ * and should call defineCustomElement and proxyInputs
+ * manually instead. Using both the @ProxyCmp and @Component
+ * decorators and useExisting (where useExisting refers to the
+ * class) causes ng-packagr to output multiple component variables
+ * which breaks treeshaking.
+ * For example, the following would be generated:
+ * let IonRadio = IonRadio_1 = class IonRadio extends ValueAccessor {
+ * Instead, we want only want the class generated:
+ * class IonRadio extends ValueAccessor {
+ */
+import { proxyInputs, proxyOutputs } from './angular-component-lib/utils';
 
 const RADIO_INPUTS = ['color', 'disabled', 'justify', 'labelPlacement', 'legacy', 'mode', 'name', 'value'];
 
-@ProxyCmp({
-  defineCustomElementFn: defineCustomElement,
-  inputs: RADIO_INPUTS,
-})
 @Component({
   selector: 'ion-radio',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -40,6 +48,8 @@ export class IonRadio extends ValueAccessor {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
+    defineCustomElement();
+    proxyInputs(IonRadio, RADIO_INPUTS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionFocus', 'ionBlur']);

--- a/packages/angular/standalone/src/directives/radio.ts
+++ b/packages/angular/standalone/src/directives/radio.ts
@@ -8,6 +8,7 @@ import {
   Injector,
   NgZone,
 } from '@angular/core';
+import type { OnInit } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ValueAccessor } from '@ionic/angular/common';
 import type { Components } from '@ionic/core/components';
@@ -44,15 +45,23 @@ const RADIO_INPUTS = ['color', 'disabled', 'justify', 'labelPlacement', 'legacy'
   ],
   standalone: true,
 })
-export class IonRadio extends ValueAccessor {
+export class IonRadio extends ValueAccessor implements OnInit {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
     defineCustomElement();
-    proxyInputs(IonRadio, RADIO_INPUTS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionFocus', 'ionBlur']);
+  }
+
+  ngOnInit(): void {
+    /**
+     * Data-bound input properties are set
+     * by Angular after the constructor, so
+     * we need to run the proxy in ngOnInit.
+     */
+    proxyInputs(IonRadio, RADIO_INPUTS);
   }
 
   @HostListener('ionSelect', ['$event.target'])

--- a/packages/angular/standalone/src/directives/range.ts
+++ b/packages/angular/standalone/src/directives/range.ts
@@ -18,7 +18,19 @@ import type {
 } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-range.js';
 
-import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
+/**
+ * Value accessor components should not use ProxyCmp
+ * and should call defineCustomElement and proxyInputs
+ * manually instead. Using both the @ProxyCmp and @Component
+ * decorators and useExisting (where useExisting refers to the
+ * class) causes ng-packagr to output multiple component variables
+ * which breaks treeshaking.
+ * For example, the following would be generated:
+ * let IonRange = IonRange_1 = class IonRange extends ValueAccessor {
+ * Instead, we want only want the class generated:
+ * class IonRange extends ValueAccessor {
+ */
+import { proxyInputs, proxyOutputs } from './angular-component-lib/utils';
 
 const RANGE_INPUTS = [
   'activeBarStart',
@@ -41,10 +53,6 @@ const RANGE_INPUTS = [
   'value',
 ];
 
-@ProxyCmp({
-  defineCustomElementFn: defineCustomElement,
-  inputs: RANGE_INPUTS,
-})
 @Component({
   selector: 'ion-range',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -64,6 +72,8 @@ export class IonRange extends ValueAccessor {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
+    defineCustomElement();
+    proxyInputs(IonRange, RANGE_INPUTS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionChange', 'ionInput', 'ionFocus', 'ionBlur', 'ionKnobMoveStart', 'ionKnobMoveEnd']);

--- a/packages/angular/standalone/src/directives/range.ts
+++ b/packages/angular/standalone/src/directives/range.ts
@@ -8,6 +8,7 @@ import {
   Injector,
   NgZone,
 } from '@angular/core';
+import type { OnInit } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ValueAccessor } from '@ionic/angular/common';
 import type {
@@ -68,15 +69,23 @@ const RANGE_INPUTS = [
   ],
   standalone: true,
 })
-export class IonRange extends ValueAccessor {
+export class IonRange extends ValueAccessor implements OnInit {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
     defineCustomElement();
-    proxyInputs(IonRange, RANGE_INPUTS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionChange', 'ionInput', 'ionFocus', 'ionBlur', 'ionKnobMoveStart', 'ionKnobMoveEnd']);
+  }
+
+  ngOnInit(): void {
+    /**
+     * Data-bound input properties are set
+     * by Angular after the constructor, so
+     * we need to run the proxy in ngOnInit.
+     */
+    proxyInputs(IonRange, RANGE_INPUTS);
   }
 
   @HostListener('ionChange', ['$event.target'])

--- a/packages/angular/standalone/src/directives/searchbar.ts
+++ b/packages/angular/standalone/src/directives/searchbar.ts
@@ -8,6 +8,7 @@ import {
   Injector,
   NgZone,
 } from '@angular/core';
+import type { OnInit } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ValueAccessor } from '@ionic/angular/common';
 import type { SearchbarInputEventDetail, SearchbarChangeEventDetail, Components } from '@ionic/core/components';
@@ -67,16 +68,24 @@ const SEARCHBAR_METHODS = ['setFocus', 'getInputElement'];
   ],
   standalone: true,
 })
-export class IonSearchbar extends ValueAccessor {
+export class IonSearchbar extends ValueAccessor implements OnInit {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
     defineCustomElement();
-    proxyInputs(IonSearchbar, SEARCHBAR_INPUTS);
-    proxyMethods(IonSearchbar, SEARCHBAR_METHODS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionInput', 'ionChange', 'ionCancel', 'ionClear', 'ionBlur', 'ionFocus']);
+  }
+
+  ngOnInit(): void {
+    /**
+     * Data-bound input properties are set
+     * by Angular after the constructor, so
+     * we need to run the proxy in ngOnInit.
+     */
+    proxyInputs(IonSearchbar, SEARCHBAR_INPUTS);
+    proxyMethods(IonSearchbar, SEARCHBAR_METHODS);
   }
 
   @HostListener('ionInput', ['$event.target'])

--- a/packages/angular/standalone/src/directives/segment.ts
+++ b/packages/angular/standalone/src/directives/segment.ts
@@ -8,6 +8,7 @@ import {
   Injector,
   NgZone,
 } from '@angular/core';
+import type { OnInit } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ValueAccessor } from '@ionic/angular/common';
 import type { SegmentChangeEventDetail, Components } from '@ionic/core/components';
@@ -44,15 +45,23 @@ const SEGMENT_INPUTS = ['color', 'disabled', 'mode', 'scrollable', 'selectOnFocu
   ],
   standalone: true,
 })
-export class IonSegment extends ValueAccessor {
+export class IonSegment extends ValueAccessor implements OnInit {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
     defineCustomElement();
-    proxyInputs(IonSegment, SEGMENT_INPUTS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionChange']);
+  }
+
+  ngOnInit(): void {
+    /**
+     * Data-bound input properties are set
+     * by Angular after the constructor, so
+     * we need to run the proxy in ngOnInit.
+     */
+    proxyInputs(IonSegment, SEGMENT_INPUTS);
   }
 
   @HostListener('ionChange', ['$event.target'])

--- a/packages/angular/standalone/src/directives/segment.ts
+++ b/packages/angular/standalone/src/directives/segment.ts
@@ -13,14 +13,22 @@ import { ValueAccessor } from '@ionic/angular/common';
 import type { SegmentChangeEventDetail, Components } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-segment.js';
 
-import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
+/**
+ * Value accessor components should not use ProxyCmp
+ * and should call defineCustomElement and proxyInputs
+ * manually instead. Using both the @ProxyCmp and @Component
+ * decorators and useExisting (where useExisting refers to the
+ * class) causes ng-packagr to output multiple component variables
+ * which breaks treeshaking.
+ * For example, the following would be generated:
+ * let IonSegment = IonSegment_1 = class IonSegment extends ValueAccessor {
+ * Instead, we want only want the class generated:
+ * class IonSegment extends ValueAccessor {
+ */
+import { proxyInputs, proxyOutputs } from './angular-component-lib/utils';
 
 const SEGMENT_INPUTS = ['color', 'disabled', 'mode', 'scrollable', 'selectOnFocus', 'swipeGesture', 'value'];
 
-@ProxyCmp({
-  defineCustomElementFn: defineCustomElement,
-  inputs: SEGMENT_INPUTS,
-})
 @Component({
   selector: 'ion-segment',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -40,6 +48,8 @@ export class IonSegment extends ValueAccessor {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
+    defineCustomElement();
+    proxyInputs(IonSegment, SEGMENT_INPUTS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionChange']);

--- a/packages/angular/standalone/src/directives/select.ts
+++ b/packages/angular/standalone/src/directives/select.ts
@@ -8,6 +8,7 @@ import {
   Injector,
   NgZone,
 } from '@angular/core';
+import type { OnInit } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ValueAccessor } from '@ionic/angular/common';
 import type { SelectChangeEventDetail, Components } from '@ionic/core/components';
@@ -68,16 +69,24 @@ const SELECT_METHODS = ['open'];
   ],
   standalone: true,
 })
-export class IonSelect extends ValueAccessor {
+export class IonSelect extends ValueAccessor implements OnInit {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
     defineCustomElement();
-    proxyInputs(IonSelect, SELECT_INPUTS);
-    proxyMethods(IonSelect, SELECT_METHODS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionChange', 'ionCancel', 'ionDismiss', 'ionFocus', 'ionBlur']);
+  }
+
+  ngOnInit(): void {
+    /**
+     * Data-bound input properties are set
+     * by Angular after the constructor, so
+     * we need to run the proxy in ngOnInit.
+     */
+    proxyInputs(IonSelect, SELECT_INPUTS);
+    proxyMethods(IonSelect, SELECT_METHODS);
   }
 
   @HostListener('ionChange', ['$event.target'])

--- a/packages/angular/standalone/src/directives/select.ts
+++ b/packages/angular/standalone/src/directives/select.ts
@@ -13,7 +13,19 @@ import { ValueAccessor } from '@ionic/angular/common';
 import type { SelectChangeEventDetail, Components } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-select.js';
 
-import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
+/**
+ * Value accessor components should not use ProxyCmp
+ * and should call defineCustomElement and proxyInputs
+ * manually instead. Using both the @ProxyCmp and @Component
+ * decorators and useExisting (where useExisting refers to the
+ * class) causes ng-packagr to output multiple component variables
+ * which breaks treeshaking.
+ * For example, the following would be generated:
+ * let IonSelect = IonSelect_1 = class IonSelect extends ValueAccessor {
+ * Instead, we want only want the class generated:
+ * class IonSelect extends ValueAccessor {
+ */
+import { proxyInputs, proxyMethods, proxyOutputs } from './angular-component-lib/utils';
 
 const SELECT_INPUTS = [
   'cancelText',
@@ -39,11 +51,8 @@ const SELECT_INPUTS = [
   'value',
 ];
 
-@ProxyCmp({
-  defineCustomElementFn: defineCustomElement,
-  inputs: SELECT_INPUTS,
-  methods: ['open'],
-})
+const SELECT_METHODS = ['open'];
+
 @Component({
   selector: 'ion-select',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -63,6 +72,9 @@ export class IonSelect extends ValueAccessor {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
+    defineCustomElement();
+    proxyInputs(IonSelect, SELECT_INPUTS);
+    proxyMethods(IonSelect, SELECT_METHODS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionChange', 'ionCancel', 'ionDismiss', 'ionFocus', 'ionBlur']);

--- a/packages/angular/standalone/src/directives/textarea.ts
+++ b/packages/angular/standalone/src/directives/textarea.ts
@@ -8,6 +8,7 @@ import {
   Injector,
   NgZone,
 } from '@angular/core';
+import type { OnInit } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ValueAccessor } from '@ionic/angular/common';
 import type { TextareaChangeEventDetail, TextareaInputEventDetail, Components } from '@ionic/core/components';
@@ -77,16 +78,24 @@ const TEXTAREA_METHODS = ['setFocus', 'getInputElement'];
   ],
   standalone: true,
 })
-export class IonTextarea extends ValueAccessor {
+export class IonTextarea extends ValueAccessor implements OnInit {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
     defineCustomElement();
-    proxyInputs(IonTextarea, TEXTAREA_INPUTS);
-    proxyMethods(IonTextarea, TEXTAREA_METHODS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionChange', 'ionInput', 'ionBlur', 'ionFocus']);
+  }
+
+  ngOnInit(): void {
+    /**
+     * Data-bound input properties are set
+     * by Angular after the constructor, so
+     * we need to run the proxy in ngOnInit.
+     */
+    proxyInputs(IonTextarea, TEXTAREA_INPUTS);
+    proxyMethods(IonTextarea, TEXTAREA_METHODS);
   }
 
   @HostListener('ionInput', ['$event.target'])

--- a/packages/angular/standalone/src/directives/textarea.ts
+++ b/packages/angular/standalone/src/directives/textarea.ts
@@ -13,7 +13,19 @@ import { ValueAccessor } from '@ionic/angular/common';
 import type { TextareaChangeEventDetail, TextareaInputEventDetail, Components } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-textarea.js';
 
-import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
+/**
+ * Value accessor components should not use ProxyCmp
+ * and should call defineCustomElement and proxyInputs
+ * manually instead. Using both the @ProxyCmp and @Component
+ * decorators and useExisting (where useExisting refers to the
+ * class) causes ng-packagr to output multiple component variables
+ * which breaks treeshaking.
+ * For example, the following would be generated:
+ * let IonTextarea = IonTextarea_1 = class IonTextarea extends ValueAccessor {
+ * Instead, we want only want the class generated:
+ * class IonTextarea extends ValueAccessor {
+ */
+import { proxyInputs, proxyMethods, proxyOutputs } from './angular-component-lib/utils';
 
 const TEXTAREA_INPUTS = [
   'autoGrow',
@@ -48,11 +60,8 @@ const TEXTAREA_INPUTS = [
   'wrap',
 ];
 
-@ProxyCmp({
-  defineCustomElementFn: defineCustomElement,
-  inputs: TEXTAREA_INPUTS,
-  methods: ['setFocus', 'getInputElement'],
-})
+const TEXTAREA_METHODS = ['setFocus', 'getInputElement'];
+
 @Component({
   selector: 'ion-textarea',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -72,6 +81,9 @@ export class IonTextarea extends ValueAccessor {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
+    defineCustomElement();
+    proxyInputs(IonTextarea, TEXTAREA_INPUTS);
+    proxyMethods(IonTextarea, TEXTAREA_METHODS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionChange', 'ionInput', 'ionBlur', 'ionFocus']);

--- a/packages/angular/standalone/src/directives/toggle.ts
+++ b/packages/angular/standalone/src/directives/toggle.ts
@@ -8,6 +8,7 @@ import {
   Injector,
   NgZone,
 } from '@angular/core';
+import type { OnInit } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ValueAccessor, setIonicClasses } from '@ionic/angular/common';
 import type { ToggleChangeEventDetail, Components } from '@ionic/core/components';
@@ -55,15 +56,23 @@ const TOGGLE_INPUTS = [
   ],
   standalone: true,
 })
-export class IonToggle extends ValueAccessor {
+export class IonToggle extends ValueAccessor implements OnInit {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
     defineCustomElement();
-    proxyInputs(IonToggle, TOGGLE_INPUTS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionChange', 'ionFocus', 'ionBlur']);
+  }
+
+  ngOnInit(): void {
+    /**
+     * Data-bound input properties are set
+     * by Angular after the constructor, so
+     * we need to run the proxy in ngOnInit.
+     */
+    proxyInputs(IonToggle, TOGGLE_INPUTS);
   }
 
   writeValue(value: boolean): void {

--- a/packages/angular/standalone/src/directives/toggle.ts
+++ b/packages/angular/standalone/src/directives/toggle.ts
@@ -13,7 +13,19 @@ import { ValueAccessor, setIonicClasses } from '@ionic/angular/common';
 import type { ToggleChangeEventDetail, Components } from '@ionic/core/components';
 import { defineCustomElement } from '@ionic/core/components/ion-toggle.js';
 
-import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
+/**
+ * Value accessor components should not use ProxyCmp
+ * and should call defineCustomElement and proxyInputs
+ * manually instead. Using both the @ProxyCmp and @Component
+ * decorators and useExisting (where useExisting refers to the
+ * class) causes ng-packagr to output multiple component variables
+ * which breaks treeshaking.
+ * For example, the following would be generated:
+ * let IonToggle = IonToggle_1 = class IonToggle extends ValueAccessor {
+ * Instead, we want only want the class generated:
+ * class IonToggle extends ValueAccessor {
+ */
+import { proxyInputs, proxyOutputs } from './angular-component-lib/utils';
 
 const TOGGLE_INPUTS = [
   'checked',
@@ -28,10 +40,6 @@ const TOGGLE_INPUTS = [
   'value',
 ];
 
-@ProxyCmp({
-  defineCustomElementFn: defineCustomElement,
-  inputs: TOGGLE_INPUTS,
-})
 @Component({
   selector: 'ion-toggle',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -51,6 +59,8 @@ export class IonToggle extends ValueAccessor {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone, injector: Injector) {
     super(injector, r);
+    defineCustomElement();
+    proxyInputs(IonToggle, TOGGLE_INPUTS);
     c.detach();
     this.el = r.nativeElement;
     proxyOutputs(this, this.el, ['ionChange', 'ionFocus', 'ionBlur']);

--- a/packages/angular/test/base/e2e/src/standalone/value-accessors.spec.ts
+++ b/packages/angular/test/base/e2e/src/standalone/value-accessors.spec.ts
@@ -14,6 +14,10 @@ describe('Value Accessors', () => {
       cy.get('ion-checkbox').should('have.class', 'ion-dirty');
       cy.get('ion-checkbox').should('have.class', 'ion-valid');
     });
+
+    it('should proxy inputs on load', () => {
+      cy.get('ion-checkbox').should('have.prop', 'color', 'danger');
+    });
   });
 
   describe('Input', () => {
@@ -48,6 +52,10 @@ describe('Value Accessors', () => {
       cy.get('ion-input[formControlName="inputNumber"]').should('have.class', 'ion-valid');
 
     });
+
+    it('should proxy inputs on load', () => {
+      cy.get('ion-input').first().should('have.prop', 'color', 'danger');
+    });
   });
 
   describe('Radio Group', () => {
@@ -62,6 +70,10 @@ describe('Value Accessors', () => {
       cy.get('#formValue').should('have.text', JSON.stringify({ radioGroup: '2' }, null, 2));
       cy.get('ion-radio-group').should('have.class', 'ion-dirty');
       cy.get('ion-radio-group').should('have.class', 'ion-valid');
+    });
+
+    it('should proxy inputs on load', () => {
+      cy.get('ion-radio').first().should('have.prop', 'color', 'danger');
     });
   });
 
@@ -80,6 +92,10 @@ describe('Value Accessors', () => {
       cy.get('ion-searchbar').should('have.class', 'ion-dirty');
       cy.get('ion-searchbar').should('have.class', 'ion-valid');
     });
+
+    it('should proxy inputs on load', () => {
+      cy.get('ion-searchbar').should('have.prop', 'color', 'danger');
+    });
   });
 
   describe('Segment', () => {
@@ -94,6 +110,10 @@ describe('Value Accessors', () => {
       cy.get('#formValue').should('have.text', JSON.stringify({ segment: 'Free' }, null, 2));
       cy.get('ion-segment').should('have.class', 'ion-dirty');
       cy.get('ion-segment').should('have.class', 'ion-valid');
+    });
+
+    it('should proxy inputs on load', () => {
+      cy.get('ion-segment').should('have.prop', 'color', 'danger');
     });
   });
 
@@ -113,6 +133,10 @@ describe('Value Accessors', () => {
       cy.get('ion-select').should('have.class', 'ion-dirty');
       cy.get('ion-select').should('have.class', 'ion-valid');
     });
+
+    it('should proxy inputs on load', () => {
+      cy.get('ion-select').should('have.prop', 'color', 'danger');
+    });
   });
 
   describe('Textarea', () => {
@@ -130,6 +154,10 @@ describe('Value Accessors', () => {
       cy.get('ion-textarea').should('have.class', 'ion-dirty');
       cy.get('ion-textarea').should('have.class', 'ion-valid');
     });
+
+    it('should proxy inputs on load', () => {
+      cy.get('ion-textarea').should('have.prop', 'color', 'danger');
+    });
   });
 
   describe('Toggle', () => {
@@ -144,6 +172,10 @@ describe('Value Accessors', () => {
       cy.get('#formValue').should('have.text', JSON.stringify({ toggle: true }, null, 2));
       cy.get('ion-toggle').should('have.class', 'ion-dirty');
       cy.get('ion-toggle').should('have.class', 'ion-valid');
+    });
+
+    it('should proxy inputs on load', () => {
+      cy.get('ion-toggle').should('have.prop', 'color', 'danger');
     });
   });
 

--- a/packages/angular/test/base/e2e/src/standalone/value-accessors.spec.ts
+++ b/packages/angular/test/base/e2e/src/standalone/value-accessors.spec.ts
@@ -107,7 +107,7 @@ describe('Value Accessors', () => {
       cy.get('ion-select').click();
       cy.get('ion-popover').should('be.visible');
 
-      cy.get('ion-popover ion-radio:first-of-type').click();
+      cy.get('ion-popover ion-radio-group ion-radio').first().click();
 
       cy.get('#formValue').should('have.text', JSON.stringify({ select: 'apples' }, null, 2));
       cy.get('ion-select').should('have.class', 'ion-dirty');

--- a/packages/angular/test/base/e2e/src/standalone/value-accessors.spec.ts
+++ b/packages/angular/test/base/e2e/src/standalone/value-accessors.spec.ts
@@ -20,6 +20,14 @@ describe('Value Accessors', () => {
     });
   });
 
+  describe('Datetime', () => {
+    beforeEach(() => cy.visit('/standalone/value-accessors/datetime'));
+
+    it('should proxy inputs on load', () => {
+      cy.get('ion-datetime').should('have.prop', 'color', 'danger');
+    });
+  });
+
   describe('Input', () => {
     beforeEach(() => cy.visit('/standalone/value-accessors/input'));
 
@@ -76,6 +84,15 @@ describe('Value Accessors', () => {
       cy.get('ion-radio').first().should('have.prop', 'color', 'danger');
     });
   });
+
+  describe('Range', () => {
+    beforeEach(() => cy.visit('/standalone/value-accessors/range'));
+
+    it('should proxy inputs on load', () => {
+      cy.get('ion-range').should('have.prop', 'color', 'danger');
+    });
+  });
+
 
   describe('Searchbar', () => {
     beforeEach(() => cy.visit('/standalone/value-accessors/searchbar'));

--- a/packages/angular/test/base/e2e/src/standalone/value-accessors.spec.ts
+++ b/packages/angular/test/base/e2e/src/standalone/value-accessors.spec.ts
@@ -97,6 +97,24 @@ describe('Value Accessors', () => {
     });
   });
 
+  describe('Select', () => {
+    beforeEach(() => cy.visit('/standalone/value-accessors/select'));
+
+    it('should update the form value', () => {
+      cy.get('#formValue').should('have.text', JSON.stringify({ select: 'bananas' }, null, 2));
+      cy.get('ion-select').should('have.class', 'ion-pristine');
+
+      cy.get('ion-select').click();
+      cy.get('ion-popover').should('be.visible');
+
+      cy.get('ion-popover ion-radio:first-of-type').click();
+
+      cy.get('#formValue').should('have.text', JSON.stringify({ select: 'apples' }, null, 2));
+      cy.get('ion-select').should('have.class', 'ion-dirty');
+      cy.get('ion-select').should('have.class', 'ion-valid');
+    });
+  });
+
   describe('Textarea', () => {
     beforeEach(() => cy.visit('/standalone/value-accessors/textarea'));
 

--- a/packages/angular/test/base/src/app/standalone/app-standalone/app.routes.ts
+++ b/packages/angular/test/base/src/app/standalone/app-standalone/app.routes.ts
@@ -37,6 +37,7 @@ export const routes: Routes = [
           { path: 'range', loadComponent: () => import('../value-accessors/range/range.component').then(c => c.RangeComponent) },
           { path: 'searchbar', loadComponent: () => import('../value-accessors/searchbar/searchbar.component').then(c => c.SearchbarComponent) },
           { path: 'segment', loadComponent: () => import('../value-accessors/segment/segment.component').then(c => c.SegmentComponent) },
+          { path: 'select', loadComponent: () => import('../value-accessors/select/select.component').then(c => c.SelectComponent) },
           { path: 'textarea', loadComponent: () => import('../value-accessors/textarea/textarea.component').then(c => c.TextareaComponent) },
           { path: 'toggle', loadComponent: () => import('../value-accessors/toggle/toggle.component').then(c => c.ToggleComponent) },
           { path: '**', redirectTo: 'checkbox' }

--- a/packages/angular/test/base/src/app/standalone/value-accessors/checkbox/checkbox.component.html
+++ b/packages/angular/test/base/src/app/standalone/value-accessors/checkbox/checkbox.component.html
@@ -6,6 +6,6 @@
   </p>
 
   <app-value-accessor-test [formGroup]="form">
-    <ion-checkbox formControlName="checkbox"></ion-checkbox>
+    <ion-checkbox color="danger" formControlName="checkbox"></ion-checkbox>
   </app-value-accessor-test>
 </div>

--- a/packages/angular/test/base/src/app/standalone/value-accessors/datetime/datetime.component.html
+++ b/packages/angular/test/base/src/app/standalone/value-accessors/datetime/datetime.component.html
@@ -6,6 +6,6 @@
   </p>
 
   <app-value-accessor-test [formGroup]="form">
-    <ion-datetime formControlName="datetime"></ion-datetime>
+    <ion-datetime color="danger" formControlName="datetime"></ion-datetime>
   </app-value-accessor-test>
 </div>

--- a/packages/angular/test/base/src/app/standalone/value-accessors/input/input.component.html
+++ b/packages/angular/test/base/src/app/standalone/value-accessors/input/input.component.html
@@ -5,7 +5,7 @@
   </p>
 
   <app-value-accessor-test [formGroup]="form">
-    <ion-input label="String" formControlName="inputString"></ion-input>
+    <ion-input color="danger" label="String" formControlName="inputString"></ion-input>
     <ion-input label="Number" type="number" formControlName="inputNumber"></ion-input>
   </app-value-accessor-test>
 </div>

--- a/packages/angular/test/base/src/app/standalone/value-accessors/radio-group/radio-group.component.html
+++ b/packages/angular/test/base/src/app/standalone/value-accessors/radio-group/radio-group.component.html
@@ -7,7 +7,7 @@
 
   <app-value-accessor-test [formGroup]="form">
     <ion-radio-group formControlName="radioGroup">
-      <ion-radio value="1">One</ion-radio>
+      <ion-radio color="danger" value="1">One</ion-radio>
       <ion-radio value="2">Two</ion-radio>
     </ion-radio-group>
   </app-value-accessor-test>

--- a/packages/angular/test/base/src/app/standalone/value-accessors/range/range.component.html
+++ b/packages/angular/test/base/src/app/standalone/value-accessors/range/range.component.html
@@ -4,6 +4,6 @@
     This test checks the form integrations with ion-range to make sure values are correctly assigned to the form group.
   </p>
   <app-value-accessor-test [formGroup]="form">
-    <ion-range formControlName="range"></ion-range>
+    <ion-range color="danger" formControlName="range"></ion-range>
   </app-value-accessor-test>
 </div>

--- a/packages/angular/test/base/src/app/standalone/value-accessors/searchbar/searchbar.component.html
+++ b/packages/angular/test/base/src/app/standalone/value-accessors/searchbar/searchbar.component.html
@@ -5,6 +5,6 @@
     group.
   </p>
   <app-value-accessor-test [formGroup]="form">
-    <ion-searchbar label="String" formControlName="searchbar"></ion-searchbar>
+    <ion-searchbar color="danger" label="String" formControlName="searchbar"></ion-searchbar>
   </app-value-accessor-test>
 </div>

--- a/packages/angular/test/base/src/app/standalone/value-accessors/segment/segment.component.html
+++ b/packages/angular/test/base/src/app/standalone/value-accessors/segment/segment.component.html
@@ -6,7 +6,7 @@
   </p>
 
   <app-value-accessor-test [formGroup]="form">
-    <ion-segment formControlName="segment">
+    <ion-segment color="danger" formControlName="segment">
       <ion-segment-button value="Paid">
         <ion-label>Paid</ion-label>
       </ion-segment-button>

--- a/packages/angular/test/base/src/app/standalone/value-accessors/select/select.component.html
+++ b/packages/angular/test/base/src/app/standalone/value-accessors/select/select.component.html
@@ -6,7 +6,7 @@
   </p>
 
   <app-value-accessor-test [formGroup]="form">
-    <ion-select label="Favorite Fruit" formControlName="select" interface="popover">
+    <ion-select color="danger" label="Favorite Fruit" formControlName="select" interface="popover">
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>
     </ion-select>

--- a/packages/angular/test/base/src/app/standalone/value-accessors/select/select.component.html
+++ b/packages/angular/test/base/src/app/standalone/value-accessors/select/select.component.html
@@ -1,0 +1,14 @@
+<div>
+  <h1>IonSelect Value Accessors</h1>
+  <p>
+    This test checks the form integrations with ion-select to make sure values are correctly assigned to the form
+    group.
+  </p>
+
+  <app-value-accessor-test [formGroup]="form">
+    <ion-select label="Favorite Fruit" formControlName="select" interface="popover">
+      <ion-select-option value="apples">Apples</ion-select-option>
+      <ion-select-option value="bananas">Bananas</ion-select-option>
+    </ion-select>
+  </app-value-accessor-test>
+</div>

--- a/packages/angular/test/base/src/app/standalone/value-accessors/select/select.component.ts
+++ b/packages/angular/test/base/src/app/standalone/value-accessors/select/select.component.ts
@@ -1,0 +1,26 @@
+import { Component } from "@angular/core";
+import { FormBuilder, FormsModule, ReactiveFormsModule, Validators } from "@angular/forms";
+import { IonSelect, IonSelectOption } from "@ionic/angular/standalone";
+import { ValueAccessorTestComponent } from "../value-accessor-test/value-accessor-test.component";
+
+@Component({
+  selector: 'app-select',
+  templateUrl: 'select.component.html',
+  standalone: true,
+  imports: [
+    IonSelect,
+    IonSelectOption,
+    ReactiveFormsModule,
+    FormsModule,
+    ValueAccessorTestComponent
+  ]
+})
+export class SelectComponent {
+
+  form = this.fb.group({
+    select: ['bananas', Validators.required],
+  });
+
+  constructor(private fb: FormBuilder) { }
+
+}

--- a/packages/angular/test/base/src/app/standalone/value-accessors/textarea/textarea.component.html
+++ b/packages/angular/test/base/src/app/standalone/value-accessors/textarea/textarea.component.html
@@ -6,6 +6,6 @@
   </p>
 
   <app-value-accessor-test [formGroup]="form">
-    <ion-textarea label="String" formControlName="textarea"></ion-textarea>
+    <ion-textarea color="danger" label="String" formControlName="textarea"></ion-textarea>
   </app-value-accessor-test>
 </div>

--- a/packages/angular/test/base/src/app/standalone/value-accessors/toggle/toggle.component.html
+++ b/packages/angular/test/base/src/app/standalone/value-accessors/toggle/toggle.component.html
@@ -5,6 +5,6 @@
   </p>
 
   <app-value-accessor-test [formGroup]="form">
-    <ion-toggle formControlName="toggle"></ion-toggle>
+    <ion-toggle color="danger" formControlName="toggle"></ion-toggle>
   </app-value-accessor-test>
 </div>


### PR DESCRIPTION
Issue number: resolves #28358

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

https://github.com/ionic-team/ionic-framework/commit/28f2ec9c62fc301b432a7bca9a985b8ce90ef843 exposed a (possible) `ng-packagr` bug where the form control components were being re-assigned, which breaks treeshaking. These components were considered side effects and were always being pulled into the bundle.

This resulted in a higher than expected bundle size. This issue appears to be caused by using 2 decorators **and** referring to the class in `useExisting` (for providers). Doing just one of these does not reproduce the issue.

The compiled output looks something like this:

```typescript
let IonToggle = IonToggle_1 = /*@__PURE__*/ class IonToggle extends ValueAccessor {
    constructor(c, r, z, injector) {
        super(injector, r);
        this.z = z;
        c.detach();
        this.el = r.nativeElement;
        proxyOutputs(this, this.el, ['ionChange', 'ionFocus', 'ionBlur']);
    }
    writeValue(value) {
        this.elementRef.nativeElement.checked = this.lastValue = value;
        setIonicClasses(this.elementRef);
    }
    handleIonChange(el) {
        this.handleValueChange(el, el.checked);
    }
};
/** @nocollapse */ IonToggle.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "14.2.12", ngImport: i0, type: IonToggle, deps: [{ token: i0.ChangeDetectorRef }, { token: i0.ElementRef }, { token: i0.NgZone }, { token: i0.Injector }], target: i0.ɵɵFactoryTarget.Component });
/** @nocollapse */ IonToggle.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "14.2.12", type: IonToggle, isStandalone: true, selector: "ion-toggle", inputs: { checked: "checked", color: "color", disabled: "disabled", enableOnOffLabels: "enableOnOffLabels", justify: "justify", labelPlacement: "labelPlacement", legacy: "legacy", mode: "mode", name: "name", value: "value" }, host: { listeners: { "ionChange": "handleIonChange($event.target)" } }, providers: [
        {
            provide: NG_VALUE_ACCESSOR,
            useExisting: IonToggle_1,
            multi: true,
        },
    ], usesInheritance: true, ngImport: i0, template: '<ng-content></ng-content>', isInline: true, changeDetection: i0.ChangeDetectionStrategy.OnPush });
IonToggle = IonToggle_1 = __decorate([
    ProxyCmp({
        defineCustomElementFn: defineCustomElement$1i,
        inputs: TOGGLE_INPUTS,
    })
], IonToggle);
```

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed the `ProxyCmp` usage in favor of manually calling proxyInputs and proxyMethods.
-  Also saw that select was missing a form control test, so I added one

The compiled code now looks something like this:

```typescript
class IonToggle extends ValueAccessor {
    constructor(c, r, z, injector) {
        super(injector, r);
        this.z = z;
        defineCustomElement$1i();
        proxyInputs(IonToggle, TOGGLE_INPUTS);
        c.detach();
        this.el = r.nativeElement;
        proxyOutputs(this, this.el, ['ionChange', 'ionFocus', 'ionBlur']);
    }
    writeValue(value) {
        this.elementRef.nativeElement.checked = this.lastValue = value;
        setIonicClasses(this.elementRef);
    }
    handleIonChange(el) {
        this.handleValueChange(el, el.checked);
    }
}
/** @nocollapse */ IonToggle.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "14.2.12", ngImport: i0, type: IonToggle, deps: [{ token: i0.ChangeDetectorRef }, { token: i0.ElementRef }, { token: i0.NgZone }, { token: i0.Injector }], target: i0.ɵɵFactoryTarget.Component });
/** @nocollapse */ IonToggle.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "14.2.12", type: IonToggle, isStandalone: true, selector: "ion-toggle", inputs: { checked: "checked", color: "color", disabled: "disabled", enableOnOffLabels: "enableOnOffLabels", justify: "justify", labelPlacement: "labelPlacement", legacy: "legacy", mode: "mode", name: "name", value: "value" }, host: { listeners: { "ionChange": "handleIonChange($event.target)" } }, providers: [
        {
            provide: NG_VALUE_ACCESSOR,
            useExisting: IonToggle,
            multi: true,
        },
    ], usesInheritance: true, ngImport: i0, template: '<ng-content></ng-content>', isInline: true, changeDetection: i0.ChangeDetectionStrategy.OnPush });
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Ryan provided some context on a related Stencil bug where doing reassignments broke treeshaking in Webpack. While the source of this bug is not Stencil, understanding the Stencil bug helped me better understand this issue:

https://github.com/ionic-team/stencil/issues/3191
https://github.com/ionic-team/stencil/pull/3248
https://github.com/ionic-team/stencil/pull/4188 (fixes an issue introduced in the above stencil PR)

Dev build: `7.5.1-dev.11697480817.10fa2601`