### PR TITLE
fix(angular): transition plays when using browser buttons

### DIFF
--- a/packages/angular/common/src/providers/nav-controller.ts
+++ b/packages/angular/common/src/providers/nav-controller.ts
@@ -37,9 +37,9 @@ export class NavController {
     if (router) {
       router.events.subscribe((ev) => {
         if (ev instanceof NavigationStart) {
+          // restoredState is set if the browser back/forward button is used
           const id = ev.restoredState ? ev.restoredState.navigationId : ev.id;
-          this.guessDirection = id < this.lastNavId ? 'back' : 'forward';
-          this.guessAnimation = !ev.restoredState ? this.guessDirection : undefined;
+          this.guessDirection = this.guessAnimation = id < this.lastNavId ? 'back' : 'forward';
           this.lastNavId = this.guessDirection === 'forward' ? ev.id : id;
         }
       });


### PR DESCRIPTION
Issue number: resolves #16569

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Ionic Angular's routing integration disables page transitions when using the browser back/forward buttons.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Transitions now play when using the back/forward buttons

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

We're not aware of any breaking changes here, though it's possible some developers were relying on this behavior. As a result, we are targeting Ionic 8 to minimize any potential negative impact this fix may have on developers.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Supersedes https://github.com/ionic-team/ionic-framework/pull/28188

Dev build: `7.5.6-dev.11700068172.15ce9b35`