### PR TITLE
chore(ci): clear JSDelivr cache for Ionic Next

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,9 @@ jobs:
           "path": [
             "/npm/@ionic/core@6/dist/ionic/ionic.esm.js",
             "/npm/@ionic/core@latest/dist/ionic/ionic.esm.js",
+            "/npm/@ionic/core@next/dist/ionic/ionic.esm.js",
             "/npm/@ionic/core@6/css/ionic.bundle.css",
             "/npm/@ionic/core@latest/css/ionic.bundle.css"
+            "/npm/@ionic/core@next/css/ionic.bundle.css"
           ]}'
         shell: bash


### PR DESCRIPTION
The cache for the `next` tag is not cleared on release. As a result, the Ionic 8 playgrounds break since the entry point is cached. The cached entry point references JS chunks that no longer exist.