### PR TITLE
refactor(datetime): remove safari 14 hack

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1662,14 +1662,6 @@ export class Datetime implements ComponentInterface {
         disabled={disabled}
         value={todayString}
         onIonChange={(ev: CustomEvent) => {
-          // TODO(FW-1823) Remove this when iOS 14 support is dropped.
-          // Due to a Safari 14 issue we need to destroy
-          // the scroll listener before we update state
-          // and trigger a re-render.
-          if (this.destroyCalendarListener) {
-            this.destroyCalendarListener();
-          }
-
           const { value } = ev.detail;
           const findPart = parts.find(({ month, day, year }) => value === `${year}-${month}-${day}`);
 
@@ -1682,10 +1674,6 @@ export class Datetime implements ComponentInterface {
             ...activePart,
             ...findPart,
           });
-
-          // We can re-attach the scroll listener after
-          // the working parts have been updated.
-          this.initializeCalendarListener();
 
           ev.stopPropagation();
         }}
@@ -1793,14 +1781,6 @@ export class Datetime implements ComponentInterface {
         disabled={disabled}
         value={pickerColumnValue}
         onIonChange={(ev: CustomEvent) => {
-          // TODO(FW-1823) Remove this when iOS 14 support is dropped.
-          // Due to a Safari 14 issue we need to destroy
-          // the scroll listener before we update state
-          // and trigger a re-render.
-          if (this.destroyCalendarListener) {
-            this.destroyCalendarListener();
-          }
-
           this.setWorkingParts({
             ...workingParts,
             day: ev.detail.value,
@@ -1810,10 +1790,6 @@ export class Datetime implements ComponentInterface {
             ...activePart,
             day: ev.detail.value,
           });
-
-          // We can re-attach the scroll listener after
-          // the working parts have been updated.
-          this.initializeCalendarListener();
 
           ev.stopPropagation();
         }}
@@ -1848,14 +1824,6 @@ export class Datetime implements ComponentInterface {
         disabled={disabled}
         value={workingParts.month}
         onIonChange={(ev: CustomEvent) => {
-          // TODO(FW-1823) Remove this when iOS 14 support is dropped.
-          // Due to a Safari 14 issue we need to destroy
-          // the scroll listener before we update state
-          // and trigger a re-render.
-          if (this.destroyCalendarListener) {
-            this.destroyCalendarListener();
-          }
-
           this.setWorkingParts({
             ...workingParts,
             month: ev.detail.value,
@@ -1865,10 +1833,6 @@ export class Datetime implements ComponentInterface {
             ...activePart,
             month: ev.detail.value,
           });
-
-          // We can re-attach the scroll listener after
-          // the working parts have been updated.
-          this.initializeCalendarListener();
 
           ev.stopPropagation();
         }}
@@ -1902,14 +1866,6 @@ export class Datetime implements ComponentInterface {
         disabled={disabled}
         value={workingParts.year}
         onIonChange={(ev: CustomEvent) => {
-          // TODO(FW-1823) Remove this when iOS 14 support is dropped.
-          // Due to a Safari 14 issue we need to destroy
-          // the scroll listener before we update state
-          // and trigger a re-render.
-          if (this.destroyCalendarListener) {
-            this.destroyCalendarListener();
-          }
-
           this.setWorkingParts({
             ...workingParts,
             year: ev.detail.value,
@@ -1919,10 +1875,6 @@ export class Datetime implements ComponentInterface {
             ...activePart,
             year: ev.detail.value,
           });
-
-          // We can re-attach the scroll listener after
-          // the working parts have been updated.
-          this.initializeCalendarListener();
 
           ev.stopPropagation();
         }}


### PR DESCRIPTION
Issue number: Internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

This code was added to account for a Safari 14 issue that would cause datetime to render incorrectly. The Safari bug was fixed starting in Safari 15. However, Ionic v7 supported back to Safari 14.

More context is available [here](https://github.com/ionic-team/ionic-framework/pull/24421#discussion_r796113907)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed the Safari 14 workarounds since Ionic v8 does not support Safari 14

I tested on iOS 15, 16, and 17 to verify that removing this hack does not cause any issues. Also verified that removing this hack does reproduce the issue on iOS 14 (to verify that I am reproducing the original issue correctly) 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
