### PR TITLE
feat(react): use tabs without router

### DIFF
--- a/core/src/components/tabs/tabs.tsx
+++ b/core/src/components/tabs/tabs.tsx
@@ -43,16 +43,7 @@ export class Tabs implements NavOutlet {
 
   async componentWillLoad() {
     if (!this.useRouter) {
-      /**
-       * Router is used if it exists and there is no `no-router` attribute
-       * and the `ion-tab` is not being used.
-       *
-       * If the router is not being used, then the tabs will behave as a
-       * basic tab-based navigation without the history stack or URL updates
-       * associated with the router.
-       */
-      this.useRouter =
-        !!document.querySelector('ion-router') && !this.el.closest('[no-router]') && !this.el.querySelector('ion-tab');
+      this.useRouter = !!document.querySelector('ion-router') && !this.el.closest('[no-router]');
     }
     if (!this.useRouter) {
       const tabs = this.tabs;

--- a/core/src/components/tabs/tabs.tsx
+++ b/core/src/components/tabs/tabs.tsx
@@ -43,7 +43,16 @@ export class Tabs implements NavOutlet {
 
   async componentWillLoad() {
     if (!this.useRouter) {
-      this.useRouter = !!document.querySelector('ion-router') && !this.el.closest('[no-router]');
+      /**
+       * Router is used if it exists and there is no `no-router` attribute
+       * and the `ion-tab` is not being used.
+       *
+       * If the router is not being used, then the tabs will behave as a
+       * basic tab-based navigation without the history stack or URL updates
+       * associated with the router.
+       */
+      this.useRouter =
+        !!document.querySelector('ion-router') && !this.el.closest('[no-router]') && !this.el.querySelector('ion-tab');
     }
     if (!this.useRouter) {
       const tabs = this.tabs;

--- a/core/src/components/tabs/tabs.tsx
+++ b/core/src/components/tabs/tabs.tsx
@@ -43,7 +43,17 @@ export class Tabs implements NavOutlet {
 
   async componentWillLoad() {
     if (!this.useRouter) {
-      this.useRouter = !!document.querySelector('ion-router') && !this.el.closest('[no-router]');
+      /**
+       * JavaScript andd StencilJS use `ion-router`, while
+       * the other frameworks use `ion-router-outlet`.
+       *
+       * If either component is present then tabs will not use
+       * a basic tab-based navigation. It will use the history
+       * stack or URL updates associated with the router.
+       */
+      this.useRouter =
+        (!!document.querySelector('ion-router') || !!this.el.querySelector('ion-router-outlet')) &&
+        !this.el.closest('[no-router]');
     }
     if (!this.useRouter) {
       const tabs = this.tabs;

--- a/core/src/components/tabs/tabs.tsx
+++ b/core/src/components/tabs/tabs.tsx
@@ -52,7 +52,7 @@ export class Tabs implements NavOutlet {
        * stack or URL updates associated with the router.
        */
       this.useRouter =
-        (!!document.querySelector('ion-router') || !!this.el.querySelector('ion-router-outlet')) &&
+        (!!this.el.querySelector('ion-router-outlet') || !!document.querySelector('ion-router')) &&
         !this.el.closest('[no-router]');
     }
     if (!this.useRouter) {

--- a/packages/react/src/components/inner-proxies.ts
+++ b/packages/react/src/components/inner-proxies.ts
@@ -4,6 +4,7 @@ import { defineCustomElement as defineIonBackButton } from '@ionic/core/componen
 import { defineCustomElement as defineIonRouterOutlet } from '@ionic/core/components/ion-router-outlet.js';
 import { defineCustomElement as defineIonTabBar } from '@ionic/core/components/ion-tab-bar.js';
 import { defineCustomElement as defineIonTabButton } from '@ionic/core/components/ion-tab-button.js';
+import { defineCustomElement as defineIonTabs } from '@ionic/core/components/ion-tabs.js';
 import type { JSX as IoniconsJSX } from 'ionicons';
 import { defineCustomElement as defineIonIcon } from 'ionicons/components/ion-icon.js';
 
@@ -18,6 +19,12 @@ export const IonTabBarInner = /*@__PURE__*/ createReactComponent<JSX.IonTabBar, 
   undefined,
   undefined,
   defineIonTabBar
+);
+export const IonTabsInner = /*@__PURE__*/ createReactComponent<JSX.IonTabs, HTMLIonTabsElement>(
+  'ion-tabs',
+  undefined,
+  undefined,
+  defineIonTabs
 );
 export const IonBackButtonInner = /*@__PURE__*/ createReactComponent<
   Omit<JSX.IonBackButton, 'icon'>,

--- a/packages/react/src/components/navigation/IonTabBar.tsx
+++ b/packages/react/src/components/navigation/IonTabBar.tsx
@@ -21,6 +21,7 @@ interface InternalProps extends IonTabBarProps {
   forwardedRef?: React.ForwardedRef<HTMLIonIconElement>;
   onSetCurrentTab: (tab: string, routeInfo: RouteInfo) => void;
   routeInfo: RouteInfo;
+  routerOutletRef?: React.RefObject<HTMLIonRouterOutletElement> | undefined;
 }
 
 interface TabUrls {
@@ -182,7 +183,7 @@ class IonTabBarUnwrapped extends React.PureComponent<InternalProps, IonTabBarSta
   ) {
     const tappedTab = this.state.tabs[e.detail.tab];
     const originalHref = tappedTab.originalHref;
-    const currentHref = e.detail.href;
+    const currentHref = this.props.routerOutletRef?.current ? e.detail.href : '';
     const { activeTab: prevActiveTab } = this.state;
 
     if (onClickFn) {

--- a/packages/react/src/components/navigation/IonTabBar.tsx
+++ b/packages/react/src/components/navigation/IonTabBar.tsx
@@ -183,6 +183,11 @@ class IonTabBarUnwrapped extends React.PureComponent<InternalProps, IonTabBarSta
   ) {
     const tappedTab = this.state.tabs[e.detail.tab];
     const originalHref = tappedTab.originalHref;
+    /**
+     * If the router outlet is not defined, then the tabs is being used
+     * as a basic tab navigation without the router. In this case, we
+     * don't want to update the href else the URL will change.
+     */
     const currentHref = this.props.routerOutletRef?.current ? e.detail.href : '';
     const { activeTab: prevActiveTab } = this.state;
 

--- a/packages/react/src/components/navigation/IonTabs.tsx
+++ b/packages/react/src/components/navigation/IonTabs.tsx
@@ -155,7 +155,7 @@ export const IonTabs = /*@__PURE__*/ (() =>
       });
 
       if (!outlet && !hasTab) {
-        throw new Error('IonTabs must contain an IonRouterOutlet');
+        throw new Error('IonTabs must contain an IonRouterOutlet or an IonTab');
       }
       if (outlet && hasTab) {
         throw new Error('IonTabs cannot contain an IonRouterOutlet and an IonTab at the same time');

--- a/packages/react/src/components/navigation/IonTabs.tsx
+++ b/packages/react/src/components/navigation/IonTabs.tsx
@@ -173,13 +173,15 @@ export const IonTabs = /*@__PURE__*/ (() =>
           {this.context.hasIonicRouter() ? (
             <PageManager className={className ? `${className}` : ''} routeInfo={this.context.routeInfo} {...props}>
               <IonTabsInner {...this.props}>
-                {React.Children.map(children, (child: any) => {
-                  if (child.type === IonTabBar || child.type.isTabBar) {
-                    /**
-                     * The modified tabBar needs to be returned to include
-                     * the context and the overridden methods.
-                     */
-                    return tabBar;
+                {React.Children.map(children, (child: React.ReactNode) => {
+                  if (React.isValidElement(child)) {
+                    if (child.type === IonTabBar || (child.type as any).isTabBar) {
+                      /**
+                       * The modified tabBar needs to be returned to include
+                       * the context and the overridden methods.
+                       */
+                      return tabBar;
+                    }
                   }
                   return child;
                 })}

--- a/packages/react/src/components/navigation/IonTabs.tsx
+++ b/packages/react/src/components/navigation/IonTabs.tsx
@@ -5,6 +5,8 @@ import { NavContext } from '../../contexts/NavContext';
 import PageManager from '../../routing/PageManager';
 import { HTMLElementSSR } from '../../utils/HTMLElementSSR';
 import { IonRouterOutlet } from '../IonRouterOutlet';
+import { IonTabsInner } from '../inner-proxies';
+import { IonTab } from '../proxies';
 
 import { IonTabBar } from './IonTabBar';
 import type { IonTabsContextState } from './IonTabsContext';
@@ -91,6 +93,7 @@ export const IonTabs = /*@__PURE__*/ (() =>
     render() {
       let outlet: React.ReactElement<{}> | undefined;
       let tabBar: React.ReactElement | undefined;
+      let hasIonTab = false;
       const { className, onIonTabsDidChange, onIonTabsWillChange, ...props } = this.props;
 
       const children =
@@ -107,6 +110,12 @@ export const IonTabs = /*@__PURE__*/ (() =>
           outlet = React.cloneElement(child);
         } else if (child.type === Fragment && child.props.children[0].type === IonRouterOutlet) {
           outlet = child.props.children[0];
+        } else if (child.type === IonTab) {
+          /**
+           * This indicates that IonTabs will be using a basic tab-based navigation
+           * without the history stack or URL updates associated with the router.
+           */
+          hasIonTab = true;
         }
 
         let childProps: any = {
@@ -144,11 +153,18 @@ export const IonTabs = /*@__PURE__*/ (() =>
         }
       });
 
-      if (!outlet) {
+      if (!outlet && !hasIonTab) {
         throw new Error('IonTabs must contain an IonRouterOutlet');
+      }
+      if (outlet && hasIonTab) {
+        throw new Error('IonTabs cannot contain an IonRouterOutlet and an IonTab at the same time');
       }
       if (!tabBar) {
         throw new Error('IonTabs needs a IonTabBar');
+      }
+
+      if (hasIonTab) {
+        return <IonTabsInner className={className ? `${className}` : ''} {...props} />;
       }
 
       return (

--- a/packages/react/src/components/navigation/IonTabs.tsx
+++ b/packages/react/src/components/navigation/IonTabs.tsx
@@ -171,7 +171,18 @@ export const IonTabs = /*@__PURE__*/ (() =>
         <IonTabsContext.Provider value={this.ionTabContextState}>
           {this.context.hasIonicRouter() ? (
             <PageManager className={className ? `${className}` : ''} routeInfo={this.context.routeInfo} {...props}>
-              <IonTabsInner {...this.props}></IonTabsInner>
+              <IonTabsInner {...this.props}>
+                {React.Children.map(children, (child: any) => {
+                  if (child.type === IonTabBar || child.type.isTabBar) {
+                    /**
+                     * The modified tabBar needs to be returned to include
+                     * the context and the overridden methods.
+                     */
+                    return tabBar;
+                  }
+                  return child;
+                })}
+              </IonTabsInner>
             </PageManager>
           ) : (
             <div className={className ? `${className}` : 'ion-tabs'} {...props} style={hostStyles}>

--- a/packages/react/src/components/navigation/IonTabs.tsx
+++ b/packages/react/src/components/navigation/IonTabs.tsx
@@ -168,6 +168,18 @@ export const IonTabs = /*@__PURE__*/ (() =>
         return <IonTabsInner {...this.props}></IonTabsInner>;
       }
 
+      /**
+       * TODO(ROU-11051)
+       *
+       * There is no error handling for the case where there
+       * is no associated Route for the given IonTabButton.
+       *
+       * More investigation is needed to determine how to
+       * handle this to prevent any overwriting of the
+       * IonTabButton's onClick handler and how the routing
+       * is handled.
+       */
+
       return (
         <IonTabsContext.Provider value={this.ionTabContextState}>
           {this.context.hasIonicRouter() ? (

--- a/packages/react/src/components/navigation/IonTabs.tsx
+++ b/packages/react/src/components/navigation/IonTabs.tsx
@@ -164,20 +164,14 @@ export const IonTabs = /*@__PURE__*/ (() =>
       }
 
       if (hasIonTab) {
-        return <IonTabsInner className={className ? `${className}` : ''} {...props} />;
+        return <IonTabsInner {...this.props}></IonTabsInner>;
       }
 
       return (
         <IonTabsContext.Provider value={this.ionTabContextState}>
           {this.context.hasIonicRouter() ? (
             <PageManager className={className ? `${className}` : ''} routeInfo={this.context.routeInfo} {...props}>
-              <ion-tabs className="ion-tabs" style={hostStyles}>
-                {tabBar.props.slot === 'top' ? tabBar : null}
-                <div style={tabsInner} className="tabs-inner">
-                  {outlet}
-                </div>
-                {tabBar.props.slot === 'bottom' ? tabBar : null}
-              </ion-tabs>
+              <IonTabsInner {...this.props}></IonTabsInner>
             </PageManager>
           ) : (
             <div className={className ? `${className}` : 'ion-tabs'} {...props} style={hostStyles}>

--- a/packages/react/src/components/navigation/IonTabs.tsx
+++ b/packages/react/src/components/navigation/IonTabs.tsx
@@ -93,7 +93,8 @@ export const IonTabs = /*@__PURE__*/ (() =>
     render() {
       let outlet: React.ReactElement<{}> | undefined;
       let tabBar: React.ReactElement | undefined;
-      let hasIonTab = false;
+      // Check if IonTabs has any IonTab children
+      let hasTab = false;
       const { className, onIonTabsDidChange, onIonTabsWillChange, ...props } = this.props;
 
       const children =
@@ -115,7 +116,7 @@ export const IonTabs = /*@__PURE__*/ (() =>
            * This indicates that IonTabs will be using a basic tab-based navigation
            * without the history stack or URL updates associated with the router.
            */
-          hasIonTab = true;
+          hasTab = true;
         }
 
         let childProps: any = {
@@ -153,17 +154,17 @@ export const IonTabs = /*@__PURE__*/ (() =>
         }
       });
 
-      if (!outlet && !hasIonTab) {
+      if (!outlet && !hasTab) {
         throw new Error('IonTabs must contain an IonRouterOutlet');
       }
-      if (outlet && hasIonTab) {
+      if (outlet && hasTab) {
         throw new Error('IonTabs cannot contain an IonRouterOutlet and an IonTab at the same time');
       }
       if (!tabBar) {
         throw new Error('IonTabs needs a IonTabBar');
       }
 
-      if (hasIonTab) {
+      if (hasTab) {
         return <IonTabsInner {...this.props}></IonTabsInner>;
       }
 

--- a/packages/react/test/base/src/App.tsx
+++ b/packages/react/test/base/src/App.tsx
@@ -26,6 +26,7 @@ import OverlayHooks from './pages/overlay-hooks/OverlayHooks';
 import OverlayComponents from './pages/overlay-components/OverlayComponents';
 import KeepContentsMounted from './pages/overlay-components/KeepContentsMounted';
 import Tabs from './pages/Tabs';
+import TabsBasic from './pages/TabsBasic';
 import Icons from './pages/Icons';
 import NavComponent from './pages/navigation/NavComponent';
 import IonModalConditionalSibling from './pages/overlay-components/IonModalConditionalSibling';
@@ -60,6 +61,7 @@ const App: React.FC = () => (
         <Route path="/keep-contents-mounted" component={KeepContentsMounted} />
         <Route path="/navigation" component={NavComponent} />
         <Route path="/tabs" component={Tabs} />
+        <Route path="/tabs-basic" component={TabsBasic} />
         <Route path="/icons" component={Icons} />
       </IonRouterOutlet>
     </IonReactRouter>

--- a/packages/react/test/base/src/pages/Main.tsx
+++ b/packages/react/test/base/src/pages/Main.tsx
@@ -37,6 +37,9 @@ const Main: React.FC<MainProps> = () => {
           <IonItem routerLink="/tabs">
             <IonLabel>Tabs</IonLabel>
           </IonItem>
+          <IonItem routerLink="/tabs-basic">
+            <IonLabel>Tabs with Basic Navigation</IonLabel>
+          </IonItem>
           <IonItem routerLink="/icons">
             <IonLabel>Icons</IonLabel>
           </IonItem>

--- a/packages/react/test/base/src/pages/TabsBasic.tsx
+++ b/packages/react/test/base/src/pages/TabsBasic.tsx
@@ -4,8 +4,16 @@ import { IonLabel, IonTabBar, IonTabButton, IonTabs, IonTab } from '@ionic/react
 interface TabsProps {}
 
 const TabsBasic: React.FC<TabsProps> = () => {
+  const onTabWillChange = (event: CustomEvent) => {
+    console.log('onIonTabsWillChange', event.detail.tab);
+  };
+
+  const onTabDidChange = (event: CustomEvent) => {
+    console.log('onIonTabsDidChange:', event.detail.tab);
+  };
+
   return (
-    <IonTabs>
+    <IonTabs onIonTabsWillChange={onTabWillChange} onIonTabsDidChange={onTabDidChange}>
       <IonTab tab="tab1">
         <IonLabel>Tab 1 Content</IonLabel>
       </IonTab>

--- a/packages/react/test/base/src/pages/TabsBasic.tsx
+++ b/packages/react/test/base/src/pages/TabsBasic.tsx
@@ -14,7 +14,7 @@ const TabsBasic: React.FC<TabsProps> = () => {
       </IonTab>
       <IonTabBar slot="bottom">
         <IonTabButton tab="tab1">
-          <IonLabel>Tabs 1</IonLabel>
+          <IonLabel>Tab 1</IonLabel>
         </IonTabButton>
         <IonTabButton tab="tab2">
           <IonLabel>Tab 2</IonLabel>

--- a/packages/react/test/base/src/pages/TabsBasic.tsx
+++ b/packages/react/test/base/src/pages/TabsBasic.tsx
@@ -5,7 +5,7 @@ interface TabsProps {}
 
 const TabsBasic: React.FC<TabsProps> = () => {
   return (
-    <IonTabs noOutlet={true}>
+    <IonTabs>
       <IonTab tab="tab1">
         <IonLabel>Tab 1 Content</IonLabel>
       </IonTab>

--- a/packages/react/test/base/src/pages/TabsBasic.tsx
+++ b/packages/react/test/base/src/pages/TabsBasic.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { IonLabel, IonTabBar, IonTabButton, IonTabs, IonTab } from '@ionic/react';
+
+interface TabsProps {}
+
+const TabsBasic: React.FC<TabsProps> = () => {
+  return (
+    <IonTabs noOutlet={true}>
+      <IonTab tab="tab1">
+        <IonLabel>Tab 1 Content</IonLabel>
+      </IonTab>
+      <IonTab tab="tab2">
+        <IonLabel>Tab 2 Content</IonLabel>
+      </IonTab>
+      <IonTabBar slot="bottom">
+        <IonTabButton tab="tab1">
+          <IonLabel>Tabs 1</IonLabel>
+        </IonTabButton>
+        <IonTabButton tab="tab2">
+          <IonLabel>Tab 2</IonLabel>
+        </IonTabButton>
+      </IonTabBar>
+    </IonTabs>
+  );
+};
+
+export default TabsBasic;

--- a/packages/react/test/base/tests/e2e/specs/tabs/tabs.cy.ts
+++ b/packages/react/test/base/tests/e2e/specs/tabs/tabs.cy.ts
@@ -34,5 +34,13 @@ describe('IonTabs', () => {
       cy.get('ion-tab[tab="tab1"]').should('be.visible');
       cy.get('ion-tab[tab="tab2"]').should('not.be.visible');
     });
+
+    it('should not change the URL when clicking the tab button', () => {
+      cy.url().should('include', '/tabs-basic');
+
+      cy.get('ion-tab-button[tab="tab2"]').click();
+
+      cy.url().should('include', '/tabs-basic');
+    });
   });
 });

--- a/packages/react/test/base/tests/e2e/specs/tabs/tabs.cy.ts
+++ b/packages/react/test/base/tests/e2e/specs/tabs/tabs.cy.ts
@@ -1,15 +1,38 @@
 describe('IonTabs', () => {
-  beforeEach(() => {
-    cy.visit('/tabs/tab1');
+  describe('With IonRouterOutlet', () => {
+    beforeEach(() => {
+      cy.visit('/tabs/tab1');
+    });
+  
+    it('should handle onClick handlers on IonTabButton', () => {
+      const stub = cy.stub();
+  
+      cy.on('window:alert', stub);
+      cy.get('ion-tab-button[tab="tab1"]').click().then(() => {
+        expect(stub.getCall(0)).to.be.calledWith('Tab was clicked')
+      });
+  
+    });
   });
 
-  it('should handle onClick handlers on IonTabButton', () => {
-    const stub = cy.stub();
-
-    cy.on('window:alert', stub);
-    cy.get('ion-tab-button[tab="tab1"]').click().then(() => {
-      expect(stub.getCall(0)).to.be.calledWith('Tab was clicked')
+  describe('Without IonRouterOutlet', () => {
+    beforeEach(() => {
+      cy.visit('/tabs-basic');
     });
-
+  
+    it('should show correct tab when clicking the tab button', () => {
+      cy.get('ion-tab[tab="tab1"]').should('be.visible');
+      cy.get('ion-tab[tab="tab2"]').should('not.be.visible');
+  
+      cy.get('ion-tab-button[tab="tab2"]').click();
+  
+      cy.get('ion-tab[tab="tab1"]').should('not.be.visible');
+      cy.get('ion-tab[tab="tab2"]').should('be.visible');
+  
+      cy.get('ion-tab-button[tab="tab1"]').click();
+  
+      cy.get('ion-tab[tab="tab1"]').should('be.visible');
+      cy.get('ion-tab[tab="tab2"]').should('not.be.visible');
+    });
   });
 });


### PR DESCRIPTION
Issue number: part of #25184 

This PR does not completely close the issue since it only addresses the React portion. The other frameworks will be done through other PRs.

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

React: Developers have to provide `IonRouterOutlet` to use `IonTabs`. This means that developers are forced to tie their tabs to a router.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `IonTabs` can be used without a router outlet as long as `IonTab` is a child and `IonRouterOutlet` is not.
- Added a test.
- Added a test page: `/tabs-basic`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->

Developers who are still using `IonTabs` with `IonRouterOutlet` will not experience any changes. This feature PR introduces another option to use `IonTabs`, no changes for the current implementation.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: 8.2.8-dev.11724280606.1a8c11d4
