### PR TITLE
refactor(refresher): use new step color tokens

### DIFF
--- a/core/src/components/refresher/refresher.ios.vars.scss
+++ b/core/src/components/refresher/refresher.ios.vars.scss
@@ -7,7 +7,7 @@ $refresher-ios-icon-color:            $text-color !default;
 $refresher-ios-text-color:            $text-color !default;
 
 /// @prop - Color of the native refresher spinner
-$refresher-ios-native-spinner-color:  var(--ion-color-step-450, var(--ion-text-color-step-450, #747577)) !default;
+$refresher-ios-native-spinner-color:  var(--ion-color-step-550, var(--ion-text-color-step-450, #747577)) !default;
 
 /// @prop - Width of the native refresher spinner
 $refresher-ios-native-spinner-width:  32px !default;

--- a/core/src/components/refresher/refresher.ios.vars.scss
+++ b/core/src/components/refresher/refresher.ios.vars.scss
@@ -7,7 +7,7 @@ $refresher-ios-icon-color:            $text-color !default;
 $refresher-ios-text-color:            $text-color !default;
 
 /// @prop - Color of the native refresher spinner
-$refresher-ios-native-spinner-color:  var(--ion-color-step-450, #747577) !default;
+$refresher-ios-native-spinner-color:  var(--ion-color-step-450, var(--ion-text-color-step-450, #747577)) !default;
 
 /// @prop - Width of the native refresher spinner
 $refresher-ios-native-spinner-width:  32px !default;

--- a/core/src/components/refresher/refresher.ios.vars.scss
+++ b/core/src/components/refresher/refresher.ios.vars.scss
@@ -7,7 +7,7 @@ $refresher-ios-icon-color:            $text-color !default;
 $refresher-ios-text-color:            $text-color !default;
 
 /// @prop - Color of the native refresher spinner
-$refresher-ios-native-spinner-color:  var(--ion-color-step-550, var(--ion-text-color-step-450, #747577)) !default;
+$refresher-ios-native-spinner-color:  var(--ion-color-step-450, var(--ion-background-color-step-450, #747577)) !default;
 
 /// @prop - Width of the native refresher spinner
 $refresher-ios-native-spinner-width:  32px !default;

--- a/core/src/components/refresher/refresher.md.vars.scss
+++ b/core/src/components/refresher/refresher.md.vars.scss
@@ -10,7 +10,7 @@ $refresher-md-text-color:                     $text-color !default;
 $refresher-md-native-spinner-color:           #{ion-color(primary, base)} !default;
 
 /// @prop - Border of the native refresher spinner
-$refresher-md-native-spinner-border:          1px solid var(--ion-color-step-200, var(--ion-text-color-step-200, #ececec)) !default;
+$refresher-md-native-spinner-border:          1px solid var(--ion-color-step-800, var(--ion-text-color-step-200, #ececec)) !default;
 
 /// @prop - Background of the native refresher spinner
 $refresher-md-native-spinner-background:      var(--ion-color-step-250, var(--ion-background-color-step-250, #ffffff)) !default;

--- a/core/src/components/refresher/refresher.md.vars.scss
+++ b/core/src/components/refresher/refresher.md.vars.scss
@@ -10,7 +10,7 @@ $refresher-md-text-color:                     $text-color !default;
 $refresher-md-native-spinner-color:           #{ion-color(primary, base)} !default;
 
 /// @prop - Border of the native refresher spinner
-$refresher-md-native-spinner-border:          1px solid var(--ion-color-step-800, var(--ion-text-color-step-200, #ececec)) !default;
+$refresher-md-native-spinner-border:          1px solid var(--ion-color-step-200, var(--ion-background-color-step-200, #ececec)) !default;
 
 /// @prop - Background of the native refresher spinner
 $refresher-md-native-spinner-background:      var(--ion-color-step-250, var(--ion-background-color-step-250, #ffffff)) !default;

--- a/core/src/components/refresher/refresher.md.vars.scss
+++ b/core/src/components/refresher/refresher.md.vars.scss
@@ -10,10 +10,10 @@ $refresher-md-text-color:                     $text-color !default;
 $refresher-md-native-spinner-color:           #{ion-color(primary, base)} !default;
 
 /// @prop - Border of the native refresher spinner
-$refresher-md-native-spinner-border:          1px solid var(--ion-color-step-200, #ececec) !default;
+$refresher-md-native-spinner-border:          1px solid var(--ion-color-step-200, var(--ion-text-color-step-200, #ececec)) !default;
 
 /// @prop - Background of the native refresher spinner
-$refresher-md-native-spinner-background:      var(--ion-color-step-250, #ffffff) !default;
+$refresher-md-native-spinner-background:      var(--ion-color-step-250, var(--ion-background-color-step-250, #ffffff)) !default;
 
 /// @prop - Box shadow of the native refresher spinner
 $refresher-md-native-spinner-box-shadow:      0px 1px 6px rgba(0, 0, 0, 0.1) !default;


### PR DESCRIPTION
Issue number: Internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
The refresher uses the --ion-color-step tokens or a fallback.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The refresher colors use the --ion-color-step tokens or the --ion-text-color-step tokens or a fallback
- The refresher background colors use the --ion-color-step tokens or the --ion-background-color-step tokens or a fallback

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->

<!-- 
## Other information

Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
