### PR TITLE
fix(range): emit correct value when knob is at start of bar

### DIFF
--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -449,7 +449,7 @@ export class Range implements ComponentInterface {
    */
   private onEnd(detail: GestureDetail | MouseEvent) {
     const { contentEl, initialContentScrollY } = this;
-    const currentX = (detail as GestureDetail).currentX || (detail as MouseEvent).clientX;
+    const currentX = (detail as GestureDetail).currentX ?? (detail as MouseEvent).clientX;
 
     /**
      * The `pressedKnob` can be undefined if the user never


### PR DESCRIPTION
Issue number: resolves #29792

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When the user drags the range knob (most easily reproduced in fullscreen mode) and the gesture emits a current x position of `0`, the range incorrectly emits a value of `NaN`.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `ion-range` does not emit `NaN` and instead emits the correct range value for the knob

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
