### PR TITLE
test(toast): reset config to avoid unnecessary setTimeouts

### DIFF
--- a/core/src/components/toast/test/toast.spec.tsx
+++ b/core/src/components/toast/test/toast.spec.tsx
@@ -93,6 +93,19 @@ describe('toast: a11y smoke test', () => {
 });
 
 describe('toast: duration config', () => {
+  afterEach(() => {
+    /**
+     * Important: Reset the config
+     * after each test as it is not
+     * automatically reset.
+     * Otherwise, toasts in other tests
+     * will take on any toastDuration value
+     * set and timeouts will potentially run
+     * after tests are finished.
+     */
+    config.reset({});
+  });
+
   it('should have duration set to 0', async () => {
     const page = await newSpecPage({
       components: [Toast],


### PR DESCRIPTION
Issue number: Internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Team members are running into unexpected errors running spec tests:

```
TypeError: Cannot read properties of undefined (reading '$instanceValues$')
```

This line is the culprit: https://github.com/ionic-team/ionic-framework/blob/f885a5526addab8abf93a95de8980e4ef78cbd36/core/src/components/toast/test/toast.spec.tsx#L108
We set the Ionic config for toastDuration to 5000. This means that on present a setTimeout callback will fire after 5000ms and dismiss the toast. For this test, this is fine because we never present the toast therefore the setTimeout  is never created.

The problem is that this config is not automatically reset between tests. As a result, when we have tests that only present the toast (and never dismiss it) the duration is also 5000 there: https://github.com/ionic-team/ionic-framework/blob/f885a5526addab8abf93a95de8980e4ef78cbd36/core/src/components/toast/test/toast.spec.tsx#L179-L184

This results in a bunch of setTimeouts being created. The timeout callback runs dismiss, and the body of that function tries to access data on the host toast. Since the toast instance has already been torn down (since the tests are done), the undefined error occurs.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Reset the Ionic config after the test that sets `toastDuration` to `5000`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
