### PR TITLE
chore(angular): remove type merging for schematic options

### DIFF
--- a/packages/angular/src/schematics/utils/config.ts
+++ b/packages/angular/src/schematics/utils/config.ts
@@ -117,7 +117,6 @@ export function addCli(host: Tree, collectionName: string): void | never {
   writeConfig(host, angularJson);
 }
 
-// TODO(FW-5639): can remove [property: string]: any; when upgrading @angular/cli dev-dep to v16 or later
 export function addSchematics(
   host: Tree,
   schematicName: string,

--- a/packages/angular/src/schematics/utils/config.ts
+++ b/packages/angular/src/schematics/utils/config.ts
@@ -121,7 +121,7 @@ export function addCli(host: Tree, collectionName: string): void | never {
 export function addSchematics(
   host: Tree,
   schematicName: string,
-  schematicOpts: SchematicOptions & { [property: string]: any }
+  schematicOpts: SchematicOptions
 ): void | never {
   const angularJson = readConfig<any>(host);
 

--- a/packages/angular/src/schematics/utils/config.ts
+++ b/packages/angular/src/schematics/utils/config.ts
@@ -117,11 +117,7 @@ export function addCli(host: Tree, collectionName: string): void | never {
   writeConfig(host, angularJson);
 }
 
-export function addSchematics(
-  host: Tree,
-  schematicName: string,
-  schematicOpts: SchematicOptions
-): void | never {
+export function addSchematics(host: Tree, schematicName: string, schematicOpts: SchematicOptions): void | never {
   const angularJson = readConfig<any>(host);
 
   if (angularJson.schematics === undefined) {


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`schematicOpts` has an intersection type in order to be backward compatible.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Remove the added type since `SchematicOptions` type now includes `[property: string]: any;` with Angular 16.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->

`schematicOpts` has the same type, just a different way of getting it.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

N/A
