### PR TITLE
fix(angular): add missing 'compareWith' input to standalone ion-radio-group

### DIFF
--- a/packages/angular/standalone/src/directives/radio-group.ts
+++ b/packages/angular/standalone/src/directives/radio-group.ts
@@ -16,7 +16,7 @@ import { defineCustomElement } from '@ionic/core/components/ion-radio-group.js';
 
 import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
 
-const RADIO_GROUP_INPUTS = ['allowEmptySelection', 'name', 'value'];
+const RADIO_GROUP_INPUTS = ['allowEmptySelection', 'compareWith', 'name', 'value'];
 
 /**
  * Pulling the provider into an object and using PURE  works


### PR DESCRIPTION
Issue number: resolves #29826

---------

## What is the current behavior?

When using `compareWith` on `ion-radio-group` in Ionic Angular Standalone the following error is thrown:

```
NG8002: Can't bind to 'compareWith' since it isn't a known property of 'ion-radio-group'.
```

## What is the new behavior?

- `compareWith` on `ion-radio-group` in Angular Standalone is available

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
