### PR TITLE
fix(backdrop): remove tabindex for improved accessibility

### DIFF
--- a/core/src/components/backdrop/backdrop.tsx
+++ b/core/src/components/backdrop/backdrop.tsx
@@ -51,7 +51,6 @@ export class Backdrop implements ComponentInterface {
     const mode = getIonMode(this);
     return (
       <Host
-        tabindex="-1"
         aria-hidden="true"
         class={{
           [mode]: true,


### PR DESCRIPTION
Issue number: resolves #29773

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Certain Chrome and Edge versions (confirmed: Chrome v127 and Edge v127) would indicate that the backdrop has an accessibility violation:

```
Blocked aria-hidden on a <ion-backdrop> element because the element that just received
focus must not be hidden from assistive technology users. Avoid using aria-hidden on a
focused element or its ancestor. Consider using the inert attribute instead, which will also
prevent focus. For more details, see the aria-hidden section of the WAI-ARIA specification at
```

The error is happening because `tabindex` and `aria-hidden` are being passed to `ion-backdrop`. The `tabindex` attribute is used to make an element focusable, regardless of value. When `aria-hidden` is applied to an element, then the element is hidden from screen readers. This violates the accessibility standards since `ion-backdrop` would be considered a focusable element but not visible to screen readers.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed `tabindex`, this aligns with frameworks known for accessibility (Chakra UI)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `8.3.4-dev.11729533091.1ac77a0c`

How to test:

1. Use either Chrome v127 or Edge v127
2. Navigate to the [alert basic page](https://ionic-framework-3pvgcj4b9-ionic1.vercel.app/src/components/alert/test/basic) from the `main` branch
3. Open browser console
4. Click on the first button on the alert page
5. Click on the backdrop
6. Notice the error message in the browser console (if you don't see it, then use a private browser or clear cache)
7. Navigate to the [alert basic page](https://ionic-framework-git-rou-11175-ionic1.vercel.app/src/components/alert/test/basic) from the `ROU-11175` branch
8. Repeat steps 2-6
9. Verify that the error does not appear