### PR TITLE
fix(angular): add formatOptions property to standalone datetime

### DIFF
--- a/packages/angular/standalone/src/directives/datetime.ts
+++ b/packages/angular/standalone/src/directives/datetime.ts
@@ -24,6 +24,7 @@ const DATETIME_INPUTS = [
   'disabled',
   'doneText',
   'firstDayOfWeek',
+  'formatOptions',
   'highlightedDates',
   'hourCycle',
   'hourValues',


### PR DESCRIPTION
Issue number: resolves #29464

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The standalone component for `ion-datetime` is missing the `formatOptions` property. This component wrapper is manually maintained and was missed when developing the feature.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds the missing `formatOptions` property to the `ion-datetime` for the angular standalone component

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
