### PR TITLE
docs(angular test app): include instructions for updating nightly build

### DIFF
--- a/packages/angular/test/README.md
+++ b/packages/angular/test/README.md
@@ -113,5 +113,6 @@ Note: You may encounter some other peer dependency issues not covered by the Ang
 7. Open `./github/workflows/build.yml` and find the `test-angular-e2e` job.
 8. Find the `apps` field under `matrix`.
 9. Add "ng14" to the `apps` field.
-10. Similar to steps 7-9, add "ng14" in the `./github/workflows/stencil-nightly.yml` `test-angular-e2e` job.
-11. Commit these changes and push.
+10. Open `./github/workflows/stencil-nightly.yml` and find the `test-angular-e2e` job.
+11. Repeat steps 8 and 9.
+12. Commit these changes and push.

--- a/packages/angular/test/README.md
+++ b/packages/angular/test/README.md
@@ -113,4 +113,5 @@ Note: You may encounter some other peer dependency issues not covered by the Ang
 7. Open `./github/workflows/build.yml` and find the `test-angular-e2e` job.
 8. Find the `apps` field under `matrix`.
 9. Add "ng14" to the `apps` field.
-10. Commit these changes and push.
+10. Similar to steps 7-9, add "ng14" in the `./github/workflows/stencil-nightly.yml` `test-angular-e2e` job.
+11. Commit these changes and push.


### PR DESCRIPTION
Issue number: None

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
People adding a new Angular test app don't know they need to update the Stencil nightly build.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Documentation exists for adding a new Angular version to the Stencil nightly build when creating a new Angular test app..

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

This is related to #28945

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
