### PR TITLE
fix(SafeAreas): fix iOS fallback

### DIFF
--- a/core/src/css/ionic/core.ionic.scss
+++ b/core/src/css/ionic/core.ionic.scss
@@ -223,7 +223,7 @@ ion-toast-controller,
 
 html.plt-ios.plt-hybrid,
 html.plt-ios.plt-pwa {
-  --ion-statusbar-padding: globals.$ionic-space-m;
+  --ion-statusbar-padding: #{globals.$ionic-space-500};
 }
 
 @supports (padding-top: 20px) {


### PR DESCRIPTION
Issue number: internal

---------
- fix ion-statusbar css var fallback;


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
- CSS var --ion-statusbar-padding was not working because the Sass variable was not escaped.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->
