### PR TITLE
test(react): re-enable picker tests

### DIFF
--- a/packages/react/test/base/tests/e2e/specs/overlay-components/IonPicker.cy.ts
+++ b/packages/react/test/base/tests/e2e/specs/overlay-components/IonPicker.cy.ts
@@ -1,9 +1,4 @@
-/**
- * TODO: Skipping for now to avoid the CE build issue
- * where child components do not get registered.
- * Re-enable after this is resolved in Stencil 2.9.
- */
-describe.skip('IonPicker', () => {
+describe('IonPicker', () => {
   beforeEach(() => {
     cy.visit('/overlay-components/picker');
   });

--- a/packages/react/test/base/tests/e2e/specs/overlay-hooks/useIonPicker.cy.ts
+++ b/packages/react/test/base/tests/e2e/specs/overlay-hooks/useIonPicker.cy.ts
@@ -1,10 +1,4 @@
-/**
- * TODO: Skipping for now to avoid the CE build issue
- * where child components do not get registered.
- * Re-enable after this is resolved in Stencil 2.9.
- */
-
-describe.skip('useIonPicker', () => {
+describe('useIonPicker', () => {
   beforeEach(() => {
     cy.visit('/overlay-hooks/picker');
   });


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The `IonPicker` tests in the React app were skipped due to a Stencil bug that has since been resolved.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Tests re-enabled.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
