### PR TITLE
refactor(toast): remove cssClass from ToastButton

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -153,3 +153,5 @@ This allows components to inherit the color properly when used outside of Ionic 
 <h4 id="version-8x-toast">Toast</h4>
 
 - `cssClass` has been removed from the `ToastButton` interface. This was previously used to apply a custom class to the toast buttons. Developers can use the "button" shadow part to style the buttons.
+
+For more information on styling toast buttons, refer to the [Toast Theming documentation](https://ionicframework.com/docs/api/toast#theming).

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -149,3 +149,7 @@ This allows components to inherit the color properly when used outside of Ionic 
 - `ion-picker` and `ion-picker-column` have been renamed to `ion-picker-legacy` and `ion-picker-legacy-column`, respectively. This change was made to accommodate the new inline picker component while allowing developers to continue to use the legacy picker during this migration period.
   - Only the component names have been changed. Usages such as `ion-picker` or `IonPicker` should be changed to `ion-picker-legacy` and `IonPickerLegacy`, respectively.
   - Non-component usages such as `pickerController` or `useIonPicker` remain unchanged. The new picker displays inline with your page content and does not have equivalents for these non-component usages.
+
+<h4 id="version-8x-toast">Toast</h4>
+
+- `cssClass` has been removed from the `ToastButton` interface. This was previously used to apply a custom class to the toast buttons. Developers can use the "button" shadow part to style the buttons.

--- a/core/src/components/toast/toast-interface.ts
+++ b/core/src/components/toast/toast-interface.ts
@@ -4,6 +4,7 @@ import type { IonicSafeString } from '../../utils/sanitization';
 export interface ToastOptions {
   header?: string;
   message?: string | IonicSafeString;
+  cssClass?: string | string[];
   duration?: number;
   buttons?: (ToastButton | string)[];
   position?: 'top' | 'bottom' | 'middle';

--- a/core/src/components/toast/toast-interface.ts
+++ b/core/src/components/toast/toast-interface.ts
@@ -4,7 +4,6 @@ import type { IonicSafeString } from '../../utils/sanitization';
 export interface ToastOptions {
   header?: string;
   message?: string | IonicSafeString;
-  cssClass?: string | string[];
   duration?: number;
   buttons?: (ToastButton | string)[];
   position?: 'top' | 'bottom' | 'middle';
@@ -27,18 +26,12 @@ export interface ToastOptions {
 
 export type ToastLayout = 'baseline' | 'stacked';
 
-// TODO FW-4923 remove cssClass property
-
 export interface ToastButton {
   text?: string;
   icon?: string;
   side?: 'start' | 'end';
   role?: 'cancel' | string;
 
-  /**
-   * @deprecated Use the toast button's CSS Shadow Parts instead.
-   */
-  cssClass?: string | string[];
   htmlAttributes?: { [key: string]: any };
   handler?: () => boolean | void | Promise<boolean | void>;
 }

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -778,7 +778,6 @@ const buttonClass = (button: ToastButton): CssClassMap => {
     [`toast-button-${button.role}`]: button.role !== undefined,
     'ion-focusable': true,
     'ion-activatable': true,
-    ...getClassMap(button.cssClass),
   };
 };
 


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The deprecated `cssClass` is still part of `ToastButton` even though the buttons can be access through shadow parts.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed `cssClass` from `ToastButton`
- Updated the Breaking Change file to inform developers that they can add their styles through the "button" shadow part.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

N/A