### PR TITLE
refactor: exportable md animations for modal

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -4,6 +4,8 @@ export { createAnimation } from './utils/animation/animation';
 export { getIonPageElement } from './utils/transition';
 export { iosTransitionAnimation } from './utils/transition/ios.transition';
 export { mdTransitionAnimation } from './utils/transition/md.transition';
+export { mdEnterModalAniamtion } from 'core/src/components/modal/animations/md.enter'
+export { mdLeaveModalAniamtion } from 'core/src/components/modal/animations/md.leave'
 export { getTimeGivenProgression } from './utils/animation/cubic-bezier';
 export { createGesture } from './utils/gesture';
 export { initialize } from './global/ionic-global';


### PR DESCRIPTION
It is convenient from the point of view when ios style need md style animation (https://ionicframework.com/docs/api/modal#enteranimation) that would not copy the code in the application and always use the latest changes.

exportable `mdEnterModalAnimation` and `mdLeaveModalAnimation`
