### PR TITLE
fix(angular): prevent provideIonicAngular from being used at component level

### DIFF
--- a/packages/angular/standalone/src/providers/ionic-angular.ts
+++ b/packages/angular/standalone/src/providers/ionic-angular.ts
@@ -1,6 +1,6 @@
 import { DOCUMENT } from '@angular/common';
-import { APP_INITIALIZER } from '@angular/core';
-import type { Provider } from '@angular/core';
+import { APP_INITIALIZER, makeEnvironmentProviders } from '@angular/core';
+import type { EnvironmentProviders } from '@angular/core';
 import { AngularDelegate, ConfigToken, provideComponentInputBinding } from '@ionic/angular/common';
 import { initialize } from '@ionic/core/components';
 import type { IonicConfig } from '@ionic/core/components';
@@ -8,13 +8,8 @@ import type { IonicConfig } from '@ionic/core/components';
 import { ModalController } from './modal-controller';
 import { PopoverController } from './popover-controller';
 
-export const provideIonicAngular = (config?: IonicConfig): Provider[] => {
-  /**
-   * TODO FW-4967
-   * Use makeEnvironmentProviders once Angular 14 support is dropped.
-   * This prevents provideIonicAngular from being accidentally referenced in an @Component.
-   */
-  return [
+export const provideIonicAngular = (config?: IonicConfig): EnvironmentProviders => {
+  return makeEnvironmentProviders([
     {
       provide: ConfigToken,
       useValue: config,
@@ -29,7 +24,7 @@ export const provideIonicAngular = (config?: IonicConfig): Provider[] => {
     AngularDelegate,
     ModalController,
     PopoverController,
-  ];
+  ]);
 };
 
 const initializeIonicAngular = (config: IonicConfig, doc: Document) => {


### PR DESCRIPTION
Issue number: Internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`provideIonicAngular` in the standalone package is used to bootstrap Ionic and provide global config options, and should only be called at the application root. However, developers are currently able to accidentally use the provider at the Angular component level, which should not be done.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Wrapped the returned providers in [`makeEnvironmentProviders`](https://angular.io/api/core/makeEnvironmentProviders), an Angular API that prevents the providers from being used in a `@Component` decorator.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

The `makeEnvironmentProviders` API was added in Angular 15, meaning 14 will no longer work. However, we're already dropping support for 14 and 15 in the base branch of this PR, so no additional updates to the breaking changes guide are needed.

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
