### PR TITLE
test(radio): skip Safari on legacy tab key tests

### DIFF
--- a/core/src/components/radio/test/legacy/a11y/radio.e2e.ts
+++ b/core/src/components/radio/test/legacy/a11y/radio.e2e.ts
@@ -6,10 +6,11 @@ import { configs, test } from '@utils/test/playwright';
  */
 configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('radio: a11y'), () => {
-    // TODO(FW-5218)
-    test('tabbing should switch between radio groups', async ({ page, pageUtils }) => {
+    test.beforeEach(async ({ page, skip }) => {
+      skip.browser('webkit', 'Tabbing is flaky in Safari');
       await page.goto(`/src/components/radio/test/legacy/a11y`, config);
-
+    });
+    test('tabbing should switch between radio groups', async ({ page, pageUtils }) => {
       const firstGroupRadios = page.locator('#first-group ion-radio');
       const secondGroupRadios = page.locator('#second-group ion-radio');
 
@@ -22,10 +23,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       await pageUtils.pressKeys('shift+Tab');
       await expect(firstGroupRadios.nth(0)).toBeFocused();
     });
-    // TODO(FW-5218)
     test('using arrow keys should move between enabled radios within group', async ({ page, pageUtils }) => {
-      await page.goto(`/src/components/radio/test/legacy/a11y`, config);
-
       const firstGroupRadios = page.locator('#first-group ion-radio');
 
       await pageUtils.pressKeys('Tab');

--- a/core/src/components/radio/test/legacy/a11y/radio.e2e.ts
+++ b/core/src/components/radio/test/legacy/a11y/radio.e2e.ts
@@ -7,7 +7,7 @@ import { configs, test } from '@utils/test/playwright';
 configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('radio: a11y'), () => {
     // TODO(FW-5218)
-    test.fixme('tabbing should switch between radio groups', async ({ page, pageUtils }) => {
+    test('tabbing should switch between radio groups', async ({ page, pageUtils }) => {
       await page.goto(`/src/components/radio/test/legacy/a11y`, config);
 
       const firstGroupRadios = page.locator('#first-group ion-radio');
@@ -23,7 +23,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       await expect(firstGroupRadios.nth(0)).toBeFocused();
     });
     // TODO(FW-5218)
-    test.fixme('using arrow keys should move between enabled radios within group', async ({ page, pageUtils }) => {
+    test('using arrow keys should move between enabled radios within group', async ({ page, pageUtils }) => {
       await page.goto(`/src/components/radio/test/legacy/a11y`, config);
 
       const firstGroupRadios = page.locator('#first-group ion-radio');


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Legacy radio has tests that use `Tab` key presses. These tend to flake at unknown moments and were skipped until a fix can be implemented.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Unable to replicate the flakiness locally or on GitHub. However, it only fails on Safari so the tests were re-enabled except for Safari.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This only happens on legacy. The legacy form controls will also be removed in the future. Due to this, these tests will be removed anyways at that time.
