### PR TITLE
chore(jest): toHaveShadowPart custom matcher

### DIFF
--- a/core/setupJest.js
+++ b/core/setupJest.js
@@ -1,0 +1,21 @@
+expect.extend({
+  toHaveShadowPart(received, part) {
+    if (typeof part !== 'string') {
+      throw new Error('expected toHaveShadowPart to be called with a string of the CSS shadow part name');
+    }
+
+    if (received.shadowRoot === null) {
+      throw new Error('expected toHaveShadowPart to be called on an element with a shadow root');
+    }
+
+    const shadowPart = received.shadowRoot.querySelector(`[part="${part}"]`);
+    const pass = shadowPart !== null;
+
+    const message = `expected ${received.tagName.toLowerCase()} to have shadow part "${part}"`;
+
+    return {
+      pass,
+      message: () => message,
+    };
+  },
+});

--- a/core/src/components/range/test/range.spec.ts
+++ b/core/src/components/range/test/range.spec.ts
@@ -237,13 +237,14 @@ describe('range: item adjustments', () => {
         html: `<ion-range pin="true" snaps="true" value="50" label="Label"></ion-range>`,
       });
       const range = page.body.querySelector('ion-range')!;
-      expect(range.shadowRoot!.querySelector('[part="label"]')).not.toBe(null);
-      expect(range.shadowRoot!.querySelector('[part="pin"]')).not.toBe(null);
-      expect(range.shadowRoot!.querySelector('[part="knob"]')).not.toBe(null);
-      expect(range.shadowRoot!.querySelector('[part="bar"]')).not.toBe(null);
-      expect(range.shadowRoot!.querySelector('[part="bar-active"]')).not.toBe(null);
-      expect(range.shadowRoot!.querySelector('[part="tick"]')).not.toBe(null);
-      expect(range.shadowRoot!.querySelector('[part="tick-active"]')).not.toBe(null);
+
+      expect(range).toHaveShadowPart('label');
+      expect(range).toHaveShadowPart('pin');
+      expect(range).toHaveShadowPart('knob');
+      expect(range).toHaveShadowPart('bar');
+      expect(range).toHaveShadowPart('bar-active');
+      expect(range).toHaveShadowPart('tick');
+      expect(range).toHaveShadowPart('tick-active');
     });
   });
 });

--- a/core/src/jest.d.ts
+++ b/core/src/jest.d.ts
@@ -1,0 +1,5 @@
+declare namespace jest {
+  interface Matchers<R> {
+    toHaveShadowPart(part: string): R;
+  }
+}

--- a/core/stencil.config.ts
+++ b/core/stencil.config.ts
@@ -252,6 +252,7 @@ export const config: Config = {
       "@utils/test": ["<rootDir>/src/utils/test/utils"],
       "@utils/logging": ["<rootDir>/src/utils/logging"],
     },
+    setupFilesAfterEnv: ['./setupJest.js']
   },
   preamble: '(C) Ionic http://ionicframework.com - MIT License',
   globalScript: 'src/global/ionic-global.ts',


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds a custom matcher to the jest configuration for Stencil to enable using `expect(el).toHaveShadowPart('partName')`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
