### PR TITLE
feat(input): add hover state to the ionic theme

### DIFF
--- a/core/src/components/input/input.ionic.scss
+++ b/core/src/components/input/input.ionic.scss
@@ -1,3 +1,4 @@
+@use "../../foundations/ionic.vars.scss" as tokens;
 @import "./input";
 @import "./input.ionic.vars";
 @import "./input.ionic.outline.scss";
@@ -24,8 +25,7 @@
 // ----------------------------------------------------------------
 
 .input-bottom .helper-text {
-  // TODO(FW-6112): Verify the design token is correct once it's available and remove the hardcoded value.
-  color: var(--ionic-color-neutral-600, #535353);
+  color: #{tokens.$ionic-color-neutral-600};
 }
 
 .input-bottom .error-text {
@@ -37,7 +37,6 @@
 
 @media (any-hover: hover) {
   :host(:hover) {
-    // TODO(FW-6112): Verify the design token is correct once it's available and remove the hardcoded value.
-    --border-color: var(--ionic-color-neutral-600, #535353);
+    --border-color: #{tokens.$ionic-color-neutral-600};
   }
 }

--- a/core/src/components/input/input.ionic.scss
+++ b/core/src/components/input/input.ionic.scss
@@ -25,7 +25,7 @@
 // ----------------------------------------------------------------
 
 .input-bottom .helper-text {
-  color: #{tokens.$ionic-color-neutral-600};
+  color: tokens.$ionic-color-neutral-600;
 }
 
 .input-bottom .error-text {

--- a/core/src/components/input/input.ionic.scss
+++ b/core/src/components/input/input.ionic.scss
@@ -31,3 +31,13 @@
 .input-bottom .error-text {
   color: var(--highlight-color-invalid);
 }
+
+// Input Hover
+// ----------------------------------------------------------------
+
+@media (any-hover: hover) {
+  :host(:hover) {
+    // TODO(FW-6112): Verify the design token is correct once it's available and remove the hardcoded value.
+    --border-color: var(--ionic-color-neutral-600, #535353);
+  }
+}


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
The ionic input does not have a hover state.

## What is the new behavior?
Adds a hover state. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
We do not currently have a way to test hover states. See https://github.com/microsoft/playwright/issues/12077 for more information. 