### PR TITLE
chore(theme): add body color

### DIFF
--- a/core/scripts/testing/themes/dark.css
+++ b/core/scripts/testing/themes/dark.css
@@ -105,6 +105,8 @@
   --ion-item-background: #000000;
 
   --ion-card-background: #1c1c1d;
+
+  color: var(--ion-text-color);
 }
 
 /*
@@ -148,4 +150,6 @@
   --ion-tab-bar-background: #1f1f1f;
 
   --ion-card-background: #1e1e1e;
+
+  color: var(--ion-text-color);
 }


### PR DESCRIPTION
Issue number: None

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
There is no default body color. 

Note: This has not affected apps based on the starters since they contain `<meta name="color-scheme" content="light dark" />` and those provide a default text color of white or black based on the color scheme. However, if we wanted to change the default theme color from white or black to something a bit different, and if components aren't wrapped in an `<ion-content>`, it would be good to have this fallback.

Also, currently, tests of some components need to be wrapped in an `<ion-content>` to get a default text color, since they don't have access to that `meta` tag. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- There is a default body color
- Tests no longer need to be wrapped in an `<ion-content>` to have a default body color

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This PR is targeting the color contrast feature branch.
