### PR TITLE
fix(themes): modify the dark themes to use :root for mode-specific styles

### DIFF
--- a/core/src/css/themes/dark.always.scss
+++ b/core/src/css/themes/dark.always.scss
@@ -4,10 +4,10 @@
   @include dark-base-theme();
 }
 
-.ios body {
+:root.ios {
   @include dark-ios-theme();
 }
 
-.md body {
+:root.md {
   @include dark-md-theme();
 }

--- a/core/src/css/themes/dark.system.scss
+++ b/core/src/css/themes/dark.system.scss
@@ -5,11 +5,11 @@
     @include dark-base-theme();
   }
 
-  .ios body {
+  :root.ios {
     @include dark-ios-theme();
   }
 
-  .md body {
+  :root.md {
     @include dark-md-theme();
   }
 }


### PR DESCRIPTION
Issue number: N/A

---------

## What is the current behavior?
The `system` and `always` dark theme files target the mode-specific styles by using the following selectors:

```scss
:root {
  @include dark-base-theme();
}

.ios body {
  @include dark-ios-theme();
}

.md body {
  @include dark-md-theme();
}
```

This is an issue because then users **cannot** override the dark theme by targeting `html.ios`, they must use target the `body`.

## What is the new behavior?
Updates the selector to target the `:root` with the mode-specific class:

```scss
:root {
  @include dark-base-theme();
}

:root.ios {
  @include dark-ios-theme();
}

:root.md {
  @include dark-md-theme();
}
```

This makes more sense, since we want it to still be global but mode-specific, and allows users to override it on the `html` selector if desired. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
