### PR TITLE
refactor(angular): update test app to use NgFor instead of CommonModule

### DIFF
--- a/packages/angular/test/base/src/app/standalone/value-accessors/value-accessor-test/value-accessor-test.component.ts
+++ b/packages/angular/test/base/src/app/standalone/value-accessors/value-accessor-test/value-accessor-test.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule, JsonPipe, KeyValuePipe } from "@angular/common";
+import { NgFor, JsonPipe, KeyValuePipe } from "@angular/common";
 import { Component, Input } from "@angular/core";
 import { FormGroup, FormsModule, ReactiveFormsModule } from "@angular/forms";
 
@@ -11,13 +11,7 @@ import { FormGroup, FormsModule, ReactiveFormsModule } from "@angular/forms";
     FormsModule,
     JsonPipe,
     KeyValuePipe,
-    /**
-     * NgFor directive is not available until Angular 15.
-     * We import the CommonModule for now.
-     *
-     * TODO: FW-5197 Replace with NgFor when dropping Angular 14 support.
-     */
-    CommonModule
+    NgFor
   ]
 })
 export class ValueAccessorTestComponent {


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
Angular test app imports `CommonModule`

## What is the new behavior?
Angular test app imports `NgFor` since we dropped support for Angular 14

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other Information

This can be tested locally by [building the Angular test app](https://github.com/ionic-team/ionic-framework/blob/FW-5196/packages/angular/test/README.md) in both `ng16` and `ng17` and running it to confirm it works properly. 