### PR TITLE
fix(datetime): enter closes keyboard when typing time

### DIFF
--- a/core/src/components/picker-internal/picker-internal.tsx
+++ b/core/src/components/picker-internal/picker-internal.tsx
@@ -227,6 +227,7 @@ export class PickerInternal implements ComponentInterface {
    * column is focused.
    */
   private enterInputMode = (columnEl?: HTMLIonPickerColumnInternalElement, focusInput = true) => {
+    console.log('enter');
     const { inputEl, el } = this;
     if (!inputEl) {
       return;
@@ -550,6 +551,21 @@ export class PickerInternal implements ComponentInterface {
           tabindex={-1}
           inputmode="numeric"
           type="number"
+          onKeyDown={(ev: KeyboardEvent) => {
+            /**
+             * The "Enter" key represents
+             * the user submitting their time
+             * selection, so we should blur the
+             * input (and therefore close the keyboard)
+             *
+             * Updating the picker's state to no longer
+             * be in input mode is handled in the onBlur
+             * callback below.
+             */
+            if (ev.key === 'Enter') {
+              this.inputEl?.blur();
+            }
+          }}
           ref={(el) => (this.inputEl = el)}
           onInput={() => this.onInputChange()}
           onBlur={() => this.exitInputMode()}

--- a/core/src/components/picker-internal/picker-internal.tsx
+++ b/core/src/components/picker-internal/picker-internal.tsx
@@ -265,6 +265,7 @@ export class PickerInternal implements ComponentInterface {
 
       inputEl.focus();
     } else {
+      // TODO FW-5900 Use keydown instead
       el.addEventListener('keypress', this.onKeyPress);
       this.destroyKeypressListener = () => {
         el.removeEventListener('keypress', this.onKeyPress);

--- a/core/src/components/picker-internal/picker-internal.tsx
+++ b/core/src/components/picker-internal/picker-internal.tsx
@@ -227,7 +227,6 @@ export class PickerInternal implements ComponentInterface {
    * column is focused.
    */
   private enterInputMode = (columnEl?: HTMLIonPickerColumnInternalElement, focusInput = true) => {
-    console.log('enter');
     const { inputEl, el } = this;
     if (!inputEl) {
       return;

--- a/core/src/components/picker-internal/test/keyboard-entry/picker-internal.e2e.ts
+++ b/core/src/components/picker-internal/test/keyboard-entry/picker-internal.e2e.ts
@@ -133,5 +133,44 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       await expect(ionChange).toHaveReceivedEventDetail({ text: '00', value: 12 });
       await expect(column).toHaveJSProperty('value', 12);
     });
+    test.only('pressing Enter should dismiss the keyboard', async ({ page }) => {
+      test.info().annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/28325',
+      });
+      await page.setContent(
+        `
+        <ion-picker-internal>
+          <ion-picker-column-internal></ion-picker-column-internal>
+        </ion-picker-internal>
+
+        <script>
+          const column = document.querySelector('ion-picker-column-internal');
+          column.items = [
+            { text: '00', value: 12 },
+            { text: '01', value: 1 },
+            { text: '02', value: 2 },
+            { text: '03', value: 3 },
+            { text: '04', value: 4 },
+            { text: '05', value: 5 }
+          ];
+          column.value = 5;
+          column.numericInput = true;
+        </script>
+      `,
+        config
+      );
+
+      const column = page.locator('ion-picker-column-internal');
+      await column.click();
+
+      const input = page.locator('ion-picker-internal input');
+      await expect(input).toBeFocused();
+
+      // pressing Enter should blur the input and therefore close the keyboard
+      await page.keyboard.press('Enter');
+
+      await expect(input).not.toBeFocused();
+    });
   });
 });

--- a/core/src/components/picker-internal/test/keyboard-entry/picker-internal.e2e.ts
+++ b/core/src/components/picker-internal/test/keyboard-entry/picker-internal.e2e.ts
@@ -133,7 +133,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       await expect(ionChange).toHaveReceivedEventDetail({ text: '00', value: 12 });
       await expect(column).toHaveJSProperty('value', 12);
     });
-    test.only('pressing Enter should dismiss the keyboard', async ({ page }) => {
+    test('pressing Enter should dismiss the keyboard', async ({ page }) => {
       test.info().annotations.push({
         type: 'issue',
         description: 'https://github.com/ionic-team/ionic-framework/issues/28325',


### PR DESCRIPTION
Issue number: resolves #28325

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When typing the time into the date picker pressing "Enter" does not close the on-screen keyboard.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Pressing "Enter" closes the on-screen keyboard

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


Test:

⚠️ While I have a test for this, please also test this on a physical Android device.

1. Go to `src/components/datetime/test/basic`
2. Open the time picker (in any of the date times)
3. Tap the time to open the keyboard
4. Press "Enter" on Android. Observe that the keyboard closes.

Dev build: `7.6.6-dev.11705528328.1ef5e17b`