### PR TITLE
chore(vue): pin version for test app

### DIFF
--- a/packages/vue/test/apps/vue3/package.json
+++ b/packages/vue/test/apps/vue3/package.json
@@ -19,7 +19,7 @@
     "@ionic/vue": "^6.0.12",
     "@ionic/vue-router": "^6.0.12",
     "ionicons": "^6.0.4",
-    "vue": "^3.4.14",
+    "vue": "3.4.27",
     "vue-router": "^4.2.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

CI tests are failing because of a recent patch from Vue. They start to fail on Vue v3.4.28.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Pinned Vue v3.4.27 until we can determine a fix.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

N/A
