### PR TITLE
fix(angular): add focusTrap prop to modal and popover

### DIFF
--- a/packages/angular/common/src/overlays/modal.ts
+++ b/packages/angular/common/src/overlays/modal.ts
@@ -60,6 +60,7 @@ const MODAL_INPUTS = [
   'cssClass',
   'enterAnimation',
   'event',
+  'focusTrap',
   'handle',
   'handleBehavior',
   'initialBreakpoint',

--- a/packages/angular/common/src/overlays/popover.ts
+++ b/packages/angular/common/src/overlays/popover.ts
@@ -56,6 +56,7 @@ const POPOVER_INPUTS = [
   'dismissOnSelect',
   'enterAnimation',
   'event',
+  'focusTrap',
   'isOpen',
   'keyboardClose',
   'leaveAnimation',


### PR DESCRIPTION
Issue number: resolves #29728

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The `focusTrap` property was missed when adding focus trapping configuration to the modal and popover. This results in a type error when developers attempt to assign to the property.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds `focusTrap` property to `ion-modal` and `ion-popover` for the angular component wrappers
- Resolves type warnings when using the property in angular

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `8.2.6-dev.11721672792.195afb09`
