### PR TITLE
chore: fallback to framework team with codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,8 @@
 # In each subsection folders are ordered first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
+* @ionic-team/framework
+
 # Frameworks
 
 ## Angular


### PR DESCRIPTION
I noticed that Dependabot PRs never had anyone assigned: https://github.com/ionic-team/ionic-framework/pull/28586

The reason was that we removed `* @ionic-team/framework` when we adjusted the codeowners in https://github.com/ionic-team/ionic-framework/pull/27573. 

My original reasoning for why we should remove it was wrong. GitHub only assigns reviewers within a team if the team itself is assigned. By removing the team from being reviewed, only people listed in the codeowners file would be assigned. As an added example, PRs that do not match codeowners currently have no one assigned: https://github.com/ionic-team/ionic-framework/pull/28430
