### PR TITLE
feat(vue): add optional IonicConfig type parameter to IonicVue plugin

### DIFF
--- a/packages/vue/src/ionic-vue.ts
+++ b/packages/vue/src/ionic-vue.ts
@@ -21,7 +21,7 @@ const getHelperFunctions = () => {
   };
 };
 
-export const IonicVue: Plugin = {
+export const IonicVue: Plugin<[IonicConfig?]> = {
   async install(_: App, config: IonicConfig = {}) {
     /**
      * By default Ionic Framework hides elements that


### PR DESCRIPTION
Issue number: https://github.com/ionic-team/ionic-framework/issues/29659

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
while using `.use(IonicVue, {})`, the config object has no autocomplete.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Add type autocomplete on plugin option in VueJS package.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
