### PR TITLE
refactor(breadcrumb): use new step color tokens

### DIFF
--- a/core/src/components/breadcrumb/breadcrumb.ios.vars.scss
+++ b/core/src/components/breadcrumb/breadcrumb.ios.vars.scss
@@ -4,7 +4,7 @@
 // --------------------------------------------------
 
 /// @prop - Color of the breadcrumb
-$breadcrumb-ios-color:                             var(--ion-color-step-150, var(--ion-text-color-step-850, #2d4665)) !default;
+$breadcrumb-ios-color:                             var(--ion-color-step-850, var(--ion-background-color-step-850, #2d4665)) !default;
 
 /// @prop - Color of the active breadcrumb
 $breadcrumb-ios-color-active:                      var(--ion-text-color, #03060b) !default;
@@ -13,13 +13,13 @@ $breadcrumb-ios-color-active:                      var(--ion-text-color, #03060b
 $breadcrumb-ios-background-focused:                var(--ion-color-step-50, var(--ion-background-color-step-50, rgba(233, 237, 243, 0.7))) !default;
 
 /// @prop - Color of the breadcrumb icon
-$breadcrumb-ios-icon-color:                        var(--ion-color-step-600, var(--ion-text-color-step-400, #92a0b3)) !default;
+$breadcrumb-ios-icon-color:                        var(--ion-color-step-400, var(--ion-background-color-step-400, #92a0b3)) !default;
 
 /// @prop - Color of the breadcrumb icon when active
-$breadcrumb-ios-icon-color-active:                 var(--ion-color-step-150, var(--ion-text-color-step-850, #242d39)) !default;
+$breadcrumb-ios-icon-color-active:                 var(--ion-color-step-850, var(--ion-background-color-step-850, #242d39)) !default;
 
 /// @prop - Color of the breadcrumb icon when focused
-$breadcrumb-ios-icon-color-focused:                var(--ion-color-step-250, var(--ion-text-color-step-750, #445b78)) !default;
+$breadcrumb-ios-icon-color-focused:                var(--ion-color-step-750, var(--ion-background-color-step-750, #445b78)) !default;
 
 /// @prop - Color of the breadcrumb separator
 $breadcrumb-ios-separator-color:                   $breadcrumb-separator-color !default;

--- a/core/src/components/breadcrumb/breadcrumb.ios.vars.scss
+++ b/core/src/components/breadcrumb/breadcrumb.ios.vars.scss
@@ -4,7 +4,7 @@
 // --------------------------------------------------
 
 /// @prop - Color of the breadcrumb
-$breadcrumb-ios-color:                             var(--ion-color-step-850, var(--ion-background-color-step-850, #2d4665)) !default;
+$breadcrumb-ios-color:                             var(--ion-color-step-850, var(--ion-text-color-step-150, #2d4665)) !default;
 
 /// @prop - Color of the active breadcrumb
 $breadcrumb-ios-color-active:                      var(--ion-text-color, #03060b) !default;

--- a/core/src/components/breadcrumb/breadcrumb.ios.vars.scss
+++ b/core/src/components/breadcrumb/breadcrumb.ios.vars.scss
@@ -4,22 +4,22 @@
 // --------------------------------------------------
 
 /// @prop - Color of the breadcrumb
-$breadcrumb-ios-color:                             var(--ion-color-step-850, #2d4665) !default;
+$breadcrumb-ios-color:                             var(--ion-color-step-850, var(--ion-text-color-step-850, #2d4665)) !default;
 
 /// @prop - Color of the active breadcrumb
 $breadcrumb-ios-color-active:                      var(--ion-text-color, #03060b) !default;
 
 /// @prop - Background color of the focused breadcrumb
-$breadcrumb-ios-background-focused:                var(--ion-color-step-50, rgba(233, 237, 243, 0.7)) !default;
+$breadcrumb-ios-background-focused:                var(--ion-color-step-50, var(--ion-background-color-step-50,rgba(233, 237, 243, 0.7))) !default;
 
 /// @prop - Color of the breadcrumb icon
-$breadcrumb-ios-icon-color:                        var(--ion-color-step-400, #92a0b3) !default;
+$breadcrumb-ios-icon-color:                        var(--ion-color-step-400, var(--ion-text-color-step-400, #92a0b3)) !default;
 
 /// @prop - Color of the breadcrumb icon when active
-$breadcrumb-ios-icon-color-active:                 var(--ion-color-step-850, #242d39) !default;
+$breadcrumb-ios-icon-color-active:                 var(--ion-color-step-850, var(--ion-text-color-step-850, #242d39)) !default;
 
 /// @prop - Color of the breadcrumb icon when focused
-$breadcrumb-ios-icon-color-focused:                var(--ion-color-step-750, #445b78) !default;
+$breadcrumb-ios-icon-color-focused:                var(--ion-color-step-750, var(--ion-text-color-step-750, #445b78)) !default;
 
 /// @prop - Color of the breadcrumb separator
 $breadcrumb-ios-separator-color:                   $breadcrumb-separator-color !default;
@@ -28,7 +28,7 @@ $breadcrumb-ios-separator-color:                   $breadcrumb-separator-color !
 $breadcrumb-ios-indicator-color:                   $breadcrumb-ios-separator-color !default;
 
 /// @prop - Background color of the breadcrumb indicator
-$breadcrumb-ios-indicator-background:              var(--ion-color-step-100, #e9edf3) !default;
+$breadcrumb-ios-indicator-background:              var(--ion-color-step-100, var(--ion-background-color-step-100, #e9edf3)) !default;
 
 /// @prop - Background color of the breadcrumb indicator when focused
-$breadcrumb-ios-indicator-background-focused:      var(--ion-color-step-150, #d9e0ea) !default;
+$breadcrumb-ios-indicator-background-focused:      var(--ion-color-step-150, var(--ion-background-color-step-150, #d9e0ea)) !default;

--- a/core/src/components/breadcrumb/breadcrumb.ios.vars.scss
+++ b/core/src/components/breadcrumb/breadcrumb.ios.vars.scss
@@ -13,13 +13,13 @@ $breadcrumb-ios-color-active:                      var(--ion-text-color, #03060b
 $breadcrumb-ios-background-focused:                var(--ion-color-step-50, var(--ion-background-color-step-50, rgba(233, 237, 243, 0.7))) !default;
 
 /// @prop - Color of the breadcrumb icon
-$breadcrumb-ios-icon-color:                        var(--ion-color-step-400, var(--ion-background-color-step-400, #92a0b3)) !default;
+$breadcrumb-ios-icon-color:                        var(--ion-color-step-400, var(--ion-text-color-step-600, #92a0b3)) !default;
 
 /// @prop - Color of the breadcrumb icon when active
-$breadcrumb-ios-icon-color-active:                 var(--ion-color-step-850, var(--ion-background-color-step-850, #242d39)) !default;
+$breadcrumb-ios-icon-color-active:                 var(--ion-color-step-850, var(--ion-text-color-step-150, #242d39)) !default;
 
 /// @prop - Color of the breadcrumb icon when focused
-$breadcrumb-ios-icon-color-focused:                var(--ion-color-step-750, var(--ion-background-color-step-750, #445b78)) !default;
+$breadcrumb-ios-icon-color-focused:                var(--ion-color-step-750, var(--ion-text-color-step-250, #445b78)) !default;
 
 /// @prop - Color of the breadcrumb separator
 $breadcrumb-ios-separator-color:                   $breadcrumb-separator-color !default;

--- a/core/src/components/breadcrumb/breadcrumb.ios.vars.scss
+++ b/core/src/components/breadcrumb/breadcrumb.ios.vars.scss
@@ -4,22 +4,22 @@
 // --------------------------------------------------
 
 /// @prop - Color of the breadcrumb
-$breadcrumb-ios-color:                             var(--ion-color-step-850, var(--ion-text-color-step-850, #2d4665)) !default;
+$breadcrumb-ios-color:                             var(--ion-color-step-150, var(--ion-text-color-step-850, #2d4665)) !default;
 
 /// @prop - Color of the active breadcrumb
 $breadcrumb-ios-color-active:                      var(--ion-text-color, #03060b) !default;
 
 /// @prop - Background color of the focused breadcrumb
-$breadcrumb-ios-background-focused:                var(--ion-color-step-50, var(--ion-background-color-step-50,rgba(233, 237, 243, 0.7))) !default;
+$breadcrumb-ios-background-focused:                var(--ion-color-step-50, var(--ion-background-color-step-50, rgba(233, 237, 243, 0.7))) !default;
 
 /// @prop - Color of the breadcrumb icon
-$breadcrumb-ios-icon-color:                        var(--ion-color-step-400, var(--ion-text-color-step-400, #92a0b3)) !default;
+$breadcrumb-ios-icon-color:                        var(--ion-color-step-600, var(--ion-text-color-step-400, #92a0b3)) !default;
 
 /// @prop - Color of the breadcrumb icon when active
-$breadcrumb-ios-icon-color-active:                 var(--ion-color-step-850, var(--ion-text-color-step-850, #242d39)) !default;
+$breadcrumb-ios-icon-color-active:                 var(--ion-color-step-150, var(--ion-text-color-step-850, #242d39)) !default;
 
 /// @prop - Color of the breadcrumb icon when focused
-$breadcrumb-ios-icon-color-focused:                var(--ion-color-step-750, var(--ion-text-color-step-750, #445b78)) !default;
+$breadcrumb-ios-icon-color-focused:                var(--ion-color-step-250, var(--ion-text-color-step-750, #445b78)) !default;
 
 /// @prop - Color of the breadcrumb separator
 $breadcrumb-ios-separator-color:                   $breadcrumb-separator-color !default;

--- a/core/src/components/breadcrumb/breadcrumb.md.vars.scss
+++ b/core/src/components/breadcrumb/breadcrumb.md.vars.scss
@@ -4,13 +4,13 @@
 // --------------------------------------------------
 
 /// @prop - Color of the breadcrumb
-$breadcrumb-md-color:                               var(--ion-color-step-600, var(--ion-background-color-step-600, #677483)) !default;
+$breadcrumb-md-color:                               var(--ion-color-step-600, var(--ion-text-color-step-400, #677483)) !default;
 
 /// @prop - Color of the active breadcrumb
 $breadcrumb-md-color-active:                        var(--ion-text-color, #03060b) !default;
 
 /// @prop - Color of the focused breadcrumb
-$breadcrumb-md-color-focused:                        var(--ion-color-step-800, var(--ion-background-color-step-800, #35404e)) !default;
+$breadcrumb-md-color-focused:                        var(--ion-color-step-800, var(--ion-text-color-step-200, #35404e)) !default;
 
 /// @prop - Background color of the focused breadcrumb
 $breadcrumb-md-background-focused:                  var(--ion-color-step-50, var(--ion-background-color-step-50, #fff)) !default;

--- a/core/src/components/breadcrumb/breadcrumb.md.vars.scss
+++ b/core/src/components/breadcrumb/breadcrumb.md.vars.scss
@@ -4,22 +4,22 @@
 // --------------------------------------------------
 
 /// @prop - Color of the breadcrumb
-$breadcrumb-md-color:                               var(--ion-color-step-600, #677483) !default;
+$breadcrumb-md-color:                               var(--ion-color-step-600, var(--ion-text-color-step-600, #677483)) !default;
 
 /// @prop - Color of the active breadcrumb
 $breadcrumb-md-color-active:                        var(--ion-text-color, #03060b) !default;
 
 /// @prop - Color of the focused breadcrumb
-$breadcrumb-md-color-focused:                        var(--ion-color-step-800, #35404e) !default;
+$breadcrumb-md-color-focused:                        var(--ion-color-step-800, var(--ion-text-color-step-800, #35404e)) !default;
 
 /// @prop - Background color of the focused breadcrumb
-$breadcrumb-md-background-focused:                  var(--ion-color-step-50, #fff) !default;
+$breadcrumb-md-background-focused:                  var(--ion-color-step-50, var(--ion-background-color-step-50, #fff)) !default;
 
 /// @prop - Color of the breadcrumb icon
-$breadcrumb-md-icon-color:                          var(--ion-color-step-550, #7d8894) !default;
+$breadcrumb-md-icon-color:                          var(--ion-color-step-550, var(--ion-text-color-step-550, #7d8894)) !default;
 
 /// @prop - Color of the breadcrumb icon when active
-$breadcrumb-md-icon-color-active:                   var(--ion-color-step-850, #222d3a) !default;
+$breadcrumb-md-icon-color-active:                   var(--ion-color-step-850, var(--ion-text-color-step-850, #222d3a)) !default;
 
 /// @prop - Margin top of the breadcrumb separator
 $breadcrumb-md-separator-margin-top:                -1px !default;
@@ -40,7 +40,7 @@ $breadcrumb-md-separator-color:                     $breadcrumb-separator-color 
 $breadcrumb-md-indicator-color:                     $breadcrumb-md-separator-color !default;
 
 /// @prop - Background color of the breadcrumb indicator
-$breadcrumb-md-indicator-background:                var(--ion-color-step-100, #eef1f3) !default;
+$breadcrumb-md-indicator-background:                var(--ion-color-step-100, var(--ion-background-color-step-100, #eef1f3)) !default;
 
 /// @prop - Background color of the breadcrumb indicator when focused
-$breadcrumb-md-indicator-background-focused:        var(--ion-color-step-150, #dfe5e8) !default;
+$breadcrumb-md-indicator-background-focused:        var(--ion-color-step-150, var(--ion-background-color-step-150, #dfe5e8)) !default;

--- a/core/src/components/breadcrumb/breadcrumb.md.vars.scss
+++ b/core/src/components/breadcrumb/breadcrumb.md.vars.scss
@@ -16,10 +16,10 @@ $breadcrumb-md-color-focused:                        var(--ion-color-step-800, v
 $breadcrumb-md-background-focused:                  var(--ion-color-step-50, var(--ion-background-color-step-50, #fff)) !default;
 
 /// @prop - Color of the breadcrumb icon
-$breadcrumb-md-icon-color:                          var(--ion-color-step-550, var(--ion-background-color-step-550, #7d8894)) !default;
+$breadcrumb-md-icon-color:                          var(--ion-color-step-550, var(--ion-text-color-step-450, #7d8894)) !default;
 
 /// @prop - Color of the breadcrumb icon when active
-$breadcrumb-md-icon-color-active:                   var(--ion-color-step-850, var(--ion-background-color-step-850, #222d3a)) !default;
+$breadcrumb-md-icon-color-active:                   var(--ion-color-step-850, var(--ion-text-color-step-150, #222d3a)) !default;
 
 /// @prop - Margin top of the breadcrumb separator
 $breadcrumb-md-separator-margin-top:                -1px !default;

--- a/core/src/components/breadcrumb/breadcrumb.md.vars.scss
+++ b/core/src/components/breadcrumb/breadcrumb.md.vars.scss
@@ -4,22 +4,22 @@
 // --------------------------------------------------
 
 /// @prop - Color of the breadcrumb
-$breadcrumb-md-color:                               var(--ion-color-step-400, var(--ion-text-color-step-600, #677483)) !default;
+$breadcrumb-md-color:                               var(--ion-color-step-600, var(--ion-background-color-step-600, #677483)) !default;
 
 /// @prop - Color of the active breadcrumb
 $breadcrumb-md-color-active:                        var(--ion-text-color, #03060b) !default;
 
 /// @prop - Color of the focused breadcrumb
-$breadcrumb-md-color-focused:                        var(--ion-color-step-200, var(--ion-text-color-step-800, #35404e)) !default;
+$breadcrumb-md-color-focused:                        var(--ion-color-step-800, var(--ion-background-color-step-800, #35404e)) !default;
 
 /// @prop - Background color of the focused breadcrumb
 $breadcrumb-md-background-focused:                  var(--ion-color-step-50, var(--ion-background-color-step-50, #fff)) !default;
 
 /// @prop - Color of the breadcrumb icon
-$breadcrumb-md-icon-color:                          var(--ion-color-step-450, var(--ion-text-color-step-550, #7d8894)) !default;
+$breadcrumb-md-icon-color:                          var(--ion-color-step-550, var(--ion-background-color-step-550, #7d8894)) !default;
 
 /// @prop - Color of the breadcrumb icon when active
-$breadcrumb-md-icon-color-active:                   var(--ion-color-step-150, var(--ion-text-color-step-850, #222d3a)) !default;
+$breadcrumb-md-icon-color-active:                   var(--ion-color-step-850, var(--ion-background-color-step-850, #222d3a)) !default;
 
 /// @prop - Margin top of the breadcrumb separator
 $breadcrumb-md-separator-margin-top:                -1px !default;

--- a/core/src/components/breadcrumb/breadcrumb.md.vars.scss
+++ b/core/src/components/breadcrumb/breadcrumb.md.vars.scss
@@ -4,22 +4,22 @@
 // --------------------------------------------------
 
 /// @prop - Color of the breadcrumb
-$breadcrumb-md-color:                               var(--ion-color-step-600, var(--ion-text-color-step-600, #677483)) !default;
+$breadcrumb-md-color:                               var(--ion-color-step-400, var(--ion-text-color-step-600, #677483)) !default;
 
 /// @prop - Color of the active breadcrumb
 $breadcrumb-md-color-active:                        var(--ion-text-color, #03060b) !default;
 
 /// @prop - Color of the focused breadcrumb
-$breadcrumb-md-color-focused:                        var(--ion-color-step-800, var(--ion-text-color-step-800, #35404e)) !default;
+$breadcrumb-md-color-focused:                        var(--ion-color-step-200, var(--ion-text-color-step-800, #35404e)) !default;
 
 /// @prop - Background color of the focused breadcrumb
 $breadcrumb-md-background-focused:                  var(--ion-color-step-50, var(--ion-background-color-step-50, #fff)) !default;
 
 /// @prop - Color of the breadcrumb icon
-$breadcrumb-md-icon-color:                          var(--ion-color-step-550, var(--ion-text-color-step-550, #7d8894)) !default;
+$breadcrumb-md-icon-color:                          var(--ion-color-step-450, var(--ion-text-color-step-550, #7d8894)) !default;
 
 /// @prop - Color of the breadcrumb icon when active
-$breadcrumb-md-icon-color-active:                   var(--ion-color-step-850, var(--ion-text-color-step-850, #222d3a)) !default;
+$breadcrumb-md-icon-color-active:                   var(--ion-color-step-150, var(--ion-text-color-step-850, #222d3a)) !default;
 
 /// @prop - Margin top of the breadcrumb separator
 $breadcrumb-md-separator-margin-top:                -1px !default;

--- a/core/src/components/breadcrumb/breadcrumb.vars.scss
+++ b/core/src/components/breadcrumb/breadcrumb.vars.scss
@@ -12,4 +12,4 @@ $breadcrumb-baseline-font-size: 16px !default;
 $breadcrumb-font-size:           dynamic-font($breadcrumb-baseline-font-size) !default;
 
 /// @prop - Color of the breadcrumb separator
-$breadcrumb-separator-color:     var(--ion-color-step-550, #73849a) !default;
+$breadcrumb-separator-color:     var(--ion-color-step-550, var(--icon-text-color-step-550, #73849a)) !default;

--- a/core/src/components/breadcrumb/breadcrumb.vars.scss
+++ b/core/src/components/breadcrumb/breadcrumb.vars.scss
@@ -12,4 +12,4 @@ $breadcrumb-baseline-font-size: 16px !default;
 $breadcrumb-font-size:           dynamic-font($breadcrumb-baseline-font-size) !default;
 
 /// @prop - Color of the breadcrumb separator
-$breadcrumb-separator-color:     var(--ion-color-step-550, var(--icon-background-color-step-550, #73849a)) !default;
+$breadcrumb-separator-color:     var(--ion-color-step-550, var(--icon-text-color-step-450, #73849a)) !default;

--- a/core/src/components/breadcrumb/breadcrumb.vars.scss
+++ b/core/src/components/breadcrumb/breadcrumb.vars.scss
@@ -12,4 +12,4 @@ $breadcrumb-baseline-font-size: 16px !default;
 $breadcrumb-font-size:           dynamic-font($breadcrumb-baseline-font-size) !default;
 
 /// @prop - Color of the breadcrumb separator
-$breadcrumb-separator-color:     var(--ion-color-step-550, var(--icon-text-color-step-550, #73849a)) !default;
+$breadcrumb-separator-color:     var(--ion-color-step-450, var(--icon-text-color-step-550, #73849a)) !default;

--- a/core/src/components/breadcrumb/breadcrumb.vars.scss
+++ b/core/src/components/breadcrumb/breadcrumb.vars.scss
@@ -12,4 +12,4 @@ $breadcrumb-baseline-font-size: 16px !default;
 $breadcrumb-font-size:           dynamic-font($breadcrumb-baseline-font-size) !default;
 
 /// @prop - Color of the breadcrumb separator
-$breadcrumb-separator-color:     var(--ion-color-step-450, var(--icon-text-color-step-550, #73849a)) !default;
+$breadcrumb-separator-color:     var(--ion-color-step-550, var(--icon-background-color-step-550, #73849a)) !default;


### PR DESCRIPTION
Issue number: Internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
The breadcrumbs use the `--ion-color-step` tokens or a fallback.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The breadcrumb text colors use the `--ion-color-step` tokens or the `--ion-text-color-step` tokens or a fallback
- The breadcrumb background colors use the `--ion-color-step` tokens or the `--ion-background-color-step` tokens or a fallback

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->

<!-- 
## Other information

Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
