### PR TITLE
feat(ion-menu-button): add ionic theme base styles for ion-menu-button

### DIFF
--- a/core/src/components/menu-button/menu-button.common.scss
+++ b/core/src/components/menu-button/menu-button.common.scss
@@ -1,4 +1,4 @@
-@use "../../themes/ionic/ionic.globals.scss" as globals;
+@import "../../themes/mixins";
 
 // Menu Button
 // --------------------------------------------------
@@ -40,11 +40,11 @@
 }
 
 .button-native {
-  @include globals.border-radius(var(--border-radius));
-  @include globals.text-inherit();
-  @include globals.margin(0);
-  @include globals.padding(var(--padding-top), var(--padding-end), var(--padding-bottom), var(--padding-start));
-  @include globals.font-smoothing();
+  @include border-radius(var(--border-radius));
+  @include text-inherit();
+  @include margin(0);
+  @include padding(var(--padding-top), var(--padding-end), var(--padding-bottom), var(--padding-start));
+  @include font-smoothing();
 
   display: flex;
 
@@ -94,8 +94,8 @@
 }
 
 ion-icon {
-  @include globals.margin(0);
-  @include globals.padding(0);
+  @include margin(0);
+  @include padding(0);
 
   pointer-events: none;
 }
@@ -124,7 +124,7 @@ ion-icon {
 // --------------------------------------------------
 
 .button-native::after {
-  @include globals.button-state();
+  @include button-state();
 }
 
 @media (any-hover: hover) {

--- a/core/src/components/menu-button/menu-button.common.scss
+++ b/core/src/components/menu-button/menu-button.common.scss
@@ -1,4 +1,4 @@
-@import "../../themes/native/native.globals";
+@use "../../themes/ionic/ionic.globals.scss" as globals;
 
 // Menu Button
 // --------------------------------------------------
@@ -40,11 +40,11 @@
 }
 
 .button-native {
-  @include border-radius(var(--border-radius));
-  @include text-inherit();
-  @include margin(0);
-  @include padding(var(--padding-top), var(--padding-end), var(--padding-bottom), var(--padding-start));
-  @include font-smoothing();
+  @include globals.border-radius(var(--border-radius));
+  @include globals.text-inherit();
+  @include globals.margin(0);
+  @include globals.padding(var(--padding-top), var(--padding-end), var(--padding-bottom), var(--padding-start));
+  @include globals.font-smoothing();
 
   display: flex;
 
@@ -94,8 +94,8 @@
 }
 
 ion-icon {
-  @include margin(0);
-  @include padding(0);
+  @include globals.margin(0);
+  @include globals.padding(0);
 
   pointer-events: none;
 }
@@ -105,15 +105,6 @@ ion-icon {
 
 :host(.menu-button-hidden) {
   display: none;
-}
-
-// Menu Button: Disabled
-// --------------------------------------------------
-
-:host(.menu-button-disabled) {
-  cursor: default;
-  opacity: 0.5;
-  pointer-events: none;
 }
 
 // Menu Button: Focused
@@ -133,7 +124,7 @@ ion-icon {
 // --------------------------------------------------
 
 .button-native::after {
-  @include button-state();
+  @include globals.button-state();
 }
 
 @media (any-hover: hover) {
@@ -146,13 +137,6 @@ ion-icon {
       opacity: var(--background-hover-opacity, 0);
     }
   }
-}
-
-// Menu Button with Color
-// --------------------------------------------------
-
-:host(.ion-color) .button-native {
-  color: current-color(base);
 }
 
 // Menu Button in Toolbar: Global Theming

--- a/core/src/components/menu-button/menu-button.ionic.scss
+++ b/core/src/components/menu-button/menu-button.ionic.scss
@@ -13,10 +13,10 @@
   --color: initial;
   --padding-start: 0;
   --padding-end: 0;
+  position: relative;
 
   width: globals.$ionic-scale-1000;
   height: globals.$ionic-scale-1000;
 
   font-size: globals.$ionic-font-size-600;
-  position: relative;
 }

--- a/core/src/components/menu-button/menu-button.ionic.scss
+++ b/core/src/components/menu-button/menu-button.ionic.scss
@@ -1,0 +1,22 @@
+@use "../../themes/ionic/ionic.globals.scss" as globals;
+@import "./menu-button.common";
+
+// Menu Button Ionic
+// --------------------------------------------------
+
+:host {
+  --background-focused: currentColor;
+  --background-focused-opacity: 0.12;
+  --background-hover: currentColor;
+  --background-hover-opacity: 0.04;
+  --border-radius: #{globals.$ionic-border-radius-full};
+  --color: initial;
+  --padding-start: 0;
+  --padding-end: 0;
+
+  width: globals.$ionic-scale-1000;
+  height: globals.$ionic-scale-1000;
+
+  font-size: globals.$ionic-font-size-600;
+  position: relative;
+}

--- a/core/src/components/menu-button/menu-button.ios.scss
+++ b/core/src/components/menu-button/menu-button.ios.scss
@@ -1,5 +1,5 @@
 @import "../../themes/native/native.globals.ios";
-@import "./menu-button";
+@import "./menu-button.native";
 
 // iOS Menu Button
 // --------------------------------------------------

--- a/core/src/components/menu-button/menu-button.md.scss
+++ b/core/src/components/menu-button/menu-button.md.scss
@@ -1,5 +1,5 @@
 @import "../../themes/native/native.globals.md";
-@import "./menu-button";
+@import "./menu-button.native";
 
 // MD Menu Button
 // --------------------------------------------------

--- a/core/src/components/menu-button/menu-button.native.scss
+++ b/core/src/components/menu-button/menu-button.native.scss
@@ -1,0 +1,21 @@
+@import "../../themes/native/native.globals";
+@import "./menu-button.common";
+
+// Menu Button
+// --------------------------------------------------
+
+// Menu Button: Disabled
+// --------------------------------------------------
+
+:host(.menu-button-disabled) {
+  cursor: default;
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+// Menu Button with Color
+// --------------------------------------------------
+
+:host(.ion-color) .button-native {
+  color: current-color(base);
+}

--- a/core/src/components/menu-button/menu-button.tsx
+++ b/core/src/components/menu-button/menu-button.tsx
@@ -24,7 +24,7 @@ import { updateVisibility } from '../menu-toggle/menu-toggle-util';
   styleUrls: {
     ios: 'menu-button.ios.scss',
     md: 'menu-button.md.scss',
-    ionic: 'menu-button.md.scss',
+    ionic: 'menu-button.ionic.scss',
   },
   shadow: true,
 })


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR is being merged to ROU-10837 (ion-toolbar) where after a series of PR's are merged, the final PR will be done to next branch. This was done as most of these styles only make sense when used together in the context of the ion-toolbar, but there were a lot of changes that made sense to split in multiple PR's.

- Added new scss file for Ionic theme.
- Split the files between common and native.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->
