### PR TITLE
fix(item): router-link remains clickable with item cover

### DIFF
--- a/core/src/components/item/item.tsx
+++ b/core/src/components/item/item.tsx
@@ -191,7 +191,7 @@ export class Item implements ComponentInterface, AnchorInterface, ButtonInterfac
     );
 
     // The following elements should also stay clickable when an input with cover is present
-    const clickables = this.el.querySelectorAll('ion-anchor, ion-button, a, button');
+    const clickables = this.el.querySelectorAll('ion-router-link, ion-button, a, button');
 
     // Check for multiple inputs to change the position of the input cover to relative
     // for all of the covered inputs above


### PR DESCRIPTION
Issue number: N/A

---------

## What is the current behavior?
Item includes `ion-anchor` in the list of clickable components it queries. This component was renamed to `ion-router-link` in [v5](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING_ARCHIVE/v5.md#anchor).

## What is the new behavior?
Updates the reference to `ion-anchor` to `ion-router-link` in `ion-item`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No