### PR TITLE
feat(toast): quickly swiping dismisses toast

### DIFF
--- a/core/src/components/toast/gestures/swipe-to-dismiss.ts
+++ b/core/src/components/toast/gestures/swipe-to-dismiss.ts
@@ -228,7 +228,7 @@ export const createSwipeToDismissGesture = (
 
       /**
        * Compute the remaining amount of pixels the
-       * to toast needs to move to be fully dismissed.
+       * toast needs to move to be fully dismissed.
        */
       const remainingStepAmount = shouldDismiss ? 1 - step : step;
       remainingDistance = remainingStepAmount * MAX_SWIPE_DISTANCE;

--- a/core/src/components/toast/gestures/swipe-to-dismiss.ts
+++ b/core/src/components/toast/gestures/swipe-to-dismiss.ts
@@ -218,7 +218,7 @@ export const createSwipeToDismissGesture = (
 
       /**
        * Compute the remaining amount of pixels the
-       * to toast needs to move to be fully dismissed.
+       * toast needs to move to be fully dismissed.
        */
       remainingDistance = endOffset - startOffset;
     } else {

--- a/core/src/components/toast/gestures/swipe-to-dismiss.ts
+++ b/core/src/components/toast/gestures/swipe-to-dismiss.ts
@@ -237,7 +237,7 @@ export const createSwipeToDismissGesture = (
     /**
      * The animation speed should depend on how quickly
      * the user flicks the toast across the screen. However,
-     * it should be no slower than 300ms.
+     * it should be no slower than 200ms.
      * We use Math.abs on the remainingDistance because that value
      * can be negative when swiping up on a middle position toast.
      */


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The swipeable toast dismiss animation does not change based on how quickly the toast was swiped. This makes the animation seem sluggish.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The toast now dismisses quicker depending on how quickly users swipe.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
