### PR TITLE
fix(core): add `slot` elements to scoped "wrapper" components

### DIFF
--- a/core/src/components/buttons/buttons.tsx
+++ b/core/src/components/buttons/buttons.tsx
@@ -34,7 +34,9 @@ export class Buttons implements ComponentInterface {
           [mode]: true,
           ['buttons-collapse']: this.collapse,
         }}
-      ></Host>
+      >
+        <slot></slot>
+      </Host>
     );
   }
 }

--- a/core/src/components/label/label.tsx
+++ b/core/src/components/label/label.tsx
@@ -107,7 +107,9 @@ export class Label implements ComponentInterface {
           [`label-no-animate`]: this.noAnimate,
           'label-rtl': document.dir === 'rtl',
         })}
-      ></Host>
+      >
+        <slot></slot>
+      </Host>
     );
   }
 }


### PR DESCRIPTION

Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Previously, Stencil would allow content to project through to a component even when a slot was not present. However, with the changes in `extras.experimentalScopedSlotChanges`, this behavior was changed to hide elements without a destination slot - matching the behavior of a shadow encapsulated component.

As such, elements projected through the `ion-label` or `ion-buttons` components would no longer be visible in rendered output.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This commit adds an explicit `slot` tag to components in core leveraging "scoped" encapsulation with no rendered content (i.e. elements with only a `Host` tag and styles).

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
