### PR TITLE
Fix #29562: do not float label because of slotted items

### DIFF
--- a/core/src/components/input/input.scss
+++ b/core/src/components/input/input.scss
@@ -593,6 +593,13 @@
   max-width: calc(100% / #{$form-control-label-stacked-scale});
 }
 
+/**
+ * This removes the slotted items on floating label when empty and no focus.
+ */
+:host(.input-label-placement-floating:not(.has-focus):not(.has-value)) .native-wrapper > [slot] {
+  display: none;
+}
+
 // Start/End Slots
 // ----------------------------------------------------------------
 

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -689,7 +689,7 @@ export class Input implements ComponentInterface {
   }
 
   render() {
-    const { disabled, fill, readonly, shape, inputId, labelPlacement, el, hasFocus, clearInputIcon } = this;
+    const { disabled, fill, readonly, shape, inputId, labelPlacement, hasFocus, clearInputIcon } = this;
     const mode = getIonMode(this);
     const value = this.getValue();
     const inItem = hostContext('ion-item', this.el);
@@ -698,7 +698,6 @@ export class Input implements ComponentInterface {
     const clearIconData = clearInputIcon ?? defaultClearIcon;
 
     const hasValue = this.hasValue();
-    const hasStartEndSlots = el.querySelector('[slot="start"], [slot="end"]') !== null;
 
     /**
      * If the label is stacked, it should always sit above the input.
@@ -714,11 +713,9 @@ export class Input implements ComponentInterface {
      * other when the label isn't floating above the input. This doesn't
      * apply to the outline fill, but this was not accounted for to keep
      * things consistent.
-     *
-     * TODO(FW-5592): Remove hasStartEndSlots condition
      */
     const labelShouldFloat =
-      labelPlacement === 'stacked' || (labelPlacement === 'floating' && (hasValue || hasFocus || hasStartEndSlots));
+      labelPlacement === 'stacked' || (labelPlacement === 'floating' && (hasValue || hasFocus));
 
     return (
       <Host


### PR DESCRIPTION
Issue number: resolves #29562

---------

## What is the current behavior?
The input label is floating if an element is slotted. This is especially annoying if a password toggle is present, since it will start floating the label (even when no input is available).

## What is the new behavior?
A label will only float (if specified and) if it has a value or received focus. 

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

Screenshot before:
![image](https://github.com/user-attachments/assets/06882502-a485-4364-a5d2-89927102d1b8)

Screenshot after:
![image](https://github.com/user-attachments/assets/f44a1f51-85c5-44eb-bdac-72f384cd0366)
