### PR TITLE
fix(angular): standalone form components do not error when multiple are used

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -25,7 +25,7 @@
         "@playwright/test": "^1.39.0",
         "@rollup/plugin-node-resolve": "^8.4.0",
         "@rollup/plugin-virtual": "^2.0.3",
-        "@stencil/angular-output-target": "^0.0.1-dev.11698340434.1c94d384",
+        "@stencil/angular-output-target": "^0.8.3",
         "@stencil/react-output-target": "^0.5.3",
         "@stencil/sass": "^3.0.7",
         "@stencil/vue-output-target": "^0.8.6",
@@ -1644,9 +1644,9 @@
       }
     },
     "node_modules/@stencil/angular-output-target": {
-      "version": "0.0.1-dev.11698340434.1c94d384",
-      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.0.1-dev.11698340434.1c94d384.tgz",
-      "integrity": "sha512-qjfNOFksHjXryCHSaoDa+CyaYoeJ+MUaRVoAvkCc+84EBAh0MHpjv2w2g+mvokruksdUGH99PnKtv0Gk0tR1WA==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.8.3.tgz",
+      "integrity": "sha512-I/QO1sEx09WWUaNlA30EBhlXYftOSfSBTwYBwC65qlpHDIlD5WU3EAtKhU5IphfwhxnD63kvOoU1YvTUXFHNng==",
       "dev": true,
       "peerDependencies": {
         "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"
@@ -11579,9 +11579,9 @@
       }
     },
     "@stencil/angular-output-target": {
-      "version": "0.0.1-dev.11698340434.1c94d384",
-      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.0.1-dev.11698340434.1c94d384.tgz",
-      "integrity": "sha512-qjfNOFksHjXryCHSaoDa+CyaYoeJ+MUaRVoAvkCc+84EBAh0MHpjv2w2g+mvokruksdUGH99PnKtv0Gk0tR1WA==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.8.3.tgz",
+      "integrity": "sha512-I/QO1sEx09WWUaNlA30EBhlXYftOSfSBTwYBwC65qlpHDIlD5WU3EAtKhU5IphfwhxnD63kvOoU1YvTUXFHNng==",
       "dev": true,
       "requires": {}
     },

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -25,7 +25,7 @@
         "@playwright/test": "^1.39.0",
         "@rollup/plugin-node-resolve": "^8.4.0",
         "@rollup/plugin-virtual": "^2.0.3",
-        "@stencil/angular-output-target": "^0.8.2",
+        "@stencil/angular-output-target": "^0.0.1-dev.11698340434.1c94d384",
         "@stencil/react-output-target": "^0.5.3",
         "@stencil/sass": "^3.0.7",
         "@stencil/vue-output-target": "^0.8.6",
@@ -1644,9 +1644,9 @@
       }
     },
     "node_modules/@stencil/angular-output-target": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.8.2.tgz",
-      "integrity": "sha512-i2Oxq2VPQTo1OoP3iDN39N2f/CDO9crS8oUfGEtjwzMgMNuYSMB2VprFoVDUTwqaCP6N409M8+/wJK3oApTDuQ==",
+      "version": "0.0.1-dev.11698340434.1c94d384",
+      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.0.1-dev.11698340434.1c94d384.tgz",
+      "integrity": "sha512-qjfNOFksHjXryCHSaoDa+CyaYoeJ+MUaRVoAvkCc+84EBAh0MHpjv2w2g+mvokruksdUGH99PnKtv0Gk0tR1WA==",
       "dev": true,
       "peerDependencies": {
         "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"
@@ -11579,9 +11579,9 @@
       }
     },
     "@stencil/angular-output-target": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.8.2.tgz",
-      "integrity": "sha512-i2Oxq2VPQTo1OoP3iDN39N2f/CDO9crS8oUfGEtjwzMgMNuYSMB2VprFoVDUTwqaCP6N409M8+/wJK3oApTDuQ==",
+      "version": "0.0.1-dev.11698340434.1c94d384",
+      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.0.1-dev.11698340434.1c94d384.tgz",
+      "integrity": "sha512-qjfNOFksHjXryCHSaoDa+CyaYoeJ+MUaRVoAvkCc+84EBAh0MHpjv2w2g+mvokruksdUGH99PnKtv0Gk0tR1WA==",
       "dev": true,
       "requires": {}
     },

