### PR TITLE
feat(ion-button): add base styles for ionic theme buttons

### DIFF
--- a/core/src/components/buttons/buttons.common.scss
+++ b/core/src/components/buttons/buttons.common.scss
@@ -1,0 +1,19 @@
+@use "../../themes/mixins" as mixins;
+
+:host {
+  display: flex;
+
+  align-items: center;
+
+  transform: translateZ(0);
+}
+
+// Toolbar Buttons
+// --------------------------------------------------
+
+::slotted(*) ion-button {
+  --padding-top: 0;
+  --padding-bottom: 0;
+
+  @include mixins.margin(0);
+}

--- a/core/src/components/buttons/buttons.ionic.scss
+++ b/core/src/components/buttons/buttons.ionic.scss
@@ -1,0 +1,76 @@
+@use "./buttons.common";
+@use "../../themes/ionic/ionic.globals.scss" as globals;
+
+// Ionic Buttons
+// --------------------------------------------------
+
+::slotted(*) ion-button {
+  --padding-top: 0;
+  --padding-bottom: 0;
+  --padding-start: 0;
+  --padding-end: 0;
+  --box-shadow: none;
+}
+
+::slotted(*) .button-has-icon-only {
+  --padding-top: 0;
+  --padding-bottom: 0;
+}
+
+// Toolbar Solid Button
+// --------------------------------------------------
+
+::slotted(*) .button-solid {
+  --color: #{globals.$ionic-color-neutral-1200};
+  --background: transparent;
+  --background-activated: transparent;
+  --background-focused: currentColor;
+}
+
+// Toolbar Outline Button
+// --------------------------------------------------
+
+::slotted(*) .button-outline {
+  --color: initial;
+  --background: transparent;
+  --background-activated: transparent;
+  --background-focused: currentColor;
+  --background-hover: currentColor;
+  --border-color: currentColor;
+}
+
+// Toolbar Clear Button
+// --------------------------------------------------
+
+::slotted(*) .button-clear {
+  --color: initial;
+  --background: transparent;
+  --background-activated: transparent;
+  --background-focused: currentColor;
+  --background-hover: currentColor;
+}
+
+// Toolbar Button Icon
+// --------------------------------------------------
+
+::slotted(*) .button-has-icon-only.button-clear {
+  width: 40px;
+  height: 40px;
+}
+
+::slotted(*) ion-icon[slot="start"] {
+}
+
+::slotted(*) ion-icon[slot="end"] {
+  @include globals.margin(0);
+  @include globals.margin-horizontal(0.4em, null);
+
+  font-size: 1.4em;
+}
+
+::slotted(*) ion-icon[slot="icon-only"] {
+  @include globals.padding(0);
+  @include globals.margin(0);
+
+  font-size: 1.8em;
+}

--- a/core/src/components/buttons/buttons.ionic.scss
+++ b/core/src/components/buttons/buttons.ionic.scss
@@ -54,8 +54,8 @@
 // --------------------------------------------------
 
 ::slotted(*) .button-has-icon-only {
-  height: globals.$ionic-scale-1000;
   width: globals.$ionic-scale-1000;
+  height: globals.$ionic-scale-1000;
 }
 
 ::slotted(*) ion-icon[slot="icon-only"] {

--- a/core/src/components/buttons/buttons.ionic.scss
+++ b/core/src/components/buttons/buttons.ionic.scss
@@ -53,24 +53,11 @@
 // Toolbar Button Icon
 // --------------------------------------------------
 
-::slotted(*) .button-has-icon-only.button-clear {
-  width: 40px;
-  height: 40px;
-}
-
-::slotted(*) ion-icon[slot="start"] {
-}
-
-::slotted(*) ion-icon[slot="end"] {
-  @include globals.margin(0);
-  @include globals.margin-horizontal(0.4em, null);
-
-  font-size: 1.4em;
+::slotted(*) .button-has-icon-only {
+  height: globals.$ionic-scale-1000;
+  width: globals.$ionic-scale-1000;
 }
 
 ::slotted(*) ion-icon[slot="icon-only"] {
-  @include globals.padding(0);
-  @include globals.margin(0);
-
-  font-size: 1.8em;
+  font-size: globals.$ionic-font-size-600;
 }

--- a/core/src/components/buttons/buttons.ios.scss
+++ b/core/src/components/buttons/buttons.ios.scss
@@ -1,5 +1,5 @@
 @import "./buttons.ios.vars";
-@import "./buttons";
+@import "./buttons.native";
 
 // iOS Toolbar Default Button
 // --------------------------------------------------

--- a/core/src/components/buttons/buttons.md.scss
+++ b/core/src/components/buttons/buttons.md.scss
@@ -1,5 +1,5 @@
 @import "./buttons.md.vars";
-@import "./buttons";
+@import "./buttons.native";
 
 // Material Design Toolbar Default Button
 // --------------------------------------------------

--- a/core/src/components/buttons/buttons.native.scss
+++ b/core/src/components/buttons/buttons.native.scss
@@ -1,12 +1,7 @@
+@import "./buttons.common";
 @import "../../themes/native/native.globals";
 
 :host {
-  display: flex;
-
-  align-items: center;
-
-  transform: translateZ(0);
-
   z-index: $z-index-toolbar-buttons;
 }
 

--- a/core/src/components/buttons/buttons.tsx
+++ b/core/src/components/buttons/buttons.tsx
@@ -12,7 +12,7 @@ import { getIonTheme } from '../../global/ionic-global';
   styleUrls: {
     ios: 'buttons.ios.scss',
     md: 'buttons.md.scss',
-    ionic: 'buttons.md.scss',
+    ionic: 'buttons.ionic.scss',
   },
   scoped: true,
 })


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
This PR is being merged to ROU-10837 (ion-toolbar) where after a series of PR's are merged, the final PR will be done to next branch. This was done as most of these styles only make sense when used together in the context of the ion-toolbar, but there were a lot of changes that made sense to split in multiple PR's.

- Added new scss file for Ionic theme.
- Split the files between common and native.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->

