### PR TITLE
chore(angular): proxies file is ignored by prettier

### DIFF
--- a/packages/angular/.prettierignore
+++ b/packages/angular/.prettierignore
@@ -1,6 +1,6 @@
 dist
 scripts
 test
-src/directives/proxies.ts
+proxies.ts
 src/directives/proxies-list.ts
 src/directives/angular-component-lib/utils.ts

--- a/packages/angular/standalone/src/directives/proxies.ts
+++ b/packages/angular/standalone/src/directives/proxies.ts
@@ -73,7 +73,7 @@ import { defineCustomElement as defineIonToast } from '@ionic/core/components/io
 import { defineCustomElement as defineIonToolbar } from '@ionic/core/components/ion-toolbar.js';
 @ProxyCmp({
   defineCustomElementFn: defineIonAccordion,
-  inputs: ['disabled', 'mode', 'readonly', 'toggleIcon', 'toggleIconSlot', 'value'],
+  inputs: ['disabled', 'mode', 'readonly', 'toggleIcon', 'toggleIconSlot', 'value']
 })
 @Component({
   selector: 'ion-accordion',
@@ -81,7 +81,7 @@ import { defineCustomElement as defineIonToolbar } from '@ionic/core/components/
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'mode', 'readonly', 'toggleIcon', 'toggleIconSlot', 'value'],
-  standalone: true,
+  standalone: true
 })
 export class IonAccordion {
   protected el: HTMLElement;
@@ -91,11 +91,13 @@ export class IonAccordion {
   }
 }
 
+
 export declare interface IonAccordion extends Components.IonAccordion {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonAccordionGroup,
-  inputs: ['animated', 'disabled', 'expand', 'mode', 'multiple', 'readonly', 'value'],
+  inputs: ['animated', 'disabled', 'expand', 'mode', 'multiple', 'readonly', 'value']
 })
 @Component({
   selector: 'ion-accordion-group',
@@ -103,7 +105,7 @@ export declare interface IonAccordion extends Components.IonAccordion {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['animated', 'disabled', 'expand', 'mode', 'multiple', 'readonly', 'value'],
-  standalone: true,
+  standalone: true
 })
 export class IonAccordionGroup {
   protected el: HTMLElement;
@@ -113,6 +115,7 @@ export class IonAccordionGroup {
     proxyOutputs(this, this.el, ['ionChange']);
   }
 }
+
 
 import type { AccordionGroupChangeEventDetail as IIonAccordionGroupAccordionGroupChangeEventDetail } from '@ionic/core/components';
 
@@ -126,66 +129,29 @@ the value property.
   ionChange: EventEmitter<CustomEvent<IIonAccordionGroupAccordionGroupChangeEventDetail>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonActionSheet,
-  inputs: [
-    'animated',
-    'backdropDismiss',
-    'buttons',
-    'cssClass',
-    'enterAnimation',
-    'header',
-    'htmlAttributes',
-    'isOpen',
-    'keyboardClose',
-    'leaveAnimation',
-    'mode',
-    'subHeader',
-    'translucent',
-    'trigger',
-  ],
-  methods: ['present', 'dismiss', 'onDidDismiss', 'onWillDismiss'],
+  inputs: ['animated', 'backdropDismiss', 'buttons', 'cssClass', 'enterAnimation', 'header', 'htmlAttributes', 'isOpen', 'keyboardClose', 'leaveAnimation', 'mode', 'subHeader', 'translucent', 'trigger'],
+  methods: ['present', 'dismiss', 'onDidDismiss', 'onWillDismiss']
 })
 @Component({
   selector: 'ion-action-sheet',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [
-    'animated',
-    'backdropDismiss',
-    'buttons',
-    'cssClass',
-    'enterAnimation',
-    'header',
-    'htmlAttributes',
-    'isOpen',
-    'keyboardClose',
-    'leaveAnimation',
-    'mode',
-    'subHeader',
-    'translucent',
-    'trigger',
-  ],
-  standalone: true,
+  inputs: ['animated', 'backdropDismiss', 'buttons', 'cssClass', 'enterAnimation', 'header', 'htmlAttributes', 'isOpen', 'keyboardClose', 'leaveAnimation', 'mode', 'subHeader', 'translucent', 'trigger'],
+  standalone: true
 })
 export class IonActionSheet {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, [
-      'ionActionSheetDidPresent',
-      'ionActionSheetWillPresent',
-      'ionActionSheetWillDismiss',
-      'ionActionSheetDidDismiss',
-      'didPresent',
-      'willPresent',
-      'willDismiss',
-      'didDismiss',
-    ]);
+    proxyOutputs(this, this.el, ['ionActionSheetDidPresent', 'ionActionSheetWillPresent', 'ionActionSheetWillDismiss', 'ionActionSheetDidDismiss', 'didPresent', 'willPresent', 'willDismiss', 'didDismiss']);
   }
 }
+
 
 import type { OverlayEventDetail as IIonActionSheetOverlayEventDetail } from '@ionic/core/components';
 
@@ -228,70 +194,29 @@ Shorthand for ionActionSheetDidDismiss.
   didDismiss: EventEmitter<CustomEvent<IIonActionSheetOverlayEventDetail>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonAlert,
-  inputs: [
-    'animated',
-    'backdropDismiss',
-    'buttons',
-    'cssClass',
-    'enterAnimation',
-    'header',
-    'htmlAttributes',
-    'inputs',
-    'isOpen',
-    'keyboardClose',
-    'leaveAnimation',
-    'message',
-    'mode',
-    'subHeader',
-    'translucent',
-    'trigger',
-  ],
-  methods: ['present', 'dismiss', 'onDidDismiss', 'onWillDismiss'],
+  inputs: ['animated', 'backdropDismiss', 'buttons', 'cssClass', 'enterAnimation', 'header', 'htmlAttributes', 'inputs', 'isOpen', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'subHeader', 'translucent', 'trigger'],
+  methods: ['present', 'dismiss', 'onDidDismiss', 'onWillDismiss']
 })
 @Component({
   selector: 'ion-alert',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [
-    'animated',
-    'backdropDismiss',
-    'buttons',
-    'cssClass',
-    'enterAnimation',
-    'header',
-    'htmlAttributes',
-    'inputs',
-    'isOpen',
-    'keyboardClose',
-    'leaveAnimation',
-    'message',
-    'mode',
-    'subHeader',
-    'translucent',
-    'trigger',
-  ],
-  standalone: true,
+  inputs: ['animated', 'backdropDismiss', 'buttons', 'cssClass', 'enterAnimation', 'header', 'htmlAttributes', 'inputs', 'isOpen', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'subHeader', 'translucent', 'trigger'],
+  standalone: true
 })
 export class IonAlert {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, [
-      'ionAlertDidPresent',
-      'ionAlertWillPresent',
-      'ionAlertWillDismiss',
-      'ionAlertDidDismiss',
-      'didPresent',
-      'willPresent',
-      'willDismiss',
-      'didDismiss',
-    ]);
+    proxyOutputs(this, this.el, ['ionAlertDidPresent', 'ionAlertWillPresent', 'ionAlertWillDismiss', 'ionAlertDidDismiss', 'didPresent', 'willPresent', 'willDismiss', 'didDismiss']);
   }
 }
+
 
 import type { OverlayEventDetail as IIonAlertOverlayEventDetail } from '@ionic/core/components';
 
@@ -334,8 +259,9 @@ Shorthand for ionAlertDidDismiss.
   didDismiss: EventEmitter<CustomEvent<IIonAlertOverlayEventDetail>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: defineIonApp,
