### PR TITLE
chore(ci): pin labeler workflow to labeler@v4

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -13,7 +13,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -13,6 +13,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4
     - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   triage:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The labeler action is currently failing: https://github.com/ionic-team/ionic-framework/actions/runs/7090913880/job/19298918578?pr=28622. This is happening due to a breaking change in v5 of the action.

We currently pull from `main` for this action so we are now receiving v5 of the action: https://github.com/ionic-team/ionic-framework/blob/fe3c3d500a2afd716ebde81a75b357b7c79d4920/.github/workflows/label.yml#L16

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- This PR updates the action explicitly to v5 so we don't unexpectedly take on breaking changes

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
