### PR TITLE
chore(ci): add stubbed workflow for deploying public previews

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,24 @@
+name: 'Deploy Preview'
+description: 'Deploys the HTML test files to a public bucket for preview'
+
+on:
+  pull_request:
+    branches: [ '**' ]
+  workflow_dispatch:
+  push:
+    branches:
+      - 'next'
+
+# When pushing a new commit we should
+# cancel the previous test run to not
+# consume more runners than we need to.
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-core:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/workflows/actions/build-core


### PR DESCRIPTION
I am working on a flow that allows the design team to preview our work for the Ionic theme. To do this, we will be publishing the HTML test files to a public space and providing a link to the team. In order to manually run this workflow I need the file to exist in `main` for it to show up in https://github.com/ionic-team/ionic-framework/actions. This file has a stubbed implementation that just builds `core`.