### PR TITLE
chore(angular-server): add sync github action and update @stencil/core to 4.19.1 in core

### DIFF
--- a/.github/workflows/actions/build-angular-server/action.yml
+++ b/.github/workflows/actions/build-angular-server/action.yml
@@ -11,8 +11,8 @@ runs:
       run: npm ci
       shell: bash
       working-directory: ./packages/angular-server
-    - name: Install Dependencies
-      run: npx lerna@5 bootstrap --include-dependencies --ignore-scripts -- --legacy-peer-deps
+    - name: Sync
+      run: npm run sync
       shell: bash
       working-directory: ./packages/angular-server
     - name: Build

--- a/.github/workflows/actions/build-angular-server/action.yml
+++ b/.github/workflows/actions/build-angular-server/action.yml
@@ -11,6 +11,10 @@ runs:
       run: npm ci
       shell: bash
       working-directory: ./packages/angular-server
+    - name: Install Dependencies
+      run: npx lerna@5 bootstrap --include-dependencies --ignore-scripts -- --legacy-peer-deps
+      shell: bash
+      working-directory: ./packages/angular-server
     - name: Build
       run: npm run build.prod
       shell: bash

--- a/.github/workflows/actions/build-angular-server/action.yml
+++ b/.github/workflows/actions/build-angular-server/action.yml
@@ -6,7 +6,11 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version: 18.x
-
+    - uses: ./.github/workflows/actions/download-archive
+      with:
+        name: ionic-core
+        path: ./core
+        filename: CoreBuild.zip
     - name: Install Angular Server Dependencies
       run: npm ci
       shell: bash

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.2.2",
       "license": "MIT",
       "dependencies": {
-        "@stencil/core": "^4.19.0-dev.1719512589.a83fbd7",
+        "@stencil/core": "4.19.0-dev.1719512589.a83fbd7",
         "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       },

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.2.2",
       "license": "MIT",
       "dependencies": {
-        "@stencil/core": "^4.19.0",
+        "@stencil/core": "^4.19.0-dev.1719512589.a83fbd7",
         "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       },
@@ -1824,9 +1824,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.0.tgz",
-      "integrity": "sha512-Lky99+K9guu5fFMi3ows9q6p0/gjuZmfmVHxcPMQa5QZKSwG+D19u7G1xcd3p6I+xIfwk71gFxrmcKU1gaOCdg==",
+      "version": "4.19.0-dev.1719512589.a83fbd7",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.0-dev.1719512589.a83fbd7.tgz",
+      "integrity": "sha512-x6DI7QgIExg7LO66asehJZCnYyAvs3gq+QAPJM6l8MrdoQwyGJIpOjWbEOkCmSYAqzb8UrH/PyRK09eVRIHF2Q==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -5415,6 +5415,18 @@
       "integrity": "sha512-I3iYIfc9Q9FRifWyFSwTAvbEABWlWY32i0sAVDDPGYnaIZVugkLCZFbEcrphW6ixVPg8tt1oLwalo/JJwbEqnA==",
       "dependencies": {
         "@stencil/core": "^4.0.3"
+      }
+    },
+    "node_modules/ionicons/node_modules/@stencil/core": {
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.0.tgz",
+      "integrity": "sha512-Lky99+K9guu5fFMi3ows9q6p0/gjuZmfmVHxcPMQa5QZKSwG+D19u7G1xcd3p6I+xIfwk71gFxrmcKU1gaOCdg==",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
       }
     },
     "node_modules/is-alphabetical": {
@@ -11583,9 +11595,9 @@
       "requires": {}
     },
     "@stencil/core": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.0.tgz",
