### PR TITLE
fix(react): router creates new view instances of parameterized routes

### DIFF
--- a/packages/react-router/src/ReactRouter/ReactRouterViewStack.tsx
+++ b/packages/react-router/src/ReactRouter/ReactRouterViewStack.tsx
@@ -153,7 +153,8 @@ export class ReactRouterViewStack extends ViewStacks {
          *
          * To validate this, we need to check if the path and url match the view item's route data.
          */
-        if (match.path === v.routeData?.match?.path && match.url === v.routeData?.match?.url) {
+        const hasParameter = match.path.includes(':');
+        if (!hasParameter || (hasParameter && match.url === v.routeData?.match?.url)) {
           viewItem = v;
           return true;
         }

--- a/packages/react-router/src/ReactRouter/ReactRouterViewStack.tsx
+++ b/packages/react-router/src/ReactRouter/ReactRouterViewStack.tsx
@@ -12,7 +12,6 @@ export class ReactRouterViewStack extends ViewStacks {
     this.findLeavingViewItemByRouteInfo = this.findLeavingViewItemByRouteInfo.bind(this);
     this.getChildrenToRender = this.getChildrenToRender.bind(this);
     this.findViewItemByPathname = this.findViewItemByPathname.bind(this);
-    this.findViewItemByPath = this.findViewItemByPath.bind(this);
   }
 
   createViewItem(outletId: string, reactElement: React.ReactElement, routeInfo: RouteInfo, page?: HTMLElement) {

--- a/packages/react-router/src/ReactRouter/ReactRouterViewStack.tsx
+++ b/packages/react-router/src/ReactRouter/ReactRouterViewStack.tsx
@@ -153,7 +153,7 @@ export class ReactRouterViewStack extends ViewStacks {
          *
          * To validate this, we need to check if the path and url match the view item's route data.
          */
-        if (match.path === v.routeData.match.path && match.url === v.routeData.match.url) {
+        if (match.path === v.routeData?.match?.path && match.url === v.routeData?.match?.url) {
           viewItem = v;
           return true;
         }

--- a/packages/react-router/src/ReactRouter/StackManager.tsx
+++ b/packages/react-router/src/ReactRouter/StackManager.tsx
@@ -1,9 +1,9 @@
 import type { RouteInfo, StackContextState, ViewItem } from '@ionic/react';
 import { RouteManagerContext, StackContext, generateId, getConfig } from '@ionic/react';
 import React from 'react';
-import { matchPath } from 'react-router-dom';
 
 import { clonePageElement } from './clonePageElement';
+import { matchPath } from './utils/matchPath';
 
 // TODO(FW-2959): types
 
@@ -433,12 +433,10 @@ export default StackManager;
 function matchRoute(node: React.ReactNode, routeInfo: RouteInfo) {
   let matchedNode: React.ReactNode;
   React.Children.forEach(node as React.ReactElement, (child: React.ReactElement) => {
-    const matchProps = {
-      exact: child.props.exact,
-      path: child.props.path || child.props.from,
-      component: child.props.component,
-    };
-    const match = matchPath(routeInfo.pathname, matchProps);
+    const match = matchPath({
+      pathname: routeInfo.pathname,
+      componentProps: child.props,
+    });
     if (match) {
       matchedNode = child;
     }
@@ -459,12 +457,11 @@ function matchRoute(node: React.ReactNode, routeInfo: RouteInfo) {
 }
 
 function matchComponent(node: React.ReactElement, pathname: string, forceExact?: boolean) {
-  const matchProps = {
-    exact: forceExact ? true : node.props.exact,
-    path: node.props.path || node.props.from,
-    component: node.props.component,
-  };
-  const match = matchPath(pathname, matchProps);
-
-  return match;
+  return matchPath({
+    pathname,
+    componentProps: {
+      ...node.props,
+      exact: forceExact,
+    },
+  });
 }

--- a/packages/react-router/src/ReactRouter/utils/matchPath.ts
+++ b/packages/react-router/src/ReactRouter/utils/matchPath.ts
@@ -43,10 +43,5 @@ export const matchPath = ({
     return false;
   }
 
-  const hasParameter = match.path.includes(':');
-  if (hasParameter && pathname !== match.url) {
-    return false;
-  }
-
   return match;
 };

--- a/packages/react-router/src/ReactRouter/utils/matchPath.ts
+++ b/packages/react-router/src/ReactRouter/utils/matchPath.ts
@@ -1,0 +1,52 @@
+import { matchPath as reactRouterMatchPath } from 'react-router';
+
+interface MatchPathOptions {
+  /**
+   * The pathname to match against.
+   */
+  pathname: string;
+  /**
+   * The props to match against, they are identical to the matching props `Route` accepts.
+   */
+  componentProps: {
+    path?: string;
+    from?: string;
+    component?: any;
+    exact?: boolean;
+  };
+}
+
+/**
+ * @see https://v5.reactrouter.com/web/api/matchPath
+ */
+export const matchPath = ({
+  pathname,
+  componentProps,
+}: MatchPathOptions): false | ReturnType<typeof reactRouterMatchPath> => {
+  const { exact, component } = componentProps;
+
+  const path = componentProps.path || componentProps.from;
+  /***
+   * The props to match against, they are identical
+   * to the matching props `Route` accepts. It could also be a string
+   * or an array of strings as shortcut for `{ path }`.
+   */
+  const matchProps = {
+    exact,
+    path,
+    component,
+  };
+
+  const match = reactRouterMatchPath(pathname, matchProps);
+
+  if (!match) {
+    return false;
+  }
+
+  const hasParameter = match.path.includes(':');
+  if (hasParameter && pathname !== match.url) {
+    return false;
+  }
+
+  return match;
+};

--- a/packages/react-router/test/base/src/pages/routing/Details.tsx
+++ b/packages/react-router/test/base/src/pages/routing/Details.tsx
@@ -24,10 +24,6 @@ const Details: React.FC<DetailsProps> = () => {
     return () => console.log('Home Details unmount');
   }, []);
 
-  // useIonViewWillEnter(() => {
-  //   console.log('IVWE Details')
-  // })
-
   const nextId = parseInt(id, 10) + 1;
 
   return (
@@ -58,6 +54,9 @@ const Details: React.FC<DetailsProps> = () => {
         <IonButton routerLink={`/routing/tabs/settings/details/1`}>
           <IonLabel>Go to Settings Details 1</IonLabel>
         </IonButton>
+        <br />
+        <br />
+        <input data-testid="details-input" />
       </IonContent>
     </IonPage>
   );

--- a/packages/react-router/test/base/tests/e2e/specs/routing.cy.js
+++ b/packages/react-router/test/base/tests/e2e/specs/routing.cy.js
@@ -309,6 +309,41 @@ describe('Routing Tests', () => {
     cy.ionPageDoesNotExist('home-details-page-1');
     cy.ionPageVisible('home-page');
   });
+
+  it('should mount new view item instances of parameterized routes', () => {
+    cy.visit(`http://localhost:${port}/routing/tabs/home/details/1`);
+
+    cy.get('div.ion-page[data-pageid=home-details-page-1]')
+      .get('[data-testid="details-input"]')
+      .should('have.value', '');
+
+    cy.get('div.ion-page[data-pageid=home-details-page-1] [data-testid="details-input"]').type('1');
+
+    cy.ionNav('ion-button', 'Go to Details 2');
+    cy.ionPageVisible('home-details-page-2');
+
+    cy.get('div.ion-page[data-pageid=home-details-page-2] [data-testid="details-input"]').should('have.value', '');
+
+    cy.get('div.ion-page[data-pageid=home-details-page-2] [data-testid="details-input"]').type('2');
+
+    cy.ionNav('ion-button', 'Go to Details 3');
+    cy.ionPageVisible('home-details-page-3');
+
+    cy.get('div.ion-page[data-pageid=home-details-page-3] [data-testid="details-input"]').should('have.value', '');
+
+    cy.get('div.ion-page[data-pageid=home-details-page-3] [data-testid="details-input"]').type('3');
+
+    cy.ionBackClick('home-details-page-3');
+    cy.ionPageVisible('home-details-page-2');
+
+    cy.get('div.ion-page[data-pageid=home-details-page-2] [data-testid="details-input"]').should('have.value', '2');
+
+    cy.ionBackClick('home-details-page-2');
+    cy.ionPageVisible('home-details-page-1');
+
+    cy.get('div.ion-page[data-pageid=home-details-page-1] [data-testid="details-input"]').should('have.value', '1');
+  });
+
   /*
     Tests to add:
     Test that lifecycle events fire


### PR DESCRIPTION
Issue number: Resolves #26524 

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## Definitions

**Parameterized routes**: A route that includes one or more variables in the path segments, such as `/form/:index`. 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When an application routes from a parameterized route, to an intermediary route, to the same parameterized route, but with a different value/url, Ionic's routing logic is incorrectly reusing the view item from the first instance of the parameterized route instead of calculating that the matched path is different. This results in the wrong view item being recycled and rendered.

Another way of representing it:
- User navigates to `/form/0` which resolves `FormPage`
- User enters `0` into the form and submits the form
- User navigates to `/link`, which resolves `LinkPage`
- User navigates to `/form/1`, which resolves `FormPage`
  - However, instead of creating a new instance of `FormPage` it is reusing the instance of `FormPage` from `/form/0` which includes the form having `0` in the input.
  - The user now sees a "new view", but with cached data in the form.

This is not expected or desired. 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Ionic's routing logic will validate if the entering view item matches the match route data before reusing it. This results in new instances of the view item being constructed when using parameterized routes.

https://github.com/ionic-team/ionic-framework/assets/13732623/e7e3d03f-2848-4429-9f60-9074d0761e45


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `7.5.8-dev.11701383555.17254408`