### PR TITLE
fix(playwright): bump packages upon new release

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -35,7 +35,6 @@
       matchPackageNames: ["mcr.microsoft.com/playwright"],
       groupName: "playwright",
       matchFileNames: [
-        "core/package.json",
         "core/Dockerfile"
       ],
       versioning: "semver"

--- a/renovate.json5
+++ b/renovate.json5
@@ -22,18 +22,10 @@
       ]
     },
     {
-      matchDatasources: ["npm"],
-      matchPackagePatterns: ["@playwright/test", "@axe-core/playwright"],
+      matchPackagePatterns: ["@playwright/test", ""@axe-core/playwright", "mcr.microsoft.com/playwright"],
       groupName: "playwright",
       matchFileNames: [
-        "core/package.json"
-      ]
-    },
-    {
-      matchDatasources: ["docker"],
-      matchPackageNames: ["mcr.microsoft.com/playwright"],
-      groupName: "playwright",
-      matchFileNames: [
+        "core/package.json",
         "core/Dockerfile"
       ],
       versioning: "semver"

--- a/renovate.json5
+++ b/renovate.json5
@@ -22,7 +22,17 @@
       ]
     },
     {
-      matchPackagePatterns: ["@playwright/test", "@axe-core/playwright", "mcr.microsoft.com/playwright"],
+      matchDatasources: ["npm"],
+      matchPackagePatterns: ["@playwright/test", "@axe-core/playwright"],
+      groupName: "playwright",
+      matchFileNames: [
+        "core/package.json"
+      ],
+      "rangeStrategy": "bump"
+    },
+    {
+      matchDatasources: ["docker"],
+      matchPackageNames: ["mcr.microsoft.com/playwright"],
       groupName: "playwright",
       matchFileNames: [
         "core/package.json",

--- a/renovate.json5
+++ b/renovate.json5
@@ -22,7 +22,7 @@
       ]
     },
     {
-      matchPackagePatterns: ["@playwright/test", ""@axe-core/playwright", "mcr.microsoft.com/playwright"],
+      matchPackagePatterns: ["@playwright/test", "@axe-core/playwright", "mcr.microsoft.com/playwright"],
       groupName: "playwright",
       matchFileNames: [
         "core/package.json",


### PR DESCRIPTION
Issue number:  N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Renovate updates the Playwright packages. It's important that the Playwright within Docker and within core are the same version. However, the Playwright version within core does not update when Docker does.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a `bump` to the Renovate config, this should allow Playwright within core to update regardless if the new version satisfies the range.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I was unable to test it locally since it will only trigger when the code is within `main`.