-      "integrity": "sha512-Lky99+K9guu5fFMi3ows9q6p0/gjuZmfmVHxcPMQa5QZKSwG+D19u7G1xcd3p6I+xIfwk71gFxrmcKU1gaOCdg=="
+      "version": "4.19.0-dev.1719512589.a83fbd7",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.0-dev.1719512589.a83fbd7.tgz",
+      "integrity": "sha512-x6DI7QgIExg7LO66asehJZCnYyAvs3gq+QAPJM6l8MrdoQwyGJIpOjWbEOkCmSYAqzb8UrH/PyRK09eVRIHF2Q=="
     },
     "@stencil/react-output-target": {
       "version": "0.5.3",
@@ -14189,6 +14201,13 @@
       "integrity": "sha512-I3iYIfc9Q9FRifWyFSwTAvbEABWlWY32i0sAVDDPGYnaIZVugkLCZFbEcrphW6ixVPg8tt1oLwalo/JJwbEqnA==",
       "requires": {
         "@stencil/core": "^4.0.3"
+      },
+      "dependencies": {
+        "@stencil/core": {
+          "version": "4.19.0",
+          "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.0.tgz",
+          "integrity": "sha512-Lky99+K9guu5fFMi3ows9q6p0/gjuZmfmVHxcPMQa5QZKSwG+D19u7G1xcd3p6I+xIfwk71gFxrmcKU1gaOCdg=="
+        }
       }
     },
     "is-alphabetical": {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.2.2",
       "license": "MIT",
       "dependencies": {
-        "@stencil/core": "4.19.0-dev.1719512589.a83fbd7",
+        "@stencil/core": "^4.19.1",
         "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       },
@@ -723,7 +723,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1824,9 +1823,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.19.0-dev.1719512589.a83fbd7",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.0-dev.1719512589.a83fbd7.tgz",
-      "integrity": "sha512-x6DI7QgIExg7LO66asehJZCnYyAvs3gq+QAPJM6l8MrdoQwyGJIpOjWbEOkCmSYAqzb8UrH/PyRK09eVRIHF2Q==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.1.tgz",
+      "integrity": "sha512-fjSBctHrobeSL2+XcuX7GVk/eaUhZ/lvIu21RJmzHAPcNyueuSAEv7J/Isn4UlYNk70o+yOK72H0FTlNkUibvw==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -5415,18 +5414,6 @@
       "integrity": "sha512-I3iYIfc9Q9FRifWyFSwTAvbEABWlWY32i0sAVDDPGYnaIZVugkLCZFbEcrphW6ixVPg8tt1oLwalo/JJwbEqnA==",
       "dependencies": {
         "@stencil/core": "^4.0.3"
-      }
-    },
-    "node_modules/ionicons/node_modules/@stencil/core": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.0.tgz",
-      "integrity": "sha512-Lky99+K9guu5fFMi3ows9q6p0/gjuZmfmVHxcPMQa5QZKSwG+D19u7G1xcd3p6I+xIfwk71gFxrmcKU1gaOCdg==",
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.10.0"
       }
     },
     "node_modules/is-alphabetical": {
@@ -10806,8 +10793,7 @@
       "dependencies": {
         "is-unicode-supported": {
           "version": "1.3.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         }
       }
     },
@@ -11595,9 +11581,9 @@
       "requires": {}
     },
     "@stencil/core": {
-      "version": "4.19.0-dev.1719512589.a83fbd7",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.0-dev.1719512589.a83fbd7.tgz",
-      "integrity": "sha512-x6DI7QgIExg7LO66asehJZCnYyAvs3gq+QAPJM6l8MrdoQwyGJIpOjWbEOkCmSYAqzb8UrH/PyRK09eVRIHF2Q=="
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.1.tgz",
+      "integrity": "sha512-fjSBctHrobeSL2+XcuX7GVk/eaUhZ/lvIu21RJmzHAPcNyueuSAEv7J/Isn4UlYNk70o+yOK72H0FTlNkUibvw=="
     },
     "@stencil/react-output-target": {
       "version": "0.5.3",
@@ -14201,13 +14187,6 @@
       "integrity": "sha512-I3iYIfc9Q9FRifWyFSwTAvbEABWlWY32i0sAVDDPGYnaIZVugkLCZFbEcrphW6ixVPg8tt1oLwalo/JJwbEqnA==",
       "requires": {
         "@stencil/core": "^4.0.3"
-      },
-      "dependencies": {
-        "@stencil/core": {
-          "version": "4.19.0",
-          "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.0.tgz",
-          "integrity": "sha512-Lky99+K9guu5fFMi3ows9q6p0/gjuZmfmVHxcPMQa5QZKSwG+D19u7G1xcd3p6I+xIfwk71gFxrmcKU1gaOCdg=="
-        }
       }
     },
     "is-alphabetical": {

--- a/core/package.json
+++ b/core/package.json
@@ -31,7 +31,7 @@
     "loader/"
   ],
   "dependencies": {
-    "@stencil/core": "^4.19.0-dev.1719512589.a83fbd7",
+    "@stencil/core": "4.19.0-dev.1719512589.a83fbd7",
     "ionicons": "^7.2.2",
     "tslib": "^2.1.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -31,7 +31,7 @@
     "loader/"
   ],
   "dependencies": {
-    "@stencil/core": "^4.19.0",
+    "@stencil/core": "^4.19.0-dev.1719512589.a83fbd7",
     "ionicons": "^7.2.2",
     "tslib": "^2.1.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -31,7 +31,7 @@
     "loader/"
   ],
   "dependencies": {
-    "@stencil/core": "4.19.0-dev.1719512589.a83fbd7",
+    "@stencil/core": "^4.19.1",
     "ionicons": "^7.2.2",
     "tslib": "^2.1.0"
   },

