### PR TITLE
fix(modal): remove enable scrolling delay with sheet modal

### DIFF
--- a/core/src/components/modal/gestures/sheet.ts
+++ b/core/src/components/modal/gestures/sheet.ts
@@ -314,6 +314,17 @@ export const createSheetGesture = (
       onDismiss();
     }
 
+    /**
+     * If the sheet is going to be fully expanded then we should enable
+     * scrolling immediately. The sheet modal animation takes ~500ms to finish
+     * so if we wait until then there is a visible delay for when scrolling is
+     * re-enabled. Native iOS allows for scrolling on the sheet modal as soon
+     * as the gesture is released, so we align with that.
+     */
+    if (contentEl && snapToBreakpoint === breakpoints[breakpoints.length - 1]) {
+      contentEl.scrollY = true;
+    }
+
     return new Promise<void>((resolve) => {
       animation
         .onFinish(
@@ -333,14 +344,6 @@ export const createSheetGesture = (
                   animation.progressStart(true, 1 - snapToBreakpoint);
                   currentBreakpoint = snapToBreakpoint;
                   onBreakpointChange(currentBreakpoint);
-
-                  /**
-                   * If the sheet is fully expanded, we can safely
-                   * enable scrolling again.
-                   */
-                  if (contentEl && currentBreakpoint === breakpoints[breakpoints.length - 1]) {
-                    contentEl.scrollY = true;
-                  }
 
                   /**
                    * Backdrop should become enabled


### PR DESCRIPTION
Issue number: Part of https://github.com/ionic-team/ionic-framework/issues/24583

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

There is a noticeable delay between when users finish swiping and when scrolling is re-enabled. This is because the animation takes ~500ms to complete when finishing the swipe.

This does not align with how we [re-enable scrolling in the card modal](https://github.com/ionic-team/ionic-framework/blob/9b3cf9fbc2c5189871b2255d2d765e78509f5027/core/src/components/modal/gestures/swipe-to-close.ts#L262-L264). In the card modal, scrolling is re-enabled as soon as the gesture is released.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- To fix this, I aligned the behavior of the sheet modal with that of the card modal. As a result, whether or not the content is scrollable is now tied to the state of the gesture rather than the state of the animation.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `7.8.3-dev.11712114476.152fc43d`

Reviewers:

Please test this on a physical iOS and Android devices. Ensure that swiping the modal fully open does a) re-enable scrolling and b) re-enable scrolling without a 500ms delay.

**Card Behavior**

| Demo |
| - |
| <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/175c5721-b694-45bf-9acf-044214d979c9"></video> |

**Sheet Behavior**

| `main` | branch |
| - | - |
| <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/a6d5fffd-57a5-4d43-9856-dc28dced5417"></video> | <video src="https://github.com/ionic-team/ionic-framework/assets/2721089/797395e9-f455-4a0b-87a3-b2f72c50afab"></video> |


