### PR TITLE
chore(angular): type checking for standalone directory

### DIFF
--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -27,7 +27,7 @@
     "pretty": true,
     "removeComments": false,
     "importHelpers": true,
-    "rootDir": "src",
+    "rootDir": "./",
     "strictPropertyInitialization": false,
     "target": "es2015",
     "baseUrl": ".",
@@ -41,5 +41,5 @@
     }
   },
   "exclude": ["node_modules", "src/schematics"],
-  "files": ["src/index.ts", "common/src/index.ts"]
+  "files": ["src/index.ts", "common/src/index.ts", "standalone/src/index.ts"]
 }


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Type checking is disabled in the `standalone/` directory of the angular project.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Enables type checking in the standalone directories. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