+  defineCustomElementFn: defineIonApp
 })
 @Component({
   selector: 'ion-app',
@@ -343,7 +269,7 @@ Shorthand for ionAlertDidDismiss.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
-  standalone: true,
+  standalone: true
 })
 export class IonApp {
   protected el: HTMLElement;
@@ -353,10 +279,12 @@ export class IonApp {
   }
 }
 
+
 export declare interface IonApp extends Components.IonApp {}
 
+
 @ProxyCmp({
-  defineCustomElementFn: defineIonAvatar,
+  defineCustomElementFn: defineIonAvatar
 })
 @Component({
   selector: 'ion-avatar',
@@ -364,7 +292,7 @@ export declare interface IonApp extends Components.IonApp {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
-  standalone: true,
+  standalone: true
 })
 export class IonAvatar {
   protected el: HTMLElement;
@@ -374,11 +302,13 @@ export class IonAvatar {
   }
 }
 
+
 export declare interface IonAvatar extends Components.IonAvatar {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonBackdrop,
-  inputs: ['stopPropagation', 'tappable', 'visible'],
+  inputs: ['stopPropagation', 'tappable', 'visible']
 })
 @Component({
   selector: 'ion-backdrop',
@@ -386,7 +316,7 @@ export declare interface IonAvatar extends Components.IonAvatar {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['stopPropagation', 'tappable', 'visible'],
-  standalone: true,
+  standalone: true
 })
 export class IonBackdrop {
   protected el: HTMLElement;
@@ -397,6 +327,7 @@ export class IonBackdrop {
   }
 }
 
+
 export declare interface IonBackdrop extends Components.IonBackdrop {
   /**
    * Emitted when the backdrop is tapped.
@@ -404,9 +335,10 @@ export declare interface IonBackdrop extends Components.IonBackdrop {
   ionBackdropTap: EventEmitter<CustomEvent<void>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonBadge,
-  inputs: ['color', 'mode'],
+  inputs: ['color', 'mode']
 })
 @Component({
   selector: 'ion-badge',
@@ -414,7 +346,7 @@ export declare interface IonBackdrop extends Components.IonBackdrop {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'mode'],
-  standalone: true,
+  standalone: true
 })
 export class IonBadge {
   protected el: HTMLElement;
@@ -424,43 +356,21 @@ export class IonBadge {
   }
 }
 
+
 export declare interface IonBadge extends Components.IonBadge {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonBreadcrumb,
-  inputs: [
-    'active',
-    'color',
-    'disabled',
-    'download',
-    'href',
-    'mode',
-    'rel',
-    'routerAnimation',
-    'routerDirection',
-    'separator',
-    'target',
-  ],
+  inputs: ['active', 'color', 'disabled', 'download', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'separator', 'target']
 })
 @Component({
   selector: 'ion-breadcrumb',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [
-    'active',
-    'color',
-    'disabled',
-    'download',
-    'href',
-    'mode',
-    'rel',
-    'routerAnimation',
-    'routerDirection',
-    'separator',
-    'target',
-  ],
-  standalone: true,
+  inputs: ['active', 'color', 'disabled', 'download', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'separator', 'target'],
+  standalone: true
 })
 export class IonBreadcrumb {
   protected el: HTMLElement;
@@ -470,6 +380,7 @@ export class IonBreadcrumb {
     proxyOutputs(this, this.el, ['ionFocus', 'ionBlur']);
   }
 }
+
 
 export declare interface IonBreadcrumb extends Components.IonBreadcrumb {
   /**
@@ -482,9 +393,10 @@ export declare interface IonBreadcrumb extends Components.IonBreadcrumb {
   ionBlur: EventEmitter<CustomEvent<void>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonBreadcrumbs,
-  inputs: ['color', 'itemsAfterCollapse', 'itemsBeforeCollapse', 'maxItems', 'mode'],
+  inputs: ['color', 'itemsAfterCollapse', 'itemsBeforeCollapse', 'maxItems', 'mode']
 })
 @Component({
   selector: 'ion-breadcrumbs',
@@ -492,7 +404,7 @@ export declare interface IonBreadcrumb extends Components.IonBreadcrumb {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'itemsAfterCollapse', 'itemsBeforeCollapse', 'maxItems', 'mode'],
-  standalone: true,
+  standalone: true
 })
 export class IonBreadcrumbs {
   protected el: HTMLElement;
@@ -503,6 +415,7 @@ export class IonBreadcrumbs {
   }
 }
 
+
 import type { BreadcrumbCollapsedClickEventDetail as IIonBreadcrumbsBreadcrumbCollapsedClickEventDetail } from '@ionic/core/components';
 
 export declare interface IonBreadcrumbs extends Components.IonBreadcrumbs {
@@ -512,53 +425,18 @@ export declare interface IonBreadcrumbs extends Components.IonBreadcrumbs {
   ionCollapsedClick: EventEmitter<CustomEvent<IIonBreadcrumbsBreadcrumbCollapsedClickEventDetail>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonButton,
-  inputs: [
-    'buttonType',
-    'color',
-    'disabled',
-    'download',
-    'expand',
-    'fill',
-    'form',
-    'href',
-    'mode',
-    'rel',
-    'routerAnimation',
-    'routerDirection',
-    'shape',
-    'size',
-    'strong',
-    'target',
-    'type',
-  ],
+  inputs: ['buttonType', 'color', 'disabled', 'download', 'expand', 'fill', 'form', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'shape', 'size', 'strong', 'target', 'type']
 })
 @Component({
   selector: 'ion-button',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [
-    'buttonType',
-    'color',
-    'disabled',
-    'download',
-    'expand',
-    'fill',
-    'form',
-    'href',
-    'mode',
-    'rel',
-    'routerAnimation',
-    'routerDirection',
-    'shape',
-    'size',
-    'strong',
-    'target',
-    'type',
-  ],
-  standalone: true,
+  inputs: ['buttonType', 'color', 'disabled', 'download', 'expand', 'fill', 'form', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'shape', 'size', 'strong', 'target', 'type'],
+  standalone: true
 })
 export class IonButton {
   protected el: HTMLElement;
@@ -568,6 +446,7 @@ export class IonButton {
     proxyOutputs(this, this.el, ['ionFocus', 'ionBlur']);
   }
 }
+
 
 export declare interface IonButton extends Components.IonButton {
   /**
@@ -580,9 +459,10 @@ export declare interface IonButton extends Components.IonButton {
   ionBlur: EventEmitter<CustomEvent<void>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonButtons,
-  inputs: ['collapse'],
+  inputs: ['collapse']
 })
 @Component({
   selector: 'ion-buttons',
@@ -590,7 +470,7 @@ export declare interface IonButton extends Components.IonButton {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['collapse'],
-  standalone: true,
+  standalone: true
 })
 export class IonButtons {
   protected el: HTMLElement;
@@ -600,43 +480,21 @@ export class IonButtons {
   }
 }
 
+
 export declare interface IonButtons extends Components.IonButtons {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonCard,
-  inputs: [
-    'button',
-    'color',
-    'disabled',
-    'download',
-    'href',
-    'mode',
-    'rel',
-    'routerAnimation',
-    'routerDirection',
-    'target',
-    'type',
-  ],
+  inputs: ['button', 'color', 'disabled', 'download', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'target', 'type']
 })
 @Component({
   selector: 'ion-card',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [
-    'button',
-    'color',
-    'disabled',
-    'download',
-    'href',
-    'mode',
-    'rel',
-    'routerAnimation',
-    'routerDirection',
-    'target',
-    'type',
-  ],
-  standalone: true,
+  inputs: ['button', 'color', 'disabled', 'download', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'target', 'type'],
+  standalone: true
 })
 export class IonCard {
   protected el: HTMLElement;
@@ -646,11 +504,13 @@ export class IonCard {
   }
 }
 
+
 export declare interface IonCard extends Components.IonCard {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonCardContent,
-  inputs: ['mode'],
+  inputs: ['mode']
 })
 @Component({
   selector: 'ion-card-content',
@@ -658,7 +518,7 @@ export declare interface IonCard extends Components.IonCard {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['mode'],
-  standalone: true,
+  standalone: true
 })
 export class IonCardContent {
   protected el: HTMLElement;
@@ -668,11 +528,13 @@ export class IonCardContent {
   }
 }
 
+
 export declare interface IonCardContent extends Components.IonCardContent {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonCardHeader,
-  inputs: ['color', 'mode', 'translucent'],
+  inputs: ['color', 'mode', 'translucent']
 })
 @Component({
   selector: 'ion-card-header',
@@ -680,7 +542,7 @@ export declare interface IonCardContent extends Components.IonCardContent {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'mode', 'translucent'],
-  standalone: true,
+  standalone: true
 })
 export class IonCardHeader {
   protected el: HTMLElement;
@@ -690,11 +552,13 @@ export class IonCardHeader {
   }
 }
 
+
 export declare interface IonCardHeader extends Components.IonCardHeader {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonCardSubtitle,
-  inputs: ['color', 'mode'],
+  inputs: ['color', 'mode']
 })
 @Component({
   selector: 'ion-card-subtitle',
@@ -702,7 +566,7 @@ export declare interface IonCardHeader extends Components.IonCardHeader {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'mode'],
-  standalone: true,
+  standalone: true
 })
 export class IonCardSubtitle {
   protected el: HTMLElement;
@@ -712,11 +576,13 @@ export class IonCardSubtitle {
   }
 }
 
+
 export declare interface IonCardSubtitle extends Components.IonCardSubtitle {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonCardTitle,
-  inputs: ['color', 'mode'],
+  inputs: ['color', 'mode']
 })
 @Component({
   selector: 'ion-card-title',
@@ -724,7 +590,7 @@ export declare interface IonCardSubtitle extends Components.IonCardSubtitle {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'mode'],
-  standalone: true,
+  standalone: true
 })
 export class IonCardTitle {
   protected el: HTMLElement;
@@ -734,11 +600,13 @@ export class IonCardTitle {
   }
 }
 
+
 export declare interface IonCardTitle extends Components.IonCardTitle {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonChip,
-  inputs: ['color', 'disabled', 'mode', 'outline'],
+  inputs: ['color', 'disabled', 'mode', 'outline']
 })
 @Component({
   selector: 'ion-chip',
@@ -746,7 +614,7 @@ export declare interface IonCardTitle extends Components.IonCardTitle {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'disabled', 'mode', 'outline'],
-  standalone: true,
+  standalone: true
 })
 export class IonChip {
   protected el: HTMLElement;
@@ -756,69 +624,21 @@ export class IonChip {
   }
 }
 
+
 export declare interface IonChip extends Components.IonChip {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonCol,
-  inputs: [
-    'offset',
-    'offsetLg',
-    'offsetMd',
-    'offsetSm',
-    'offsetXl',
-    'offsetXs',
-    'pull',
-    'pullLg',
-    'pullMd',
-    'pullSm',
-    'pullXl',
-    'pullXs',
-    'push',
-    'pushLg',
-    'pushMd',
-    'pushSm',
-    'pushXl',
-    'pushXs',
-    'size',
-    'sizeLg',
-    'sizeMd',
-    'sizeSm',
-    'sizeXl',
-    'sizeXs',
-  ],
+  inputs: ['offset', 'offsetLg', 'offsetMd', 'offsetSm', 'offsetXl', 'offsetXs', 'pull', 'pullLg', 'pullMd', 'pullSm', 'pullXl', 'pullXs', 'push', 'pushLg', 'pushMd', 'pushSm', 'pushXl', 'pushXs', 'size', 'sizeLg', 'sizeMd', 'sizeSm', 'sizeXl', 'sizeXs']
 })
 @Component({
   selector: 'ion-col',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [
-    'offset',
-    'offsetLg',
-    'offsetMd',
-    'offsetSm',
-    'offsetXl',
-    'offsetXs',
-    'pull',
-    'pullLg',
-    'pullMd',
-    'pullSm',
-    'pullXl',
-    'pullXs',
-    'push',
-    'pushLg',
-    'pushMd',
-    'pushSm',
-    'pushXl',
-    'pushXs',
-    'size',
-    'sizeLg',
-    'sizeMd',
-    'sizeSm',
-    'sizeXl',
-    'sizeXs',
-  ],
-  standalone: true,
+  inputs: ['offset', 'offsetLg', 'offsetMd', 'offsetSm', 'offsetXl', 'offsetXs', 'pull', 'pullLg', 'pullMd', 'pullSm', 'pullXl', 'pullXs', 'push', 'pushLg', 'pushMd', 'pushSm', 'pushXl', 'pushXs', 'size', 'sizeLg', 'sizeMd', 'sizeSm', 'sizeXl', 'sizeXs'],
+  standalone: true
 })
 export class IonCol {
   protected el: HTMLElement;
@@ -828,12 +648,14 @@ export class IonCol {
   }
 }
 
+
 export declare interface IonCol extends Components.IonCol {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonContent,
   inputs: ['color', 'forceOverscroll', 'fullscreen', 'scrollEvents', 'scrollX', 'scrollY'],
-  methods: ['getScrollElement', 'scrollToTop', 'scrollToBottom', 'scrollByPoint', 'scrollToPoint'],
+  methods: ['getScrollElement', 'scrollToTop', 'scrollToBottom', 'scrollByPoint', 'scrollToPoint']
 })
 @Component({
   selector: 'ion-content',
@@ -841,7 +663,7 @@ export declare interface IonCol extends Components.IonCol {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'forceOverscroll', 'fullscreen', 'scrollEvents', 'scrollX', 'scrollY'],
-  standalone: true,
+  standalone: true
 })
 export class IonContent {
   protected el: HTMLElement;
@@ -851,6 +673,7 @@ export class IonContent {
     proxyOutputs(this, this.el, ['ionScrollStart', 'ionScroll', 'ionScrollEnd']);
   }
 }
+
 
 import type { ScrollBaseDetail as IIonContentScrollBaseDetail } from '@ionic/core/components';
 import type { ScrollDetail as IIonContentScrollDetail } from '@ionic/core/components';
@@ -873,9 +696,10 @@ Set `scrollEvents` to `true` to enable.
   ionScrollEnd: EventEmitter<CustomEvent<IIonContentScrollBaseDetail>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonDatetimeButton,
-  inputs: ['color', 'datetime', 'disabled', 'mode'],
+  inputs: ['color', 'datetime', 'disabled', 'mode']
 })
 @Component({
   selector: 'ion-datetime-button',
@@ -883,7 +707,7 @@ Set `scrollEvents` to `true` to enable.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'datetime', 'disabled', 'mode'],
-  standalone: true,
+  standalone: true
 })
 export class IonDatetimeButton {
   protected el: HTMLElement;
@@ -893,12 +717,14 @@ export class IonDatetimeButton {
   }
 }
 
+
 export declare interface IonDatetimeButton extends Components.IonDatetimeButton {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonFab,
   inputs: ['activated', 'edge', 'horizontal', 'vertical'],
-  methods: ['close'],
+  methods: ['close']
 })
 @Component({
   selector: 'ion-fab',
@@ -906,7 +732,7 @@ export declare interface IonDatetimeButton extends Components.IonDatetimeButton 
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['activated', 'edge', 'horizontal', 'vertical'],
-  standalone: true,
+  standalone: true
 })
 export class IonFab {
   protected el: HTMLElement;
@@ -916,51 +742,21 @@ export class IonFab {
   }
 }
 
+
 export declare interface IonFab extends Components.IonFab {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonFabButton,
-  inputs: [
-    'activated',
-    'closeIcon',
-    'color',
-    'disabled',
-    'download',
-    'href',
-    'mode',
-    'rel',
-    'routerAnimation',
-    'routerDirection',
-    'show',
-    'size',
-    'target',
-    'translucent',
-    'type',
-  ],
+  inputs: ['activated', 'closeIcon', 'color', 'disabled', 'download', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'show', 'size', 'target', 'translucent', 'type']
 })
 @Component({
   selector: 'ion-fab-button',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [
-    'activated',
-    'closeIcon',
-    'color',
-    'disabled',
-    'download',
-    'href',
-    'mode',
-    'rel',
-    'routerAnimation',
-    'routerDirection',
-    'show',
-    'size',
-    'target',
-    'translucent',
-    'type',
-  ],
-  standalone: true,
+  inputs: ['activated', 'closeIcon', 'color', 'disabled', 'download', 'href', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'show', 'size', 'target', 'translucent', 'type'],
+  standalone: true
 })
 export class IonFabButton {
   protected el: HTMLElement;
@@ -970,6 +766,7 @@ export class IonFabButton {
     proxyOutputs(this, this.el, ['ionFocus', 'ionBlur']);
   }
 }
+
 
 export declare interface IonFabButton extends Components.IonFabButton {
   /**
@@ -982,9 +779,10 @@ export declare interface IonFabButton extends Components.IonFabButton {
   ionBlur: EventEmitter<CustomEvent<void>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonFabList,
-  inputs: ['activated', 'side'],
+  inputs: ['activated', 'side']
 })
 @Component({
   selector: 'ion-fab-list',
@@ -992,7 +790,7 @@ export declare interface IonFabButton extends Components.IonFabButton {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['activated', 'side'],
-  standalone: true,
+  standalone: true
 })
 export class IonFabList {
   protected el: HTMLElement;
@@ -1002,11 +800,13 @@ export class IonFabList {
   }
 }
 
+
 export declare interface IonFabList extends Components.IonFabList {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonFooter,
-  inputs: ['collapse', 'mode', 'translucent'],
+  inputs: ['collapse', 'mode', 'translucent']
 })
 @Component({
   selector: 'ion-footer',
@@ -1014,7 +814,7 @@ export declare interface IonFabList extends Components.IonFabList {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['collapse', 'mode', 'translucent'],
-  standalone: true,
+  standalone: true
 })
 export class IonFooter {
   protected el: HTMLElement;
@@ -1024,11 +824,13 @@ export class IonFooter {
   }
 }
 
+
 export declare interface IonFooter extends Components.IonFooter {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonGrid,
-  inputs: ['fixed'],
+  inputs: ['fixed']
 })
 @Component({
   selector: 'ion-grid',
@@ -1036,7 +838,7 @@ export declare interface IonFooter extends Components.IonFooter {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['fixed'],
-  standalone: true,
+  standalone: true
 })
 export class IonGrid {
   protected el: HTMLElement;
@@ -1046,11 +848,13 @@ export class IonGrid {
   }
 }
 
+
 export declare interface IonGrid extends Components.IonGrid {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonHeader,
-  inputs: ['collapse', 'mode', 'translucent'],
+  inputs: ['collapse', 'mode', 'translucent']
 })
 @Component({
   selector: 'ion-header',
@@ -1058,7 +862,7 @@ export declare interface IonGrid extends Components.IonGrid {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['collapse', 'mode', 'translucent'],
-  standalone: true,
+  standalone: true
 })
 export class IonHeader {
   protected el: HTMLElement;
@@ -1068,11 +872,13 @@ export class IonHeader {
   }
 }
 
+
 export declare interface IonHeader extends Components.IonHeader {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonImg,
-  inputs: ['alt', 'src'],
+  inputs: ['alt', 'src']
 })
 @Component({
   selector: 'ion-img',
@@ -1080,7 +886,7 @@ export declare interface IonHeader extends Components.IonHeader {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['alt', 'src'],
-  standalone: true,
+  standalone: true
 })
 export class IonImg {
   protected el: HTMLElement;
@@ -1090,6 +896,7 @@ export class IonImg {
     proxyOutputs(this, this.el, ['ionImgWillLoad', 'ionImgDidLoad', 'ionError']);
   }
 }
+
 
 export declare interface IonImg extends Components.IonImg {
   /**
@@ -1106,10 +913,11 @@ export declare interface IonImg extends Components.IonImg {
   ionError: EventEmitter<CustomEvent<void>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonInfiniteScroll,
   inputs: ['disabled', 'position', 'threshold'],
-  methods: ['complete'],
+  methods: ['complete']
 })
 @Component({
   selector: 'ion-infinite-scroll',
@@ -1117,7 +925,7 @@ export declare interface IonImg extends Components.IonImg {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'position', 'threshold'],
-  standalone: true,
+  standalone: true
 })
 export class IonInfiniteScroll {
   protected el: HTMLElement;
@@ -1127,6 +935,7 @@ export class IonInfiniteScroll {
     proxyOutputs(this, this.el, ['ionInfinite']);
   }
 }
+
 
 export declare interface IonInfiniteScroll extends Components.IonInfiniteScroll {
   /**
@@ -1138,9 +947,10 @@ your async operation has completed.
   ionInfinite: EventEmitter<CustomEvent<void>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonInfiniteScrollContent,
-  inputs: ['loadingSpinner', 'loadingText'],
+  inputs: ['loadingSpinner', 'loadingText']
 })
 @Component({
   selector: 'ion-infinite-scroll-content',
@@ -1148,7 +958,7 @@ your async operation has completed.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['loadingSpinner', 'loadingText'],
-  standalone: true,
+  standalone: true
 })
 export class IonInfiniteScrollContent {
   protected el: HTMLElement;
@@ -1158,57 +968,21 @@ export class IonInfiniteScrollContent {
   }
 }
 
+
 export declare interface IonInfiniteScrollContent extends Components.IonInfiniteScrollContent {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonItem,
-  inputs: [
-    'button',
-    'color',
-    'counter',
-    'counterFormatter',
-    'detail',
-    'detailIcon',
-    'disabled',
-    'download',
-    'fill',
-    'href',
-    'lines',
-    'mode',
-    'rel',
-    'routerAnimation',
-    'routerDirection',
-    'shape',
-    'target',
-    'type',
-  ],
+  inputs: ['button', 'color', 'counter', 'counterFormatter', 'detail', 'detailIcon', 'disabled', 'download', 'fill', 'href', 'lines', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'shape', 'target', 'type']
 })
 @Component({
   selector: 'ion-item',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [
-    'button',
-    'color',
-    'counter',
-    'counterFormatter',
-    'detail',
-    'detailIcon',
-    'disabled',
-    'download',
-    'fill',
-    'href',
-    'lines',
-    'mode',
-    'rel',
-    'routerAnimation',
-    'routerDirection',
-    'shape',
-    'target',
-    'type',
-  ],
-  standalone: true,
+  inputs: ['button', 'color', 'counter', 'counterFormatter', 'detail', 'detailIcon', 'disabled', 'download', 'fill', 'href', 'lines', 'mode', 'rel', 'routerAnimation', 'routerDirection', 'shape', 'target', 'type'],
+  standalone: true
 })
 export class IonItem {
   protected el: HTMLElement;
@@ -1218,11 +992,13 @@ export class IonItem {
   }
 }
 
+
 export declare interface IonItem extends Components.IonItem {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonItemDivider,
-  inputs: ['color', 'mode', 'sticky'],
+  inputs: ['color', 'mode', 'sticky']
 })
 @Component({
   selector: 'ion-item-divider',
@@ -1230,7 +1006,7 @@ export declare interface IonItem extends Components.IonItem {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'mode', 'sticky'],
-  standalone: true,
+  standalone: true
 })
 export class IonItemDivider {
   protected el: HTMLElement;
@@ -1240,10 +1016,12 @@ export class IonItemDivider {
   }
 }
 
+
 export declare interface IonItemDivider extends Components.IonItemDivider {}
 
+
 @ProxyCmp({
-  defineCustomElementFn: defineIonItemGroup,
+  defineCustomElementFn: defineIonItemGroup
 })
 @Component({
   selector: 'ion-item-group',
@@ -1251,7 +1029,7 @@ export declare interface IonItemDivider extends Components.IonItemDivider {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
-  standalone: true,
+  standalone: true
 })
 export class IonItemGroup {
   protected el: HTMLElement;
@@ -1261,11 +1039,13 @@ export class IonItemGroup {
   }
 }
 
+
 export declare interface IonItemGroup extends Components.IonItemGroup {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonItemOption,
-  inputs: ['color', 'disabled', 'download', 'expandable', 'href', 'mode', 'rel', 'target', 'type'],
+  inputs: ['color', 'disabled', 'download', 'expandable', 'href', 'mode', 'rel', 'target', 'type']
 })
 @Component({
   selector: 'ion-item-option',
@@ -1273,7 +1053,7 @@ export declare interface IonItemGroup extends Components.IonItemGroup {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'disabled', 'download', 'expandable', 'href', 'mode', 'rel', 'target', 'type'],
-  standalone: true,
+  standalone: true
 })
 export class IonItemOption {
   protected el: HTMLElement;
@@ -1283,11 +1063,13 @@ export class IonItemOption {
   }
 }
 
+
 export declare interface IonItemOption extends Components.IonItemOption {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonItemOptions,
-  inputs: ['side'],
+  inputs: ['side']
 })
 @Component({
   selector: 'ion-item-options',
@@ -1295,7 +1077,7 @@ export declare interface IonItemOption extends Components.IonItemOption {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['side'],
-  standalone: true,
+  standalone: true
 })
 export class IonItemOptions {
   protected el: HTMLElement;
@@ -1306,6 +1088,7 @@ export class IonItemOptions {
   }
 }
 
+
 export declare interface IonItemOptions extends Components.IonItemOptions {
   /**
    * Emitted when the item has been fully swiped.
@@ -1313,10 +1096,11 @@ export declare interface IonItemOptions extends Components.IonItemOptions {
   ionSwipe: EventEmitter<CustomEvent<any>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonItemSliding,
   inputs: ['disabled'],
-  methods: ['getOpenAmount', 'getSlidingRatio', 'open', 'close', 'closeOpened'],
+  methods: ['getOpenAmount', 'getSlidingRatio', 'open', 'close', 'closeOpened']
 })
 @Component({
   selector: 'ion-item-sliding',
@@ -1324,7 +1108,7 @@ export declare interface IonItemOptions extends Components.IonItemOptions {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled'],
-  standalone: true,
+  standalone: true
 })
 export class IonItemSliding {
   protected el: HTMLElement;
@@ -1335,6 +1119,7 @@ export class IonItemSliding {
   }
 }
 
+
 export declare interface IonItemSliding extends Components.IonItemSliding {
   /**
    * Emitted when the sliding position changes.
@@ -1342,9 +1127,10 @@ export declare interface IonItemSliding extends Components.IonItemSliding {
   ionDrag: EventEmitter<CustomEvent<any>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonLabel,
-  inputs: ['color', 'mode', 'position'],
+  inputs: ['color', 'mode', 'position']
 })
 @Component({
   selector: 'ion-label',
@@ -1352,7 +1138,7 @@ export declare interface IonItemSliding extends Components.IonItemSliding {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'mode', 'position'],
-  standalone: true,
+  standalone: true
 })
 export class IonLabel {
   protected el: HTMLElement;
@@ -1362,12 +1148,14 @@ export class IonLabel {
   }
 }
 
+
 export declare interface IonLabel extends Components.IonLabel {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonList,
   inputs: ['inset', 'lines', 'mode'],
-  methods: ['closeSlidingItems'],
+  methods: ['closeSlidingItems']
 })
 @Component({
   selector: 'ion-list',
@@ -1375,7 +1163,7 @@ export declare interface IonLabel extends Components.IonLabel {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['inset', 'lines', 'mode'],
-  standalone: true,
+  standalone: true
 })
 export class IonList {
   protected el: HTMLElement;
@@ -1385,11 +1173,13 @@ export class IonList {
   }
 }
 
+
 export declare interface IonList extends Components.IonList {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonListHeader,
-  inputs: ['color', 'lines', 'mode'],
+  inputs: ['color', 'lines', 'mode']
 })
 @Component({
   selector: 'ion-list-header',
@@ -1397,7 +1187,7 @@ export declare interface IonList extends Components.IonList {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'lines', 'mode'],
-  standalone: true,
+  standalone: true
 })
 export class IonListHeader {
   protected el: HTMLElement;
@@ -1407,70 +1197,32 @@ export class IonListHeader {
   }
 }
 
+
 export declare interface IonListHeader extends Components.IonListHeader {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonLoading,
-  inputs: [
-    'animated',
-    'backdropDismiss',
-    'cssClass',
-    'duration',
-    'enterAnimation',
-    'htmlAttributes',
-    'isOpen',
-    'keyboardClose',
-    'leaveAnimation',
-    'message',
-    'mode',
-    'showBackdrop',
-    'spinner',
-    'translucent',
-    'trigger',
-  ],
-  methods: ['present', 'dismiss', 'onDidDismiss', 'onWillDismiss'],
+  inputs: ['animated', 'backdropDismiss', 'cssClass', 'duration', 'enterAnimation', 'htmlAttributes', 'isOpen', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'showBackdrop', 'spinner', 'translucent', 'trigger'],
+  methods: ['present', 'dismiss', 'onDidDismiss', 'onWillDismiss']
 })
 @Component({
   selector: 'ion-loading',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [
-    'animated',
-    'backdropDismiss',
-    'cssClass',
-    'duration',
-    'enterAnimation',
-    'htmlAttributes',
-    'isOpen',
-    'keyboardClose',
-    'leaveAnimation',
-    'message',
-    'mode',
-    'showBackdrop',
-    'spinner',
-    'translucent',
-    'trigger',
-  ],
-  standalone: true,
+  inputs: ['animated', 'backdropDismiss', 'cssClass', 'duration', 'enterAnimation', 'htmlAttributes', 'isOpen', 'keyboardClose', 'leaveAnimation', 'message', 'mode', 'showBackdrop', 'spinner', 'translucent', 'trigger'],
+  standalone: true
 })
 export class IonLoading {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, [
-      'ionLoadingDidPresent',
-      'ionLoadingWillPresent',
-      'ionLoadingWillDismiss',
-      'ionLoadingDidDismiss',
-      'didPresent',
-      'willPresent',
-      'willDismiss',
-      'didDismiss',
-    ]);
+    proxyOutputs(this, this.el, ['ionLoadingDidPresent', 'ionLoadingWillPresent', 'ionLoadingWillDismiss', 'ionLoadingDidDismiss', 'didPresent', 'willPresent', 'willDismiss', 'didDismiss']);
   }
 }
+
 
 import type { OverlayEventDetail as IIonLoadingOverlayEventDetail } from '@ionic/core/components';
 
@@ -1513,10 +1265,11 @@ Shorthand for ionLoadingDidDismiss.
   didDismiss: EventEmitter<CustomEvent<IIonLoadingOverlayEventDetail>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonMenu,
   inputs: ['contentId', 'disabled', 'maxEdgeStart', 'menuId', 'side', 'swipeGesture', 'type'],
-  methods: ['isOpen', 'isActive', 'open', 'close', 'toggle', 'setOpen'],
+  methods: ['isOpen', 'isActive', 'open', 'close', 'toggle', 'setOpen']
 })
 @Component({
   selector: 'ion-menu',
@@ -1524,7 +1277,7 @@ Shorthand for ionLoadingDidDismiss.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['contentId', 'disabled', 'maxEdgeStart', 'menuId', 'side', 'swipeGesture', 'type'],
-  standalone: true,
+  standalone: true
 })
 export class IonMenu {
   protected el: HTMLElement;
@@ -1534,6 +1287,7 @@ export class IonMenu {
     proxyOutputs(this, this.el, ['ionWillOpen', 'ionWillClose', 'ionDidOpen', 'ionDidClose']);
   }
 }
+
 
 export declare interface IonMenu extends Components.IonMenu {
   /**
@@ -1554,9 +1308,10 @@ export declare interface IonMenu extends Components.IonMenu {
   ionDidClose: EventEmitter<CustomEvent<void>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonMenuButton,
-  inputs: ['autoHide', 'color', 'disabled', 'menu', 'mode', 'type'],
+  inputs: ['autoHide', 'color', 'disabled', 'menu', 'mode', 'type']
 })
 @Component({
   selector: 'ion-menu-button',
@@ -1564,7 +1319,7 @@ export declare interface IonMenu extends Components.IonMenu {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['autoHide', 'color', 'disabled', 'menu', 'mode', 'type'],
-  standalone: true,
+  standalone: true
 })
 export class IonMenuButton {
   protected el: HTMLElement;
@@ -1574,11 +1329,13 @@ export class IonMenuButton {
   }
 }
 
+
 export declare interface IonMenuButton extends Components.IonMenuButton {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonMenuToggle,
-  inputs: ['autoHide', 'menu'],
+  inputs: ['autoHide', 'menu']
 })
 @Component({
   selector: 'ion-menu-toggle',
@@ -1586,7 +1343,7 @@ export declare interface IonMenuButton extends Components.IonMenuButton {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['autoHide', 'menu'],
-  standalone: true,
+  standalone: true
 })
 export class IonMenuToggle {
   protected el: HTMLElement;
@@ -1596,11 +1353,13 @@ export class IonMenuToggle {
   }
 }
 
+
 export declare interface IonMenuToggle extends Components.IonMenuToggle {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonNavLink,
-  inputs: ['component', 'componentProps', 'routerAnimation', 'routerDirection'],
+  inputs: ['component', 'componentProps', 'routerAnimation', 'routerDirection']
 })
 @Component({
   selector: 'ion-nav-link',
@@ -1608,7 +1367,7 @@ export declare interface IonMenuToggle extends Components.IonMenuToggle {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['component', 'componentProps', 'routerAnimation', 'routerDirection'],
-  standalone: true,
+  standalone: true
 })
 export class IonNavLink {
   protected el: HTMLElement;
@@ -1618,11 +1377,13 @@ export class IonNavLink {
   }
 }
 
+
 export declare interface IonNavLink extends Components.IonNavLink {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonNote,
-  inputs: ['color', 'mode'],
+  inputs: ['color', 'mode']
 })
 @Component({
   selector: 'ion-note',
@@ -1630,7 +1391,7 @@ export declare interface IonNavLink extends Components.IonNavLink {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'mode'],
-  standalone: true,
+  standalone: true
 })
 export class IonNote {
   protected el: HTMLElement;
@@ -1640,68 +1401,32 @@ export class IonNote {
   }
 }
 
+
 export declare interface IonNote extends Components.IonNote {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonPicker,
-  inputs: [
-    'animated',
-    'backdropDismiss',
-    'buttons',
-    'columns',
-    'cssClass',
-    'duration',
-    'enterAnimation',
-    'htmlAttributes',
-    'isOpen',
-    'keyboardClose',
-    'leaveAnimation',
-    'mode',
-    'showBackdrop',
-    'trigger',
-  ],
-  methods: ['present', 'dismiss', 'onDidDismiss', 'onWillDismiss', 'getColumn'],
+  inputs: ['animated', 'backdropDismiss', 'buttons', 'columns', 'cssClass', 'duration', 'enterAnimation', 'htmlAttributes', 'isOpen', 'keyboardClose', 'leaveAnimation', 'mode', 'showBackdrop', 'trigger'],
+  methods: ['present', 'dismiss', 'onDidDismiss', 'onWillDismiss', 'getColumn']
 })
 @Component({
   selector: 'ion-picker',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [
-    'animated',
-    'backdropDismiss',
-    'buttons',
-    'columns',
-    'cssClass',
-    'duration',
-    'enterAnimation',
-    'htmlAttributes',
-    'isOpen',
-    'keyboardClose',
-    'leaveAnimation',
-    'mode',
-    'showBackdrop',
-    'trigger',
-  ],
-  standalone: true,
+  inputs: ['animated', 'backdropDismiss', 'buttons', 'columns', 'cssClass', 'duration', 'enterAnimation', 'htmlAttributes', 'isOpen', 'keyboardClose', 'leaveAnimation', 'mode', 'showBackdrop', 'trigger'],
+  standalone: true
 })
 export class IonPicker {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, [
-      'ionPickerDidPresent',
-      'ionPickerWillPresent',
-      'ionPickerWillDismiss',
-      'ionPickerDidDismiss',
-      'didPresent',
-      'willPresent',
-      'willDismiss',
-      'didDismiss',
-    ]);
+    proxyOutputs(this, this.el, ['ionPickerDidPresent', 'ionPickerWillPresent', 'ionPickerWillDismiss', 'ionPickerDidDismiss', 'didPresent', 'willPresent', 'willDismiss', 'didDismiss']);
   }
 }
+
 
 import type { OverlayEventDetail as IIonPickerOverlayEventDetail } from '@ionic/core/components';
 
@@ -1744,9 +1469,10 @@ Shorthand for ionPickerDidDismiss.
   didDismiss: EventEmitter<CustomEvent<IIonPickerOverlayEventDetail>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonProgressBar,
-  inputs: ['buffer', 'color', 'mode', 'reversed', 'type', 'value'],
+  inputs: ['buffer', 'color', 'mode', 'reversed', 'type', 'value']
 })
 @Component({
   selector: 'ion-progress-bar',
@@ -1754,7 +1480,7 @@ Shorthand for ionPickerDidDismiss.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['buffer', 'color', 'mode', 'reversed', 'type', 'value'],
-  standalone: true,
+  standalone: true
 })
 export class IonProgressBar {
   protected el: HTMLElement;
@@ -1764,12 +1490,14 @@ export class IonProgressBar {
   }
 }
 
+
 export declare interface IonProgressBar extends Components.IonProgressBar {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonRefresher,
   inputs: ['closeDuration', 'disabled', 'pullFactor', 'pullMax', 'pullMin', 'snapbackDuration'],
-  methods: ['complete', 'cancel', 'getProgress'],
+  methods: ['complete', 'cancel', 'getProgress']
 })
 @Component({
   selector: 'ion-refresher',
@@ -1777,7 +1505,7 @@ export declare interface IonProgressBar extends Components.IonProgressBar {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['closeDuration', 'disabled', 'pullFactor', 'pullMax', 'pullMin', 'snapbackDuration'],
-  standalone: true,
+  standalone: true
 })
 export class IonRefresher {
   protected el: HTMLElement;
@@ -1787,6 +1515,7 @@ export class IonRefresher {
     proxyOutputs(this, this.el, ['ionRefresh', 'ionPull', 'ionStart']);
   }
 }
+
 
 import type { RefresherEventDetail as IIonRefresherRefresherEventDetail } from '@ionic/core/components';
 
@@ -1808,9 +1537,10 @@ called when the async operation has completed.
   ionStart: EventEmitter<CustomEvent<void>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonRefresherContent,
-  inputs: ['pullingIcon', 'pullingText', 'refreshingSpinner', 'refreshingText'],
+  inputs: ['pullingIcon', 'pullingText', 'refreshingSpinner', 'refreshingText']
 })
 @Component({
   selector: 'ion-refresher-content',
@@ -1818,7 +1548,7 @@ called when the async operation has completed.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['pullingIcon', 'pullingText', 'refreshingSpinner', 'refreshingText'],
-  standalone: true,
+  standalone: true
 })
 export class IonRefresherContent {
   protected el: HTMLElement;
@@ -1828,10 +1558,12 @@ export class IonRefresherContent {
   }
 }
 
+
 export declare interface IonRefresherContent extends Components.IonRefresherContent {}
 
+
 @ProxyCmp({
-  defineCustomElementFn: defineIonReorder,
+  defineCustomElementFn: defineIonReorder
 })
 @Component({
   selector: 'ion-reorder',
@@ -1839,7 +1571,7 @@ export declare interface IonRefresherContent extends Components.IonRefresherCont
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
-  standalone: true,
+  standalone: true
 })
 export class IonReorder {
   protected el: HTMLElement;
@@ -1849,12 +1581,14 @@ export class IonReorder {
   }
 }
 
+
 export declare interface IonReorder extends Components.IonReorder {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonReorderGroup,
   inputs: ['disabled'],
-  methods: ['complete'],
+  methods: ['complete']
 })
 @Component({
   selector: 'ion-reorder-group',
@@ -1862,7 +1596,7 @@ export declare interface IonReorder extends Components.IonReorder {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled'],
-  standalone: true,
+  standalone: true
 })
 export class IonReorderGroup {
   protected el: HTMLElement;
@@ -1872,6 +1606,7 @@ export class IonReorderGroup {
     proxyOutputs(this, this.el, ['ionItemReorder']);
   }
 }
+
 
 import type { ItemReorderEventDetail as IIonReorderGroupItemReorderEventDetail } from '@ionic/core/components';
 
@@ -1884,10 +1619,11 @@ to be called in order to finalize the reorder action.
   ionItemReorder: EventEmitter<CustomEvent<IIonReorderGroupItemReorderEventDetail>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonRippleEffect,
   inputs: ['type'],
-  methods: ['addRipple'],
+  methods: ['addRipple']
 })
 @Component({
   selector: 'ion-ripple-effect',
@@ -1895,7 +1631,7 @@ to be called in order to finalize the reorder action.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['type'],
-  standalone: true,
+  standalone: true
 })
 export class IonRippleEffect {
   protected el: HTMLElement;
@@ -1905,10 +1641,12 @@ export class IonRippleEffect {
   }
 }
 
+
 export declare interface IonRippleEffect extends Components.IonRippleEffect {}
 
+
 @ProxyCmp({
-  defineCustomElementFn: defineIonRow,
+  defineCustomElementFn: defineIonRow
 })
 @Component({
   selector: 'ion-row',
@@ -1916,7 +1654,7 @@ export declare interface IonRippleEffect extends Components.IonRippleEffect {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
-  standalone: true,
+  standalone: true
 })
 export class IonRow {
   protected el: HTMLElement;
@@ -1926,11 +1664,13 @@ export class IonRow {
   }
 }
 
+
 export declare interface IonRow extends Components.IonRow {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonSegmentButton,
-  inputs: ['disabled', 'layout', 'mode', 'type', 'value'],
+  inputs: ['disabled', 'layout', 'mode', 'type', 'value']
 })
 @Component({
   selector: 'ion-segment-button',
@@ -1938,7 +1678,7 @@ export declare interface IonRow extends Components.IonRow {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'layout', 'mode', 'type', 'value'],
-  standalone: true,
+  standalone: true
 })
 export class IonSegmentButton {
   protected el: HTMLElement;
@@ -1948,11 +1688,13 @@ export class IonSegmentButton {
   }
 }
 
+
 export declare interface IonSegmentButton extends Components.IonSegmentButton {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonSelectOption,
-  inputs: ['disabled', 'value'],
+  inputs: ['disabled', 'value']
 })
 @Component({
   selector: 'ion-select-option',
@@ -1960,7 +1702,7 @@ export declare interface IonSegmentButton extends Components.IonSegmentButton {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'value'],
-  standalone: true,
+  standalone: true
 })
 export class IonSelectOption {
   protected el: HTMLElement;
@@ -1970,11 +1712,13 @@ export class IonSelectOption {
   }
 }
 
+
 export declare interface IonSelectOption extends Components.IonSelectOption {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonSkeletonText,
-  inputs: ['animated'],
+  inputs: ['animated']
 })
 @Component({
   selector: 'ion-skeleton-text',
@@ -1982,7 +1726,7 @@ export declare interface IonSelectOption extends Components.IonSelectOption {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['animated'],
-  standalone: true,
+  standalone: true
 })
 export class IonSkeletonText {
   protected el: HTMLElement;
@@ -1992,11 +1736,13 @@ export class IonSkeletonText {
   }
 }
 
+
 export declare interface IonSkeletonText extends Components.IonSkeletonText {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonSpinner,
-  inputs: ['color', 'duration', 'name', 'paused'],
+  inputs: ['color', 'duration', 'name', 'paused']
 })
 @Component({
   selector: 'ion-spinner',
@@ -2004,7 +1750,7 @@ export declare interface IonSkeletonText extends Components.IonSkeletonText {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'duration', 'name', 'paused'],
-  standalone: true,
+  standalone: true
 })
 export class IonSpinner {
   protected el: HTMLElement;
@@ -2014,11 +1760,13 @@ export class IonSpinner {
   }
 }
 
+
 export declare interface IonSpinner extends Components.IonSpinner {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonSplitPane,
-  inputs: ['contentId', 'disabled', 'when'],
+  inputs: ['contentId', 'disabled', 'when']
 })
 @Component({
   selector: 'ion-split-pane',
@@ -2026,7 +1774,7 @@ export declare interface IonSpinner extends Components.IonSpinner {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['contentId', 'disabled', 'when'],
-  standalone: true,
+  standalone: true
 })
 export class IonSplitPane {
   protected el: HTMLElement;
@@ -2037,6 +1785,7 @@ export class IonSplitPane {
   }
 }
 
+
 export declare interface IonSplitPane extends Components.IonSplitPane {
   /**
    * Expression to be called when the split-pane visibility has changed
@@ -2044,9 +1793,10 @@ export declare interface IonSplitPane extends Components.IonSplitPane {
   ionSplitPaneVisible: EventEmitter<CustomEvent<{ visible: boolean }>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonTabBar,
-  inputs: ['color', 'mode', 'selectedTab', 'translucent'],
+  inputs: ['color', 'mode', 'selectedTab', 'translucent']
 })
 @Component({
   selector: 'ion-tab-bar',
@@ -2054,7 +1804,7 @@ export declare interface IonSplitPane extends Components.IonSplitPane {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'mode', 'selectedTab', 'translucent'],
-  standalone: true,
+  standalone: true
 })
 export class IonTabBar {
   protected el: HTMLElement;
@@ -2064,11 +1814,13 @@ export class IonTabBar {
   }
 }
 
+
 export declare interface IonTabBar extends Components.IonTabBar {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonTabButton,
-  inputs: ['disabled', 'download', 'href', 'layout', 'mode', 'rel', 'selected', 'tab', 'target'],
+  inputs: ['disabled', 'download', 'href', 'layout', 'mode', 'rel', 'selected', 'tab', 'target']
 })
 @Component({
   selector: 'ion-tab-button',
@@ -2076,7 +1828,7 @@ export declare interface IonTabBar extends Components.IonTabBar {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'download', 'href', 'layout', 'mode', 'rel', 'selected', 'tab', 'target'],
-  standalone: true,
+  standalone: true
 })
 export class IonTabButton {
   protected el: HTMLElement;
@@ -2086,11 +1838,13 @@ export class IonTabButton {
   }
 }
 
+
 export declare interface IonTabButton extends Components.IonTabButton {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonText,
-  inputs: ['color', 'mode'],
+  inputs: ['color', 'mode']
 })
 @Component({
   selector: 'ion-text',
@@ -2098,7 +1852,7 @@ export declare interface IonTabButton extends Components.IonTabButton {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'mode'],
-  standalone: true,
+  standalone: true
 })
 export class IonText {
   protected el: HTMLElement;
@@ -2108,10 +1862,12 @@ export class IonText {
   }
 }
 
+
 export declare interface IonText extends Components.IonText {}
 
+
 @ProxyCmp({
-  defineCustomElementFn: defineIonThumbnail,
+  defineCustomElementFn: defineIonThumbnail
 })
 @Component({
   selector: 'ion-thumbnail',
@@ -2119,7 +1875,7 @@ export declare interface IonText extends Components.IonText {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
-  standalone: true,
+  standalone: true
 })
 export class IonThumbnail {
   protected el: HTMLElement;
@@ -2129,11 +1885,13 @@ export class IonThumbnail {
   }
 }
 
+
 export declare interface IonThumbnail extends Components.IonThumbnail {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonTitle,
-  inputs: ['color', 'size'],
+  inputs: ['color', 'size']
 })
 @Component({
   selector: 'ion-title',
@@ -2141,7 +1899,7 @@ export declare interface IonThumbnail extends Components.IonThumbnail {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'size'],
-  standalone: true,
+  standalone: true
 })
 export class IonTitle {
   protected el: HTMLElement;
@@ -2151,76 +1909,32 @@ export class IonTitle {
   }
 }
 
+
 export declare interface IonTitle extends Components.IonTitle {}
+
 
 @ProxyCmp({
   defineCustomElementFn: defineIonToast,
-  inputs: [
-    'animated',
-    'buttons',
-    'color',
-    'cssClass',
-    'duration',
-    'enterAnimation',
-    'header',
-    'htmlAttributes',
-    'icon',
-    'isOpen',
-    'keyboardClose',
-    'layout',
-    'leaveAnimation',
-    'message',
-    'mode',
-    'position',
-    'translucent',
-    'trigger',
-  ],
-  methods: ['present', 'dismiss', 'onDidDismiss', 'onWillDismiss'],
+  inputs: ['animated', 'buttons', 'color', 'cssClass', 'duration', 'enterAnimation', 'header', 'htmlAttributes', 'icon', 'isOpen', 'keyboardClose', 'layout', 'leaveAnimation', 'message', 'mode', 'position', 'positionAnchor', 'translucent', 'trigger'],
+  methods: ['present', 'dismiss', 'onDidDismiss', 'onWillDismiss']
 })
 @Component({
   selector: 'ion-toast',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [
-    'animated',
-    'buttons',
-    'color',
-    'cssClass',
-    'duration',
-    'enterAnimation',
-    'header',
-    'htmlAttributes',
-    'icon',
-    'isOpen',
-    'keyboardClose',
-    'layout',
-    'leaveAnimation',
-    'message',
-    'mode',
-    'position',
-    'translucent',
-    'trigger',
-  ],
-  standalone: true,
+  inputs: ['animated', 'buttons', 'color', 'cssClass', 'duration', 'enterAnimation', 'header', 'htmlAttributes', 'icon', 'isOpen', 'keyboardClose', 'layout', 'leaveAnimation', 'message', 'mode', 'position', 'positionAnchor', 'translucent', 'trigger'],
+  standalone: true
 })
 export class IonToast {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, [
-      'ionToastDidPresent',
-      'ionToastWillPresent',
-      'ionToastWillDismiss',
-      'ionToastDidDismiss',
-      'didPresent',
-      'willPresent',
-      'willDismiss',
-      'didDismiss',
-    ]);
+    proxyOutputs(this, this.el, ['ionToastDidPresent', 'ionToastWillPresent', 'ionToastWillDismiss', 'ionToastDidDismiss', 'didPresent', 'willPresent', 'willDismiss', 'didDismiss']);
   }
 }
+
 
 import type { OverlayEventDetail as IIonToastOverlayEventDetail } from '@ionic/core/components';
 
@@ -2263,9 +1977,10 @@ Shorthand for ionToastDidDismiss.
   didDismiss: EventEmitter<CustomEvent<IIonToastOverlayEventDetail>>;
 }
 
+
 @ProxyCmp({
   defineCustomElementFn: defineIonToolbar,
-  inputs: ['color', 'mode'],
+  inputs: ['color', 'mode']
 })
 @Component({
   selector: 'ion-toolbar',
@@ -2273,7 +1988,7 @@ Shorthand for ionToastDidDismiss.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'mode'],
-  standalone: true,
+  standalone: true
 })
 export class IonToolbar {
   protected el: HTMLElement;
@@ -2283,4 +1998,7 @@ export class IonToolbar {
   }
 }
 
+
 export declare interface IonToolbar extends Components.IonToolbar {}
+
+


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Prettier is configured to ignore the `proxies.ts` file in the `src` directory only. This means it is adjusting whitespace/commas/etc on the `proxies.ts` file in the `standalone` directory which we do not want because we will always get diffs whenever `npm run build` is run in `core`.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updated prettier config to ignore all `proxies.ts` files in the `angular` package
- Re-generated the proxies file

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
