### PR TITLE
fix(radio-group): radio disabled prop can be undefined

### DIFF
--- a/core/src/components/radio-group/radio-group.tsx
+++ b/core/src/components/radio-group/radio-group.tsx
@@ -130,6 +130,14 @@ export class RadioGroup implements ComponentInterface {
      * using the `name` attribute.
      */
     const selectedRadio = ev.target && (ev.target as HTMLElement).closest('ion-radio');
+    /**
+     * Our current disabled prop definition causes Stencil to mark it
+     * as optional. While this is not desired, fixing this behavior
+     * in Stencil is a significant breaking change, so this effort is
+     * being de-risked in STENCIL-917. Until then, we compromise
+     * here by checking for falsy `disabled` values instead of strictly
+     * checking `disabled === false`.
+     */
     if (selectedRadio && !selectedRadio.disabled) {
       const currentValue = this.value;
       const newValue = selectedRadio.value;

--- a/core/src/components/radio-group/radio-group.tsx
+++ b/core/src/components/radio-group/radio-group.tsx
@@ -130,7 +130,7 @@ export class RadioGroup implements ComponentInterface {
      * using the `name` attribute.
      */
     const selectedRadio = ev.target && (ev.target as HTMLElement).closest('ion-radio');
-    if (selectedRadio && selectedRadio.disabled === false) {
+    if (selectedRadio && !selectedRadio.disabled) {
       const currentValue = this.value;
       const newValue = selectedRadio.value;
       if (newValue !== currentValue) {


### PR DESCRIPTION
Issue number: resolves #28677

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Defining disabled a `@Prop() disabled = false` causes Stencil to mark this property as optional. This behavior is not desired on our end, but making the property required would be a breaking change. Additionally, the root issue is due to how Stencil resolves types. 

For example, `disabled` is [optional in the LocalJSX namespace](https://github.com/ionic-team/ionic-framework/blob/e96a1457a32646fa23c8218cb3cca4a8215ad115/core/src/components.d.ts#L6921) but [required in the Components namespace](https://github.com/ionic-team/ionic-framework/blob/e96a1457a32646fa23c8218cb3cca4a8215ad115/core/src/components.d.ts#L2239). Addressing this inside of Stencil is significant breaking change. As a result, the team has decided to compromise and support the falsy `disabled` state for radio for now. Other Ionic components that support the `disabled` prop also check for falsy values.

Stencil plans to de-risk this in https://ionic-cloud.atlassian.net/browse/STENCIL-917.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Radio Group now looks at falsy values instead of strictly checking `false`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


Dev build: `7.6.2-dev.11703182244.1165aeec`