### PR TITLE
chore: remove matchMedia check

### DIFF
--- a/core/src/components/split-pane/split-pane.tsx
+++ b/core/src/components/split-pane/split-pane.tsx
@@ -118,6 +118,7 @@ export class SplitPane implements ComponentInterface {
     };
 
     const mediaList = window.matchMedia(mediaQuery);
+    // TODO FW-5869
     (mediaList as any).addListener(callback as any);
     this.rmL = () => (mediaList as any).removeListener(callback as any);
     this.visible = mediaList.matches;

--- a/core/src/components/split-pane/split-pane.tsx
+++ b/core/src/components/split-pane/split-pane.tsx
@@ -112,17 +112,15 @@ export class SplitPane implements ComponentInterface {
       return;
     }
 
-    if ((window as any).matchMedia) {
-      // Listen on media query
-      const callback = (q: MediaQueryList) => {
-        this.visible = q.matches;
-      };
+    // Listen on media query
+    const callback = (q: MediaQueryList) => {
+      this.visible = q.matches;
+    };
 
-      const mediaList = window.matchMedia(mediaQuery);
-      (mediaList as any).addListener(callback as any);
-      this.rmL = () => (mediaList as any).removeListener(callback as any);
-      this.visible = mediaList.matches;
-    }
+    const mediaList = window.matchMedia(mediaQuery);
+    (mediaList as any).addListener(callback as any);
+    this.rmL = () => (mediaList as any).removeListener(callback as any);
+    this.visible = mediaList.matches;
   }
 
   private isPane(element: HTMLElement): boolean {


### PR DESCRIPTION
Issue number: Internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

As part of FW-2832 the team has an initiative to remove much of the `any` usage in favor of stronger types. This will make modifications to this codebase safer as we will have access to proper type checking.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed the `any` case from window.matchMedia. This causes the linter to fail because `window.matchMedia` is always defined. I removed the check altogether. `matchMedia` is supported on all browsers that Ionic 7 supports. This should not cause any changes for Ionic developers, but I want to ship this a) in a separate patch and b) in a minor release to de-risk just in case there's an edge case I am not considering

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
