### PR TITLE
fix(modal): apply black background to correct element

### DIFF
--- a/core/src/components/modal/animations/ios.enter.ts
+++ b/core/src/components/modal/animations/ios.enter.ts
@@ -51,9 +51,9 @@ export const iosEnterAnimation = (baseEl: HTMLElement, opts: ModalAnimationOptio
       overflow: 'hidden',
     });
 
-    const bodyEl = document.body;
+    const appEl = baseEl.closest('ion-app');
 
-    if (isMobile) {
+    if (isMobile && appEl) {
       /**
        * Fallback for browsers that does not support `max()` (ex: Firefox)
        * No need to worry about statusbar padding since engines like Gecko
@@ -68,7 +68,7 @@ export const iosEnterAnimation = (baseEl: HTMLElement, opts: ModalAnimationOptio
         .afterStyles({
           transform: finalTransform,
         })
-        .beforeAddWrite(() => bodyEl.style.setProperty('background-color', 'black'))
+        .beforeAddWrite(() => appEl.style.setProperty('background-color', 'black'))
         .addElement(presentingEl)
         .keyframes([
           { offset: 0, filter: 'contrast(1)', transform: 'translateY(0px) scale(1)', borderRadius: '0px' },

--- a/core/src/components/modal/animations/ios.leave.ts
+++ b/core/src/components/modal/animations/ios.leave.ts
@@ -34,7 +34,9 @@ export const iosLeaveAnimation = (baseEl: HTMLElement, opts: ModalAnimationOptio
     .duration(duration)
     .addAnimation(wrapperAnimation);
 
-  if (presentingEl) {
+  const appEl = baseEl.closest('ion-app');
+
+  if (presentingEl && appEl) {
     const isMobile = window.innerWidth < 768;
     const hasCardModal =
       presentingEl.tagName === 'ION-MODAL' && (presentingEl as HTMLIonModalElement).presentingElement !== undefined;
@@ -52,14 +54,12 @@ export const iosLeaveAnimation = (baseEl: HTMLElement, opts: ModalAnimationOptio
         presentingEl.style.setProperty('overflow', '');
 
         const numModals = (
-          Array.from(bodyEl.querySelectorAll('ion-modal:not(.overlay-hidden)')) as HTMLIonModalElement[]
+          Array.from(appEl.querySelectorAll('ion-modal:not(.overlay-hidden)')) as HTMLIonModalElement[]
         ).filter((m) => m.presentingElement !== undefined).length;
         if (numModals <= 1) {
-          bodyEl.style.setProperty('background-color', '');
+          appEl.style.setProperty('background-color', '');
         }
       });
-
-    const bodyEl = document.body;
 
     if (isMobile) {
       const transformOffset = !CSS.supports('width', 'max(0px, 1px)') ? '30px' : 'max(30px, var(--ion-safe-area-top))';


### PR DESCRIPTION
Issue number: Resolves #28546

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?

Card dialog applies black background to entire page. This will cause glitchy looking behavior when the keyboard shows/hides with Capacitor keyboard mode = "ionic" when https://github.com/ionic-team/capacitor-plugins/issues/1904 is fixed, and currently causes glitches if you use the workaround [here](https://github.com/ionic-team/capacitor/issues/1540#issuecomment-735221275).

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Black background is applied to `<ion-app>`, not document.body.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

|Before|After|
|---|---|
|<video src="https://github.com/ionic-team/ionic-framework/assets/2166114/63b2a461-1192-4a42-baae-bcfed3e413e1"></video>| <video src="https://github.com/ionic-team/ionic-framework/assets/2166114/fa1e864f-915e-4ad9-9d79-48c93b43b433"></video>|

