### PR TITLE
docs(contributing): update component guide with order for states

### DIFF
--- a/.github/COMPONENT-GUIDE.md
+++ b/.github/COMPONENT-GUIDE.md
@@ -143,77 +143,6 @@ The following CSS _at the bare minimum_ should be added for the disabled class, 
 
 TODO
 
-### Activated
-
-The activated state should be enabled for elements with actions on "press". It usually changes the opacity or background of an element.
-
-> [!WARNING]
->`:active` should not be used here as it is not received on mobile Safari unless the element has a `touchstart` listener (which we don't necessarily want to have to add to every element). From [Safari Web Content Guide](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/AdjustingtheTextSize/AdjustingtheTextSize.html):
->
->> On iOS, mouse events are sent so quickly that the down or active state is never received. Therefore, the `:active` pseudo state is triggered only when there is a touch event set on the HTML element
-
-> Make sure the component has the correct [component structure](#component-structure) before continuing.
-
-#### JavaScript
-
-The `ion-activatable` class needs to be set on an element that can be activated:
-
-```jsx
-render() {
-  return (
-    <Host class='ion-activatable'>
-      <slot></slot>
-    </Host>
-  );
-}
-```
-
-Once that is done, the element will get the `ion-activated` class added on press after a small delay. This delay exists so that the active state does not show up when an activatable element is tapped while scrolling.
-
-In addition to setting that class, `ion-activatable-instant` can be set in order to have an instant press with no delay:
-
-```jsx
-<Host class='ion-activatable ion-activatable-instant'>
-```
-
-#### CSS
-
-```css
- /**
-   * @prop --color-activated: Color of the button when pressed
-   * @prop --background-activated: Background of the button when pressed
-   * @prop --background-activated-opacity: Opacity of the background when pressed
-   */
-```
-
-Style the `ion-activated` class based on the spec for that element:
-
-```scss
-:host(.ion-activated) .button-native {
-  color: var(--color-activated);
-
-  &::after {
-    background: var(--background-activated);
-
-    opacity: var(--background-activated-opacity);
-  }
-}
-```
-
-> [!IMPORTANT]
-> Order matters! Activated should be after the focused & hover states.
-
-#### User Customization
-
-Setting the activated state on the `::after` pseudo-element allows the user to customize the activated state without knowing what the default opacity is set at. A user can customize in the following ways to have a solid red background on press, or they can leave out `--background-activated-opacity` and the button will use the default activated opacity to match the spec.
-
-```css
-ion-button {
-  --background-activated: red;
-  --background-activated-opacity: 1;
-}
-```
-
 
 ### Focused
 
@@ -334,6 +263,78 @@ Setting the hover state on the `::after` pseudo-element allows the user to custo
 ion-button {
   --background-hover: red;
   --background-hover-opacity: 1;
+}
+```
+
+
+### Activated
+
+The activated state should be enabled for elements with actions on "press". It usually changes the opacity or background of an element.
+
+> [!WARNING]
+>`:active` should not be used here as it is not received on mobile Safari unless the element has a `touchstart` listener (which we don't necessarily want to have to add to every element). From [Safari Web Content Guide](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/AdjustingtheTextSize/AdjustingtheTextSize.html):
+>
+>> On iOS, mouse events are sent so quickly that the down or active state is never received. Therefore, the `:active` pseudo state is triggered only when there is a touch event set on the HTML element
+
+> Make sure the component has the correct [component structure](#component-structure) before continuing.
+
+#### JavaScript
+
+The `ion-activatable` class needs to be set on an element that can be activated:
+
+```jsx
+render() {
+  return (
+    <Host class='ion-activatable'>
+      <slot></slot>
+    </Host>
+  );
+}
+```
+
+Once that is done, the element will get the `ion-activated` class added on press after a small delay. This delay exists so that the active state does not show up when an activatable element is tapped while scrolling.
+
+In addition to setting that class, `ion-activatable-instant` can be set in order to have an instant press with no delay:
+
+```jsx
+<Host class='ion-activatable ion-activatable-instant'>
+```
+
+#### CSS
+
+```css
+ /**
+   * @prop --color-activated: Color of the button when pressed
+   * @prop --background-activated: Background of the button when pressed
+   * @prop --background-activated-opacity: Opacity of the background when pressed
+   */
+```
+
+Style the `ion-activated` class based on the spec for that element:
+
+```scss
+:host(.ion-activated) .button-native {
+  color: var(--color-activated);
+
+  &::after {
+    background: var(--background-activated);
+
+    opacity: var(--background-activated-opacity);
+  }
+}
+```
+
+> [!IMPORTANT]
+> Order matters! Activated should be after the focused & hover states.
+
+#### User Customization
+
+Setting the activated state on the `::after` pseudo-element allows the user to customize the activated state without knowing what the default opacity is set at. A user can customize in the following ways to have a solid red background on press, or they can leave out `--background-activated-opacity` and the button will use the default activated opacity to match the spec.
+
+```css
+ion-button {
+  --background-activated: red;
+  --background-activated-opacity: 1;
 }
 ```
 

--- a/.github/COMPONENT-GUIDE.md
+++ b/.github/COMPONENT-GUIDE.md
@@ -2,10 +2,10 @@
 
 - [Button States](#button-states)
   * [Component Structure](#component-structure)
-  * [Activated](#activated)
   * [Disabled](#disabled)
   * [Focused](#focused)
   * [Hover](#hover)
+  * [Activated](#activated)
   * [Ripple Effect](#ripple-effect)
   * [Example Components](#example-components)
   * [References](#references)
@@ -21,7 +21,7 @@
 
 ## Button States
 
-Any component that renders a button should have the following states: [`activated`](#activated), [`disabled`](#disabled), [`focused`](#focused), [`hover`](#hover). It should also have a [Ripple Effect](#ripple-effect) component added for Material Design.
+Any component that renders a button should have the following states: [`disabled`](#disabled), [`focused`](#focused), [`hover`](#hover), [`activated`](#activated). It should also have a [Ripple Effect](#ripple-effect) component added for Material Design.
 
 ### Component Structure
 
@@ -89,6 +89,60 @@ The following styles should be set for the CSS to work properly. Note that the `
 ```
 
 
+### Disabled
+
+The disabled state should be set via prop on all components that render a native button. Setting a disabled state will change the opacity or color of the button and remove click events from firing.
+
+#### JavaScript
+
+The `disabled` property should be set on the component:
+
+```jsx
+/**
+  * If `true`, the user cannot interact with the button.
+  */
+@Prop({ reflectToAttr: true }) disabled = false;
+```
+
+Then, the render function should add the [`aria-disabled`](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-disabled) role to the host, a class that is the element tag name followed by `disabled`, and pass the `disabled` attribute to the native button:
+
+```jsx
+render() {
+  const { disabled } = this;
+
+  return (
+    <Host
+      aria-disabled={disabled ? 'true' : null}
+      class={{
+        'button-disabled': disabled
+      }}
+    >
+      <button disabled={disabled}>
+        <slot></slot>
+      </button>
+    </Host>
+  );
+}
+```
+
+> Note: if the class being added was for `ion-back-button` it would be `back-button-disabled`.
+
+#### CSS
+
+The following CSS _at the bare minimum_ should be added for the disabled class, but it should be styled to match the spec:
+
+```css
+:host(.button-disabled) {
+  cursor: default;
+  opacity: .5;
+  pointer-events: none;
+}
+```
+
+#### User Customization
+
+TODO
+
 ### Activated
 
 The activated state should be enabled for elements with actions on "press". It usually changes the opacity or background of an element.
@@ -146,8 +200,8 @@ Style the `ion-activated` class based on the spec for that element:
 }
 ```
 
-> Order is important! Activated should be after the focused & hover states.
-
+> [!IMPORTANT]
+> Order matters! Activated should be after the focused & hover states.
 
 #### User Customization
 
@@ -161,63 +215,9 @@ ion-button {
 ```
 
 
-### Disabled
-
-The disabled state should be set via prop on all components that render a native button. Setting a disabled state will change the opacity or color of the button and remove click events from firing.
-
-#### JavaScript
-
-The `disabled` property should be set on the component:
-
-```jsx
-/**
-  * If `true`, the user cannot interact with the button.
-  */
-@Prop({ reflectToAttr: true }) disabled = false;
-```
-
-Then, the render function should add the [`aria-disabled`](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-disabled) role to the host, a class that is the element tag name followed by `disabled`, and pass the `disabled` attribute to the native button:
-
-```jsx
-render() {
-  const { disabled } = this;
-
-  return (
-    <Host
-      aria-disabled={disabled ? 'true' : null}
-      class={{
-        'button-disabled': disabled
-      }}
-    >
-      <button disabled={disabled}>
-        <slot></slot>
-      </button>
-    </Host>
-  );
-}
-```
-
-> Note: if the class being added was for `ion-back-button` it would be `back-button-disabled`.
-
-#### CSS
-
-The following CSS _at the bare minimum_ should be added for the disabled class, but it should be styled to match the spec:
-
-```css
-:host(.button-disabled) {
-  cursor: default;
-  opacity: .5;
-  pointer-events: none;
-}
-```
-
-#### User Customization
-
-TODO
-
 ### Focused
 
-The focused state should be enabled for elements with actions when tabbed to via the keyboard. This will only work inside of an `ion-app`. It usually changes the opacity or background of an element. 
+The focused state should be enabled for elements with actions when tabbed to via the keyboard. This will only work inside of an `ion-app`. It usually changes the opacity or background of an element.
 
 > [!WARNING]
 > Do not use `:focus` because that will cause the focus to apply even when an element is tapped (because the element is now focused). Instead, we only want the focus state to be shown when it makes sense which is what the `.ion-focusable` utility mentioned below does.
@@ -269,7 +269,8 @@ Style the `ion-focused` class based on the spec for that element:
 }
 ```
 
-> Order is important! Focused should be after the activated and before the hover state.
+> [!IMPORTANT]
+> Order matters! Focused should be before the activated and hover states.
 
 
 #### User Customization
@@ -286,7 +287,7 @@ ion-button {
 
 ### Hover
 
-The [hover state](https://developer.mozilla.org/en-US/docs/Web/CSS/:hover) happens when a user moves their cursor on top of an element without pressing on it. It should not happen on mobile, only on desktop devices that support hover. 
+The [hover state](https://developer.mozilla.org/en-US/docs/Web/CSS/:hover) happens when a user moves their cursor on top of an element without pressing on it. It should not happen on mobile, only on desktop devices that support hover.
 
 > [!NOTE]
 > Some Android devices [incorrectly report their inputs](https://issues.chromium.org/issues/40855702) which can result in certain devices receiving hover events when they should not.
@@ -321,7 +322,8 @@ Style the `:hover` based on the spec for that element:
 }
 ```
 
-> Order is important! Hover should be before the activated state.
+> [!IMPORTANT]
+> Order matters! Hover should be before the activated state.
 
 
 #### User Customization

--- a/.github/COMPONENT-GUIDE.md
+++ b/.github/COMPONENT-GUIDE.md
@@ -297,7 +297,7 @@ Once that is done, the element will get the `ion-activated` class added on press
 In addition to setting that class, `ion-activatable-instant` can be set in order to have an instant press with no delay:
 
 ```jsx
-<Host class='ion-activatable ion-activatable-instant'>
+<Host class="ion-activatable ion-activatable-instant">
 ```
 
 #### CSS

--- a/.github/COMPONENT-GUIDE.md
+++ b/.github/COMPONENT-GUIDE.md
@@ -199,7 +199,7 @@ Style the `ion-focused` class based on the spec for that element:
 ```
 
 > [!IMPORTANT]
-> Order matters! Focused should be before the activated and hover states.
+> Order matters! Focused should be **before** the activated and hover states.
 
 
 #### User Customization
@@ -252,7 +252,7 @@ Style the `:hover` based on the spec for that element:
 ```
 
 > [!IMPORTANT]
-> Order matters! Hover should be before the activated state.
+> Order matters! Hover should be **before** the activated state.
 
 
 #### User Customization
@@ -325,7 +325,7 @@ Style the `ion-activated` class based on the spec for that element:
 ```
 
 > [!IMPORTANT]
-> Order matters! Activated should be after the focused & hover states.
+> Order matters! Activated should be **after** the focused & hover states.
 
 #### User Customization
 

--- a/.github/COMPONENT-GUIDE.md
+++ b/.github/COMPONENT-GUIDE.md
@@ -285,7 +285,7 @@ The `ion-activatable` class needs to be set on an element that can be activated:
 ```jsx
 render() {
   return (
-    <Host class='ion-activatable'>
+    <Host class="ion-activatable">
       <slot></slot>
     </Host>
   );

--- a/.github/COMPONENT-GUIDE.md
+++ b/.github/COMPONENT-GUIDE.md
@@ -125,7 +125,8 @@ render() {
 }
 ```
 
-> Note: if the class being added was for `ion-back-button` it would be `back-button-disabled`.
+> [!NOTE]
+> If the class being added was for `ion-back-button` it would be `back-button-disabled`.
 
 #### CSS
 
@@ -154,6 +155,7 @@ The focused state should be enabled for elements with actions when tabbed to via
 > [!NOTE]
 > The [`:focus-visible`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) pseudo-class mostly does the same thing as our JavaScript-driven utility. However, it does not work well with Shadow DOM components as the element that receives focus is typically inside of the Shadow DOM, but we usually want to set the `:focus-visible` state on the host so we can style other parts of the component. Using other combinations such as `:has(:focus-visible)` does not work because `:has` does not pierce the Shadow DOM (as that would leak implementation details about the Shadow DOM contents). `:focus-within` does work with the Shadow DOM, but that has the same problem as `:focus` that was mentioned before. Unfortunately, a [`:focus-visible-within` pseudo-class does not exist yet](https://github.com/WICG/focus-visible/issues/151).
 
+> [!IMPORTANT]
 > Make sure the component has the correct [component structure](#component-structure) before continuing.
 
 #### JavaScript
@@ -221,6 +223,7 @@ The [hover state](https://developer.mozilla.org/en-US/docs/Web/CSS/:hover) happe
 > [!NOTE]
 > Some Android devices [incorrectly report their inputs](https://issues.chromium.org/issues/40855702) which can result in certain devices receiving hover events when they should not.
 
+> [!IMPORTANT]
 > Make sure the component has the correct [component structure](#component-structure) before continuing.
 
 #### CSS
@@ -276,6 +279,7 @@ The activated state should be enabled for elements with actions on "press". It u
 >
 >> On iOS, mouse events are sent so quickly that the down or active state is never received. Therefore, the `:active` pseudo state is triggered only when there is a touch event set on the HTML element
 
+> [!IMPORTANT]
 > Make sure the component has the correct [component structure](#component-structure) before continuing.
 
 #### JavaScript

--- a/.github/COMPONENT-GUIDE.md
+++ b/.github/COMPONENT-GUIDE.md
@@ -165,7 +165,7 @@ The `ion-focusable` class needs to be set on an element that can be focused:
 ```jsx
 render() {
   return (
-    <Host class='ion-focusable'>
+    <Host class="ion-focusable">
       <slot></slot>
     </Host>
   );


### PR DESCRIPTION
Updates the component guide to use the proper order for the `focused`, `hover`, and `activated` states. Reorders the sections based on the recommended order and adds emphasis and blockquotes to call out the order. 

I have created ticket [FW-6039](https://outsystemsrd.atlassian.net/browse/FW-6039) for investigating components that don't follow the recommended order here.