### PR TITLE
chore: add resolves to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Issue number: #
+Issue number: resolves #
 
 ---------
 


### PR DESCRIPTION
I've noticed a few instances where the team forgets to add the "resolves" keyword (or similar "closes"/"fixes" keywords) when linking a PR to an issue. GitHub will not link the PR with the issue and will not close the issue on PR merge unless one of these keywords is used.

I've updated the PR template to add the "resolves" keyword so team members don't need to worry about remembering to add it.
