### PR TITLE
fix(vue): incorrect view rendered when using router.go(-n)

### DIFF
--- a/packages/vue-router/__tests__/locationHistory.spec.ts
+++ b/packages/vue-router/__tests__/locationHistory.spec.ts
@@ -84,4 +84,25 @@ describe('Location History', () => {
     expect(locationHistory.canGoBack(1, 0, 1)).toEqual(true);
     expect(locationHistory.canGoBack(2, 0, 1)).toEqual(false);
   });
+
+  it('should correctly find the last location', () => {
+    const [home, pageA, pageB, pageC] = [
+      { pathname: '/home' },
+      { pathname: '/page-a', pushedByRoute: '/home' },
+      { pathname: '/page-b', pushedByRoute: '/page-a' },
+      { pathname: '/page-c', pushedByRoute: '/page-b' },
+    ];
+
+    locationHistory.add(home);
+    locationHistory.add(pageA);
+    locationHistory.add(pageB);
+    locationHistory.add(pageC);
+
+    expect(locationHistory.findLastLocation(pageB)).toEqual(pageA);
+    expect(locationHistory.findLastLocation(pageB, -2)).toEqual(home);
+
+    expect(locationHistory.findLastLocation(pageC)).toEqual(pageB);
+    expect(locationHistory.findLastLocation(pageC, -2)).toEqual(pageA);
+    expect(locationHistory.findLastLocation(pageC, -3)).toEqual(home);
+  });
 });

--- a/packages/vue-router/src/locationHistory.ts
+++ b/packages/vue-router/src/locationHistory.ts
@@ -239,15 +239,14 @@ export const createLocationHistory = () => {
         }
       }
     }
-    if (delta < -1) {
-      return locationHistory[locationHistory.length - 1 + delta];
-    } else {
-      for (let i = locationHistory.length - 2; i >= 0; i--) {
-        const ri = locationHistory[i];
-        if (ri) {
-          if (ri.pathname === routeInfo.pushedByRoute) {
+    for (let i = locationHistory.length - 2; i >= 0; i--) {
+      const ri = locationHistory[i];
+      if (ri) {
+        if (ri.pathname === routeInfo.pushedByRoute) {
+          if (delta >= -1) {
             return ri;
           }
+          return locationHistory[i + 1 + delta]
         }
       }
     }


### PR DESCRIPTION
This PR fixes the navigation issue related to `router.go` that was identified in issue #28201. After working on this issue I realised that @xxllxhdj has already created a PR for this in #29847. While their fix is great, I have added tests that replicate the issue and approached the problem using the existing code.

The core problem was that when using `findLastLocation` with deltas less than -1, the code no longer checked relative to the specified route.

## What is the current behavior?

If a user navigates from `/home` -> `/pageA` -> `/pageB` -> `/pageC` -> `/pageB` (by navigating backwards) then `router.go(-2)` is called the URL will be updated to `/home` correctly, but the app will try to render `/pageA`.

## What is the new behavior?

The app will correctly render `/pageA`, which matches the URL.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
