### PR TITLE
chore(ci): update labeler workflow for labeler@v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,10 +5,21 @@
 # For more information, see:
 # https://github.com/actions/labeler
 
-'package: core': ['core/**/*']
+'package: core':
+  - changed-files:
+    - core/**/*
 
-'package: angular': ['packages/angular/**/*', 'packages/angular-*/**/*']
+'package: angular':
+  - changed-files:
+    - packages/angular/**/*
+    - packages/angular-*/**/*
 
-'package: react': ['packages/react/**/*', 'packages/react-*/**/*']
+'package: react':
+  - changed-files:
+    - packages/react/**/*
+    - packages/react-*/**/*
 
-'package: vue': ['packages/vue/**/*', 'packages/vue-*/**/*']
+'package: vue':
+  - changed-files:
+    - packages/vue/**/*
+    - packages/vue-*/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,17 +5,10 @@
 # For more information, see:
 # https://github.com/actions/labeler
 
-'package: core':
-  - core/**/*
+'package: core': ['core/**/*']
 
-'package: angular':
-  - packages/angular/**/*
-  - packages/angular-*/**/*
+'package: angular': ['packages/angular/**/*', 'packages/angular-*/**/*']
 
-'package: react':
-  - packages/react/**/*
-  - packages/react-*/**/*
+'package: react': ['packages/react/**/*', 'packages/react-*/**/*']
 
-'package: vue':
-  - packages/vue/**/*
-  - packages/vue-*/**/*
+'package: vue': ['packages/vue/**/*', 'packages/vue-*/**/*']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,19 +7,16 @@
 
 'package: core':
   - changed-files:
-    - core/**/*
+    - any-glob-to-any-file: ['core/**/*']
 
 'package: angular':
   - changed-files:
-    - packages/angular/**/*
-    - packages/angular-*/**/*
+    - any-glob-to-any-file: ['packages/angular/**/*', 'packages/angular-*/**/*']
 
 'package: react':
   - changed-files:
-    - packages/react/**/*
-    - packages/react-*/**/*
+    - any-glob-to-any-file: ['packages/react/**/*', 'packages/react-*/**/*']
 
 'package: vue':
   - changed-files:
-    - packages/vue/**/*
-    - packages/vue-*/**/*
+    - any-glob-to-any-file: ['packages/vue/**/*', 'packages/vue-*/**/*']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,17 +6,17 @@
 # https://github.com/actions/labeler
 
 'package: core':
-  - changed-files:
-    - any-glob-to-any-file: ['core/**/*']
+- changed-files:
+  - any-glob-to-any-file: ['core/**/*']
 
 'package: angular':
-  - changed-files:
-    - any-glob-to-any-file: ['packages/angular/**/*', 'packages/angular-*/**/*']
+- changed-files:
+  - any-glob-to-any-file: ['packages/angular/**/*', 'packages/angular-*/**/*']
 
 'package: react':
-  - changed-files:
-    - any-glob-to-any-file: ['packages/react/**/*', 'packages/react-*/**/*']
+- changed-files:
+  - any-glob-to-any-file: ['packages/react/**/*', 'packages/react-*/**/*']
 
 'package: vue':
-  - changed-files:
-    - any-glob-to-any-file: ['packages/vue/**/*', 'packages/vue-*/**/*']
+- changed-files:
+  - any-glob-to-any-file: ['packages/vue/**/*', 'packages/vue-*/**/*']

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -13,7 +13,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The labeler action is currently failing: https://github.com/ionic-team/ionic-framework/actions/runs/7090913880/job/19298918578?pr=28622. This is happening due to a breaking change in v5 of the action.

We currently pull from `main` for this action so we are now receiving v5 of the action: https://github.com/ionic-team/ionic-framework/blob/fe3c3d500a2afd716ebde81a75b357b7c79d4920/.github/workflows/label.yml#L16

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- This PR updates the action explicitly to v5 so we don't unexpectedly take on breaking changes
- This PR also updates the labeler yaml file to account for the v5 breaking changes

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
