### PR TITLE
fix(overlays): do not return focus if application has already moved focus manually

### DIFF
--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -496,7 +496,7 @@ export const present = async <OverlayPresentOptions>(
    * from returning focus as a result.
    */
   if (overlay.el.tagName !== 'ION-TOAST') {
-    focusPreviousElementOnDismiss(overlay.el);
+    focusPreviousElementOnDismissIfNeeded(overlay.el);
   }
 
   /**
@@ -520,7 +520,7 @@ export const present = async <OverlayPresentOptions>(
  * to where they were before they
  * opened the overlay.
  */
-const focusPreviousElementOnDismiss = async (overlayEl: any) => {
+const focusPreviousElementOnDismissIfNeeded = async (overlayEl: any) => {
   let previousElement = document.activeElement as HTMLElement | null;
   if (!previousElement) {
     return;
@@ -533,7 +533,17 @@ const focusPreviousElementOnDismiss = async (overlayEl: any) => {
   }
 
   await overlayEl.onDidDismiss();
-  previousElement.focus();
+
+  /**
+   * If the user has already removed focus
+   * from the overlay (For example, focusing
+   * a text box after tapping a button in an
+   * action sheet) then don't restore focus
+   * to previous element
+   */
+  if (document.activeElement === null || document.activeElement === document.body) {
+    previousElement.focus();
+  }
 };
 
 export const dismiss = async <OverlayDismissOptions>(

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -496,7 +496,7 @@ export const present = async <OverlayPresentOptions>(
    * from returning focus as a result.
    */
   if (overlay.el.tagName !== 'ION-TOAST') {
-    focusPreviousElementOnDismissIfNeeded(overlay.el);
+    restoreElementFocus(overlay.el);
   }
 
   /**
@@ -520,7 +520,7 @@ export const present = async <OverlayPresentOptions>(
  * to where they were before they
  * opened the overlay.
  */
-const focusPreviousElementOnDismissIfNeeded = async (overlayEl: any) => {
+const restoreElementFocus = async (overlayEl: any) => {
   let previousElement = document.activeElement as HTMLElement | null;
   if (!previousElement) {
     return;
@@ -535,11 +535,28 @@ const focusPreviousElementOnDismissIfNeeded = async (overlayEl: any) => {
   await overlayEl.onDidDismiss();
 
   /**
-   * If the user has already removed focus
-   * from the overlay (For example, focusing
-   * a text box after tapping a button in an
-   * action sheet) then don't restore focus
-   * to previous element
+   * After onDidDismiss, the overlay loses focus
+   * because it is removed from the document
+   *
+   * > An element will also lose focus [...]
+   * > if the element is removed from the document)
+   *
+   * https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event
+   *
+   * Additionally, `document.activeElement` returns:
+   *
+   * > The Element which currently has focus,
+   * > `<body>` or null if there is
+   * > no focused element.
+   *
+   * https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement#value
+   *
+   * However, if the user has already focused
+   * an element sometime between onWillDismiss
+   * and onDidDismiss (for example, focusing a
+   * text box after tapping a button in an
+   * action sheet) then don't restore focus to
+   * previous element
    */
   if (document.activeElement === null || document.activeElement === document.body) {
     previousElement.focus();


### PR DESCRIPTION
Issue number: resolves #28849

---------

## What is the current behavior?

If the developer tries to set focus to a custom element on overlay dismissal, Ionic will always override that focus.

## What is the new behavior?

- If focus is already set by developer during dismissal, then Ionic will not restore focus to previous element

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

In the before video, you can see the text box is focused by developer code when "Mention User" is tapped, which opens the keyboard. Shortly after that, when the bottom sheet fully dismisses, Ionic focuses the button, removing focus from the text box and hiding the keyboard.

In the after, Ionic detects that the developer has already focused the text box and does not change that focus.

|Before|After|
|---|---|
|<video src="https://github.com/ionic-team/ionic-framework/assets/2166114/47d55eff-29af-4019-ac3c-00f9fe722ca7"></video>| <video src="https://github.com/ionic-team/ionic-framework/assets/2166114/508ae466-d037-41eb-b518-92338a122b22"></video>|
