### PR TITLE
fix(datetime): do not animate to new value when multiple values in different months are set

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1284,21 +1284,42 @@ export class Datetime implements ComponentInterface {
       (month !== undefined && month !== workingParts.month) || (year !== undefined && year !== workingParts.year);
     const bodyIsVisible = el.classList.contains('datetime-ready');
     const { isGridStyle, showMonthAndYear } = this;
-    if (isGridStyle && didChangeMonth && bodyIsVisible && !showMonthAndYear) {
-      this.animateToDate(targetValue);
-    } else {
-      /**
-       * We only need to do this if we didn't just animate to a new month,
-       * since that calls prevMonth/nextMonth which calls setWorkingParts for us.
-       */
-      this.setWorkingParts({
-        month,
-        day,
-        year,
-        hour,
-        minute,
-        ampm,
-      });
+
+    let areAllSelectedDatesInSameMonth = true;
+    if (Array.isArray(valueToProcess)) {
+      const firstMonth = valueToProcess[0].month;
+      for (const date of valueToProcess) {
+        if (date.month !== firstMonth) {
+          areAllSelectedDatesInSameMonth = false;
+          break;
+        }
+      }
+    }
+
+    /**
+     * If there is more than one date selected
+     * and the dates aren't all in the same month,
+     * then we should neither animate to the date
+     * nor update the working parts because we do
+     * not know which date the user wants to view.
+     */
+    if (areAllSelectedDatesInSameMonth) {
+      if (isGridStyle && didChangeMonth && bodyIsVisible && !showMonthAndYear) {
+        this.animateToDate(targetValue);
+      } else {
+        /**
+         * We only need to do this if we didn't just animate to a new month,
+         * since that calls prevMonth/nextMonth which calls setWorkingParts for us.
+         */
+        this.setWorkingParts({
+          month,
+          day,
+          year,
+          hour,
+          minute,
+          ampm,
+        });
+      }
     }
   };
 

--- a/core/src/components/datetime/test/multiple/datetime.e2e.ts
+++ b/core/src/components/datetime/test/multiple/datetime.e2e.ts
@@ -159,6 +159,10 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
     });
 
     test('should scroll to new month when value is updated with multiple dates in the same month', async ({ page }) => {
+    test.info().annotations.push({
+      type: 'issue',
+      description: 'https://github.com/ionic-team/ionic-framework/issues/28602',
+    });
       const datetime = await datetimeFixture.goto(config, MULTIPLE_DATES_SEPARATE_MONTHS);
       await datetime.evaluate((el: HTMLIonDatetimeElement, dates: string[]) => {
         el.value = dates;

--- a/core/src/components/datetime/test/multiple/datetime.e2e.ts
+++ b/core/src/components/datetime/test/multiple/datetime.e2e.ts
@@ -158,6 +158,18 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
       });
     });
 
