### PR TITLE
refactor(segment-button): update to use new step token

### DIFF
--- a/core/src/components/segment-button/segment-button.ios.vars.scss
+++ b/core/src/components/segment-button/segment-button.ios.vars.scss
@@ -13,7 +13,7 @@ $segment-button-ios-background-checked:               $segment-button-ios-backgr
 $segment-button-ios-color:                            $text-color !default;
 
 /// @prop - Background of the checked segment button indicator
-$segment-button-ios-indicator-color:                  var(--ion-color-step-350, $background-color) !default;
+$segment-button-ios-indicator-color:                  var(--ion-color-step-350, var(--ion-background-color-step-350, $background-color)) !default;
 
 /// @prop - Margin of the segment button
 $segment-button-ios-margin:                           2px !default;


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?
The segment button checked indicator only uses the `--ion-color-step-350` variable with a fallback to the `--ion-background-color`.

## What is the new behavior?
The segment button checked indicator falls back to using the `--ion-background-color-step-350` variable if it is defined but prioritizes `--ion-color-step-350` if it is also defined. This is the new step color token added for high-contrast themes.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

No visual diffs are expected.