### PR TITLE
chore: add v7-lts option for backporting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,7 @@ on:
         type: choice
         description: Which npm tag should this be published to?
         options:
-          - latest
-          - next
-          - v5-lts
-          - v4-lts
+          - v7-lts
       preid:
         type: choice
         description: Which prerelease identifier should be used? This is only needed when version is "prepatch", "preminor", "premajor", or "prerelease".


### PR DESCRIPTION
This PR adds a "v7-lts" NPM tag for backporting fixes to v7.