### PR TITLE
feat(checkbox): add shadow part for label

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -315,6 +315,7 @@ ion-checkbox,css-prop,--checkmark-width
 ion-checkbox,css-prop,--size
 ion-checkbox,css-prop,--transition
 ion-checkbox,part,container
+ion-checkbox,part,label
 ion-checkbox,part,mark
 
 ion-chip,shadow

--- a/core/src/components/checkbox/checkbox.scss
+++ b/core/src/components/checkbox/checkbox.scss
@@ -90,13 +90,6 @@
 }
 
 .label-text-wrapper {
-  /**
-   * This ensures that double tapping this text
-   * clicks the <label> and focuses the checkbox
-   * when a screen reader is enabled.
-   */
-  pointer-events: none;
-
   text-overflow: ellipsis;
 
   white-space: nowrap;
@@ -173,7 +166,6 @@ input {
   opacity: 0;
 }
 
-
 // Justify Content
 // ---------------------------------------------
 
@@ -200,7 +192,6 @@ input {
   align-items: center;
 }
 
-
 // Label Placement - Start
 // ----------------------------------------------------------------
 
@@ -221,7 +212,6 @@ input {
   @include margin(null, $form-control-label-margin, null, 0);
 }
 
-
 // Label Placement - End
 // ----------------------------------------------------------------
 
@@ -241,7 +231,6 @@ input {
 :host(.checkbox-label-placement-end) .label-text-wrapper {
   @include margin(null, 0, null, $form-control-label-margin);
 }
-
 
 // Label Placement - Fixed
 // ----------------------------------------------------------------
@@ -316,7 +305,6 @@ input {
 :host(.checkbox-indeterminate) .checkbox-icon path {
   opacity: 1;
 }
-
 
 // Disabled Checkbox
 // ---------------------------------------------

--- a/core/src/components/checkbox/checkbox.tsx
+++ b/core/src/components/checkbox/checkbox.tsx
@@ -18,6 +18,7 @@ import type { CheckboxChangeEventDetail } from './checkbox-interface';
  * @slot - The label text to associate with the checkbox. Use the "labelPlacement" property to control where the label is placed relative to the checkbox.
  *
  * @part container - The container for the checkbox mark.
+ * @part label - The label text describing the checkbox.
  * @part mark - The checkmark used to indicate the checked state.
  */
 @Component({
@@ -284,6 +285,7 @@ export class Checkbox implements ComponentInterface {
               'label-text-wrapper': true,
               'label-text-wrapper-hidden': el.textContent === '',
             }}
+            part="label"
           >
             <slot></slot>
           </div>

--- a/core/src/components/checkbox/test/checkbox.spec.ts
+++ b/core/src/components/checkbox/test/checkbox.spec.ts
@@ -2,6 +2,23 @@ import { newSpecPage } from '@stencil/core/testing';
 
 import { Checkbox } from '../checkbox';
 
+describe('ion-checkbox: shadow parts', () => {
+  it('should render the checkbox with shadow parts', async () => {
+    const page = await newSpecPage({
+      components: [Checkbox],
+      html: `
+        <ion-checkbox>Checkbox</ion-checkbox>
+      `,
+    });
+
+    const checkbox = page.body.querySelector('ion-checkbox')!;
+
+    expect(checkbox.shadowRoot!.querySelector('[part="container"]')).not.toBe(null);
+    expect(checkbox.shadowRoot!.querySelector('[part="label"]')).not.toBe(null);
+    expect(checkbox.shadowRoot!.querySelector('[part="mark"]')).not.toBe(null);
+  });
+});
+
 describe('ion-checkbox: disabled', () => {
   it('clicking disabled checkbox should not toggle checked state', async () => {
     const page = await newSpecPage({

--- a/core/src/components/checkbox/test/checkbox.spec.ts
+++ b/core/src/components/checkbox/test/checkbox.spec.ts
@@ -13,9 +13,9 @@ describe('ion-checkbox: shadow parts', () => {
 
     const checkbox = page.body.querySelector('ion-checkbox')!;
 
-    expect(checkbox.shadowRoot!.querySelector('[part="container"]')).not.toBe(null);
-    expect(checkbox.shadowRoot!.querySelector('[part="label"]')).not.toBe(null);
-    expect(checkbox.shadowRoot!.querySelector('[part="mark"]')).not.toBe(null);
+    expect(checkbox).toHaveShadowPart('container');
+    expect(checkbox).toHaveShadowPart('label');
+    expect(checkbox).toHaveShadowPart('mark');
   });
 });
 


### PR DESCRIPTION
Issue number: Part of #28300 

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Developers are unable to adjust margin, width, etc. of the checkbox label

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Checkbox label has a shadow part.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
As part of this work, I investigated moving `pointer-events: none` up the DOM tree so developers wouldn't be able to override it with the shadow part. In my testing, I was unable to see any difference in behavior with vs without `pointer-events: none`. Therefore, I removed it entirely.
