### PR TITLE
chore: assign team members instead of members from team

### DIFF
--- a/.github/workflows/assign-issues.yml
+++ b/.github/workflows/assign-issues.yml
@@ -13,7 +13,6 @@ jobs:
       - name: 'Auto-assign issue'
         uses: pozil/auto-assign-issue@edee9537367a8fbc625d27f9e10aa8bad47b8723 # v1.13.0
         with:
-          repo-token: ${{ secrets.IONITRON_TOKEN }}
-          teams: framework
+          assginees: liamdebeas, sean-perkins, brandyscarney, amandaejohnston, mapsandapps, thetaPC
           numOfAssignee: 1
           allowSelfAssign: false


### PR DESCRIPTION
The token I was using didn't have the correct permissions, and I need to figure out how to generate a new token (I don't think I have access to the account where these tokens live). For now, I'm going to hard code the team members until I can figure out the token access out.