--- a/core/package.json
+++ b/core/package.json
@@ -47,7 +47,7 @@
     "@playwright/test": "^1.39.0",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@rollup/plugin-virtual": "^2.0.3",
-    "@stencil/angular-output-target": "^0.8.2",
+    "@stencil/angular-output-target": "^0.0.1-dev.11698340434.1c94d384",
     "@stencil/react-output-target": "^0.5.3",
     "@stencil/sass": "^3.0.7",
     "@stencil/vue-output-target": "^0.8.6",

--- a/core/package.json
+++ b/core/package.json
@@ -47,7 +47,7 @@
     "@playwright/test": "^1.39.0",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@rollup/plugin-virtual": "^2.0.3",
-    "@stencil/angular-output-target": "^0.0.1-dev.11698340434.1c94d384",
+    "@stencil/angular-output-target": "^0.8.3",
     "@stencil/react-output-target": "^0.5.3",
     "@stencil/sass": "^3.0.7",
     "@stencil/vue-output-target": "^0.8.6",

--- a/packages/angular/.prettierignore
+++ b/packages/angular/.prettierignore
@@ -3,4 +3,4 @@ scripts
 test
 proxies.ts
 src/directives/proxies-list.ts
-src/directives/angular-component-lib/utils.ts
+**/*/angular-component-lib/utils.ts

--- a/packages/angular/src/directives/angular-component-lib/utils.ts
+++ b/packages/angular/src/directives/angular-component-lib/utils.ts
@@ -19,7 +19,7 @@ export const proxyInputs = (Cmp: any, inputs: string[]) => {
        * we set configurable: true to indicate these
        * properties can be changed.
        */
-      configurable: true
+      configurable: true,
     });
   });
 };

--- a/packages/angular/src/directives/angular-component-lib/utils.ts
+++ b/packages/angular/src/directives/angular-component-lib/utils.ts
@@ -12,6 +12,14 @@ export const proxyInputs = (Cmp: any, inputs: string[]) => {
       set(val: any) {
         this.z.runOutsideAngular(() => (this.el[item] = val));
       },
+      /**
+       * In the event that proxyInputs is called
+       * multiple times re-defining these inputs
+       * will cause an error to be thrown. As a result
+       * we set configurable: true to indicate these
+       * properties can be changed.
+       */
+      configurable: true
     });
   });
 };

--- a/packages/angular/standalone/src/directives/angular-component-lib/utils.ts
+++ b/packages/angular/standalone/src/directives/angular-component-lib/utils.ts
@@ -19,7 +19,7 @@ export const proxyInputs = (Cmp: any, inputs: string[]) => {
        * we set configurable: true to indicate these
        * properties can be changed.
        */
-      configurable: true
+      configurable: true,
     });
   });
 };

--- a/packages/angular/standalone/src/directives/angular-component-lib/utils.ts
+++ b/packages/angular/standalone/src/directives/angular-component-lib/utils.ts
@@ -12,6 +12,14 @@ export const proxyInputs = (Cmp: any, inputs: string[]) => {
       set(val: any) {
         this.z.runOutsideAngular(() => (this.el[item] = val));
       },
+      /**
+       * In the event that proxyInputs is called
+       * multiple times re-defining these inputs
+       * will cause an error to be thrown. As a result
+       * we set configurable: true to indicate these
+       * properties can be changed.
+       */
+      configurable: true
     });
   });
 };


### PR DESCRIPTION
Issue number: resolves #28418

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Due to https://github.com/ionic-team/stencil-ds-output-targets/issues/397, calling `proxyInputs` for the form controls caused an error to be logged in developer applications.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updated to a version of the Angular output targets with a patch for this error
- I also excluded the `utils.ts` from all `angular-component-lib` directories from prettier since it was causing a diff. These changes are autogenerated so we should not be linting them anyways.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `7.5.3-dev.11698340692.18daff2f`