### PR TITLE
fix(angular): add ionNavWillChange and ionNavDidChange types for nav

### DIFF
--- a/packages/angular/common/src/directives/navigation/nav.ts
+++ b/packages/angular/common/src/directives/navigation/nav.ts
@@ -1,4 +1,4 @@
-import { ElementRef, Injector, EnvironmentInjector, NgZone, ChangeDetectorRef, Directive } from '@angular/core';
+import { ElementRef, Injector, EnvironmentInjector, NgZone, ChangeDetectorRef, Directive, EventEmitter } from '@angular/core';
 import type { Components } from '@ionic/core';
 
 import { AngularDelegate } from '../../providers/angular-delegate';
@@ -23,7 +23,16 @@ const NAV_METHODS = [
 ];
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface IonNav extends Components.IonNav {}
+export declare interface IonNav extends Components.IonNav {
+  /**
+   * Event fired when the nav will change components
+   */
+  ionNavWillChange: EventEmitter<CustomEvent<void>>;
+  /**
+   * Event fired when the nav has changed components
+   */
+  ionNavDidChange: EventEmitter<CustomEvent<void>>;
+}
 
 @ProxyCmp({
   inputs: NAV_INPUTS,

--- a/packages/angular/common/src/directives/navigation/nav.ts
+++ b/packages/angular/common/src/directives/navigation/nav.ts
@@ -1,4 +1,12 @@
-import { ElementRef, Injector, EnvironmentInjector, NgZone, ChangeDetectorRef, Directive, EventEmitter } from '@angular/core';
+import {
+  ElementRef,
+  Injector,
+  EnvironmentInjector,
+  NgZone,
+  ChangeDetectorRef,
+  Directive,
+  EventEmitter,
+} from '@angular/core';
 import type { Components } from '@ionic/core';
 
 import { AngularDelegate } from '../../providers/angular-delegate';

--- a/packages/angular/common/src/directives/navigation/nav.ts
+++ b/packages/angular/common/src/directives/navigation/nav.ts
@@ -30,7 +30,6 @@ const NAV_METHODS = [
   'getPrevious',
 ];
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export declare interface IonNav extends Components.IonNav {
   /**
    * Event fired when the nav will change components


### PR DESCRIPTION
Issue number: resolves #29114

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The event types for `ion-nav` were not correctly applied to the angular component wrapper.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `ionNavWillChange` and `ionNavDidChange` event types are added to `ion-nav` component wrapper in Angular.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `7.7.5-dev.11709823131.1d3df428`

Testing:
- Open reproduction on original issue
- Observe: Type errors for missing event properties 
- Install dev-build
- (May need to reload)
- Observe: Type errors are resolved 
