### PR TITLE
chore(ci): use correct github credentials for pushing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Configure Identity
+        # Commits from github-actions do not
+        # trigger other GitHub Actions. As a result,
+        # we publish releases from Ionitron instead
+        # so actions run when merging the release branch
+        # back into main.
+        run: |
+          git config user.name ionitron
+          git config user.email hi@ionicframework.com
+        shell: bash
       # Lerna does not automatically bump versions
       # of Ionic dependencies that have changed,
       # so we do that here.
@@ -88,6 +98,8 @@ jobs:
           git add .
           git commit -m "chore(): update package lock files"
           git push
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
 
   purge-cdn-cache:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,8 @@ jobs:
       - name: Configure Identity
         # Commits from github-actions do not
         # trigger other GitHub Actions. As a result,
-        # we publish releases from Ionitron instead
-        # so actions run when merging the release branch
+        # we push from Ionitron instead so actions
+        # run when merging the release branch
         # back into main.
         run: |
           git config user.name ionitron


### PR DESCRIPTION
The update-package-lock job did not configure Git credentials correctly. As a result, the job is unable to push the `package-lock.json` changes to the repo: https://github.com/ionic-team/ionic-framework/actions/runs/7476310958/job/20346663176

This PR configures the job with the correct credentials.