### PR TITLE
fix(segment): avoid scrolling webkit bug

### DIFF
--- a/core/src/components/segment/segment.tsx
+++ b/core/src/components/segment/segment.tsx
@@ -353,7 +353,7 @@ export class Segment implements ComponentInterface {
          * within the scroll container, the browser will attempt
          * to center by as much as it can.
          */
-        this.el.scrollBy({
+        el.scrollBy({
           top: 0,
           left: centeredX,
           behavior: smoothScroll ? 'smooth' : 'instant'

--- a/core/src/components/segment/segment.tsx
+++ b/core/src/components/segment/segment.tsx
@@ -145,12 +145,12 @@ export class Segment implements ComponentInterface {
      * before we can scroll.
      */
     raf(() => {
-     /**
-      * When the segment loads for the first
-      * time we just want to snap the active button into
-      * place instead of scroll. Smooth scrolling should only
-      * happen when the user interacts with the segment.
-      */
+      /**
+       * When the segment loads for the first
+       * time we just want to snap the active button into
+       * place instead of scroll. Smooth scrolling should only
+       * happen when the user interacts with the segment.
+       */
       this.scrollActiveButtonIntoView(false);
     });
 
@@ -338,7 +338,7 @@ export class Segment implements ComponentInterface {
          * button such that the midpoint of the active button is at the midpoint of the
          * scroll container.
          */
-        const centeredX = activeButtonLeft - (scrollContainerBox.width / 2) + (activeButtonBox.width / 2);
+        const centeredX = activeButtonLeft - scrollContainerBox.width / 2 + activeButtonBox.width / 2;
 
         /**
          * We intentionally use scrollBy here instead of scrollIntoView
@@ -356,8 +356,8 @@ export class Segment implements ComponentInterface {
         el.scrollBy({
           top: 0,
           left: centeredX,
-          behavior: smoothScroll ? 'smooth' : 'instant'
-        })
+          behavior: smoothScroll ? 'smooth' : 'instant',
+        });
       }
     }
   }


### PR DESCRIPTION
Issue number: resolves #28373

---------


🚨 Reviewers: Please test this on Chrome, Firefox, and Safari

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The fix in https://github.com/ionic-team/ionic-framework/commit/1167a9325fb930b6c727bc26889f5488d9620062 uncovered a WebKit bug where scrolling an element using `scrollIntoView` during an accelerated transition causes the segment to jump during the transition. `scrollIntoView` can cause parent elements to also scroll, and given that the entering view begins outside the viewport, it's possible this triggered some sort of WebKit bug where it was trying to scroll the element into view.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updated the internal implementation to use `scrollBy` instead of `scrollIntoView`. `scrollBy` does not attempt to scroll parent elements which avoids the WebKit issue.
- I also updated the initial scroll to be instant rather than smoothly scroll. If a segment is added to the DOM, I'd expect it to be added with the correct scroll position (after the first render that is), so animating on load seemed like a strange behavior. User interaction will continue to use smooth scrolling though.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


Dev build: `7.5.2-dev.11697638908.1f04980a`