### PR TITLE
fix(angular): add missing menu controller methods

### DIFF
--- a/packages/angular/common/src/providers/menu-controller.ts
+++ b/packages/angular/common/src/providers/menu-controller.ts
@@ -1,5 +1,4 @@
 import type { MenuControllerI, AnimationBuilder, MenuI, Animation } from '@ionic/core/components';
-// import { Animation } from '@ionic/core/components';
 
 export class MenuController implements MenuControllerI {
   constructor(private menuController: MenuControllerI) {}

--- a/packages/angular/common/src/providers/menu-controller.ts
+++ b/packages/angular/common/src/providers/menu-controller.ts
@@ -1,6 +1,7 @@
-import type { MenuControllerI } from '@ionic/core/components';
+import type { MenuControllerI, AnimationBuilder, MenuI } from '@ionic/core/components';
+import { Animation } from '@ionic/core/components';
 
-export class MenuController {
+export class MenuController implements MenuControllerI {
   constructor(private menuController: MenuControllerI) {}
 
   /**
@@ -97,5 +98,33 @@ export class MenuController {
    */
   getMenus(): Promise<HTMLIonMenuElement[]> {
     return this.menuController.getMenus();
+  }
+
+  registerAnimation(name: string, animation: AnimationBuilder): void {
+    return this.menuController.registerAnimation(name, animation);
+  }
+
+  isAnimating(): Promise<boolean> {
+    return this.menuController.isAnimating();
+  }
+
+  _getOpenSync(): HTMLIonMenuElement | undefined {
+    return this.menuController._getOpenSync();
+  }
+
+  _createAnimation(type: string, menuCmp: MenuI): Promise<Animation> {
+    return this.menuController._createAnimation(type, menuCmp);
+  }
+
+  _register(menu: MenuI): void {
+    return this.menuController._register(menu);
+  }
+
+  _unregister(menu: MenuI): void {
+    return this.menuController._unregister(menu);
+  }
+
+  _setOpen(menu: MenuI, shouldOpen: boolean, animated: boolean): Promise<boolean> {
+    return this.menuController._setOpen(menu, shouldOpen, animated);
   }
 }

--- a/packages/angular/common/src/providers/menu-controller.ts
+++ b/packages/angular/common/src/providers/menu-controller.ts
@@ -1,5 +1,5 @@
-import type { MenuControllerI, AnimationBuilder, MenuI } from '@ionic/core/components';
-import { Animation } from '@ionic/core/components';
+import type { MenuControllerI, AnimationBuilder, MenuI, Animation } from '@ionic/core/components';
+// import { Animation } from '@ionic/core/components';
 
 export class MenuController implements MenuControllerI {
   constructor(private menuController: MenuControllerI) {}


### PR DESCRIPTION
Issue number: resolves #20053 

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

There are a few methods that that are missing for the menu in the Angular packages. This leads to users to not being able to use methods like `isAnimating()`. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The missing methods have been added by implementing `MenuControllerI`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: 7.5.8-dev.11701461830.1be851fd