### PR TITLE
fix(vue): incorrect view rendered when using router.go(-n) 

### DIFF
--- a/packages/vue-router/src/locationHistory.ts
+++ b/packages/vue-router/src/locationHistory.ts
@@ -240,7 +240,11 @@ export const createLocationHistory = () => {
       }
     }
     if (delta < -1) {
-      return locationHistory[locationHistory.length - 1 + delta];
+      let routeIndex = locationHistory.findIndex(history => history === routeInfo);
+      if (routeIndex === -1) {
+        routeIndex = locationHistory.length - 1;
+      }
+      return locationHistory[Math.max(0, routeIndex + delta)];
     } else {
       for (let i = locationHistory.length - 2; i >= 0; i--) {
         const ri = locationHistory[i];


### PR DESCRIPTION
Issue number: resolves #28201

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Say you have the following application history:

`/pageA` --> `/pageB` --> `/pageC` --> `/pageD` -->  back to `/pageC`

If you were to call router.go(-2) on `/pageC`,  you would be brought back to `/pageB`. But the address in the browser address bar is correct.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

In above case, if you were to call router.go(-2) on `/pageC`,  you would be brought back to `/pageA`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
