### PR TITLE
chore(ci): add `--debug --verbose` to stencil nightly build

### DIFF
--- a/.github/workflows/actions/build-core-stencil-prerelease/action.yml
+++ b/.github/workflows/actions/build-core-stencil-prerelease/action.yml
@@ -22,7 +22,7 @@ runs:
       run: npm i @stencil/core@${{ inputs.stencil-version }}
       shell: bash
     - name: Build Core
-      run: npm run build -- --ci
+      run: npm run build -- --ci --debug --verbose
       working-directory: ./core
       shell: bash
     - uses: ./.github/workflows/actions/upload-archive


### PR DESCRIPTION

Set the `--debug` and `--verbose` flags on the Stencil Nightly CI build.

## What is the current behavior?

The Stencil nightly build doesn't provide all the information that it could!

## What is the new behavior?

This sets the `--debug` and `--verbose` flags when calling `npm run build` in the 'Build Ionic Core with Stencil Prerelease' github action, which is used by the workflow which installs nightly Stencil builds and builds framework with it, thereby checking for regressions.

This change will just ensure that this nightly build provides a bit more information.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->

