### PR TITLE
refactor(react, react-router): build works on windows

### DIFF
--- a/packages/react-router/rollup.config.mjs
+++ b/packages/react-router/rollup.config.mjs
@@ -1,4 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
+const external = ['react', 'react-dom', 'react-router', 'react-router-dom', 'history'];
 
 export default {
   input: 'src/index.ts',
@@ -9,8 +10,8 @@ export default {
       sourcemap: true,
     }
   ],
-  external: (id) => !/^(\.|\/)/.test(id),
   plugins: [
     typescript(),
   ],
+  external: id => external.includes(id) || id.startsWith('@ionic/core') || id.startsWith('ionicons') || id.startsWith('@ionic/react'),
 };

--- a/packages/react-router/rollup.config.mjs
+++ b/packages/react-router/rollup.config.mjs
@@ -1,5 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
-const external = ['react', 'react-dom', 'react-router', 'react-router-dom', 'history'];
+const external = ['react', 'react-dom', 'react-router', 'react-router-dom', 'history', 'tslib'];
 
 export default {
   input: 'src/index.ts',

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -1,5 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
-const external = ['react', 'react-dom', 'react-router', 'react-router-dom', 'history'];
+const external = ['react', 'react-dom', 'react-router', 'react-router-dom', 'history', 'tslib'];
 
 export default {
   input: 'src/index.ts',

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -1,4 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
+const external = ['react', 'react-dom', 'react-router', 'react-router-dom', 'history'];
 
 export default {
   input: 'src/index.ts',
@@ -11,8 +12,8 @@ export default {
       sourcemap: true,
     }
   ],
-  external: (id) => !/^(\.|\/)/.test(id),
   plugins: [
     typescript(),
   ],
+  external: id => external.includes(id) || id.startsWith('@ionic/core') || id.startsWith('ionicons'),
 };


### PR DESCRIPTION
Issue number: Internal
---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

React and React Router packages do not build correctly on Windows because certain dependencies were not marked as external.
## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 3rd party packages are correctly marked as external


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
