### PR TITLE
test(input): remove the .only within fill

### DIFF
--- a/core/src/components/input/test/fill/input.e2e.ts
+++ b/core/src/components/input/test/fill/input.e2e.ts
@@ -109,7 +109,7 @@ configs({ modes: ['md'] }).forEach(({ title, screenshot, config }) => {
         const input = page.locator('ion-input');
         await expect(input).toHaveScreenshot(screenshot(`input-fill-outline-label-floating`));
       });
-      test.only('padding should be customizable', async ({ page }) => {
+      test('padding should be customizable', async ({ page }) => {
         /**
          * Requires padding at the top to prevent the label
          * from being clipped by the top of the input.


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The `.only` managed to get into the codebase. This is not the correct structure.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed `.only` from the input test.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

N/A
