### PR TITLE
fix(content): main landmark is set correctly

### DIFF
--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -428,12 +428,12 @@ export class Content implements ComponentInterface {
     const mode = getIonMode(this);
     const forceOverscroll = this.shouldForceOverscroll();
     const transitionShadow = mode === 'ios';
-    const TagType = isMainContent ? 'main' : ('div' as any);
 
     this.resize();
 
     return (
       <Host
+        role={isMainContent ? 'main' : undefined}
         class={createColorClasses(this.color, {
           [mode]: true,
           'content-sizing': hostContext('ion-popover', this.el),
@@ -446,19 +446,19 @@ export class Content implements ComponentInterface {
         }}
       >
         <div ref={(el) => (this.backgroundContentEl = el)} id="background-content" part="background"></div>
-        <TagType
+        <div
           class={{
             'inner-scroll': true,
             'scroll-x': scrollX,
             'scroll-y': scrollY,
             overscroll: (scrollX || scrollY) && forceOverscroll,
           }}
-          ref={(scrollEl: HTMLElement) => (this.scrollEl = scrollEl!)}
+          ref={(scrollEl) => (this.scrollEl = scrollEl)}
           onScroll={this.scrollEvents ? (ev: UIEvent) => this.onScroll(ev) : undefined}
           part="scroll"
         >
           <slot></slot>
-        </TagType>
+        </div>
 
         {transitionShadow ? (
           <div class="transition-effect">

--- a/core/src/components/refresher/test/a11y/refresher.e2e.ts
+++ b/core/src/components/refresher/test/a11y/refresher.e2e.ts
@@ -23,16 +23,7 @@ configs({ directions: ['ltr'], modes: ['md'], themes: ['light', 'dark'] }).forEa
 
       await expect(refresher).toHaveClass(/refresher-pulling/);
 
-      /**
-       * TODO(FW-5765): remove `disableRules('region')` when the following issues are resolved:
-       *
-       * The Axe test fails because a landmark role like `<main>` is missing from the top level.
-       *
-       * It also fails when adding a `<main>` element because
-       * the `<ion-content>` component already has a `<main>` element.
-       * This leads to a nested `<main>` element which is not allowed.
-       */
-      const results = await new AxeBuilder({ page }).disableRules('region').analyze();
+      const results = await new AxeBuilder({ page }).analyze();
 
       expect(results.violations).toEqual([]);
     });


### PR DESCRIPTION
Issue number: Internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Maria noted that the way we set the main landmark is not correct and causes accessibility violations.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Instead of rendering a main element inside of ion-content, the content itself is the main landmark.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
