### PR TITLE
refactor(picker): update to use new step token

### DIFF
--- a/core/src/components/picker/picker.ios.scss
+++ b/core/src/components/picker/picker.ios.scss
@@ -10,5 +10,5 @@
 }
 
 :host .picker-highlight {
-  background: var(--highlight-background, var(--ion-color-step-150, #eeeeef));
+  background: var(--highlight-background, var(--ion-color-step-150, var(--ion-background-color-step-150, #eeeeef)));
 }


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?
The picker highlight only uses the `--ion-color-step-150` variable with a fallback to `#eeeeef`.

## What is the new behavior?
The picker highlight falls back to using the `--ion-background-color-step-150` variable if it is defined but prioritizes `--ion-color-step-150` if it is also defined. This is the new step color token added for high-contrast themes.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

No visual diffs are expected.