### PR TITLE
fix(overlays): do not hide root when toast appears

### DIFF
--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -510,7 +510,17 @@ export const present = async <OverlayPresentOptions>(
     return;
   }
 
-  setRootAriaHidden(true);
+  
+  /**
+   * Due to accessibility guidelines, toasts do not have
+   * focus traps.
+   * 
+   * All other overlays should have focus traps to prevent
+   * the keyboard focus from leaving the overlay.
+   */
+  if (overlay.el.tagName !== 'ION-TOAST') {
+    setRootAriaHidden(true);
+  }
 
   document.body.classList.add(BACKDROP_NO_SCROLL);
 

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -639,13 +639,26 @@ export const dismiss = async <OverlayDismissOptions>(
     return false;
   }
 
-  const lastOverlay = doc !== undefined && getPresentedOverlays(doc).length === 1;
+  /**
+   * For accessibility, toasts lack focus traps and don’t receive
+   * `aria-hidden` on the root element when presented.
+   *
+   * All other overlays use focus traps to keep keyboard focus
+   * within the overlay, setting `aria-hidden` on the root element
+   * to enhance accessibility.
+   *
+   * Therefore, we must remove `aria-hidden` from the root element
+   * when the last non-toast overlay is dismissed.
+   */
+  const overlaysNotToast = doc !== undefined ? getPresentedOverlays(doc).filter((o) => o.tagName !== 'ION-TOAST') : [];
+
+  const lastOverlayNotToast = overlaysNotToast.length === 1 && overlaysNotToast[0].id === overlay.el.id;
 
   /**
-   * If this is the last visible overlay then
-   * we want to re-add the root to the accessibility tree.
+   * If this is the last visible overlay that is not a toast
+   * then we want to re-add the root to the accessibility tree.
    */
-  if (lastOverlay) {
+  if (lastOverlayNotToast) {
     setRootAriaHidden(false);
     document.body.classList.remove(BACKDROP_NO_SCROLL);
   }

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -510,11 +510,10 @@ export const present = async <OverlayPresentOptions>(
     return;
   }
 
-  
   /**
    * Due to accessibility guidelines, toasts do not have
    * focus traps.
-   * 
+   *
    * All other overlays should have focus traps to prevent
    * the keyboard focus from leaving the overlay.
    */


### PR DESCRIPTION
Issue number: stemmed from #29773

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Certain Chrome and Edge versions (confirmed: Chrome v127, v128, v129 and Edge v127) would indicate that certain elements have an accessibility violation:

```
Blocked aria-hidden on a "ELEMENT NAME" element because the element that just received
focus must not be hidden from assistive technology users. Avoid using aria-hidden on a
focused element or its ancestor. Consider using the inert attribute instead, which will also
prevent focus. For more details, see the aria-hidden section of the WAI-ARIA specification at
```

This issue happens when a toast appears and the users clicks on any element that is not related to toast. This is due to the main content having an `aria-hidden` so users should not to be able to interact with any of those elements. This isn't an issue when an overlay uses a backdrop, like `ion-alert` because the backdrop prevents a user from interacting with those elements.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When toast is present, the main content no longer has an `aria-hidden`. This aligns with accessibility guidelines. I also verified with other Framework, MD states "Don't trap focus in the snackbar. Users should be able to freely navigate in and out."

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `8.3.4-dev.11729879684.1ea28919`

1. Clone this [repo](https://github.com/brandyscarney/test-angular-overlays)
2. Install deps
3. Run the app on a private browser (Chrome v127, v128, v129 or Edge v127)
4. Open browser console
5. Click on "Open Toast" button
6. Click on any element other than "Open Toast" button, like "Open Popover"
7. Notice the error message
8. Close private browser
9. Install dev build: `npm install @ionic/angular@8.3.4-dev.11729879684.1ea28919`
10. Repeat steps 4-7
11. Verify that the error message doesn't occur
