### PR TITLE
fix(overlay): do not hide overlay if toast is presented

### DIFF
--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -975,7 +975,7 @@ const hideOverlaysFromScreenReaders = (newTopMostOverlay: HTMLIonOverlayElement)
     if (nextPresentedOverlay.hasAttribute('aria-hidden')) {
       presentedOverlay.setAttribute('aria-hidden', 'true');
       /**
-       * If the next overlay is a Toast this does not have aria-hidden then current overlay
+       * If the next overlay is a Toast that does not have aria-hidden then current overlay
        * should not have aria-hidden either so focus can remain in the current overlay.
        */
     } else if (nextPresentedOverlay.tagName !== 'ION-TOAST') {

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -992,7 +992,6 @@ const hideOverlaysFromScreenReaders = (newTopMostOverlay: HTMLIonOverlayElement)
 const revealOverlaysToScreenReaders = () => {
   if (doc === undefined) return;
 
-  // If there are other overlays presented, unhide the new topmost one from screen readers.
   const overlays = getPresentedOverlays(doc);
 
   for (let i = overlays.length - 1; i >= 0; i--) {

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -1003,15 +1003,14 @@ const revealOverlaysToScreenReaders = () => {
      * could be more Toasts underneath. Additionally, we need to unhide the closest non-Toast
      * overlay too so focus can move there since focus is never automatically moved to the Toast.
      */
-    if (currentOverlay.tagName === 'ION-TOAST') {
-      currentOverlay.removeAttribute('aria-hidden');
-      /**
-       * If we found a non-Toast element then we can just remove aria-hidden and stop searching entirely
-       * since this overlay should always receive focus. As a result, all underlying overlays should still
-       * be hidden from screen readers.
-       */
-    } else {
-      currentOverlay.removeAttribute('aria-hidden');
+    currentOverlay.removeAttribute('aria-hidden');
+    
+    /**
+     * If we found a non-Toast element then we can just remove aria-hidden and stop searching entirely
+     * since this overlay should always receive focus. As a result, all underlying overlays should still
+     * be hidden from screen readers.
+     */
+    if (currentOverlay.tagName !== 'ION-TOAST') {
       break;
     }
   }

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -549,7 +549,13 @@ export const present = async <OverlayPresentOptions>(
    */
   if (doc !== undefined) {
     const presentedOverlays = getPresentedOverlays(doc);
-    presentedOverlays.forEach((o) => o.setAttribute('aria-hidden', 'true'));
+    presentedOverlays.forEach((o, i) => {
+      if (i === presentedOverlays.length - 1 && overlay.el.tagName === 'ION-TOAST') {
+        return;
+      }
+
+      o.setAttribute('aria-hidden', 'true');
+    });
   }
 
   overlay.presented = true;
@@ -728,7 +734,18 @@ export const dismiss = async <OverlayDismissOptions>(
    * topmost one from screen readers.
    */
   if (doc !== undefined) {
-    getPresentedOverlay(doc)?.removeAttribute('aria-hidden');
+    const overlays = getPresentedOverlays(doc);
+
+    for (let i = overlays.length - 1; i >= 0; i--) {
+      const overlay = overlays[i];
+
+      if (overlay.tagName === 'ION-TOAST') {
+        overlay.removeAttribute('aria-hidden');
+      } else {
+        overlay.removeAttribute('aria-hidden');
+        break;
+      }
+    }
   }
 
   return true;

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -971,14 +971,12 @@ const hideOverlaysFromScreenReaders = (newTopMostOverlay: HTMLIonOverlayElement)
     const presentedOverlay = overlays[i];
     const nextPresentedOverlay = overlays[i + 1] ?? newTopMostOverlay;
 
-    // If next overlay has aria-hidden then all remaining overlays will have it too.
-    if (nextPresentedOverlay.hasAttribute('aria-hidden')) {
-      presentedOverlay.setAttribute('aria-hidden', 'true');
-      /**
-       * If the next overlay is a Toast that does not have aria-hidden then current overlay
-       * should not have aria-hidden either so focus can remain in the current overlay.
-       */
-    } else if (nextPresentedOverlay.tagName !== 'ION-TOAST') {
+    /**
+     * If next overlay has aria-hidden then all remaining overlays will have it too.
+     * Or, if the next overlay is a Toast that does not have aria-hidden then current overlay
+     * should not have aria-hidden either so focus can remain in the current overlay.
+     */
+    if (nextPresentedOverlay.hasAttribute('aria-hidden') || nextPresentedOverlay.tagName !== 'ION-TOAST') {
       presentedOverlay.setAttribute('aria-hidden', 'true');
     }
   }
@@ -1004,7 +1002,7 @@ const revealOverlaysToScreenReaders = () => {
      * overlay too so focus can move there since focus is never automatically moved to the Toast.
      */
     currentOverlay.removeAttribute('aria-hidden');
-    
+
     /**
      * If we found a non-Toast element then we can just remove aria-hidden and stop searching entirely
      * since this overlay should always receive focus. As a result, all underlying overlays should still

--- a/core/src/utils/test/overlays/overlays.spec.ts
+++ b/core/src/utils/test/overlays/overlays.spec.ts
@@ -195,7 +195,7 @@ describe('aria-hidden on individual overlays', () => {
     expect(modalOne.hasAttribute('aria-hidden')).toEqual(false);
   });
 
-  it('should not hide previous overlay is top-most overlay is toast', async () => {
+  it('should not hide previous overlay if top-most overlay is toast', async () => {
     const page = await newSpecPage({
       components: [Modal, Toast],
       html: `

--- a/core/src/utils/test/overlays/overlays.spec.ts
+++ b/core/src/utils/test/overlays/overlays.spec.ts
@@ -195,14 +195,14 @@ describe('aria-hidden on individual overlays', () => {
     expect(modalOne.hasAttribute('aria-hidden')).toEqual(false);
   });
 
-  it.only('should not hide previous overlay is top-most overlay is toast', async () => {
+  it('should not hide previous overlay is top-most overlay is toast', async () => {
     const page = await newSpecPage({
       components: [Modal, Toast],
       html: `
         <ion-modal id="m-one"></ion-modal>
+        <ion-modal id="m-two"></ion-modal>
         <ion-toast id="t-one"></ion-toast>
         <ion-toast id="t-two"></ion-toast>
-        <ion-modal id="m-two"></ion-modal>
       `,
     });
 
@@ -212,24 +212,52 @@ describe('aria-hidden on individual overlays', () => {
     const toastTwo = page.body.querySelector<HTMLIonModalElement>('ion-toast#t-two')!;
 
     await modalOne.present();
+    await modalTwo.present();
     await toastOne.present();
     await toastTwo.present();
 
-    expect(modalOne.hasAttribute('aria-hidden')).toEqual(false);
+    expect(modalOne.hasAttribute('aria-hidden')).toEqual(true);
+    expect(modalTwo.hasAttribute('aria-hidden')).toEqual(false);
     expect(toastOne.hasAttribute('aria-hidden')).toEqual(false);
     expect(toastTwo.hasAttribute('aria-hidden')).toEqual(false);
 
+    await toastTwo.dismiss();
+
+    expect(modalOne.hasAttribute('aria-hidden')).toEqual(true);
+    expect(modalTwo.hasAttribute('aria-hidden')).toEqual(false);
+    expect(toastOne.hasAttribute('aria-hidden')).toEqual(false);
+
+    await toastOne.dismiss();
+
+    expect(modalOne.hasAttribute('aria-hidden')).toEqual(true);
+    expect(modalTwo.hasAttribute('aria-hidden')).toEqual(false);
+  });
+
+  it('should hide previous overlay even with a toast that is not the top-most overlay', async () => {
+    const page = await newSpecPage({
+      components: [Modal, Toast],
+      html: `
+        <ion-modal id="m-one"></ion-modal>
+        <ion-toast id="t-one"></ion-toast>
+        <ion-modal id="m-two"></ion-modal>
+      `,
+    });
+
+    const modalOne = page.body.querySelector<HTMLIonModalElement>('ion-modal#m-one')!;
+    const modalTwo = page.body.querySelector<HTMLIonModalElement>('ion-modal#m-two')!;
+    const toastOne = page.body.querySelector<HTMLIonModalElement>('ion-toast#t-one')!;
+
+    await modalOne.present();
+    await toastOne.present();
     await modalTwo.present();
 
     expect(modalOne.hasAttribute('aria-hidden')).toEqual(true);
     expect(toastOne.hasAttribute('aria-hidden')).toEqual(true);
-    expect(toastTwo.hasAttribute('aria-hidden')).toEqual(true);
     expect(modalTwo.hasAttribute('aria-hidden')).toEqual(false);
 
     await modalTwo.dismiss();
 
     expect(modalOne.hasAttribute('aria-hidden')).toEqual(false);
     expect(toastOne.hasAttribute('aria-hidden')).toEqual(false);
-    expect(toastTwo.hasAttribute('aria-hidden')).toEqual(false);
   });
 });

--- a/core/src/utils/test/overlays/overlays.spec.ts
+++ b/core/src/utils/test/overlays/overlays.spec.ts
@@ -1,6 +1,7 @@
 import { newSpecPage } from '@stencil/core/testing';
 
 import { Modal } from '../../../components/modal/modal';
+import { Toast } from '../../../components/toast/toast';
 import { Nav } from '../../../components/nav/nav';
 import { RouterOutlet } from '../../../components/router-outlet/router-outlet';
 import { setRootAriaHidden } from '../../overlays';
@@ -191,6 +192,38 @@ describe('aria-hidden on individual overlays', () => {
 
     // modalOne will become the topmost overlay; ensure it isn't still hidden from screen readers
     await modalOne.present();
+    expect(modalOne.hasAttribute('aria-hidden')).toEqual(false);
+  });
+
+  it('should not hide previous overlay is top-most overlay is toast', async () => {
+    const page = await newSpecPage({
+      components: [Modal, Toast],
+      html: `
+        <ion-modal id="one"></ion-modal>
+        <ion-toast></ion-toast>
+        <ion-modal id="two"></ion-modal>
+      `,
+    });
+
+    const modalOne = page.body.querySelector<HTMLIonModalElement>('ion-modal#one')!;
+    const modalTwo = page.body.querySelector<HTMLIonModalElement>('ion-modal#two')!;
+    const toast = page.body.querySelector<HTMLIonModalElement>('ion-toast')!;
+
+    await modalOne.present();
+    await toast.present();
+
+    expect(modalOne.hasAttribute('aria-hidden')).toEqual(false);
+
+    await modalTwo.present();
+
+    expect(modalOne.hasAttribute('aria-hidden')).toEqual(true);
+    expect(toast.hasAttribute('aria-hidden')).toEqual(true);
+    expect(modalTwo.hasAttribute('aria-hidden')).toEqual(false);
+
+    await modalTwo.dismiss();
+
+    expect(toast.hasAttribute('aria-hidden')).toEqual(false);
+
     expect(modalOne.hasAttribute('aria-hidden')).toEqual(false);
   });
 });

--- a/core/src/utils/test/overlays/overlays.spec.ts
+++ b/core/src/utils/test/overlays/overlays.spec.ts
@@ -195,35 +195,41 @@ describe('aria-hidden on individual overlays', () => {
     expect(modalOne.hasAttribute('aria-hidden')).toEqual(false);
   });
 
-  it('should not hide previous overlay is top-most overlay is toast', async () => {
+  it.only('should not hide previous overlay is top-most overlay is toast', async () => {
     const page = await newSpecPage({
       components: [Modal, Toast],
       html: `
-        <ion-modal id="one"></ion-modal>
-        <ion-toast></ion-toast>
-        <ion-modal id="two"></ion-modal>
+        <ion-modal id="m-one"></ion-modal>
+        <ion-toast id="t-one"></ion-toast>
+        <ion-toast id="t-two"></ion-toast>
+        <ion-modal id="m-two"></ion-modal>
       `,
     });
 
-    const modalOne = page.body.querySelector<HTMLIonModalElement>('ion-modal#one')!;
-    const modalTwo = page.body.querySelector<HTMLIonModalElement>('ion-modal#two')!;
-    const toast = page.body.querySelector<HTMLIonModalElement>('ion-toast')!;
+    const modalOne = page.body.querySelector<HTMLIonModalElement>('ion-modal#m-one')!;
+    const modalTwo = page.body.querySelector<HTMLIonModalElement>('ion-modal#m-two')!;
+    const toastOne = page.body.querySelector<HTMLIonModalElement>('ion-toast#t-one')!;
+    const toastTwo = page.body.querySelector<HTMLIonModalElement>('ion-toast#t-two')!;
 
     await modalOne.present();
-    await toast.present();
+    await toastOne.present();
+    await toastTwo.present();
 
     expect(modalOne.hasAttribute('aria-hidden')).toEqual(false);
+    expect(toastOne.hasAttribute('aria-hidden')).toEqual(false);
+    expect(toastTwo.hasAttribute('aria-hidden')).toEqual(false);
 
     await modalTwo.present();
 
     expect(modalOne.hasAttribute('aria-hidden')).toEqual(true);
-    expect(toast.hasAttribute('aria-hidden')).toEqual(true);
+    expect(toastOne.hasAttribute('aria-hidden')).toEqual(true);
+    expect(toastTwo.hasAttribute('aria-hidden')).toEqual(true);
     expect(modalTwo.hasAttribute('aria-hidden')).toEqual(false);
 
     await modalTwo.dismiss();
 
-    expect(toast.hasAttribute('aria-hidden')).toEqual(false);
-
     expect(modalOne.hasAttribute('aria-hidden')).toEqual(false);
+    expect(toastOne.hasAttribute('aria-hidden')).toEqual(false);
+    expect(toastTwo.hasAttribute('aria-hidden')).toEqual(false);
   });
 });


### PR DESCRIPTION
Issue number: resolves #29139 

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When implementing https://github.com/ionic-team/ionic-framework/pull/28997 we did not consider the case where a Toast could be presented. When presenting a Toast after presenting a Modal the linked change causes the Modal to be hidden from screen readers.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- If the top-most overlay is a Toast then the closest non-Toast overlay is also not hidden from screen readers. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `7.7.5-dev.11710260658.1fc29a6c`