### PR TITLE
fix(angular): add old IonBackButtonDelegate import

### DIFF
--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -6,6 +6,8 @@ export { SelectValueAccessorDirective as SelectValueAccessor } from './directive
 export { TextValueAccessorDirective as TextValueAccessor } from './directives/control-value-accessors/text-value-accessor';
 export { IonTabs } from './directives/navigation/ion-tabs';
 export { IonBackButton } from './directives/navigation/ion-back-button';
+// TODO FW-5889
+export { IonBackButton as IonBackButtonDelegate } from './directives/navigation/ion-back-button';
 export { IonNav } from './directives/navigation/ion-nav';
 export { IonRouterOutlet } from './directives/navigation/ion-router-outlet';
 export {


### PR DESCRIPTION
Issue number: resolves #28827

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

This import was renamed to `IonBackButton` as part of https://github.com/ionic-team/ionic-framework/pull/28311/commits/9f20780d66a113410e5450139f8ecab3a9d4a0c9. However, we did not consider that some developers are importing this to use with `ViewChild`. While we should keep alignment with other component imports, we need to support the old import until we can make a breaking change in Ionic 8.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds the old IonBackButtonDelegate import

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Dev build: `7.6.5-dev.11705352188.1c6cdb08`