### PR TITLE
refactor(angular, react, vue): add missing test app msg

### DIFF
--- a/packages/angular/test/build.sh
+++ b/packages/angular/test/build.sh
@@ -22,6 +22,12 @@ FULL_BASE_DIR="${BASE_DIR}/."
 # The full path to the built application.
 BUILD_APP_DIR="${BUILD_DIR}/${APP_DIR}/"
 
+# Make sure the full app directory exists.
+if [ ! -d $FULL_APP_DIR ]; then
+  echo "Could not find test app: ${FULL_APP_DIR}"
+  exit 1
+fi
+
 # Make the build directory if it does not already exist.
 mkdir -p $BUILD_DIR
 

--- a/packages/react/test/build.sh
+++ b/packages/react/test/build.sh
@@ -22,6 +22,12 @@ FULL_BASE_DIR="${BASE_DIR}/."
 # The full path to the built application.
 BUILD_APP_DIR="${BUILD_DIR}/${APP_DIR}/"
 
+# Make sure the full app directory exists.
+if [ ! -d $FULL_APP_DIR ]; then
+  echo "Could not find test app: ${FULL_APP_DIR}"
+  exit 1
+fi
+
 # Make the build directory if it does not already exist.
 mkdir -p $BUILD_DIR
 

--- a/packages/vue/test/build.sh
+++ b/packages/vue/test/build.sh
@@ -22,6 +22,12 @@ FULL_BASE_DIR="${BASE_DIR}/."
 # The full path to the built application.
 BUILD_APP_DIR="${BUILD_DIR}/${APP_DIR}/"
 
+# Make sure the full app directory exists.
+if [ ! -d $FULL_APP_DIR ]; then
+  echo "Could not find test app: ${FULL_APP_DIR}"
+  exit 1
+fi
+
 # Make the build directory if it does not already exist.
 mkdir -p $BUILD_DIR
 


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The packages, Angular, React, and Vue, will accept any `app_dir` parameter when passing it to the build script. This can lead to a user to entering a directory that doesn't exist within `test/apps`. If this happens, then the build folder will include an incomplete test app.

For example:
1. `./build ng13`
2. This creates a `build/ng13` folder, but the folder only contains the contents from the `base` folder. This causes it to be incomplete.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Provides a message that the provided app directory doesn't exist.
- Does not create the incomplete app when an invalid app directory is given.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  4. Update the BREAKING.md file with the breaking change.
  5. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

N/A
