### PR TITLE
fix(datetime): navigating months in RTL works correctly

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -900,7 +900,8 @@ export class Datetime implements ComponentInterface {
          * Check below the next line ensures that we did not
          * swipe and abort (i.e. we swiped but we are still on the current month).
          */
-        const month = calendarBodyRef.scrollLeft <= 2 ? startMonth : endMonth;
+        const condition = isRTL(this.el) ? calendarBodyRef.scrollLeft >= -2 : calendarBodyRef.scrollLeft <= 2;
+        const month = condition ? startMonth : endMonth;
 
         /**
          * The edge of the month must be lined up with


### PR DESCRIPTION
Issue number: resolves #29198

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

In https://github.com/ionic-team/ionic-framework/pull/27917 I failed to account for RTL. This caused the navigation with the arrow buttons to break because the scroll position was always < 2.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Datetime now checks if the component is in RTL mode when creating the scrollLeft threshold.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
