### PR TITLE
refactor(refresher-content): remove the aria-label

### DIFF
--- a/core/src/components/refresher-content/refresher-content.tsx
+++ b/core/src/components/refresher-content/refresher-content.tsx
@@ -114,7 +114,7 @@ export class RefresherContent implements ComponentInterface {
           {this.pullingIcon && hasSpinner && (
             <div class="refresher-pulling-icon">
               <div class="spinner-arrow-container">
-                <ion-spinner name={this.pullingIcon as SpinnerTypes} aria-label="pulling icon" paused></ion-spinner>
+                <ion-spinner name={this.pullingIcon as SpinnerTypes} paused></ion-spinner>
                 {mode === 'md' && this.pullingIcon === 'circular' && (
                   <div class="arrow-container">
                     <ion-icon icon={caretBackSharp} aria-hidden="true"></ion-icon>
@@ -133,7 +133,7 @@ export class RefresherContent implements ComponentInterface {
         <div class="refresher-refreshing">
           {this.refreshingSpinner && (
             <div class="refresher-refreshing-icon">
-              <ion-spinner name={this.refreshingSpinner} aria-label="refreshing icon"></ion-spinner>
+              <ion-spinner name={this.refreshingSpinner}></ion-spinner>
             </div>
           )}
           {this.refreshingText !== undefined && this.renderRefreshingText()}

--- a/core/src/components/refresher/test/a11y/refresher.e2e.ts
+++ b/core/src/components/refresher/test/a11y/refresher.e2e.ts
@@ -23,6 +23,7 @@ configs({ directions: ['ltr'], modes: ['md'], themes: ['light', 'dark'] }).forEa
 
       await expect(refresher).toHaveClass(/refresher-pulling/);
 
+      // TODO(FW-5937): Remove the disableRules once the ticket is resolved.
       const results = await new AxeBuilder({ page }).disableRules('aria-progressbar-name').analyze();
 
       expect(results.violations).toEqual([]);

--- a/core/src/components/refresher/test/a11y/refresher.e2e.ts
+++ b/core/src/components/refresher/test/a11y/refresher.e2e.ts
@@ -23,7 +23,7 @@ configs({ directions: ['ltr'], modes: ['md'], themes: ['light', 'dark'] }).forEa
 
       await expect(refresher).toHaveClass(/refresher-pulling/);
 
-      const results = await new AxeBuilder({ page }).analyze();
+      const results = await new AxeBuilder({ page }).disableRules('aria-progressbar-name').analyze();
 
       expect(results.violations).toEqual([]);
     });


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`refresher-content` passes `aria-label` to the `ion-spinner`. This was done to improve web accessibility.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

We realized that `ion-spinner` may not have the correct `role`. We plan to investigate to determine if we should continue using `role="progressbar"` or if the component is a decorative component. Based on that research, we will update the component.

In the mean time, the code reverts back to what v7 currently has until a proper solution is implemented.

- Removed the `aria-label` because the team will re-evaluate if the spinners should use `aria-hidden` instead.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

N/A