### PR TITLE
fix: remove default light mode tokens

### DIFF
--- a/core/src/themes/ionic.theme.default.scss
+++ b/core/src/themes/ionic.theme.default.scss
@@ -94,53 +94,6 @@ $background-color-rgb:              var(--ion-background-color-rgb, $background-
 $text-color:                        var(--ion-text-color, $text-color-value) !default;
 $text-color-rgb:                    var(--ion-text-color-rgb, $text-color-rgb-value) !default;
 
-
-// Default Light Theme Step Colors
-// -------------------------------------------------------------------------------------------
-// TODO: move to core.scss after FW-5822 is done
-
-:root {
-  --ion-background-color-step-50: #{mix($text-color-value, $background-color-value, 5%)};
-  --ion-background-color-step-100: #{mix($text-color-value, $background-color-value, 10%)};
-  --ion-background-color-step-150: #{mix($text-color-value, $background-color-value, 15%)};
-  --ion-background-color-step-200: #{mix($text-color-value, $background-color-value, 20%)};
-  --ion-background-color-step-250: #{mix($text-color-value, $background-color-value, 25%)};
-  --ion-background-color-step-300: #{mix($text-color-value, $background-color-value, 30%)};
-  --ion-background-color-step-350: #{mix($text-color-value, $background-color-value, 35%)};
-  --ion-background-color-step-400: #{mix($text-color-value, $background-color-value, 40%)};
-  --ion-background-color-step-450: #{mix($text-color-value, $background-color-value, 45%)};
-  --ion-background-color-step-500: #{mix($text-color-value, $background-color-value, 50%)};
-  --ion-background-color-step-550: #{mix($text-color-value, $background-color-value, 55%)};
-  --ion-background-color-step-600: #{mix($text-color-value, $background-color-value, 60%)};
-  --ion-background-color-step-650: #{mix($text-color-value, $background-color-value, 65%)};
-  --ion-background-color-step-700: #{mix($text-color-value, $background-color-value, 70%)};
-  --ion-background-color-step-750: #{mix($text-color-value, $background-color-value, 75%)};
-  --ion-background-color-step-800: #{mix($text-color-value, $background-color-value, 80%)};
-  --ion-background-color-step-850: #{mix($text-color-value, $background-color-value, 85%)};
-  --ion-background-color-step-900: #{mix($text-color-value, $background-color-value, 90%)};
-  --ion-background-color-step-950: #{mix($text-color-value, $background-color-value, 95%)};
-
-  --ion-text-color-step-50: #{mix($background-color-value, $text-color-value, 5%)};
-  --ion-text-color-step-100: #{mix($background-color-value, $text-color-value, 10%)};
-  --ion-text-color-step-150: #{mix($background-color-value, $text-color-value, 15%)};
-  --ion-text-color-step-200: #{mix($background-color-value, $text-color-value, 20%)};
-  --ion-text-color-step-250: #{mix($background-color-value, $text-color-value, 25%)};
-  --ion-text-color-step-300: #{mix($background-color-value, $text-color-value, 30%)};
-  --ion-text-color-step-350: #{mix($background-color-value, $text-color-value, 35%)};
-  --ion-text-color-step-400: #{mix($background-color-value, $text-color-value, 40%)};
-  --ion-text-color-step-450: #{mix($background-color-value, $text-color-value, 45%)};
-  --ion-text-color-step-500: #{mix($background-color-value, $text-color-value, 50%)};
-  --ion-text-color-step-550: #{mix($background-color-value, $text-color-value, 55%)};
-  --ion-text-color-step-600: #{mix($background-color-value, $text-color-value, 60%)};
-  --ion-text-color-step-650: #{mix($background-color-value, $text-color-value, 65%)};
-  --ion-text-color-step-700: #{mix($background-color-value, $text-color-value, 70%)};
-  --ion-text-color-step-750: #{mix($background-color-value, $text-color-value, 75%)};
-  --ion-text-color-step-800: #{mix($background-color-value, $text-color-value, 80%)};
-  --ion-text-color-step-850: #{mix($background-color-value, $text-color-value, 85%)};
-  --ion-text-color-step-900: #{mix($background-color-value, $text-color-value, 90%)};
-  --ion-text-color-step-950: #{mix($background-color-value, $text-color-value, 95%)};
-}
-
 // Default Foreground and Background Step Colors
 // -------------------------------------------------------------------------------------------
 // Color Steps are used to provide variations in text and background colors of elements.


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

In https://github.com/ionic-team/ionic-framework/pull/28814, we updated the default and dark themes to define the stepped color tokens. This caused the light mode fallback colors to never apply when we added support for the new stepped colors to components such has datetime button.

For example, `date time-button` has a default theme fallback of [#edeef0](https://github.com/ionic-team/ionic-framework/blob/58639c7a1e0417c2b8bf7d709ea2efd600b44021/core/src/components/datetime-button/datetime-button.scss#L27).

When updating to support the new step colors, the syntax will be `var(--ion-color-step-300, var(--ion-background-color-step-300), #edeef0)`. However, since `--ion-background-color-step-300` is always defined, the fallback of `#edeef0` will never be used.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The default theme stepped colors are not defined. Instead, we rely on the sass variable token fallbacks. The dark mode tokens remain unchanged.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
