### PR TITLE
feat(ion-searchbar): add ionic theme base styles for searchbar

### DIFF
--- a/core/src/components/searchbar/searchbar.common.scss
+++ b/core/src/components/searchbar/searchbar.common.scss
@@ -1,4 +1,4 @@
-@import "../../themes/native/native.globals";
+@import "../../themes/mixins";
 
 // Searchbar
 // --------------------------------------------------
@@ -20,7 +20,7 @@
   --placeholder-color: initial;
   --placeholder-font-style: initial;
   --placeholder-font-weight: initial;
-  --placeholder-opacity: #{$placeholder-opacity};
+  --placeholder-opacity: 0.5;
 
   @include font-smoothing();
 
@@ -33,22 +33,7 @@
 
   color: var(--color);
 
-  font-family: $font-family-base;
   box-sizing: border-box;
-}
-
-:host(.ion-color) {
-  color: current-color(contrast);
-}
-
-:host(.ion-color) .searchbar-input {
-  background: current-color(base);
-}
-
-:host(.ion-color) .searchbar-clear-button,
-:host(.ion-color) .searchbar-cancel-button,
-:host(.ion-color) .searchbar-search-icon {
-  color: inherit;
 }
 
 .searchbar-search-icon {
@@ -159,10 +144,4 @@
 
 :host(.searchbar-has-value.searchbar-should-show-clear) .searchbar-clear-button {
   display: block;
-}
-
-:host(.searchbar-disabled) {
-  cursor: default;
-  opacity: 0.4;
-  pointer-events: none;
 }

--- a/core/src/components/searchbar/searchbar.ionic.scss
+++ b/core/src/components/searchbar/searchbar.ionic.scss
@@ -1,0 +1,71 @@
+@use "searchbar.common";
+@use "../../themes/ionic/ionic.globals.scss" as globals;
+
+// iOS Searchbar
+// --------------------------------------------------
+
+:host {
+  --background: #{globals.$ionic-color-neutral-100};
+  --border-radius: #{globals.$ionic-border-radius-800};
+  --box-shadow: none;
+  --cancel-button-color: #{globals.$ionic-color-neutral-800};
+  --clear-button-color: #{globals.$ionic-color-neutral-800};
+  --color: #{globals.$ionic-color-neutral-800};
+  --icon-color: #{globals.$ionic-color-neutral-800};
+
+  @include globals.padding(0);
+
+  min-height: globals.$ionic-scale-1000;
+
+  contain: content;
+}
+
+.searchbar-input-container {
+  min-height: globals.$ionic-scale-1000;
+}
+
+// Searchbar Search Icon
+// -----------------------------------------
+
+.searchbar-search-icon {
+  display: none;
+}
+
+// Searchbar Input Field
+// -----------------------------------------
+
+.searchbar-input {
+  @include globals.padding(globals.$ionic-space-300);
+
+  height: 100%;
+
+  font-size: globals.$ionic-font-size-350;
+  font-weight: globals.$ionic-font-weight-regular;
+
+  contain: strict;
+}
+
+// Searchbar Clear Input Icon
+// -----------------------------------------
+
+.searchbar-clear-button {
+  @include globals.position(50%, globals.$ionic-space-200, null, null);
+
+  transform: translateY(-50%);
+
+  position: absolute;
+
+  contain: strict;
+
+  width: globals.$ionic-scale-600;
+  height: globals.$ionic-scale-600;
+
+  font-size: globals.$ionic-font-size-400;
+}
+
+// Searchbar in Toolbar
+// -----------------------------------------
+
+:host-context(ion-toolbar) {
+  min-height: globals.$ionic-scale-1000;
+}

--- a/core/src/components/searchbar/searchbar.ionic.scss
+++ b/core/src/components/searchbar/searchbar.ionic.scss
@@ -51,16 +51,16 @@
 .searchbar-clear-button {
   @include globals.position(50%, globals.$ionic-space-200, null, null);
 
-  transform: translateY(-50%);
-
   position: absolute;
-
-  contain: strict;
 
   width: globals.$ionic-scale-600;
   height: globals.$ionic-scale-600;
 
+  transform: translateY(-50%);
+
   font-size: globals.$ionic-font-size-400;
+
+  contain: strict;
 }
 
 // Searchbar in Toolbar

--- a/core/src/components/searchbar/searchbar.ios.scss
+++ b/core/src/components/searchbar/searchbar.ios.scss
@@ -1,4 +1,4 @@
-@import "./searchbar";
+@import "./searchbar.native";
 @import "./searchbar.ios.vars";
 
 // iOS Searchbar

--- a/core/src/components/searchbar/searchbar.md.scss
+++ b/core/src/components/searchbar/searchbar.md.scss
@@ -1,4 +1,4 @@
-@import "./searchbar";
+@import "./searchbar.native";
 @import "./searchbar.md.vars";
 
 // Material Design Searchbar

--- a/core/src/components/searchbar/searchbar.native.scss
+++ b/core/src/components/searchbar/searchbar.native.scss
@@ -1,0 +1,31 @@
+@import "../../themes/native/native.globals";
+@import "searchbar.common";
+
+// Searchbar
+// --------------------------------------------------
+
+:host {
+  --placeholder-opacity: #{$placeholder-opacity};
+
+  font-family: $font-family-base;
+}
+
+:host(.ion-color) {
+  color: current-color(contrast);
+}
+
+:host(.ion-color) .searchbar-input {
+  background: current-color(base);
+}
+
+:host(.ion-color) .searchbar-clear-button,
+:host(.ion-color) .searchbar-cancel-button,
+:host(.ion-color) .searchbar-search-icon {
+  color: inherit;
+}
+
+:host(.searchbar-disabled) {
+  cursor: default;
+  opacity: 0.4;
+  pointer-events: none;
+}

--- a/core/src/components/searchbar/searchbar.tsx
+++ b/core/src/components/searchbar/searchbar.tsx
@@ -21,7 +21,7 @@ import type { SearchbarChangeEventDetail, SearchbarInputEventDetail } from './se
   styleUrls: {
     ios: 'searchbar.ios.scss',
     md: 'searchbar.md.scss',
-    ionic: 'searchbar.md.scss',
+    ionic: 'searchbar.ionic.scss',
   },
   scoped: true,
 })


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR is being merged to ROU-10837 (ion-toolbar) where after a series of PR's are merged, the final PR will be done to next branch. This was done as most of these styles only make sense when used together in the context of the ion-toolbar, but there were a lot of changes that made sense to split in multiple PR's.

- Added new scss file for Ionic theme.
- Split the files between common and native.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->
