### PR TITLE
docs(toggle): remove extra backtick to fix formatting

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -3211,7 +3211,7 @@ export namespace Components {
     }
     interface IonToggle {
         /**
-          * How to control the alignment of the toggle and label on the cross axis. ``"start"`: The label and control will appear on the left of the cross axis in LTR, and on the right side in RTL. `"center"`: The label and control will appear at the center of the cross axis in both LTR and RTL.
+          * How to control the alignment of the toggle and label on the cross axis. `"start"`: The label and control will appear on the left of the cross axis in LTR, and on the right side in RTL. `"center"`: The label and control will appear at the center of the cross axis in both LTR and RTL.
          */
         "alignment": 'start' | 'center';
         /**
@@ -8037,7 +8037,7 @@ declare namespace LocalJSX {
     }
     interface IonToggle {
         /**
-          * How to control the alignment of the toggle and label on the cross axis. ``"start"`: The label and control will appear on the left of the cross axis in LTR, and on the right side in RTL. `"center"`: The label and control will appear at the center of the cross axis in both LTR and RTL.
+          * How to control the alignment of the toggle and label on the cross axis. `"start"`: The label and control will appear on the left of the cross axis in LTR, and on the right side in RTL. `"center"`: The label and control will appear at the center of the cross axis in both LTR and RTL.
          */
         "alignment"?: 'start' | 'center';
         /**

--- a/core/src/components/toggle/toggle.tsx
+++ b/core/src/components/toggle/toggle.tsx
@@ -119,7 +119,7 @@ export class Toggle implements ComponentInterface {
 
   /**
    * How to control the alignment of the toggle and label on the cross axis.
-   * ``"start"`: The label and control will appear on the left of the cross axis in LTR, and on the right side in RTL.
+   * `"start"`: The label and control will appear on the left of the cross axis in LTR, and on the right side in RTL.
    * `"center"`: The label and control will appear at the center of the cross axis in both LTR and RTL.
    */
   @Prop() alignment: 'start' | 'center' = 'center';


### PR DESCRIPTION
Removes the extra backtick in the `alignment` property description that is causing formatting issues in the [Toggle documentation](https://ionicframework.com/docs/api/toggle#properties):

<img width="754" alt="Screenshot 2024-03-13 at 4 45 58 PM" src="https://github.com/ionic-team/ionic-framework/assets/6577830/d1430baf-c316-41b8-ba9c-c1b196c99d41">
