### PR TITLE
chore(ci): stability for test-core-clean-build

### DIFF
--- a/core/src/components/card/card.ionic.scss
+++ b/core/src/components/card/card.ionic.scss
@@ -5,6 +5,11 @@
 // --------------------------------------------------
 
 :host {
+  // TODO(FW-6178): Remove this once the Stencil bug is resolved.
+  /**
+   * @prop --background: Background of the card
+   * @prop --color: Color of the card
+   */
   --background: #{tokens.$ionic-color-neutral-0};
   --border-radius: #{tokens.$ionic-border-radius-rounded-small};
 

--- a/core/src/components/chip/chip.ionic.scss
+++ b/core/src/components/chip/chip.ionic.scss
@@ -9,6 +9,11 @@ $ionic-states-focus-primary: #9ec4fd;
 $ionic-states-hover: #{rgba(#05080f, 0.16)}; // We should review how to make this in the future, as we are setting scss variables with a var() and fallback, and it doesn't work inside a rgba().
 
 :host {
+  // TODO(FW-6178): Remove this once the Stencil bug is resolved.
+  /**
+   * @prop --background: Background of the chip
+   * @prop --color: Color of the chip
+   */
   --background: #{tokens.$ionic-color-neutral-10};
   --border-color: transparent;
   --border-radius: #{tokens.$ionic-border-radius-rounded-small};


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

CI will fail randomly due to which stylesheet is processed last by rollup in Stencil. This leads to random failures. 

This is caused by some of the new ionic stylesheets not importing the same common stylesheet that included the CSS variable documentation.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Temporarily copies and pastes the documentation blocks to the affected ionic stylesheets
- CI should no longer fail randomly when comparing the generated `api.txt` output
- Adds a technical debt track to track removing these changes once the bug in Stencil is resolved and released

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
