### PR TITLE
fix(tabs, tab-bar): use standalone tab bar in React

### DIFF
--- a/packages/react/src/components/navigation/IonTabs.tsx
+++ b/packages/react/src/components/navigation/IonTabs.tsx
@@ -45,6 +45,12 @@ interface Props extends LocalJSX.IonTabs {
 export const IonTabs = /*@__PURE__*/ (() =>
   class extends React.Component<Props> {
     context!: React.ContextType<typeof NavContext>;
+    /**
+     * `routerOutletRef` allows users to add a `ref` to `IonRouterOutlet`.
+     * Without this, `ref.current` will be `undefined` in the user's app,
+     * breaking their ability to access the `IonRouterOutlet` instance.
+     * Do not remove this ref.
+     */
     routerOutletRef: React.Ref<HTMLIonRouterOutletElement> = React.createRef();
     selectTabHandler?: (tag: string) => boolean;
     tabBarRef = React.createRef<any>();

--- a/packages/react/src/components/navigation/IonTabs.tsx
+++ b/packages/react/src/components/navigation/IonTabs.tsx
@@ -45,6 +45,7 @@ interface Props extends LocalJSX.IonTabs {
 export const IonTabs = /*@__PURE__*/ (() =>
   class extends React.Component<Props> {
     context!: React.ContextType<typeof NavContext>;
+    routerOutletRef: React.Ref<HTMLIonRouterOutletElement> = React.createRef();
     selectTabHandler?: (tag: string) => boolean;
     tabBarRef = React.createRef<any>();
 

--- a/packages/react/src/components/navigation/IonTabs.tsx
+++ b/packages/react/src/components/navigation/IonTabs.tsx
@@ -72,6 +72,7 @@ export const IonTabs = /*@__PURE__*/ (() =>
     ionTabContextState: IonTabsContextState = {
       activeTab: undefined,
       selectTab: () => false,
+      hasRouterOutlet: false,
     };
 
     constructor(props: Props) {
@@ -122,6 +123,8 @@ export const IonTabs = /*@__PURE__*/ (() =>
            */
           hasTab = true;
         }
+
+        this.ionTabContextState.hasRouterOutlet = !!outlet;
 
         let childProps: any = {
           ref: this.tabBarRef,

--- a/packages/react/src/components/navigation/IonTabsContext.tsx
+++ b/packages/react/src/components/navigation/IonTabsContext.tsx
@@ -3,9 +3,11 @@ import React from 'react';
 export interface IonTabsContextState {
   activeTab: string | undefined;
   selectTab: (tab: string) => boolean;
+  hasRouterOutlet: boolean;
 }
 
 export const IonTabsContext = React.createContext<IonTabsContextState>({
   activeTab: undefined,
   selectTab: () => false,
+  hasRouterOutlet: false,
 });

--- a/packages/react/src/components/navigation/IonTabsContext.tsx
+++ b/packages/react/src/components/navigation/IonTabsContext.tsx
@@ -4,10 +4,24 @@ export interface IonTabsContextState {
   activeTab: string | undefined;
   selectTab: (tab: string) => boolean;
   hasRouterOutlet: boolean;
+  tabBarProps: TabBarProps;
 }
+
+/**
+ * Tab bar can be used as a standalone component,
+ * so the props can not be passed directly to the
+ * tab bar component. Instead, props will be
+ * passed through the context.
+ */
+type TabBarProps = {
+  ref: React.RefObject<any>;
+  onIonTabsWillChange?: (e: CustomEvent) => void;
+  onIonTabsDidChange?: (e: CustomEvent) => void;
+};
 
 export const IonTabsContext = React.createContext<IonTabsContextState>({
   activeTab: undefined,
   selectTab: () => false,
   hasRouterOutlet: false,
+  tabBarProps: { ref: React.createRef() },
 });


### PR DESCRIPTION
Issue number: resolves part of #29885, resolves #29924

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

React: There are two issues here.

**Issue 1:**

Tab bar could be a standalone element within `IonTabs` and would navigate without issues with a router outlet before v8.3:

```vue
<IonTabs>
  <IonRouterOutlet></IonRouterOutlet>

  <IonTabBar></IonTabBar>
</IonTabs>
```

It would work as if it was written as:

```tsx
<IonTabs>
  <IonRouterOutlet></IonRouterOutlet>

  <IonTabBar slot="bottom">
    <!-- Buttons -->
  </IonTabBar>
</IonTabs>
```

After v8.3, any `ion-tab-bar` that was not a direct child of `ion-tabs` would lose it's expected behavior when used with a router outlet. If a user clicked on a tab button, then the content would not be redirected to that expected view.

**Issue 2:**

Users can no longer add a `ref` to the `IonRouterOutlet`, it always returns undefined.

```
<IonTabs>
      <IonRouterOutlet ref={ref}>

     <IonTabBar slot="bottom">
    <!-- Buttons -->
  </IonTabBar>
</IonTabs>
```

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

**Issue 1:**

The React tabs has been updated to pass data to the tab bar through context instead of passing it through a ref. By using a context, the data will be available for the tab bar to use regardless of its level.

**Issue 2:**

Reverted the logic for `routerOutletRef` and added a comment of the importance of it.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `8.3.3-dev.11728581904.17739cf7`

How to test **Issue 1**:

1. Create a new React Ionic Framework app (recommended to use Tabs starter)
2. Install deps
3. Move the `IonTabBar` into a separate component
4. Use the new component that holds `IonTabBar`
5. Run project
6. Click on any of the tab buttons
7. Notice that the content and URL does not update
8. Install dev build: `npm install @ionic/react@8.3.3-dev.11728581904.17739cf7`
9. Run project
10. Click on any of the tab buttons
11. Verify that the content and URL updates correctly

How to test **Issue 2**:

1. Clone the issue repo (second link at the top)
2. Install deps
3. Run project
4. Open the browser console
5. Notice that it displays an `undefined`
6. Install the dev build: `npm install @ionic/react@8.3.3-dev.11728581904.17739cf7`
7. Run project
8. Verify that the console log now displays `ion-router-outlet`
