### PR TITLE
fix(refresher): native ios refresher works on iPadOS

### DIFF
--- a/core/src/components/refresher-content/refresher-content.tsx
+++ b/core/src/components/refresher-content/refresher-content.tsx
@@ -1,13 +1,13 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Prop, h } from '@stencil/core';
 import { ENABLE_HTML_CONTENT_DEFAULT } from '@utils/config';
-import { isPlatform } from '@utils/platform';
 import { sanitizeDOMString } from '@utils/sanitization';
 import { arrowDown, caretBackSharp } from 'ionicons/icons';
 
 import { config } from '../../global/config';
 import { getIonMode } from '../../global/ionic-global';
 import type { IonicSafeString } from '../../utils/sanitization';
+import { supportsRubberBandScrolling } from '../refresher/refresher.utils';
 import type { SpinnerTypes } from '../spinner/spinner-configs';
 import { SPINNERS } from '../spinner/spinner-configs';
 
@@ -63,11 +63,17 @@ export class RefresherContent implements ComponentInterface {
 
   componentWillLoad() {
     if (this.pullingIcon === undefined) {
+      /**
+       * The native iOS refresher uses a spinner instead of
+       * an icon, so we need to see if this device supports
+       * the native iOS refresher.
+       */
+      const hasRubberBandScrolling = supportsRubberBandScrolling();
       const mode = getIonMode(this);
-      const overflowRefresher = (this.el.style as any).webkitOverflowScrolling !== undefined ? 'lines' : arrowDown;
+      const overflowRefresher = hasRubberBandScrolling ? 'lines' : arrowDown;
       this.pullingIcon = config.get(
         'refreshingIcon',
-        mode === 'ios' && isPlatform('mobile') ? config.get('spinner', overflowRefresher) : 'circular'
+        mode === 'ios' && hasRubberBandScrolling ? config.get('spinner', overflowRefresher) : 'circular'
       );
     }
     if (this.refreshingSpinner === undefined) {

--- a/core/src/components/refresher/refresher.utils.ts
+++ b/core/src/components/refresher/refresher.utils.ts
@@ -207,17 +207,29 @@ export const shouldUseNativeRefresher = async (referenceEl: HTMLIonRefresherElem
   const refreshingSpinner = referenceEl.querySelector('ion-refresher-content .refresher-refreshing ion-spinner');
 
   return (
-    pullingSpinner !== null &&
-    refreshingSpinner !== null &&
-    /**
-     * We use webkitOverflowScrolling for feature detection with rubber band scrolling
-     * on iOS. When doing referenceEl.style, webkitOverflowScrolling is undefined on non-iOS platforms.
-     * However, it will be the empty string on iOS.
-     * Note that we do not use getPropertyValue (and thus need to cast as any) because calling
-     * getPropertyValue('-webkit-overflow-scrolling') will return the empty string if it is not
-     * set on the element, even if the platform does not support that.
-     */
-    ((mode === 'ios' && isPlatform('mobile') && (referenceEl.style as any).webkitOverflowScrolling !== undefined) ||
-      mode === 'md')
+    (pullingSpinner !== null && refreshingSpinner !== null && mode === 'ios' && supportsRubberBandScrolling()) ||
+    mode === 'md'
+  );
+};
+
+/**
+ * In order to use the native iOS refresher the device must support rubber band scrolling.
+ * The ios + mobile platform check ensures that desktop Safari is not included. Desktop Safari
+ * has a slightly different rubber band effect that is not compatible with the native refresher
+ * in Ionic.
+ *
+ * We also need to be careful not to include devices that spoof their user agent.
+ * For example, when using iOS emulation in Chrome the user agent will be spoofed such that
+ * isPlatform('ios') and isPlatform('mobile') both return true. To work around this,
+ * we check to see if the apple-pay-logo is supported as a named image which is only
+ * true on Apple devices.
+ *
+ * We previously checked referencEl.style.webkitOverflowScrolling to explicitly check
+ * for rubber band support. However, this property was removed on iPadOS and it's possible
+ * that this will be removed on iOS in the future too.
+ */
+export const supportsRubberBandScrolling = () => {
+  return (
+    isPlatform('ios') && isPlatform('mobile') && CSS.supports('background: -webkit-named-image(apple-pay-logo-black)')
   );
 };

--- a/core/src/components/refresher/refresher.utils.ts
+++ b/core/src/components/refresher/refresher.utils.ts
@@ -195,23 +195,6 @@ export const translateElement = (el?: HTMLElement, value?: string, duration = 20
 // Utils
 // -----------------------------
 
-export const shouldUseNativeRefresher = async (referenceEl: HTMLIonRefresherElement, mode: string) => {
-  const refresherContent = referenceEl.querySelector('ion-refresher-content');
-  if (!refresherContent) {
-    return Promise.resolve(false);
-  }
-
-  await new Promise((resolve) => componentOnReady(refresherContent, resolve));
-
-  const pullingSpinner = referenceEl.querySelector('ion-refresher-content .refresher-pulling ion-spinner');
-  const refreshingSpinner = referenceEl.querySelector('ion-refresher-content .refresher-refreshing ion-spinner');
-
-  return (
-    (pullingSpinner !== null && refreshingSpinner !== null && mode === 'ios' && supportsRubberBandScrolling()) ||
-    mode === 'md'
-  );
-};
-
 /**
  * In order to use the native iOS refresher the device must support rubber band scrolling.
  * The ios + mobile platform check ensures that desktop Safari is not included. Desktop Safari
@@ -231,5 +214,23 @@ export const shouldUseNativeRefresher = async (referenceEl: HTMLIonRefresherElem
 export const supportsRubberBandScrolling = () => {
   return (
     isPlatform('ios') && isPlatform('mobile') && CSS.supports('background: -webkit-named-image(apple-pay-logo-black)')
+  );
+};
+
+export const shouldUseNativeRefresher = async (referenceEl: HTMLIonRefresherElement, mode: string) => {
+  const refresherContent = referenceEl.querySelector('ion-refresher-content');
+  if (!refresherContent) {
+    return Promise.resolve(false);
+  }
+
+  await new Promise((resolve) => componentOnReady(refresherContent, resolve));
+
+  const pullingSpinner = referenceEl.querySelector('ion-refresher-content .refresher-pulling ion-spinner');
+  const refreshingSpinner = referenceEl.querySelector('ion-refresher-content .refresher-refreshing ion-spinner');
+
+  return (
+    pullingSpinner !== null &&
+    refreshingSpinner !== null &&
+    ((mode === 'ios' && supportsRubberBandScrolling()) || mode === 'md')
   );
 };

--- a/core/src/components/refresher/refresher.utils.ts
+++ b/core/src/components/refresher/refresher.utils.ts
@@ -1,7 +1,6 @@
 import { writeTask } from '@stencil/core';
 import { createAnimation } from '@utils/animation/animation';
 import { clamp, componentOnReady, transitionEndAsync } from '@utils/helpers';
-import { isPlatform } from '@utils/platform';
 
 // MD Native Refresher
 // -----------------------------
@@ -197,24 +196,21 @@ export const translateElement = (el?: HTMLElement, value?: string, duration = 20
 
 /**
  * In order to use the native iOS refresher the device must support rubber band scrolling.
- * The ios + mobile platform check ensures that desktop Safari is not included. Desktop Safari
- * has a slightly different rubber band effect that is not compatible with the native refresher
- * in Ionic.
+ * As part of this, we need to exclude Desktop Safari because it has a slightly different rubber band effect that is not compatible with the native refresher in Ionic.
  *
  * We also need to be careful not to include devices that spoof their user agent.
  * For example, when using iOS emulation in Chrome the user agent will be spoofed such that
- * isPlatform('ios') and isPlatform('mobile') both return true. To work around this,
+ * navigator.maxTouchPointer > 0. To work around this,
  * we check to see if the apple-pay-logo is supported as a named image which is only
  * true on Apple devices.
  *
  * We previously checked referencEl.style.webkitOverflowScrolling to explicitly check
  * for rubber band support. However, this property was removed on iPadOS and it's possible
  * that this will be removed on iOS in the future too.
+ *
  */
 export const supportsRubberBandScrolling = () => {
-  return (
-    isPlatform('ios') && isPlatform('mobile') && CSS.supports('background: -webkit-named-image(apple-pay-logo-black)')
-  );
+  return navigator.maxTouchPoints > 0 && CSS.supports('background: -webkit-named-image(apple-pay-logo-black)');
 };
 
 export const shouldUseNativeRefresher = async (referenceEl: HTMLIonRefresherElement, mode: string) => {


### PR DESCRIPTION
Issue number: resolves #28617

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

We currently check to see if `webkitOverflowScrolling` is supported on the refresher's style object in order to enable to native iOS refresher. This works well for iOS, but it does not work for iPadOS. This is because this property was removed in iPadOS 13: https://developer.apple.com/documentation/safari-release-notes/safari-13-release-notes

> Disabled -webkit-overflow-scrolling: touch on iPad. All frames and scrollable overflow areas now use accelerated one-finger scrolling without changing stacking.

As a result, the native iOS refresher does not activate on iPadOS.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- I think it's safe to assume that `webkitOverflowScrolling` may be removed on iOS in the future too since it was already removed on iPadOS. As a result, I implemented a solution that avoids checking this.
- The `CSS.supports` check is required because otherwise the native iOS refresher would be activated in an emulated environment such as Chrome dev tools because the user agent is spoofed. The `apple-pay-logo-black` named image is only supported on Apple devices.

Risks:

- Apple could remove the `apple-pay-logo-black` named image in the future. However, we currently use this check elsewhere in Ionic too and it has worked well: https://github.com/ionic-team/ionic-framework/blob/60303aad23f823488afc8f8824e9c72e3ab86acc/core/src/components/datetime/datetime.ios.scss#L177.
- Apple could add touch emulation to desktop Safari which could cause the native refresher to activate when using responsive design mode for testing. However, this would only impact app developer and would not impact production use cases.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `7.5.8-dev.11703088210.14a72b83`

Co-authored-by: Sean Perkins <sean-perkins@users.noreply.github.com>