### PR TITLE
feat(button): update md button to use md3 padding

### DIFF
--- a/core/src/components/button/button.ios.scss
+++ b/core/src/components/button/button.ios.scss
@@ -119,13 +119,8 @@
   --border-radius: 4px;
 }
 
-// TODO(FW-6202): remove the custom padding styles
 :host(.button-round) {
   --border-radius: 999px;
-  --padding-top: #{$button-ios-round-padding-top};
-  --padding-start: #{$button-ios-round-padding-start};
-  --padding-end: #{$button-ios-round-padding-end};
-  --padding-bottom: #{$button-ios-round-padding-bottom};
 }
 
 :host(.button-rectangular) {

--- a/core/src/components/button/button.ios.vars.scss
+++ b/core/src/components/button/button.ios.vars.scss
@@ -113,21 +113,6 @@ $button-ios-clear-opacity-activated: 0.4;
 /// @prop - Opacity of the clear button on hover
 $button-ios-clear-opacity-hover: 0.6;
 
-// iOS Round Button
-// --------------------------------------------------
-
-/// @prop - Padding top of the round button
-$button-ios-round-padding-top: $button-round-padding-top;
-
-/// @prop - Padding end of the round button
-$button-ios-round-padding-end: $button-round-padding-end;
-
-/// @prop - Padding bottom of the round button
-$button-ios-round-padding-bottom: $button-round-padding-bottom;
-
-/// @prop - Padding start of the round button
-$button-ios-round-padding-start: $button-round-padding-start;
-
 // iOS Decorator Button
 // --------------------------------------------------
 

--- a/core/src/components/button/button.md.scss
+++ b/core/src/components/button/button.md.scss
@@ -18,9 +18,9 @@
   font-size: #{$button-md-font-size};
   font-weight: #{$button-md-font-weight};
 
-  letter-spacing: #{$button-md-letter-spacing};
+  letter-spacing: 0.06em;
 
-  text-transform: #{$button-md-text-transform};
+  text-transform: uppercase;
 }
 
 // Solid Button
@@ -78,13 +78,8 @@
   --border-radius: 4px;
 }
 
-// TODO(FW-6202): remove the custom padding styles
 :host(.button-round) {
   --border-radius: 999px;
-  --padding-top: #{$button-md-round-padding-top};
-  --padding-start: #{$button-md-round-padding-start};
-  --padding-end: #{$button-md-round-padding-end};
-  --padding-bottom: #{$button-md-round-padding-bottom};
 }
 
 :host(.button-rectangular) {

--- a/core/src/components/button/button.md.scss
+++ b/core/src/components/button/button.md.scss
@@ -18,9 +18,9 @@
   font-size: #{$button-md-font-size};
   font-weight: #{$button-md-font-weight};
 
-  letter-spacing: 0.06em;
+  letter-spacing: #{$button-md-letter-spacing};
 
-  text-transform: uppercase;
+  text-transform: #{$button-md-text-transform};
 }
 
 // Solid Button

--- a/core/src/components/button/button.md.vars.scss
+++ b/core/src/components/button/button.md.vars.scss
@@ -19,13 +19,13 @@ $button-md-margin-start: 2px;
 $button-md-padding-top: 8px;
 
 /// @prop - Padding end of the button
-$button-md-padding-end: 24px;
+$button-md-padding-end: 1.1em;
 
 /// @prop - Padding bottom of the button
 $button-md-padding-bottom: $button-md-padding-top;
 
 /// @prop - Padding start of the button
-$button-md-padding-start: $button-md-padding-end;
+$button-md-padding-start: 1.1em;
 
 /// @prop - Minimum height of the button
 $button-md-min-height: 36px;
@@ -35,6 +35,11 @@ $button-md-font-size: dynamic-font(14px);
 
 /// @prop - Font weight of the button text
 $button-md-font-weight: 500;
+
+/// @prop - Capitalization of the button text
+$button-md-text-transform: uppercase;
+
+$button-md-letter-spacing: 0.06em;
 
 /// @prop - Box shadow of the button
 $button-md-box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14),

