### PR TITLE
chore(picker): mark ionInputModeChange as internal

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -909,7 +909,6 @@ ion-note,css-prop,--color
 
 ion-picker,shadow
 ion-picker,prop,mode,"ios" | "md",undefined,false,false
-ion-picker,event,ionInputModeChange,PickerChangeEventDetail,true
 ion-picker,css-prop,--fade-background-rgb
 ion-picker,css-prop,--highlight-background
 ion-picker,css-prop,--highlight-border-radius

--- a/core/src/components/picker/picker.tsx
+++ b/core/src/components/picker/picker.tsx
@@ -26,6 +26,9 @@ export class Picker implements ComponentInterface {
 
   @Element() el!: HTMLIonPickerElement;
 
+  /**
+   * @internal
+   */
   @Event() ionInputModeChange!: EventEmitter<PickerChangeEventDetail>;
 
   /**

--- a/packages/angular/src/directives/proxies.ts
+++ b/packages/angular/src/directives/proxies.ts
@@ -1432,17 +1432,11 @@ export class IonPicker {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionInputModeChange']);
   }
 }
 
 
-import type { PickerChangeEventDetail as IIonPickerPickerChangeEventDetail } from '@ionic/core';
-
-export declare interface IonPicker extends Components.IonPicker {
-
-  ionInputModeChange: EventEmitter<CustomEvent<IIonPickerPickerChangeEventDetail>>;
-}
+export declare interface IonPicker extends Components.IonPicker {}
 
 
 @ProxyCmp({

--- a/packages/angular/standalone/src/directives/proxies.ts
+++ b/packages/angular/standalone/src/directives/proxies.ts
@@ -1426,17 +1426,11 @@ export class IonPicker {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionInputModeChange']);
   }
 }
 
 
-import type { PickerChangeEventDetail as IIonPickerPickerChangeEventDetail } from '@ionic/core/components';
-
-export declare interface IonPicker extends Components.IonPicker {
-
-  ionInputModeChange: EventEmitter<CustomEvent<IIonPickerPickerChangeEventDetail>>;
-}
+export declare interface IonPicker extends Components.IonPicker {}
 
 
 @ProxyCmp({


### PR DESCRIPTION
When reviewing https://github.com/ionic-team/ionic-docs/pull/3321 I noticed that the `ionInputModeChange` event on `ion-picker` was documented. This is an internal API only used for text entry mode (which is also an internal API). This PR adds the `@internal` comment so it is not publicly documented.