--- a/packages/angular-server/package-lock.json
+++ b/packages/angular-server/package-lock.json
@@ -23,6 +23,7 @@
         "@angular/platform-server": "^16.0.0",
         "@ionic/eslint-config": "^0.3.0",
         "@ionic/prettier-config": "^2.0.0",
+        "@types/node": "^20.14.9",
         "@typescript-eslint/eslint-plugin": "^5.2.0",
         "eslint": "^7.32.0",
         "eslint-plugin-import": "^2.25.2",
@@ -1654,6 +1655,15 @@
       "version": "0.0.29",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
+      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -6006,6 +6016,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/unique-filename": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
@@ -7281,6 +7297,15 @@
     "@types/json5": {
       "version": "0.0.29",
       "dev": true
+    },
+    "@types/node": {
+      "version": "20.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
+      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/resolve": {
       "version": "1.20.2",
@@ -10081,6 +10106,12 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "unique-filename": {
       "version": "3.0.0",

--- a/packages/angular-server/package-lock.json
+++ b/packages/angular-server/package-lock.json
@@ -23,7 +23,6 @@
         "@angular/platform-server": "^16.0.0",
         "@ionic/eslint-config": "^0.3.0",
         "@ionic/prettier-config": "^2.0.0",
-        "@types/node": "^20.14.9",
         "@typescript-eslint/eslint-plugin": "^5.2.0",
         "eslint": "^7.32.0",
         "eslint-plugin-import": "^2.25.2",
@@ -1655,16 +1654,6 @@
       "version": "0.0.29",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "20.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
-      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -6017,13 +6006,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/unique-filename": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
@@ -7299,15 +7281,6 @@
     "@types/json5": {
       "version": "0.0.29",
       "dev": true
-    },
-    "@types/node": {
-      "version": "20.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
-      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
-      "dev": true,
-      "requires": {
-        "undici-types": "~5.26.4"
-      }
     },
     "@types/resolve": {
       "version": "1.20.2",
@@ -10108,12 +10081,6 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
-    },
-    "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
     },
     "unique-filename": {
       "version": "3.0.0",

--- a/packages/angular-server/package-lock.json
+++ b/packages/angular-server/package-lock.json
@@ -23,6 +23,7 @@
         "@angular/platform-server": "^16.0.0",
         "@ionic/eslint-config": "^0.3.0",
         "@ionic/prettier-config": "^2.0.0",
+        "@types/node": "^20.14.9",
         "@typescript-eslint/eslint-plugin": "^5.2.0",
         "eslint": "^7.32.0",
         "eslint-plugin-import": "^2.25.2",
@@ -1654,6 +1655,16 @@
       "version": "0.0.29",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
+      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -6006,6 +6017,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unique-filename": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
@@ -7281,6 +7299,15 @@
     "@types/json5": {
       "version": "0.0.29",
       "dev": true
+    },
+    "@types/node": {
+      "version": "20.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
+      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/resolve": {
       "version": "1.20.2",
@@ -10081,6 +10108,12 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "unique-filename": {
       "version": "3.0.0",

--- a/packages/angular-server/package.json
+++ b/packages/angular-server/package.json
@@ -53,7 +53,6 @@
     "@angular/platform-server": "^16.0.0",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "^2.0.0",
-    "@types/node": "^20.14.9",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "eslint": "^7.32.0",
     "eslint-plugin-import": "^2.25.2",

--- a/packages/angular-server/package.json
+++ b/packages/angular-server/package.json
@@ -53,6 +53,7 @@
     "@angular/platform-server": "^16.0.0",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "^2.0.0",
+    "@types/node": "^20.14.9",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "eslint": "^7.32.0",
     "eslint-plugin-import": "^2.25.2",

--- a/packages/angular-server/package.json
+++ b/packages/angular-server/package.json
@@ -32,7 +32,8 @@
     "lint": "eslint . --ext .ts && npm run prettier",
     "lint.fix": "eslint . --ext .ts --fix && npm run prettier.fix",
     "prettier": "prettier \"**/*.ts\" --check",
-    "prettier.fix": "prettier \"**/*.ts\" --write"
+    "prettier.fix": "prettier \"**/*.ts\" --write",
+    "sync": "sh ./scripts/sync.sh"
   },
   "peerDependencies": {
     "@angular/core": ">=16.0.0",

--- a/packages/angular-server/scripts/sync.sh
+++ b/packages/angular-server/scripts/sync.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# Copy core dist
+rm -rf node_modules/@ionic/core/dist node_modules/@ionic/core/components
+cp -a ../../core/dist node_modules/@ionic/core/dist
+cp -a ../../core/hydrate node_modules/@ionic/core/
+cp -a ../../core/components node_modules/@ionic/core/components
+cp -a ../../core/package.json node_modules/@ionic/core/package.json

--- a/packages/angular-server/scripts/sync.sh
+++ b/packages/angular-server/scripts/sync.sh
@@ -2,9 +2,11 @@
 
 set -e
 
-# Copy core dist
-rm -rf node_modules/@ionic/core/dist node_modules/@ionic/core/components
-cp -a ../../core/dist node_modules/@ionic/core/dist
-cp -a ../../core/hydrate node_modules/@ionic/core/
-cp -a ../../core/components node_modules/@ionic/core/components
-cp -a ../../core/package.json node_modules/@ionic/core/package.json
+# Delete old packages
+rm -f *.tgz
+
+# Pack @ionic/core
+npm pack ../../core
+
+# Install Dependencies
+npm install *.tgz --no-save


### PR DESCRIPTION
Issue number: internal

---------

This PR does a couple things:

**1 - Adds a `sync` command to get the latest `core` build in `angular-server`**

The release process for `angular-server` failed [here](https://github.com/ionic-team/ionic-framework/actions/runs/9686982182/job/26730689874). This failure was only made apparent because the Lerna command [here](https://github.com/ionic-team/ionic-framework/blob/52ff0505e86dc204cb2fd2fdaf67229e6eeb36f8/.github/workflows/actions/publish-npm/action.yml#L35) runs prior to building each package. 

This should have been caught by CI on the [update to @stencil/core to v4.19.0](https://github.com/ionic-team/ionic-framework/pull/29666), but the `angular-server` package is the only package that doesn't sync `core` before it builds. This PR adds a `sync` command so that `angular-server` will use the latest core build during the normal build action. 

**2 - Resolving types errors in `angular-server`**

After properly syncing `core` in `angular-server` using the command added, running build fails with the following:

<img width="400px" alt="Screenshot 2024-06-27 at 1 16 15 PM" src="https://github.com/ionic-team/ionic-framework/assets/6577830/68d74750-821b-4776-b563-124d8fa06a79">

This was a regression in Stencil. `@stencil/core` has been updated to resolve these errors so the build passes.  