### PR TITLE
refactor(angular): platform uses correct core instance

### DIFF
--- a/packages/angular/common/src/providers/platform.ts
+++ b/packages/angular/common/src/providers/platform.ts
@@ -62,7 +62,7 @@ export class Platform {
   resize = new Subject<void>();
 
   constructor(
-    @Inject(DOCUMENT) private doc: any,
+    @Inject(DOCUMENT) protected doc: any,
     zone: NgZone,
     private isPlatform: typeof _isPlatform,
     private getPlatforms: typeof _getPlatforms

--- a/packages/angular/common/src/providers/platform.ts
+++ b/packages/angular/common/src/providers/platform.ts
@@ -1,7 +1,12 @@
 import { DOCUMENT } from '@angular/common';
-import { NgZone, Inject, Injectable } from '@angular/core';
-import { getPlatforms, isPlatform } from '@ionic/core/components';
-import type { BackButtonEventDetail, KeyboardEventDetail, Platforms } from '@ionic/core/components';
+import { NgZone, Inject } from '@angular/core';
+import type {
+  getPlatforms as _getPlatforms,
+  isPlatform as _isPlatform,
+  BackButtonEventDetail,
+  KeyboardEventDetail,
+  Platforms,
+} from '@ionic/core/components';
 import { Subscription, Subject } from 'rxjs';
 
 // TODO(FW-2827): types
@@ -13,9 +18,6 @@ export interface BackButtonEmitter extends Subject<BackButtonEventDetail> {
   ): Subscription;
 }
 
-@Injectable({
-  providedIn: 'root',
-})
 export class Platform {
   private _readyPromise: Promise<string>;
   private win: any;
@@ -59,7 +61,12 @@ export class Platform {
    */
   resize = new Subject<void>();
 
-  constructor(@Inject(DOCUMENT) private doc: any, zone: NgZone) {
+  constructor(
+    @Inject(DOCUMENT) private doc: any,
+    zone: NgZone,
+    private isPlatform: typeof _isPlatform,
+    private getPlatforms: typeof _getPlatforms
+  ) {
     zone.run(() => {
       this.win = doc.defaultView;
       this.backButton.subscribeWithPriority = function (priority, callback) {
@@ -138,7 +145,7 @@ export class Platform {
    *
    */
   is(platformName: Platforms): boolean {
-    return isPlatform(this.win, platformName);
+    return this.isPlatform(this.win, platformName);
   }
 
   /**
@@ -161,7 +168,7 @@ export class Platform {
    * ```
    */
   platforms(): string[] {
-    return getPlatforms(this.win);
+    return this.getPlatforms(this.win);
   }
 
   /**

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -32,7 +32,6 @@ export {
   DomController,
   NavController,
   Config,
-  Platform,
   AngularDelegate,
   NavParams,
   IonicRouteStrategy,
@@ -42,6 +41,7 @@ export {
   ViewDidLeave,
 } from '@ionic/angular/common';
 export { MenuController } from './providers/menu-controller';
+export { Platform } from './providers/platform';
 
 // PACKAGE MODULE
 export { IonicModule } from './ionic-module';

--- a/packages/angular/src/providers/platform.ts
+++ b/packages/angular/src/providers/platform.ts
@@ -1,0 +1,12 @@
+import { DOCUMENT, Injectable, NgZone, Inject } from '@angular/core';
+import { Platform as PlatformBase } from '@ionic/angular/common';
+import { isPlatform, getPlatforms } from '@ionic/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class Platform extends PlatformBase {
+  constructor(@Inject(DOCUMENT) protected doc: any, zone: NgZone) {
+    super(doc, zone, isPlatform, getPlatforms);
+  }
+}

--- a/packages/angular/src/providers/platform.ts
+++ b/packages/angular/src/providers/platform.ts
@@ -1,4 +1,5 @@
-import { DOCUMENT, Injectable, NgZone, Inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { Injectable, NgZone, Inject } from '@angular/core';
 import { Platform as PlatformBase } from '@ionic/angular/common';
 import { isPlatform, getPlatforms } from '@ionic/core';
 

--- a/packages/angular/standalone/src/index.ts
+++ b/packages/angular/standalone/src/index.ts
@@ -6,6 +6,7 @@ export { IonRouterLink, IonRouterLinkWithHref } from './navigation/router-link-d
 export { IonTabs } from './navigation/tabs';
 export { provideIonicAngular } from './providers/ionic-angular';
 export { MenuController } from './providers/menu-controller';
+export { Platform } from './providers/platform';
 export {
   ActionSheetController,
   AlertController,
@@ -19,7 +20,6 @@ export {
   DomController,
   NavController,
   Config,
-  Platform,
   NavParams,
   IonicRouteStrategy,
   ViewWillEnter,

--- a/packages/angular/standalone/src/providers/platform.ts
+++ b/packages/angular/standalone/src/providers/platform.ts
@@ -1,0 +1,12 @@
+import { DOCUMENT, Injectable, NgZone, Inject } from '@angular/core';
+import { Platform as PlatformBase } from '@ionic/angular/common';
+import { isPlatform, getPlatforms } from '@ionic/core/components';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class Platform extends PlatformBase {
+  constructor(@Inject(DOCUMENT) protected doc: any, zone: NgZone) {
+    super(doc, zone, isPlatform, getPlatforms);
+  }
+}

--- a/packages/angular/standalone/src/providers/platform.ts
+++ b/packages/angular/standalone/src/providers/platform.ts
@@ -1,4 +1,5 @@
-import { DOCUMENT, Injectable, NgZone, Inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { Injectable, NgZone, Inject } from '@angular/core';
 import { Platform as PlatformBase } from '@ionic/angular/common';
 import { isPlatform, getPlatforms } from '@ionic/core/components';
 

--- a/packages/angular/test/base/e2e/src/standalone/providers.spec.ts
+++ b/packages/angular/test/base/e2e/src/standalone/providers.spec.ts
@@ -9,3 +9,17 @@ describe('Providers', () => {
     cy.get('#keyboard-height').should('have.text', '12345');
   });
 })
+
+
+describe('Providers: Platform', () => {
+  beforeEach(() => {
+    cy.visit('/standalone/providers/platform');
+  });
+
+  it('isReady should be true', () => {
+    cy.ionPageVisible('app-platform');
+
+    cy.get('#is-ready').should('have.text', 'true');
+  });
+
+});

--- a/packages/angular/test/base/src/app/standalone/app-standalone/app.routes.ts
+++ b/packages/angular/test/base/src/app/standalone/app-standalone/app.routes.ts
@@ -14,6 +14,7 @@ export const routes: Routes = [
       { path: 'router-link', loadComponent: () => import('../router-link/router-link.component').then(c => c.RouterLinkComponent) },
       { path: 'nav', loadComponent: () => import('../nav/nav.component').then(c => c.NavComponent) },
       { path: 'providers', loadComponent: () => import('../providers/providers.component').then(c => c.ProvidersComponent) },
+      { path: 'providers/platform', loadComponent: () => import('../platform/platform.component').then(c => c.PlatformComponent) },
       { path: 'overlay-controllers', loadComponent: () => import('../overlay-controllers/overlay-controllers.component').then(c => c.OverlayControllersComponent) },
       { path: 'button', loadComponent: () => import('../button/button.component').then(c => c.ButtonComponent) },
       { path: 'icon', loadComponent: () => import('../icon/icon.component').then(c => c.IconComponent) },

--- a/packages/angular/test/base/src/app/standalone/platform/platform.component.html
+++ b/packages/angular/test/base/src/app/standalone/platform/platform.component.html
@@ -1,0 +1,11 @@
+<ul>
+  <li>
+    isReady: <span id="is-ready">{{ isReady }}</span>
+  </li>
+  <li>
+    isResumed: <span id="is-resumed">{{ isResumed }}</span>
+  </li>
+  <li>
+    isPaused: <span id="is-paused">{{ isPaused }}</span>
+  </li>
+</ul>

--- a/packages/angular/test/base/src/app/standalone/platform/platform.component.ts
+++ b/packages/angular/test/base/src/app/standalone/platform/platform.component.ts
@@ -1,0 +1,39 @@
+import { Component, NgZone } from "@angular/core";
+
+import { Platform } from '@ionic/angular/standalone';
+
+@Component({
+  selector: "app-platform",
+  templateUrl: "./platform.component.html",
+  standalone: true
+})
+export class PlatformComponent {
+
+  isReady = false;
+  isResumed = false;
+  isPaused = false;
+  isResized = false;
+
+  constructor(public platform: Platform) {
+    platform.ready().then(() => {
+      NgZone.assertInAngularZone();
+      this.isReady = true;
+    });
+    platform.resume.subscribe(() => {
+      console.log('platform:resume');
+      NgZone.assertInAngularZone();
+      this.isResumed = true;
+    });
+    platform.pause.subscribe(() => {
+      console.log('platform:pause');
+      NgZone.assertInAngularZone();
+      this.isPaused = true;
+    });
+    platform.resize.subscribe(() => {
+      console.log('platform:resize');
+      NgZone.assertInAngularZone();
+      this.isResized = true;
+    });
+  }
+
+}


### PR DESCRIPTION
Issue number: Internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The `Platform` provider does not use the correct underlying instance of the utilities from either the lazy or custom elements build, depending on if the developer is using `@ionic/angular` or `@ionic/angular/standalone`. It will always use the lazy instance. 

This applied to the `is` and `platforms` functions.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `Platform` uses the instance of the utilities based on it's implementation type, e.g. `@ionic/angular/standalone` uses the custom elements build with the utilities from `@ionic/core/components`.
- `@ionic/angular` and `@ionic/angular/standalone` now export their own specific implementation of `Platform`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
