### PR TITLE
test(radio): re-enable keyboard navigation

### DIFF
--- a/core/src/components/radio/test/a11y/radio.e2e.ts
+++ b/core/src/components/radio/test/a11y/radio.e2e.ts
@@ -15,8 +15,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
     });
   });
 
-  // TODO(FW-5715): re-enable test
-  test.skip(title('radio: keyboard navigation'), () => {
+  test.describe(title('radio: keyboard navigation'), () => {
     test.beforeEach(async ({ page }) => {
       await page.setContent(
         `
@@ -64,6 +63,15 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
     test('tabbing should switch between radio groups', async ({ page, pageUtils }) => {
       const firstGroupRadios = page.locator('#first-group ion-radio');
       const secondGroupRadios = page.locator('#second-group ion-radio');
+
+      /**
+       * Wait for the first radio to be rendered before tabbing.
+       * This is necessary because the first radio may not be rendered
+       * when the page first loads.
+       *
+       * This would cause the first radio to be skipped when tabbing.
+       */
+      await firstGroupRadios.nth(0).waitFor();
 
       await pageUtils.pressKeys('Tab');
       await expect(firstGroupRadios.nth(0)).toBeFocused();

--- a/core/src/components/radio/test/a11y/radio.e2e.ts
+++ b/core/src/components/radio/test/a11y/radio.e2e.ts
@@ -16,7 +16,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
   });
 
   test.describe(title('radio: keyboard navigation'), () => {
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ page, browserName }) => {
       await page.setContent(
         `
       <ion-app>
@@ -58,20 +58,26 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
     `,
         config
       );
+
+      if (browserName === 'webkit') {
+        const radio = page.locator('#first-group ion-radio').first();
+        /**
+         * Sometimes Safari does not focus the first radio.
+         * This is a workaround to ensure the first radio is focused.
+         *
+         * Wait for the first radio to be rendered before tabbing.
+         * This is necessary because the first radio may not be rendered
+         * when the page first loads.
+         *
+         * This would cause the first radio to be skipped when tabbing.
+         */
+        await radio.waitFor();
+      }
     });
 
     test('tabbing should switch between radio groups', async ({ page, pageUtils }) => {
       const firstGroupRadios = page.locator('#first-group ion-radio');
       const secondGroupRadios = page.locator('#second-group ion-radio');
-
-      /**
-       * Wait for the first radio to be rendered before tabbing.
-       * This is necessary because the first radio may not be rendered
-       * when the page first loads.
-       *
-       * This would cause the first radio to be skipped when tabbing.
-       */
-      await firstGroupRadios.nth(0).waitFor();
 
       await pageUtils.pressKeys('Tab');
       await expect(firstGroupRadios.nth(0)).toBeFocused();

--- a/core/src/components/radio/test/legacy/a11y/radio.e2e.ts
+++ b/core/src/components/radio/test/legacy/a11y/radio.e2e.ts
@@ -6,13 +6,21 @@ import { configs, test } from '@utils/test/playwright';
  */
 configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('radio: a11y'), () => {
-    test.beforeEach(async ({ page, skip }) => {
-      skip.browser('webkit', 'Tabbing is flaky in Safari');
+    test.beforeEach(async ({ page }) => {
       await page.goto(`/src/components/radio/test/legacy/a11y`, config);
     });
     test('tabbing should switch between radio groups', async ({ page, pageUtils }) => {
       const firstGroupRadios = page.locator('#first-group ion-radio');
       const secondGroupRadios = page.locator('#second-group ion-radio');
+
+      /**
+       * Wait for the first radio to be rendered before tabbing.
+       * This is necessary because the first radio may not be rendered
+       * when the page first loads.
+       *
+       * This would cause the first radio to be skipped when tabbing.
+       */
+      await firstGroupRadios.nth(0).waitFor();
 
       await pageUtils.pressKeys('Tab');
       await expect(firstGroupRadios.nth(0)).toBeFocused();

--- a/core/src/components/radio/test/legacy/a11y/radio.e2e.ts
+++ b/core/src/components/radio/test/legacy/a11y/radio.e2e.ts
@@ -6,21 +6,27 @@ import { configs, test } from '@utils/test/playwright';
  */
 configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('radio: a11y'), () => {
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ page, browserName }) => {
       await page.goto(`/src/components/radio/test/legacy/a11y`, config);
+
+      if (browserName === 'webkit') {
+        const radio = page.locator('#first-group ion-radio').first();
+        /**
+         * Sometimes Safari does not focus the first radio.
+         * This is a workaround to ensure the first radio is focused.
+         *
+         * Wait for the first radio to be rendered before tabbing.
+         * This is necessary because the first radio may not be rendered
+         * when the page first loads.
+         *
+         * This would cause the first radio to be skipped when tabbing.
+         */
+        await radio.waitFor();
+      }
     });
     test('tabbing should switch between radio groups', async ({ page, pageUtils }) => {
       const firstGroupRadios = page.locator('#first-group ion-radio');
       const secondGroupRadios = page.locator('#second-group ion-radio');
-
-      /**
-       * Wait for the first radio to be rendered before tabbing.
-       * This is necessary because the first radio may not be rendered
-       * when the page first loads.
-       *
-       * This would cause the first radio to be skipped when tabbing.
-       */
-      await firstGroupRadios.nth(0).waitFor();
 
       await pageUtils.pressKeys('Tab');
       await expect(firstGroupRadios.nth(0)).toBeFocused();


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The keyboard navigation tests for radio were disable due to flakiness with Safari when it came to the CI.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Re-enabled the tests.

Debugging was done with a saved artifact.

The artifact didn't provide a clear reason of why it flakes. But it did seem that the test was tabbing before the Safari page finished loading. I've added a `waitFor()` to verify that the radios have rendered. This was done for Safari only to prevent any additional wait time. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

There is no great way to test this since it only flakes on GitHub.