### PR TITLE
chore(ci): checkout files when updating package-lock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,17 @@ jobs:
     needs: [finalize-release]
     runs-on: ubuntu-latest
     steps:
+      # This ensures the local version of Lerna is installed
+      # and that we do not use the global Lerna version
+      - name: Install root dependencies
+        run: npm ci
+        shell: bash
       # Lerna does not automatically bump versions
       # of Ionic dependencies that have changed,
       # so we do that here.
       - name: Bump Package Lock
         run: |
-          lerna exec "npm install --package-lock-only"
+          npx lerna exec "npm install --package-lock-only"
           git add .
           git commit -m "chore(): update package lock files"
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,17 +78,13 @@ jobs:
     needs: [finalize-release]
     runs-on: ubuntu-latest
     steps:
-      # This ensures the local version of Lerna is installed
-      # and that we do not use the global Lerna version
-      - name: Install root dependencies
-        run: npm ci
-        shell: bash
+      - uses: actions/checkout@v3
       # Lerna does not automatically bump versions
       # of Ionic dependencies that have changed,
       # so we do that here.
       - name: Bump Package Lock
         run: |
-          npx lerna exec "npm install --package-lock-only"
+          lerna exec "npm install --package-lock-only"
           git add .
           git commit -m "chore(): update package lock files"
           git push


### PR DESCRIPTION
In https://github.com/ionic-team/ionic-framework/pull/28697 I moved the package-lock work to its own step to lets us re-run that if it fails. However, I forgot to checkout the project files in that step, so there was no `package-lock.json` file to update [resulting in an error](https://github.com/ionic-team/ionic-framework/actions/runs/7398703880/job/20128761433).