### PR TITLE
chore(breaking): update picker component heading level

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -66,7 +66,7 @@ This section details the desktop browser, JavaScript framework, and mobile platf
       +  background: red;
       }
       ```
-<h2 id="version-8x-picker">Picker</h2>
+<h4 id="version-8x-picker">Picker</h4>
 
 - `ion-picker` and `ion-picker-column` have been renamed to `ion-picker-legacy` and `ion-picker-legacy-column`, respectively. This change was made to accommodate the new inline picker component while allowing developers to continue to use the legacy picker during this migration period.
   - Only the component names have been changed. Usages such as `ion-picker` or `IonPicker` should be changed to `ion-picker-legacy` and `IonPickerLegacy`, respectively.


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The picker heading level is currently an `h2`, where the other component headings are `h4`.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updates the heading level for Picker to `h4`. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
