### PR TITLE
fix(alert): do not overwrite id set in htmlAttributes

### DIFF
--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -341,7 +341,9 @@ export class Alert implements ComponentInterface, OverlayInterface {
   }
 
   componentWillLoad() {
-    setOverlayId(this.el);
+    if (!this.htmlAttributes?.id) {
+      setOverlayId(this.el);
+    }
     this.inputsChanged();
     this.buttonsChanged();
   }

--- a/core/src/components/alert/test/alert.spec.tsx
+++ b/core/src/components/alert/test/alert.spec.tsx
@@ -2,6 +2,7 @@ import { newSpecPage } from '@stencil/core/testing';
 
 import { config } from '../../../global/config';
 import { Alert } from '../alert';
+import { h } from '@stencil/core';
 
 describe('alert: custom html', () => {
   it('should not allow for custom html by default', async () => {
@@ -38,4 +39,16 @@ describe('alert: custom html', () => {
     expect(content.textContent).toContain('Custom Text');
     expect(content.querySelector('button.custom-html')).toBe(null);
   });
+
+  it('should not overwrite the id set in htmlAttributes', async () => {
+    const id = 'custom-id'
+    const page = await newSpecPage({
+      components: [Alert],
+      template: () => <ion-alert htmlAttributes={{id}} overlayIndex={-1}></ion-alert>
+    });
+
+    const alert = page.body.querySelector('ion-alert')!;
+    expect(alert.id).toBe(id);
+  });
+
 });

--- a/core/src/components/alert/test/alert.spec.tsx
+++ b/core/src/components/alert/test/alert.spec.tsx
@@ -41,14 +41,13 @@ describe('alert: custom html', () => {
   });
 
   it('should not overwrite the id set in htmlAttributes', async () => {
-    const id = 'custom-id'
+    const id = 'custom-id';
     const page = await newSpecPage({
       components: [Alert],
-      template: () => <ion-alert htmlAttributes={{id}} overlayIndex={-1}></ion-alert>
+      template: () => <ion-alert htmlAttributes={{ id }} overlayIndex={-1}></ion-alert>,
     });
 
     const alert = page.body.querySelector('ion-alert')!;
     expect(alert.id).toBe(id);
   });
-
 });


### PR DESCRIPTION
Issue number: resolves #29704

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
Setting the id of an alert via htmlAttributes doesn't work due to it being overwritten by the overlay id.

## What is the new behavior?
Setting the id of an alert via htmlAttributes works.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

First time PR, long time fan. Please let me know if I missed any of the contributing guidelines, happy to change anything!