### PR TITLE
refactor(position): remove host-context usage from mixin

### DIFF
--- a/core/src/themes/ionic.mixins.scss
+++ b/core/src/themes/ionic.mixins.scss
@@ -400,30 +400,9 @@
     }
   } @else {
     @at-root {
-      @supports (inset-inline-start: 0) {
-        & {
-          inset-inline-start: $start;
-          inset-inline-end: $end;
-        }
-      }
-    }
-
-    // TODO FW-3766
-    @at-root {
-      @supports not (inset-inline-start: 0) {
-        & {
-          @include ltr() {
-            left: $start;
-            right: $end;
-          }
-          @include rtl() {
-            left: unset;
-            right: unset;
-
-            left: $end;
-            right: $start;
-          }
-        }
+      & {
+        inset-inline-start: $start;
+        inset-inline-end: $end;
       }
     }
   }


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The `position` mixin checks if `inset-inline-start` is supported by the browser since v7 supports browsers that don't support `inset-inline-start`. If it's not then it would depend on `host-context` to apply the correct styles based on the app direction.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

v8 supports browsers that does support `inset-inline-start` so the check is no longer needed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

N/A
