### PR TITLE
chore: remove v5 and v4 lts tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ on:
         options:
           - latest
           - next
-          - v5-lts
-          - v4-lts
       preid:
         type: choice
         description: Which prerelease identifier should be used? This is only needed when version is "prepatch", "preminor", "premajor", or "prerelease".


### PR DESCRIPTION
This PR removes the v5 and v4 lts tags from the release scripts. The main branch should always be used to deploy to the latest/next tags and never in the past. Instead, the version branches have the option to deploy to their respective LTS tags.