### PR TITLE
refactor(scss): properly prefix string imports

### DIFF
--- a/core/src/components/item/item.common.scss
+++ b/core/src/components/item/item.common.scss
@@ -1,4 +1,3 @@
-@import "../../themes/functions.string";
 @import "../../themes/mixins";
 
 // Item

--- a/core/src/components/radio/radio.common.scss
+++ b/core/src/components/radio/radio.common.scss
@@ -1,4 +1,3 @@
-@import "../../themes/functions.string";
 @import "../../themes/mixins";
 @import "./radio.vars.scss";
 

--- a/core/src/components/segment-button/segment-button.common.scss
+++ b/core/src/components/segment-button/segment-button.common.scss
@@ -1,4 +1,3 @@
-@import "../../themes/functions.string";
 @import "../../themes/mixins";
 
 // Segment Button: Common

--- a/core/src/components/spinner/spinner.common.scss
+++ b/core/src/components/spinner/spinner.common.scss
@@ -1,5 +1,3 @@
-@import "../../themes/functions.string";
-@import "../../themes/functions.color";
 @import "../../themes/mixins";
 
 // Spinners

--- a/core/src/components/spinner/spinner.common.scss
+++ b/core/src/components/spinner/spinner.common.scss
@@ -1,4 +1,6 @@
 @import "../../themes/mixins";
+// Required to use the current-color function
+@import "../../themes/functions.color";
 
 // Spinners
 // --------------------------------------------------

--- a/core/src/components/toast/toast.common.scss
+++ b/core/src/components/toast/toast.common.scss
@@ -1,4 +1,6 @@
 @import "../../themes/mixins";
+// Required to use the current-color function
+@import "../../themes/functions.color";
 
 // Toast
 // --------------------------------------------------

--- a/core/src/components/toast/toast.common.scss
+++ b/core/src/components/toast/toast.common.scss
@@ -1,7 +1,4 @@
 @import "../../themes/mixins";
-// Necessary for the mixins to work.
-@import "../../themes/functions.string";
-@import "../../themes/functions.color";
 
 // Toast
 // --------------------------------------------------

--- a/core/src/themes/mixins.scss
+++ b/core/src/themes/mixins.scss
@@ -309,7 +309,7 @@
 // ----------------------------------------------------------
 @mixin svg-background-image($svg, $flip-rtl: false) {
   $url: url-encode($svg);
-  $viewBox: str-split(str-extract($svg, "viewBox='", "'"), " ");
+  $viewBox: string.str-split(string.str-extract($svg, "viewBox='", "'"), " ");
 
   @if $flip-rtl != true or $viewBox == null {
     @include multi-dir() {
@@ -318,9 +318,9 @@
   } @else {
     $transform: "transform='translate(#{nth($viewBox, 3)}, 0) scale(-1, 1)'";
     $flipped-url: $svg;
-    $flipped-url: str-replace($flipped-url, "<path", "<path #{$transform}");
-    $flipped-url: str-replace($flipped-url, "<line", "<line #{$transform}");
-    $flipped-url: str-replace($flipped-url, "<polygon", "<polygon #{$transform}");
+    $flipped-url: string.str-replace($flipped-url, "<path", "<path #{$transform}");
+    $flipped-url: string.str-replace($flipped-url, "<line", "<line #{$transform}");
+    $flipped-url: string.str-replace($flipped-url, "<polygon", "<polygon #{$transform}");
     $flipped-url: url-encode($flipped-url);
 
     @include ltr() {
@@ -575,10 +575,10 @@
 
   @each $transform in $transforms {
     @if (str-index($transform, translate3d)) {
-      $transform: str-replace($transform, "translate3d(");
-      $transform: str-replace($transform, ")");
+      $transform: string.str-replace($transform, "translate3d(");
+      $transform: string.str-replace($transform, ")");
 
-      $coordinates: str-split($transform, ",");
+      $coordinates: string.str-split($transform, ",");
 
       $x: nth($coordinates, 1);
       $y: nth($coordinates, 2);


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?
The mixins file is not using prefixing the string functions, resulting in the string function file needing to be imported to work in the `*.common.scss` files. 

## What is the new behavior?
Properly prefix the string function calls.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Steps to test:
1. Switch to the `next` branch
2. Navigate to the `core` directory in your terminal and run the local server
3. Open all `*.common.scss` files that import the following line and remove it:
    ```scss
    @import "../../themes/functions.string";
    ```
4. See the error in the terminal: `$n: Invalid index 2 for a list with 1 elements.`
5. Switch to this branch, see the error is gone without the imports
