### PR TITLE
chore: remove safari 11 code

### DIFF
--- a/core/src/css/core.scss
+++ b/core/src/css/core.scss
@@ -220,16 +220,6 @@ html.plt-ios.plt-hybrid, html.plt-ios.plt-pwa {
   }
 }
 
-// TODO: remove once Safari 11.2 is no longer supported
-@supports (padding-top: constant(safe-area-inset-top)) {
-  html {
-    --ion-safe-area-top: constant(safe-area-inset-top);
-    --ion-safe-area-bottom: constant(safe-area-inset-bottom);
-    --ion-safe-area-left: constant(safe-area-inset-left);
-    --ion-safe-area-right: constant(safe-area-inset-right);
-  }
-}
-
 @supports (padding-top: env(safe-area-inset-top)) {
   html {
     --ion-safe-area-top: env(safe-area-inset-top);


### PR DESCRIPTION
Older versions of WebKit used an old `constant()` syntax for safe area variables: https://caniuse.com/?search=env

As of Safari 11.3, `env()` is supported instead. We haven't supported Safari 11 in years, so I think this is safe to remove.