### PR TITLE
fix(nav): getLength is part of the public API

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -83,7 +83,7 @@ This allows components to inherit the color properly when used outside of Ionic 
 
 <h4 id="version-8x-nav">Nav</h4>
 
-- `getLength` returns `Promise<number>` instead of `<number>`. This method was not previously available in Nav's TypeScript interface, but developers could still access it by casting Nav as `any`. Applications that do that will need to make sure to `await` `getLength` before accessing the returned value.
+- `getLength` returns `Promise<number>` instead of `<number>`. This method was not previously available in Nav's TypeScript interface, but developers could still access it by casting Nav as `any`. Developers should ensure they `await` their `getLength` call before accessing the returned value.
 
 <h4 id="version-8x-picker">Picker</h4>
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -19,6 +19,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
   - [Button](#version-8x-button)
   - [Content](#version-8x-content)
   - [Datetime](#version-8x-datetime)
+  - [Nav](#version-8x-nav)
   - [Picker](#version-8x-picker)
 
 <h2 id="version-8x-browser-platform-support">Browser and Platform Support</h2>
@@ -79,6 +80,10 @@ This allows components to inherit the color properly when used outside of Ionic 
       +  background: red;
       }
       ```
+
+<h4 id="version-8x-nav">Nav</h4>
+
+- `getLength` returns `Promise<number>` instead of `<number>`. This method was not previously available in Nav's TypeScript interface, but developers could still access it by casting Nav as `any`. Applications that do that will need to make sure to `await` `getLength` before accessing the returned value.
 
 <h4 id="version-8x-picker">Picker</h4>
 

--- a/core/api.txt
+++ b/core/api.txt
@@ -884,6 +884,7 @@ ion-nav,prop,swipeGesture,boolean | undefined,undefined,false,false
 ion-nav,method,canGoBack,canGoBack(view?: ViewController) => Promise<boolean>
 ion-nav,method,getActive,getActive() => Promise<ViewController | undefined>
 ion-nav,method,getByIndex,getByIndex(index: number) => Promise<ViewController | undefined>
+ion-nav,method,getLength,getLength() => Promise<number>
 ion-nav,method,getPrevious,getPrevious(view?: ViewController) => Promise<ViewController | undefined>
 ion-nav,method,insert,insert<T extends NavComponent>(insertIndex: number, component: T, componentProps?: ComponentProps<T> | null, opts?: NavOptions | null, done?: TransitionDoneFn) => Promise<boolean>
 ion-nav,method,insertPages,insertPages(insertIndex: number, insertComponents: NavComponent[] | NavComponentWithProps[], opts?: NavOptions | null, done?: TransitionDoneFn) => Promise<boolean>

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -1823,6 +1823,10 @@ export namespace Components {
          */
         "getByIndex": (index: number) => Promise<ViewController | undefined>;
         /**
+          * Returns the number of views in the stack.
+         */
+        "getLength": () => Promise<number>;
+        /**
           * Get the previous view.
           * @param view The view to get.
          */

--- a/core/src/components/nav/nav.tsx
+++ b/core/src/components/nav/nav.tsx
@@ -483,8 +483,12 @@ export class Nav implements NavOutlet {
     return this.getPreviousSync(view);
   }
 
-  getLength() {
-    return this.views.length;
+  /**
+   * Returns the number of views in the stack.
+   */
+  @Method()
+  async getLength(): Promise<number> {
+    return Promise.resolve(this.views.length);
   }
 
   private getActiveSync(): ViewController | undefined {

--- a/core/src/components/nav/test/nav-controller.spec.ts
+++ b/core/src/components/nav/test/nav-controller.spec.ts
@@ -23,7 +23,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(push1Done).toHaveBeenCalledWith(hasCompleted, requiresTransition, view1, undefined, 'forward');
-      expect(nav.getLength()).toEqual(1);
+      expect(await nav.getLength()).toEqual(1);
       expect(nav['views'][0].component).toEqual(MockView1);
 
       // Push 2
@@ -32,7 +32,7 @@ describe('NavController', () => {
 
       expect(push2Done).toHaveBeenCalledWith(hasCompleted, requiresTransition, view2, view1, 'forward');
 
-      expect(nav.getLength()).toEqual(2);
+      expect(await nav.getLength()).toEqual(2);
       expect(nav['views'][0].component).toEqual(MockView1);
       expect(nav['views'][1].component).toEqual(MockView2);
 
@@ -41,7 +41,7 @@ describe('NavController', () => {
       await nav.push(view3, null, { animated: false }, push3Done);
 
       expect(push3Done).toHaveBeenCalledWith(hasCompleted, requiresTransition, view3, view2, 'forward');
-      expect(nav.getLength()).toEqual(3);
+      expect(await nav.getLength()).toEqual(3);
       expect(nav['views'][0].component).toEqual(MockView1);
       expect(nav['views'][1].component).toEqual(MockView2);
       expect(nav['views'][2].component).toEqual(MockView3);
@@ -50,7 +50,7 @@ describe('NavController', () => {
       const view4 = mockView(MockView4);
       await nav.push(view4, null, { animated: false }, push4Done);
       expect(push4Done).toHaveBeenCalledWith(hasCompleted, requiresTransition, view4, view3, 'forward');
-      expect(nav.getLength()).toEqual(4);
+      expect(await nav.getLength()).toEqual(4);
       expect(nav['views'][0].component).toEqual(MockView1);
       expect(nav['views'][1].component).toEqual(MockView2);
       expect(nav['views'][2].component).toEqual(MockView3);
@@ -59,7 +59,7 @@ describe('NavController', () => {
       // Pop 1
       await nav.pop({ animated: false }, pop1Done);
       expect(pop1Done).toHaveBeenCalledWith(hasCompleted, requiresTransition, view3, view4, 'back');
-      expect(nav.getLength()).toEqual(3);
+      expect(await nav.getLength()).toEqual(3);
       expect(nav['views'][0].component).toEqual(MockView1);
       expect(nav['views'][1].component).toEqual(MockView2);
       expect(nav['views'][2].component).toEqual(MockView3);
@@ -67,14 +67,14 @@ describe('NavController', () => {
       // Pop 2
       await nav.pop({ animated: false }, pop2Done);
       expect(pop2Done).toHaveBeenCalledWith(hasCompleted, requiresTransition, view2, view3, 'back');
-      expect(nav.getLength()).toEqual(2);
+      expect(await nav.getLength()).toEqual(2);
       expect(nav['views'][0].component).toEqual(MockView1);
       expect(nav['views'][1].component).toEqual(MockView2);
 
       // Pop 3
       await nav.pop({ animated: false }, pop3Done);
       expect(pop3Done).toHaveBeenCalledWith(hasCompleted, requiresTransition, view1, view2, 'back');
-      expect(nav.getLength()).toEqual(1);
+      expect(await nav.getLength()).toEqual(1);
       expect(nav['views'][0].component).toEqual(MockView1);
     }, 10000);
   });
@@ -86,7 +86,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, view1, undefined, 'forward');
-      expect(nav.getLength()).toEqual(1);
+      expect(await nav.getLength()).toEqual(1);
       expect(nav['views'][0].component).toEqual(MockView1);
       expect(nav['isTransitioning']).toEqual(false);
     }, 10000);
@@ -102,7 +102,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, view2, view1, 'forward');
-      expect(nav.getLength()).toEqual(2);
+      expect(await nav.getLength()).toEqual(2);
       expect(nav['views'][0].component).toEqual(MockView1);
       expect(nav['views'][1].component).toEqual(MockView2);
       expect(nav['isTransitioning']).toEqual(false);
@@ -134,7 +134,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, view2, view1, 'forward');
-      expect(nav.getLength()).toEqual(2);
+      expect(await nav.getLength()).toEqual(2);
     }, 10000);
   });
 
@@ -156,9 +156,9 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = false;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, undefined, undefined, undefined);
-      expect(nav.getLength()).toEqual(4);
+      expect(await nav.getLength()).toEqual(4);
       expect(nav['views'][0].component).toEqual(MockView4);
-      expect(nav['views'][nav.getLength() - 1].component).toEqual(MockView3);
+      expect(nav['views'][(await nav.getLength()) - 1].component).toEqual(MockView3);
     }, 10000);
 
     it('should insert at the end when given -1', async () => {
@@ -172,8 +172,8 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, view2, view1, 'forward');
-      expect(nav.getLength()).toEqual(2);
-      expect(nav['views'][nav.getLength() - 1].component).toEqual(MockView2);
+      expect(await nav.getLength()).toEqual(2);
+      expect(nav['views'][(await nav.getLength()) - 1].component).toEqual(MockView2);
     }, 10000);
 
     it('should insert at the end when given a number greater than actual length', async () => {
@@ -185,8 +185,8 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, view2, view1, 'forward');
-      expect(nav.getLength()).toEqual(2);
-      expect(nav['views'][nav.getLength() - 1].component).toEqual(MockView2);
+      expect(await nav.getLength()).toEqual(2);
+      expect(nav['views'][(await nav.getLength()) - 1].component).toEqual(MockView2);
     }, 10000);
 
     it('should not insert if null view', (done) => {
@@ -197,14 +197,14 @@ describe('NavController', () => {
         .then(() => {
           fail('it should not succeed');
         })
-        .catch((err: Error) => {
+        .catch(async (err: Error) => {
           const hasCompleted = false;
           const requiresTransition = false;
           const rejectReason = new Error('invalid views to insert');
           expect(err).toEqual(rejectReason);
           expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, rejectReason);
-          expect(nav.getLength()).toEqual(1);
-          expect(nav['views'][nav.getLength() - 1].component).toEqual(MockView1);
+          expect(await nav.getLength()).toEqual(1);
+          expect(nav['views'][(await nav.getLength()) - 1].component).toEqual(MockView1);
           done();
         });
     }, 10000);
@@ -232,7 +232,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = false;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, undefined, undefined, undefined);
-      expect(nav.getLength()).toEqual(5);
+      expect(await nav.getLength()).toEqual(5);
       expect(nav['views'][0].component).toEqual(MockView1);
       expect(nav['views'][1].component).toEqual(MockView4);
       expect(nav['views'][2].component).toEqual(MockView5);
@@ -251,13 +251,13 @@ describe('NavController', () => {
         .then(() => {
           fail('it should not succeed');
         })
-        .catch((err: any) => {
+        .catch(async (err: any) => {
           const hasCompleted = false;
           const requiresTransition = false;
           const rejectReason = new Error('no views in the stack to be removed');
           expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, rejectReason);
           expect(err).toEqual(rejectReason);
-          expect(nav.getLength()).toEqual(0);
+          expect(await nav.getLength()).toEqual(0);
           expect(nav['isTransitioning']).toEqual(false);
           done();
         });
@@ -287,7 +287,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, view1, view2, 'back');
-      expect(nav.getLength()).toEqual(1);
+      expect(await nav.getLength()).toEqual(1);
       expect(nav['views'][0].component).toEqual(MockView1);
       expect(nav['isTransitioning']).toEqual(false);
     }, 10000);
@@ -305,7 +305,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, view2, view3, 'back');
-      expect(nav.getLength()).toEqual(2);
+      expect(await nav.getLength()).toEqual(2);
       expect(nav['views'][0].component).toEqual(MockView1);
       expect(nav['views'][1].component).toEqual(MockView2);
     }, 10000);
@@ -322,7 +322,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, view2, view4, 'back');
-      expect(nav.getLength()).toEqual(2);
+      expect(await nav.getLength()).toEqual(2);
       expect(nav['views'][0].component).toEqual(MockView1);
       expect(nav['views'][1].component).toEqual(MockView2);
     }, 10000);
@@ -368,7 +368,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, view1, view4, 'back');
-      expect(nav.getLength()).toEqual(1);
+      expect(await nav.getLength()).toEqual(1);
       expect(nav['views'][0].component).toEqual(MockView1);
     }, 10000);
   });
@@ -415,7 +415,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, view1, view4, 'back');
-      expect(nav.getLength()).toEqual(1);
+      expect(await nav.getLength()).toEqual(1);
       expect(nav['views'][0].component).toEqual(MockView1);
     }, 10000);
 
@@ -427,7 +427,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = false;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, undefined, undefined, undefined);
-      expect(nav.getLength()).toEqual(1);
+      expect(await nav.getLength()).toEqual(1);
       expect(nav['views'][0].component).toEqual(MockView1);
     }, 10000);
   });
@@ -474,7 +474,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = false;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, undefined, undefined, undefined);
-      expect(nav.getLength()).toEqual(1);
+      expect(await nav.getLength()).toEqual(1);
       expect(nav['views'][0].component).toEqual(MockView4);
     }, 10000);
 
@@ -527,7 +527,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = false;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, undefined, undefined, undefined);
-      expect(nav.getLength()).toEqual(3);
+      expect(await nav.getLength()).toEqual(3);
       expect(nav['views'][0].component).toEqual(MockView1);
       expect(nav['views'][1].component).toEqual(MockView2);
       expect(nav['views'][2].component).toEqual(MockView5);
@@ -574,7 +574,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, view2, view4, 'back');
-      expect(nav.getLength()).toEqual(2);
+      expect(await nav.getLength()).toEqual(2);
       expect(nav['views'][0].component).toEqual(MockView1);
       expect(nav['views'][1].component).toEqual(MockView2);
     }, 10000);
@@ -613,7 +613,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = false;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, undefined, undefined, undefined);
-      expect(nav.getLength()).toEqual(1);
+      expect(await nav.getLength()).toEqual(1);
       expect(nav['views'][0].component).toEqual(MockView3);
     }, 10000);
 
@@ -649,7 +649,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, view2, view3, 'back');
-      expect(nav.getLength()).toEqual(1);
+      expect(await nav.getLength()).toEqual(1);
       expect(nav['views'][0].component).toEqual(MockView2);
     }, 10000);
 
@@ -685,7 +685,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, view1, view3, 'back');
-      expect(nav.getLength()).toEqual(1);
+      expect(await nav.getLength()).toEqual(1);
       expect(nav['views'][0].component).toEqual(MockView1);
     }, 10000);
 
@@ -708,7 +708,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, view4, view3, 'back');
-      expect(nav.getLength()).toEqual(1);
+      expect(await nav.getLength()).toEqual(1);
       expect(nav['views'][0].component).toEqual(MockView4);
     }, 10000);
   });
@@ -732,7 +732,7 @@ describe('NavController', () => {
       const hasCompleted = true;
       const requiresTransition = true;
       expect(trnsDone).toHaveBeenCalledWith(hasCompleted, requiresTransition, view5, view2, 'back');
-      expect(nav.getLength()).toEqual(2);
+      expect(await nav.getLength()).toEqual(2);
       expect(nav['views'][0].component).toEqual(MockView4);
       expect(nav['views'][1].component).toEqual(MockView5);
     }, 10000);


### PR DESCRIPTION
Issue number: resolves #28826

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`getLength` used to be a public method on `ion-nav`. However, the `@Method` decorator was removed in https://github.com/ionic-team/ionic-framework/commit/1d46973785aa204e13a44a740c9df75751d9f88d#diff-4b2ac275268173207c99a590b0ced8b67dc3d697815eb51a3c0546ee7cb0c0aeR429-L445.

While the removal of `@Method` from `isAnimating` was likely intentional, the team thinks that removing it from `getLength` was an accident. Otherwise, it's challenging to call methods like `removeIndex` if you don't know how many items are in the stack. For example, if a developer wants to remove the second to last item, they need to know how many items are in the stack so they don't give an index that is out of bounds.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `getLength` is now a public method

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->

The team is considering this to be a breaking change. As part of this, `getLength` must return `Promise<number>` instead of `number` as all public methods must return promises. While this API wasn't documented by mistake, it's technically always been a public API. As a result, JS-only developers can access `getLength` synchronously and TypeScript developers can do the same if they typecast Nav as `any`. Given that the return signature is different, we are going to ship this in a major release.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
