### PR TITLE
chore(deps): upgrade stencil to v4.17.2

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.0.1",
       "license": "MIT",
       "dependencies": {
-        "@stencil/core": "^4.17.1",
+        "@stencil/core": "^4.17.2",
         "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       },
@@ -1786,9 +1786,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.17.1.tgz",
-      "integrity": "sha512-nlARe1QtK5abnCG8kPQKJMWiELg39vKabvf3ebm6YEhQA35CgrxC1pVYTsYq3yktJKoY+k+VzGRnATLKyaLbvA==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.17.2.tgz",
+      "integrity": "sha512-MX7yaLmpTU9iZvCire9nhecTcE0qBlV0vPWrLMeIXewYN7/hb8B3NjnhQyBKC93FDPI8NBRmt6KIugLw9zcRZg==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -11516,9 +11516,9 @@
       "requires": {}
     },
     "@stencil/core": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.17.1.tgz",
-      "integrity": "sha512-nlARe1QtK5abnCG8kPQKJMWiELg39vKabvf3ebm6YEhQA35CgrxC1pVYTsYq3yktJKoY+k+VzGRnATLKyaLbvA=="
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.17.2.tgz",
+      "integrity": "sha512-MX7yaLmpTU9iZvCire9nhecTcE0qBlV0vPWrLMeIXewYN7/hb8B3NjnhQyBKC93FDPI8NBRmt6KIugLw9zcRZg=="
     },
     "@stencil/react-output-target": {
       "version": "0.5.3",

--- a/core/package.json
+++ b/core/package.json
@@ -31,7 +31,7 @@
     "loader/"
   ],
   "dependencies": {
-    "@stencil/core": "^4.17.1",
+    "@stencil/core": "^4.17.2",
     "ionicons": "^7.2.2",
     "tslib": "^2.1.0"
   },


### PR DESCRIPTION
Issue number: resolves #29393

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

With Stencil v4.17.1, in Angular apps Stencil's `MockDoc` will be bundled with the consumer's code resulting in a significant increase to the main chunk. 

|v8.0.0|
|---|
|![CleanShot 2024-04-29 at 11 14 36@2x](https://github.com/ionic-team/ionic-framework/assets/13732623/78d6dd63-3816-4da5-8ada-2bfa823a6800)|

|v8.0.1|
|---|
|![CleanShot 2024-04-29 at 11 15 38@2x](https://github.com/ionic-team/ionic-framework/assets/13732623/d21315a8-049f-4874-8a87-996feeb5bd12)|


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updates to v4.17.2 of Stencil, which resolves this regression 🎉 

|Dev-build|
|---|
|![CleanShot 2024-04-29 at 11 17 50@2x](https://github.com/ionic-team/ionic-framework/assets/13732623/a54d1e4c-f9a7-4df9-9064-4b3ae875df11)|

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `8.0.2-dev.11714402065.169342dc`