### PR TITLE
docs(app): add setFocus to the documentation

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -143,6 +143,7 @@ ion-alert,css-prop,--width,ios
 ion-alert,css-prop,--width,md
 
 ion-app,none
+ion-app,method,setFocus,setFocus(elements: HTMLElement[]) => Promise<void>
 
 ion-avatar,shadow
 ion-avatar,css-prop,--border-radius,ios

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -304,6 +304,9 @@ export namespace Components {
         "trigger": string | undefined;
     }
     interface IonApp {
+        /**
+          * Used to set focus on an element that uses `ion-focusable`. Do not use this if focusing the element as a result of a keyboard event as the focus utility should handle this for us. This method should be used when we want to programmatically focus an element as a result of another user action. (Ex: We focus the first element inside of a popover when the user presents it, but the popover is not always presented as a result of keyboard action.)
+         */
         "setFocus": (elements: HTMLElement[]) => Promise<void>;
     }
     interface IonAvatar {

--- a/core/src/components/app/app.tsx
+++ b/core/src/components/app/app.tsx
@@ -61,7 +61,6 @@ export class App implements ComponentInterface {
   }
 
   /**
-   * @internal
    * Used to set focus on an element that uses `ion-focusable`.
    * Do not use this if focusing the element as a result of a keyboard
    * event as the focus utility should handle this for us. This method

--- a/packages/angular/src/directives/proxies.ts
+++ b/packages/angular/src/directives/proxies.ts
@@ -188,6 +188,7 @@ Shorthand for ionAlertDidDismiss.
 
 
 @ProxyCmp({
+  methods: ['setFocus']
 })
 @Component({
   selector: 'ion-app',

--- a/packages/angular/standalone/src/directives/proxies.ts
+++ b/packages/angular/standalone/src/directives/proxies.ts
@@ -266,7 +266,8 @@ Shorthand for ionAlertDidDismiss.
 
 
 @ProxyCmp({
-  defineCustomElementFn: defineIonApp
+  defineCustomElementFn: defineIonApp,
+  methods: ['setFocus']
 })
 @Component({
   selector: 'ion-app',


### PR DESCRIPTION
Issue number: resolves #29830

---------

## What is the current behavior?
The `setFocus` method on `ion-app` is marked internal.

## What is the new behavior?
Document the `setFocus` method as a way for developers to programmatically focus elements. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The method isn’t new, it was just marked as internal, which prevented it from being documented. I can mark this as a `feat` though if anyone thinks it should be.

Related documentation PR: https://github.com/ionic-team/ionic-docs/pull/3842