### PR TITLE
feat: add dynamic font scaling for Picker component

### DIFF
--- a/core/src/components/picker/picker.ios.vars.scss
+++ b/core/src/components/picker/picker.ios.vars.scss
@@ -31,7 +31,7 @@ $picker-ios-button-height:                        $picker-ios-toolbar-height !de
 $picker-ios-button-text-color:                    ion-color(primary, base) !default;
 
 /// @prop - Font size of the picker button
-$picker-ios-button-font-size:                     16px !default;
+$picker-ios-button-font-size:                     dynamic-font-min(1, 16px) !default;
 
 /// @prop - Padding top of the picker button
 $picker-ios-button-padding-top:                   0 !default;
@@ -79,7 +79,7 @@ $picker-ios-option-padding-start:                 $picker-ios-option-padding-end
 $picker-ios-option-text-color:                    $item-ios-color !default;
 
 /// @prop - Font size of the picker option
-$picker-ios-option-font-size:                     20px !default;
+$picker-ios-option-font-size:                     dynamic-font-min(1, 20px) !default;
 
 /// @prop - Height of the picker option
 $picker-ios-option-height:                        42px !default;

--- a/core/src/components/picker/picker.md.vars.scss
+++ b/core/src/components/picker/picker.md.vars.scss
@@ -34,7 +34,7 @@ $picker-md-button-text-color:                       ion-color(primary, base) !de
 $picker-md-button-background-color:                 transparent !default;
 
 /// @prop - Font size of the picker button
-$picker-md-button-font-size:                        14px !default;
+$picker-md-button-font-size:                        dynamic-font(14px) !default;
 
 /// @prop - Padding top of the picker column
 $picker-md-column-padding-top:                      0 !default;
@@ -64,7 +64,7 @@ $picker-md-option-padding-start:                    $picker-md-option-padding-en
 $picker-md-option-text-color:                       $item-md-color !default;
 
 /// @prop - Font size of the picker option
-$picker-md-option-font-size:                        22px !default;
+$picker-md-option-font-size:                        dynamic-font(22px) !default;
 
 /// @prop - Height of the picker option
 $picker-md-option-height:                           42px !default;


### PR DESCRIPTION
Issue number: Issue number: resolves https://github.com/ionic-team/ionic-framework/issues/24638, resolves https://github.com/ionic-team/ionic-framework/issues/18592

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Developers have requested that Ionic Framework support the dynamic type
feature on iOS for accessibility purposes. Ionic applications do not
respond to font scaling on iOS which can create inaccessible
applications particularly for users with low vision for Picker component. Ionic apps on
Android devices currently support the Android equivalent due to
functionality in the Chromium webview.

Developers have also requested a way of adjusting the fonts in their
Ionic Picker component consistently.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Ionic components now use `rem` instead of `px` where appropriate. This
means devs can change the font size on `html` and the text in supported
Ionic components will scale up/down appropriately
- Add support for Dynamic Type on iOS (the iOS version of Dynamic Font
Scaling)
-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
