### PR TITLE
fix(react): add onPointerDown, onTouchEnd, add onTouchMove

### DIFF
--- a/packages/react/src/components/navigation/IonTabButton.tsx
+++ b/packages/react/src/components/navigation/IonTabButton.tsx
@@ -10,6 +10,9 @@ type Props = LocalJSX.IonTabButton &
     routerOptions?: RouterOptions;
     ref?: React.Ref<HTMLIonTabButtonElement>;
     onClick?: (e: CustomEvent) => void;
+    onPointerDown?: React.PointerEventHandler<HTMLIonTabButtonElement>;
+    onTouchEnd?: React.TouchEventHandler<HTMLIonTabButtonElement>;
+    onTouchMove?: React.TouchEventHandler<HTMLIonTabButtonElement>;
   };
 
 export const IonTabButton = /*@__PURE__*/ (() =>
@@ -40,8 +43,16 @@ export const IonTabButton = /*@__PURE__*/ (() =>
        * component would result in duplicate handler calls.
        */
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { onClick, ...rest } = this.props;
-      return <IonTabButtonInner onIonTabButtonClick={this.handleIonTabButtonClick} {...rest}></IonTabButtonInner>;
+      const { onClick, onPointerDown, onTouchEnd, onTouchMove, ...rest } = this.props;
+      return (
+        <IonTabButtonInner
+          onIonTabButtonClick={this.handleIonTabButtonClick}
+          onPointerDown={onPointerDown}
+          onTouchEnd={onTouchEnd}
+          onTouchMove={onTouchMove}
+          {...rest}
+        ></IonTabButtonInner>
+      );
     }
 
     static get displayName() {

--- a/packages/react/src/components/navigation/IonTabButton.tsx
+++ b/packages/react/src/components/navigation/IonTabButton.tsx
@@ -43,16 +43,8 @@ export const IonTabButton = /*@__PURE__*/ (() =>
        * component would result in duplicate handler calls.
        */
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { onClick, onPointerDown, onTouchEnd, onTouchMove, ...rest } = this.props;
-      return (
-        <IonTabButtonInner
-          onIonTabButtonClick={this.handleIonTabButtonClick}
-          onPointerDown={onPointerDown}
-          onTouchEnd={onTouchEnd}
-          onTouchMove={onTouchMove}
-          {...rest}
-        ></IonTabButtonInner>
-      );
+      const { onClick, ...rest } = this.props;
+      return <IonTabButtonInner onIonTabButtonClick={this.handleIonTabButtonClick} {...rest}></IonTabButtonInner>;
     }
 
     static get displayName() {


### PR DESCRIPTION
Issue number: resolves #29174

---------

## What is the current behavior?

React throws tab errors with `IonTabButton` when binding to `onPointerDown`, `onTouchEnd` and `onTouchMove`

## What is the new behavior?

- Adds missing type definitions for `onPointerDown`, `onTouchEnd` and `onTouchMove` to `IonTaButton`
- React does not throw type errors when binding callback functions to these events

---------

## Does this introduce a breaking change?

- [ ] Yes
- [x] No