--- a/core/src/components/button/button.md.vars.scss
+++ b/core/src/components/button/button.md.vars.scss
@@ -19,13 +19,13 @@ $button-md-margin-start: 2px;
 $button-md-padding-top: 8px;
 
 /// @prop - Padding end of the button
-$button-md-padding-end: 1.1em;
+$button-md-padding-end: 24px;
 
 /// @prop - Padding bottom of the button
 $button-md-padding-bottom: $button-md-padding-top;
 
 /// @prop - Padding start of the button
-$button-md-padding-start: 1.1em;
+$button-md-padding-start: $button-md-padding-end;
 
 /// @prop - Minimum height of the button
 $button-md-min-height: 36px;
@@ -35,11 +35,6 @@ $button-md-font-size: dynamic-font(14px);
 
 /// @prop - Font weight of the button text
 $button-md-font-weight: 500;
-
-/// @prop - Capitalization of the button text
-$button-md-text-transform: uppercase;
-
-$button-md-letter-spacing: 0.06em;
 
 /// @prop - Box shadow of the button
 $button-md-box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14),
@@ -90,21 +85,6 @@ $button-md-small-min-height: 2.1em;
 
 /// @prop - Font size of the small button
 $button-md-small-font-size: dynamic-font(13px);
-
-// Material Design Round Button
-// --------------------------------------------------
-
-/// @prop - Padding top of the round button
-$button-md-round-padding-top: $button-round-padding-top;
-
-/// @prop - Padding end of the round button
-$button-md-round-padding-end: $button-round-padding-end;
-
-/// @prop - Padding bottom of the round button
-$button-md-round-padding-bottom: $button-round-padding-bottom;
-
-/// @prop - Padding start of the round button
-$button-md-round-padding-start: $button-round-padding-start;
 
 // Material Design Decorator Button
 // --------------------------------------------------

--- a/core/src/components/button/button.vars.scss
+++ b/core/src/components/button/button.vars.scss
@@ -2,15 +2,3 @@
 
 // Button
 // --------------------------------------------------
-
-/// @prop - Padding top of the round button
-$button-round-padding-top: 0;
-
-/// @prop - Padding end of the round button
-$button-round-padding-end: 26px;
-
-/// @prop - Padding bottom of the round button
-$button-round-padding-bottom: $button-round-padding-top;
-
-/// @prop - Padding start of the round button
-$button-round-padding-start: $button-round-padding-end;

--- a/core/src/components/button/test/basic/index.html
+++ b/core/src/components/button/test/basic/index.html
@@ -24,9 +24,7 @@
 
       <ion-content class="ion-padding ion-text-center" id="content" no-bounce>
         <p>
-          <ion-button id="default">Enabled</ion-button>
-          <ion-button fill="outline">Enabled</ion-button>
-          <ion-button fill="clear" class="ion-focused">Enabled</ion-button>
+          <ion-button id="default">Default</ion-button>
           <ion-button class="ion-focused">Default.focused</ion-button>
           <ion-button class="ion-activated">Default.activated</ion-button>
         </p>

--- a/core/src/components/button/test/basic/index.html
+++ b/core/src/components/button/test/basic/index.html
@@ -24,7 +24,9 @@
 
       <ion-content class="ion-padding ion-text-center" id="content" no-bounce>
         <p>
-          <ion-button id="default">Default</ion-button>
+          <ion-button id="default">Enabled</ion-button>
+          <ion-button fill="outline">Enabled</ion-button>
+          <ion-button fill="clear" class="ion-focused">Enabled</ion-button>
           <ion-button class="ion-focused">Default.focused</ion-button>
           <ion-button class="ion-activated">Default.activated</ion-button>
         </p>


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?
Material Design and iOS buttons set different padding amounts when the `shape` is `"round"`. This was made more apparent when we changed the default shape to round for `md`, as all of the existing screenshots showed that the buttons no longer had padding top or bottom. 

## What is the new behavior?
Removes the different padding targeting `:host(.button-round)`. All button shapes should use the same padding according to guidelines. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No