### PR TITLE
fix(react): use custom animation when going back after a replace

### DIFF
--- a/packages/react-router/src/ReactRouter/IonRouter.tsx
+++ b/packages/react-router/src/ReactRouter/IonRouter.tsx
@@ -244,11 +244,17 @@ class IonRouterInner extends React.PureComponent<IonRouteProps, IonRouteState> {
     if (routeInfo && routeInfo.pushedByRoute) {
       const prevInfo = this.locationHistory.findLastLocation(routeInfo);
       if (prevInfo) {
+        /**
+         * This needs to be passed to handleNavigate
+         * otherwise incomingRouteParams.routeAnimation
+         * will be overridden.
+         */
+        const incomingAnimation = routeAnimation || routeInfo.routeAnimation;
         this.incomingRouteParams = {
           ...prevInfo,
           routeAction: 'pop',
           routeDirection: 'back',
-          routeAnimation: routeAnimation || routeInfo.routeAnimation,
+          routeAnimation: incomingAnimation,
         };
         if (
           routeInfo.lastPathname === routeInfo.pushedByRoute ||
@@ -270,13 +276,13 @@ class IonRouterInner extends React.PureComponent<IonRouteProps, IonRouteState> {
           const goBack = history.goBack || history.back;
           goBack();
         } else {
-          this.handleNavigate(prevInfo.pathname + (prevInfo.search || ''), 'pop', 'back', routeAnimation);
+          this.handleNavigate(prevInfo.pathname + (prevInfo.search || ''), 'pop', 'back', incomingAnimation);
         }
       } else {
-        this.handleNavigate(defaultHref as string, 'pop', 'back', routeAnimation);
+        this.handleNavigate(defaultHref as string, 'pop', 'back', incomingAnimation);
       }
     } else {
-      this.handleNavigate(defaultHref as string, 'pop', 'back', routeAnimation);
+      this.handleNavigate(defaultHref as string, 'pop', 'back', incomingAnimation);
     }
   }
 

--- a/packages/react-router/src/ReactRouter/IonRouter.tsx
+++ b/packages/react-router/src/ReactRouter/IonRouter.tsx
@@ -279,10 +279,10 @@ class IonRouterInner extends React.PureComponent<IonRouteProps, IonRouteState> {
           this.handleNavigate(prevInfo.pathname + (prevInfo.search || ''), 'pop', 'back', incomingAnimation);
         }
       } else {
-        this.handleNavigate(defaultHref as string, 'pop', 'back', incomingAnimation);
+        this.handleNavigate(defaultHref as string, 'pop', 'back', routeAnimation);
       }
     } else {
-      this.handleNavigate(defaultHref as string, 'pop', 'back', incomingAnimation);
+      this.handleNavigate(defaultHref as string, 'pop', 'back', routeAnimation);
     }
   }
 


### PR DESCRIPTION
Issue number: resolves #28673

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When reviewing https://github.com/ionic-team/ionic-framework/pull/28671 I noticed a bug where the custom animation was not used when going back after a replace.

`handleNavigate` will override whatever is in `incomingRouteParams`. Since we were passing `routeAnimation` (which is `undefined`), it was overriding the animation we set in `handleNavigateBack`.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `routeAnimation` is no longer overridden

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `7.6.1-dev.11702048520.13c82dad`
