### PR TITLE
docs(breaking): add v8 browser and platform support

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -12,3 +12,30 @@ This is a comprehensive list of the breaking changes introduced in the major ver
 - [Legacy](https://github.com/ionic-team/ionic-v3/blob/master/CHANGELOG.md)
 
 ## Version 8.x
+
+- [Browser and Platform Support](#version-8x-browser-platform-support)
+
+<h2 id="version-8x-browser-platform-support">Browser and Platform Support</h2>
+
+This section details the desktop browser, JavaScript framework, and mobile platform versions that are supported by Ionic 8.
+
+**Minimum Browser Versions**
+| Desktop Browser | Supported Versions |
+| --------------- | ----------------- |
+| Chrome          | 84+               |
+| Safari          | 15+               |
+| Firefox         | 75+               |
+| Edge            | 84+               |
+
+**Minimum JavaScript Framework Versions**
+| Framework | Supported Version     |
+| --------- | --------------------- |
+| Angular   | 16+                   |
+| React     | 17+                   |
+| Vue       | 3.0.6+                |
+
+**Minimum Mobile Platform Versions**
+| Platform | Supported Version      |
+| -------- | ---------------------- |
+| iOS      | 15+                    |
+| Android  | 5.1+ with Chromium 84+ |

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -22,10 +22,10 @@ This section details the desktop browser, JavaScript framework, and mobile platf
 **Minimum Browser Versions**
 | Desktop Browser | Supported Versions |
 | --------------- | ----------------- |
-| Chrome          | 84+               |
+| Chrome          | 89+               |
 | Safari          | 15+               |
 | Firefox         | 75+               |
-| Edge            | 84+               |
+| Edge            | 89+               |
 
 **Minimum JavaScript Framework Versions**
 | Framework | Supported Version     |
@@ -38,4 +38,4 @@ This section details the desktop browser, JavaScript framework, and mobile platf
 | Platform | Supported Version      |
 | -------- | ---------------------- |
 | iOS      | 15+                    |
-| Android  | 5.1+ with Chromium 84+ |
+| Android  | 5.1+ with Chromium 89+ |


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

As part of our Ionic 8 work, the team would like to define which browsers and platforms we will support.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Chromium (Chrome + Edge) support has changed from 79+ to 89+
- Firefox support has changed from 70+ to 75+
- Safari/WebKit support has changed from 14+ to 15+
- Angular support has changed from 14+ to 16+

A few notes on why I made these changes:

- These browsers have full support for [Web Animations Level 1](https://caniuse.com/?search=web%20animations). This allows us to remove the old CSS Animation fallback support from our animation library.
- These browsers have [native image lazy loading](https://caniuse.com/?search=image%20lazy%20loading) support (iOS has it starting in iOS 15.4) which allows us to reduce our dependency on `ion-img`.
- These browsers have full support for [CSS Logical Properties](https://caniuse.com/?search=logical%20properties) which will help improve our RTL support in Ionic.
- This also gives us ~3 years of Firefox and Chrome support by the time Ionic 8 comes out. Firefox 75 came out April 2020, and Chrome 89 came out February 2021.
- Dropping iOS 14 allows us to remove several iOS 14-related hacks in item, datetime, and more.
- Dropping iOS 14 still lets us support >94% of iPhones and >91% of iPads as of May 2023 (https://developer.apple.com/support/app-store/).
- Dropping Angular 14 and 15 allows us to remove several Angular specific hacks. Angular 14 LTS ends at the end of 2023, and Angular 15 LTS ends in May 2024, so these versions are not being supported by the Angular team for much longer. By the time Ionic 8 is out, Angular 17 should be released with Angular 18 coming soon.
## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
