### PR TITLE
refactor(modal): update to use new step token

### DIFF
--- a/core/src/components/modal/modal.scss
+++ b/core/src/components/modal/modal.scss
@@ -129,7 +129,7 @@ ion-backdrop {
 
   border: 0;
 
-  background: var(--ion-color-step-350, #c0c0be);
+  background: var(--ion-color-step-350, var(--ion-background-color-step-350, #c0c0be));
 
   cursor: pointer;
 


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?
The modal handle only uses the `--ion-color-step-350` variable with a fallback to `#c0c0be`.

## What is the new behavior?
The modal handle falls back to using the `--ion-background-color-step-350` variable if it is defined but prioritizes `--ion-color-step-350` if it is also defined. This is the new step color token added for high-contrast themes.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

No visual diffs are expected.