### PR TITLE
fix(nav): adds component props to allow kebab-case

### DIFF
--- a/packages/vue/src/components/IonNav.ts
+++ b/packages/vue/src/components/IonNav.ts
@@ -4,7 +4,7 @@ import { defineComponent, h, shallowRef } from "vue";
 
 import { VueDelegate } from "../framework-delegate";
 
-export const IonNav = /*@__PURE__*/ defineComponent(() => {
+export const IonNav = /*@__PURE__*/ defineComponent((props) => {
   defineCustomElement();
   const views = shallowRef([]);
 
@@ -19,8 +19,39 @@ export const IonNav = /*@__PURE__*/ defineComponent(() => {
 
   const delegate = VueDelegate(addView, removeView);
   return () => {
-    return h("ion-nav", { delegate }, views.value);
+    return h("ion-nav", { ...props, delegate }, views.value);
   };
 });
 
 IonNav.name = "IonNav";
+
+/**
+ * The default values follow what is defined at
+ * https://ionicframework.com/docs/api/nav#properties
+ * otherwise the default values on the Web Component
+ * may be overridden. For example, if the default animated value
+ * is not `true` below, then Vue would default the prop to `false`
+ * which would override the Web Component default of `true`.
+ */
+IonNav.props = {
+  animated: {
+    type: Boolean,
+    default: true
+  },
+  animation: {
+    type: Function,
+    default: undefined
+  },
+  root: {
+    type: [Function, Object, String],
+    default: undefined
+  },
+  rootParams: {
+    type: Object,
+    default: undefined
+  },
+  swipeGesture: {
+    type: Boolean,
+    default: undefined
+  }
+}


### PR DESCRIPTION
Issue number: #28611

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
It's not possible to pass props that are not camelCase to the `IonNav` component.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- It is now possible to set a props with kebab-case instead of camelCase (for example, `root-params` instead of `rootParams`)

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
⚠️ This is my first PR for ionic so I hope I didn't miss important steps into the process. I also checked on my project that the fix is working well. Thank you! 🙂