+    test('should scroll to new month when value is updated with multiple dates in the same month', async ({ page }) => {
+      const datetime = await datetimeFixture.goto(config, MULTIPLE_DATES_SEPARATE_MONTHS);
+      await datetime.evaluate((el: HTMLIonDatetimeElement, dates: string[]) => {
+        el.value = dates;
+      }, MULTIPLE_DATES);
+
+      await page.waitForChanges();
+
+      const monthYear = datetime.locator('.calendar-month-year');
+      await expect(monthYear).toHaveText(/June 2022/);
+    });
+
     test('should not scroll to new month when value is updated with dates in different months', async ({ page }) => {
       const datetime = await datetimeFixture.goto(config, MULTIPLE_DATES);
       await datetime.evaluate((el: HTMLIonDatetimeElement, dates: string[]) => {

--- a/core/src/components/datetime/test/multiple/datetime.e2e.ts
+++ b/core/src/components/datetime/test/multiple/datetime.e2e.ts
@@ -5,7 +5,7 @@ import { configs, test } from '@utils/test/playwright';
 
 const SINGLE_DATE = '2022-06-01';
 const MULTIPLE_DATES = ['2022-06-01', '2022-06-02', '2022-06-03'];
-const MULTIPLE_DATES_SEPARATE_MONTHS = ['2022-04-01', '2022-05-01', '2022-06-01'];
+const MULTIPLE_DATES_SEPARATE_MONTHS = ['2022-03-01', '2022-04-01', '2022-05-01'];
 
 interface DatetimeMultipleConfig {
   multiple?: boolean;
@@ -158,10 +158,13 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
       });
     });
 
-    test('multiple default values across months should display at least one value', async () => {
-      const datetime = await datetimeFixture.goto(config, MULTIPLE_DATES_SEPARATE_MONTHS);
+    test('should not scroll to new month when value is updated with dates in different months', async ({ page }) => {
+      const datetime = await datetimeFixture.goto(config, MULTIPLE_DATES);
+      await datetime.evaluate((el: HTMLIonDatetimeElement) => el.value = MULTIPLE_DATES_SEPARATE_MONTHS);
+      await page.waitForChanges();
+
       const monthYear = datetime.locator('.calendar-month-year');
-      await expect(monthYear).toHaveText(/April 2022/);
+      await expect(monthYear).toHaveText(/June 2022/);
     });
 
     test('with buttons, should only update value when confirm is called', async ({ page }) => {

--- a/core/src/components/datetime/test/multiple/datetime.e2e.ts
+++ b/core/src/components/datetime/test/multiple/datetime.e2e.ts
@@ -160,7 +160,7 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
 
     test('should not scroll to new month when value is updated with dates in different months', async ({ page }) => {
       const datetime = await datetimeFixture.goto(config, MULTIPLE_DATES);
-      await datetime.evaluate((el: HTMLIonDatetimeElement) => el.value = MULTIPLE_DATES_SEPARATE_MONTHS);
+      await datetime.evaluate((el: HTMLIonDatetimeElement) => (el.value = MULTIPLE_DATES_SEPARATE_MONTHS));
       await page.waitForChanges();
 
       const monthYear = datetime.locator('.calendar-month-year');

--- a/core/src/components/datetime/test/multiple/datetime.e2e.ts
+++ b/core/src/components/datetime/test/multiple/datetime.e2e.ts
@@ -159,10 +159,10 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
     });
 
     test('should scroll to new month when value is updated with multiple dates in the same month', async ({ page }) => {
-    test.info().annotations.push({
-      type: 'issue',
-      description: 'https://github.com/ionic-team/ionic-framework/issues/28602',
-    });
+      test.info().annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/28602',
+      });
       const datetime = await datetimeFixture.goto(config, MULTIPLE_DATES_SEPARATE_MONTHS);
       await datetime.evaluate((el: HTMLIonDatetimeElement, dates: string[]) => {
         el.value = dates;

--- a/core/src/components/datetime/test/multiple/datetime.e2e.ts
+++ b/core/src/components/datetime/test/multiple/datetime.e2e.ts
@@ -160,7 +160,10 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
 
     test('should not scroll to new month when value is updated with dates in different months', async ({ page }) => {
       const datetime = await datetimeFixture.goto(config, MULTIPLE_DATES);
-      await datetime.evaluate((el: HTMLIonDatetimeElement) => (el.value = MULTIPLE_DATES_SEPARATE_MONTHS));
+      await datetime.evaluate((el: HTMLIonDatetimeElement, dates: string[]) => {
+        el.value = dates;
+      }, MULTIPLE_DATES_SEPARATE_MONTHS);
+
       await page.waitForChanges();
 
       const monthYear = datetime.locator('.calendar-month-year');


### PR DESCRIPTION
Issue number: resolves #28602

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

We animate to the new date when the value is changed, but we do not account for multiple selection. This behavior is valuable for when the value is set asynchronously on a different month than what it shown.

However, this is confusing when there are multiple dates selected in different months, because we do not reasonably know which date to animate to.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Datetime no longer animates to the new value if more than one date is selected, and the selected dates aren't all in the same month.

An alternative strategy would be to always animate unless one of the selected dates is in the month currently being viewed. However, this would still mean guessing at which value the user wants to see, which we are trying to avoid.

Based on this PR: https://github.com/ionic-team/ionic-framework/pull/28605

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Co-authored-by: Liam DeBeasi <liamdebeasi@users.noreply.github.com>