### PR TITLE
fix(radio): persist checked state when items are updated in radio-group

### DIFF
--- a/core/src/components/radio/radio.tsx
+++ b/core/src/components/radio/radio.tsx
@@ -112,7 +112,7 @@ export class Radio implements ComponentInterface {
 
   componentDidLoad() {
     /**
-     * The value may be `undefined` if the it
+     * The value may be `undefined` if it
      * gets set before the radio is
      * rendered. This ensures that the radio
      * is checked if the value matches. This

--- a/core/src/components/radio/radio.tsx
+++ b/core/src/components/radio/radio.tsx
@@ -110,6 +110,10 @@ export class Radio implements ComponentInterface {
    */
   @Event() ionBlur!: EventEmitter<void>;
 
+  componentDidLoad() {
+    this.updateState();
+  }
+
   /** @internal */
   @Method()
   async setFocus(ev: globalThis.Event) {

--- a/core/src/components/radio/radio.tsx
+++ b/core/src/components/radio/radio.tsx
@@ -111,6 +111,14 @@ export class Radio implements ComponentInterface {
   @Event() ionBlur!: EventEmitter<void>;
 
   componentDidLoad() {
+    /**
+     * The value may be `undefined` if the it
+     * gets set before the radio is
+     * rendered. This ensures that the radio
+     * is checked if the value matches. This
+     * happens most often when Angular is
+     * rendering the radio.
+     */
     this.updateState();
   }
 


### PR DESCRIPTION
Issue number: resolves #29442

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The state does not stay consistent when the data used to render the radios are updated.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The state updates after the component loads, this allows the value to be set after the radio is rendered.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: 8.1.1-dev.11714760012.1eab947e
