### PR TITLE
fix(tabs, tab-bar): use standalone tab bar in Vue

### DIFF
--- a/packages/vue/src/components/IonTabBar.ts
+++ b/packages/vue/src/components/IonTabBar.ts
@@ -259,9 +259,8 @@ export const IonTabBar = defineComponent({
      * the provide/inject.
      */
     const tabBarData = inject<Ref<TabBarData>>("tabBarData");
-    const hasRouterOutlet = tabBarData.value.hasRouterOutlet;
-    this.$data.tabState.hasRouterOutlet = hasRouterOutlet;
 
+    this.$data.tabState.hasRouterOutlet = tabBarData.value.hasRouterOutlet;
     this.$data._tabsWillChange = tabBarData.value._tabsWillChange;
     this.$data._tabsDidChange = tabBarData.value._tabsDidChange;
 


### PR DESCRIPTION
Issue number: resolves part of #29885

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Vue: Tab bar could be a standalone element within `ion-tabs` and would navigate without issues with a router outlet before v8.3:

```vue
<ion-tabs>
  <ion-router-outlet></ion-router-outlet>

  <TabBar></TabBar>
</ion-tabs>
```

It would work as if it was written as:

```vue
<ion-tabs>
  <ion-router-outlet></ion-router-outlet>

  <ion-tab-bar slot="bottom">
    <!-- Buttons -->
  </ion-tab-bar>
</ion-tabs>
```

After v8.3, any `ion-tab-bar` that was not a direct child of `ion-tabs` would lose it's expected behavior when used with a router outlet. If a user clicked on a tab button, then the content would not be redirected to that expected view.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The Vue tab bar's `_hasRouterOutlet` prop has been modified to accept both Boolean and `undefined` values. When the value is `undefined`, it indicates that the `ion-tab-bar` component was not found within the slotted content of `ion-tabs`. This typically occurs when the tab bar is not passed as a direct child of `ion-tabs`.

In such cases, the tab bar will perform its own check to determine if an `ion-router-outlet` is present. This check cannot be handled by `tabs`, as it would need to wait until after mounting to access the DOM, which would be too late since the tab bar would have already executed the logic that depends on `_hasRouterOutlet`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `8.3.3-dev.11728341918.1d3d4b3f`

How to test:

1. Clone the issue repro
2. Navigate to folder `8.3.0-standalone`
3. Install deps
4. Start app
5. Click on the tab buttons
6. Notice the content and URL doesn't change
7. Install dev build: `npm install @ionic/vue@8.3.3-dev.11728341918.1d3d4b3f`
8. Start app
9. Click on the tab buttons
10. Verify that the correct content and URL displays