### PR TITLE
chore(css): remove unit option from font scaling utils

### DIFF
--- a/core/src/themes/ionic.functions.font.scss
+++ b/core/src/themes/ionic.functions.font.scss
@@ -1,18 +1,19 @@
 @use "sass:math";
 
 $baselineSize: 16px !default;
-$baselineUnit: 1rem !default;
 
 /**
  * Convert a font size to a dynamic font size.
  * Fonts that participate in Dynamic Type should use
  * dynamic font sizes.
  * @param size - The initial font size including the unit (i.e. px or pt)
- * @param unit (optional) - The unit to convert to. Use this if you want to
- * convert to a unit other than $baselineUnit.
  */
-@function dynamic-font($size, $unit: $baselineUnit) {
-  @return (math.div($size, $baselineSize)) * $unit;
+@function dynamic-font($size) {
+  /**
+   * Multiplying by 1rem appends the rem unit to the number while keeping the number unaltered.
+   * Example: 1.25 * 1rem = 1.25rem
+   */
+  @return (math.div($size, $baselineSize)) * 1rem;
 }
 
 /**
@@ -20,11 +21,9 @@ $baselineUnit: 1rem !default;
  * a maximum font size.
  * @param size - The initial font size including the unit (i.e. px or pt)
  * @param maxScale - The maximum scale of the font (i.e. 2.5 for a maximum 250% scale).
- * @param unit (optional) - The unit to convert the initial font size to. Use this if you want to
- * convert to a unit other than $baselineUnit.
  */
-@function dynamic-font-max($size, $maxScale, $unit: $baselineUnit) {
-  $baseScale: dynamic-font($size, $unit);
+@function dynamic-font-max($size, $maxScale) {
+  $baseScale: dynamic-font($size);
   $maxScale: $size * $maxScale;
 
   @return min($baseScale, $maxScale);
@@ -35,11 +34,10 @@ $baselineUnit: 1rem !default;
  * a minimum font size.
  * @param size - The initial font size including the unit (i.e. px or pt)
  * @param minScale - The minimum scale of the font (i.e. 0.8 for a minimum 80% scale).
- * @param unit (optional) - The unit to convert the initial font size to. Use this if you want to
  * convert to a unit other than $baselineUnit.
  */
-@function dynamic-font-min($minScale, $size, $unit: $baselineUnit) {
-  $baseScale: dynamic-font($size, $unit);
+@function dynamic-font-min($minScale, $size) {
+  $baseScale: dynamic-font($size);
   $minScale: $size * $minScale;
 
   @return max($minScale, $baseScale);
@@ -51,11 +49,9 @@ $baselineUnit: 1rem !default;
  * @param size - The initial font size including the unit (i.e. px or pt)
  * @param minScale - The minimum scale of the font (i.e. 0.8 for a minimum 80% scale).
  * @param maxScale - The maximum scale of the font (i.e. 2.5 for a maximum 250% scale).
- * @param unit (optional) - The unit to convert the initial font size to. Use this if you want to
- * convert to a unit other than $baselineUnit.
  */
-@function dynamic-font-clamp($minScale, $baseSize, $maxScale, $unit: $baselineUnit) {
-  $baseScale: dynamic-font($baseSize, $unit);
+@function dynamic-font-clamp($minScale, $baseSize, $maxScale) {
+  $baseScale: dynamic-font($baseSize);
   $maxScale: $baseSize * $maxScale;
   $minScale: $baseSize * $minScale;
 


### PR DESCRIPTION
Maria and I were discussing this `$unit` argument and why it exists to debug some behaviors in other PRs. We discussed if it was possible to only pass the unit to convert instead of having to pass `1` and then the unit. While investigating this I realized that this argument is not used in the project anymore. Rather than refactor something that is not even being used, I'd like to remove the argument altogether to avoid confusion.
 
[Some components](https://github.com/ionic-team/ionic-framework/blob/ca0923812a89fab830c33b1e854d114c2946c988/core/src/components/item-divider/item-divider.md.scss#L54) do need to use `em` units with font scaling. In those cases they need to use a different base font size, so they can't use the `dynamic-font` functions anyways.