### PR TITLE
feat(react): allow to stack multiple same routes

### DIFF
--- a/packages/react-router/src/ReactRouter/ReactRouterViewStack.tsx
+++ b/packages/react-router/src/ReactRouter/ReactRouterViewStack.tsx
@@ -137,6 +137,8 @@ export class ReactRouterViewStack extends ViewStacks {
     return { viewItem, match };
 
     function matchView(v: ViewItem) {
+      let matchPathname;
+
       if (mustBeIonRoute && !v.ionRoute) {
         return false;
       }
@@ -146,7 +148,12 @@ export class ReactRouterViewStack extends ViewStacks {
         component: v.routeData.childProps.component,
       };
       const myMatch = matchPath(pathname, matchProps);
-      if (myMatch) {
+      
+      if (v.routeData.childProps.allowMultipleInstances) {
+        matchPathname = v.routeData.match.url !== pathname;
+      }
+
+      if (myMatch && !matchPathname) {
         viewItem = v;
         match = myMatch;
         return true;

--- a/packages/react/src/components/IonRoute.tsx
+++ b/packages/react/src/components/IonRoute.tsx
@@ -8,6 +8,7 @@ export interface IonRouteProps {
   show?: boolean;
   render: (props?: any) => JSX.Element; // TODO(FW-2959): type
   disableIonPageManagement?: boolean;
+  allowMultipleInstances?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface


### PR DESCRIPTION
Issue number: #28509

---------

## What is the current behavior?

I have looking for a solution for a long time. I have found #23455 and also #19531. 
Also I got stuck when I read about how parametrised routing should work from https://github.com/ionic-team/ionic-framework/issues/19531#issuecomment-1097133221

> For example, given a routing configuration of /a/:id, routes /a/1 and /a/2 would get two separate instances of the same component. We recommend using parameterised URLs when you need to create a new instance of a page.

But still navigating between same page with path "/a:id" -> /a/1 -> /a/2 -> /a/3 creates only one instance of view

## What is the new behavior?
After this improvement users are able to pass additional flag `allowMultipleInstances` to `<IonRoute/>` component which allows to cache multiple instances of the same parametrised route.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

Before 

https://github.com/ionic-team/ionic-framework/assets/2965120/3e60e5ee-6eb0-4312-9dfa-063168a69458

After with `allowMultipleInstances` on `<IonRoute />` component

https://github.com/ionic-team/ionic-framework/assets/2965120/e26bd7b1-86a0-44ca-8ebe-89056fd54e15
