### PR TITLE
refactor(react): export InputInputEventDetail type

### DIFF
--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -42,6 +42,7 @@ export {
   InfiniteScrollCustomEvent,
   InputCustomEvent,
   InputChangeEventDetail,
+  InputInputEventDetail,
   ItemReorderEventDetail,
   ItemReorderCustomEvent,
   ItemSlidingCustomEvent,


### PR DESCRIPTION
Issue number: resolves #29518 

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
IonInput in React apps can't import the correct type for typescript.  
## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Since it is in the file exported, people using IonInput can import the correct type.
-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x ] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Liam DeBeasi told me it was a bug a couple days ago and pointed out to where it needed to be added.