### PR TITLE
fix(react): avoid type collision with @types/react@18.2.43 and greater

### DIFF
--- a/packages/react/src/components/utils/index.tsx
+++ b/packages/react/src/components/utils/index.tsx
@@ -5,7 +5,15 @@ import React from 'react';
 import type { IonicReactProps } from '../IonicReactProps';
 
 export type IonicReactExternalProps<PropType, ElementType> = PropType &
-  Omit<React.HTMLAttributes<ElementType>, 'style'> &
+  /**
+   * TODO: FW-5753
+   *
+   * The `placeholder` property was removed from `HTMLAttributes` in @types/react@18.2.43
+   * https://github.com/DefinitelyTyped/DefinitelyTyped/commit/b954269038de46b4b2f1756a9f2f020cbc66a326
+   *
+   * This is a temporary workaround until @ionic/react is updated to >=18.2.43.
+   */
+  Omit<React.HTMLAttributes<ElementType>, 'style' | 'placeholder'> &
   IonicReactProps;
 
 export const createForwardRef = <PropType, ElementType>(


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Ionic React projects using `@types/react@18.2.43` or greater will run into a type-check error on build with `IonRouterOutlet` and potentially other components:

```
Property 'placeholder' is missing in type '{ children: Element[]; }' but required in type 'Pick<IonRouterOutlet & { basePath?: string | undefined; ref?: Ref<any> | undefined; ionPage?: boolean | undefined; } & IonicReactProps & Omit<...>, "color" | ... 254 more ... | "ionPage">'.
```

Definitely typed decided to make a breaking type change in a patch release: https://github.com/DefinitelyTyped/DefinitelyTyped/commit/b954269038de46b4b2f1756a9f2f020cbc66a326


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Patches the type to allow for compatibility between React v16, 17 and 18. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Testing

1. Create a new Ionic react project with the "list" template.
2. Run `npm run build`
3. Observe: Exception posted above
4. Install the dev-build
5. Run `npm run build`
6. Observe: No exception, build passes
7. You can additionally serve the app to verify no runtime exceptions/broken behavior. 

Dev-build: `7.6.1-dev.11702322681.17e39348`
