### PR TITLE
fix(core): malformed URIs will not throw exception

### DIFF
--- a/core/src/global/config.ts
+++ b/core/src/global/config.ts
@@ -60,7 +60,13 @@ export const configFromURL = (win: Window) => {
     .slice(1)
     .split('&')
     .map((entry) => entry.split('='))
-    .map(([key, value]) => [decodeURIComponent(key), decodeURIComponent(value)])
+    .map(([key, value]) => {
+      try {
+        return [decodeURIComponent(key), decodeURIComponent(value)];
+      } catch (e) {
+        return ['', ''];
+      }
+    })
     .filter(([key]) => startsWith(key, IONIC_PREFIX))
     .map(([key, value]) => [key.slice(IONIC_PREFIX.length), value])
     .forEach(([key, value]) => {

--- a/core/src/global/test/config-controller.spec.ts
+++ b/core/src/global/test/config-controller.spec.ts
@@ -1,5 +1,5 @@
 import type { IonicConfig } from '../../interface';
-import { Config } from '../config';
+import { Config, configFromURL } from '../config';
 
 describe('Config', () => {
   it('should get a value from the config', () => {
@@ -81,5 +81,17 @@ describe('Config', () => {
     expect(config.get('text0' as any, 'HEY')).toEqual('HEY');
     config.set('text0' as any, 'hola');
     expect(config.get('text0' as any, 'HEY')).toEqual('hola');
+  });
+
+  it('should not throw an exception with a malformed URI', () => {
+    // https://github.com/ionic-team/ionic-framework/issues/29479
+
+    expect(
+      configFromURL({
+        location: {
+          search: '?test=%',
+        },
+      } as unknown as Window)
+    ).toEqual({});
   });
 });


### PR DESCRIPTION
Issue number: resolves #29479

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

If an application includes a malformed URI, an Ionic Framework can "crash" due to an uncaught exception in parsing the URI for the Ionic config.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Handle the malformed URI fallback if the config cannot be determined
- Added unit tests for this case

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
