### PR TITLE
refactor(input): update to use correct step tokens

### DIFF
--- a/core/src/components/input/input.scss
+++ b/core/src/components/input/input.scss
@@ -402,7 +402,7 @@
 .input-bottom .helper-text {
   display: block;
 
-  color: #{$background-color-step-550};
+  color: #{$text-color-step-450};
 }
 
 :host(.ion-touched.ion-invalid) .input-bottom .error-text {
@@ -424,7 +424,7 @@
    */
   @include margin-horizontal(auto, null);
 
-  color: #{$background-color-step-550};
+  color: #{$text-color-step-450};
 
   white-space: nowrap;
 


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Input has a couple of styles that were using the wrong step tokens. Non-text colors (background, border, etc) should be using `$background-color-step-*` while text colors (like color) should be using `$text-color-step-*`.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-  Updated the `color` to use `$text-color-step-*` instead of `$background-color-step-*`.

The correct number is to subtract wrong token number from 1000. For example:

```scss
// wrong
color: #{$background-color-step-550};
```

1000 - 550 = 450

```scss
// correct
color: #{$text-color-step-450};
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

No visual differences are expected.