### PR TITLE
chore: update PR template for breaking changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,12 @@ Issue number: resolves #
 - [ ] Yes
 - [ ] No
 
-<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
+<!--
+  If this introduces a breaking change:
+  1. Describe the impact and migration path for existing applications below.
+  2. Update the BREAKING.md file with the breaking change.
+  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
+-->
 
 
 ## Other information


### PR DESCRIPTION
The team had feedback during a sprint retro that the breaking change process documentation was a bit spread out. In particular, some team members were not clear that you need to a) update the breaking.md file and b) add the "BREAKING CHANGE" comment to the commit description.

This PR adds both of these things are comments for awareness.