### PR TITLE
fix(segment): setting value via binding updates button state

### DIFF
--- a/core/src/components/segment/segment.tsx
+++ b/core/src/components/segment/segment.tsx
@@ -141,6 +141,14 @@ export class Segment implements ComponentInterface {
     this.setCheckedClasses();
 
     /**
+     * If the value changes before watchers
+     * are setup, then the ionSelect watch callback
+     * will not fire. As a result, we manually
+     * fire this event when Select is loaded.
+     */
+    this.ionSelect.emit({ value: this.value });
+
+    /**
      * We need to wait for the buttons to all be rendered
      * before we can scroll.
      */


### PR DESCRIPTION
Issue number: resolves #28816

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The value is set on Segment asynchronously when binding it in Angular. However, the timing works out such that the value changes after `connectedCallback` is fired but before any Stencil Watchers are configured. As a result, our `value` property watcher does not fire which causes `ionSelect` to not be emitted. Segment Buttons rely on this event to know when to update their state (if the value changes such that a segment button is now selected). This results in a checked segment button not appearing checked.

This is similar to other issues that have been fixed:

https://github.com/ionic-team/ionic-framework/pull/28510
https://github.com/ionic-team/ionic-framework/pull/28488
https://github.com/ionic-team/ionic-framework/pull/28526

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Segment now emits `ionSelect` on `componentDidLoad` so that any descendant segment buttons can update correctly.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `7.6.5-dev.11705415448.16878103`

This is a timing issue with Stencil, so I am unable to write a reliable automated test. Reviewers should test the dev build in the repro provided in the linked issue.