### PR TITLE
fix: check for scrollEl existence

### DIFF
--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -320,6 +320,9 @@ export class Content implements ComponentInterface {
   @Method()
   async scrollToBottom(duration = 0): Promise<void> {
     const scrollEl = await this.getScrollElement();
+    if (!scrollEl) {
+      return;
+    }
     const y = scrollEl!.scrollHeight - scrollEl!.clientHeight;
     return this.scrollToPoint(undefined, y, duration);
   }


### PR DESCRIPTION
ion-content is breaking CI environments when the scrollable element is not reachable and the consumer needs to run `content.scrollToBottom()`

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
N/A
## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
```
TypeError: Cannot read properties of undefined (reading 'scrollHeight')

      at Content.<anonymous> (../../node_modules/@ionic/core/components/ion-content.js:242:28)
      at fulfilled (../../node_modules/tslib/tslib.js:166:62)
      at _ZoneDelegate.Object.<anonymous>._ZoneDelegate.invoke (../../node_modules/zone.js/bundles/zone.umd.js:411:30)
      at AsyncTestZoneSpec.Object.<anonymous>.AsyncTestZoneSpec.onInvoke (../../node_modules/zone.js/bundles/zone-testing.umd.js:1261:47)
      at ProxyZoneSpec.Object.<anonymous>.ProxyZoneSpec.onInvoke (../../node_modules/zone.js/bundles/zone-testing.umd.js:297:43)
```

