### PR TITLE
fix(segment-view): add missing ionic theme fallback to the segment-view

### DIFF
--- a/core/src/components/segment-view/segment-view.tsx
+++ b/core/src/components/segment-view/segment-view.tsx
@@ -8,6 +8,7 @@ import type { SegmentViewScrollEvent } from './segment-view-interface';
   styleUrls: {
     ios: 'segment-view.ios.scss',
     md: 'segment-view.md.scss',
+    ionic: 'segment-view.md.scss',
   },
   shadow: true,
 })


### PR DESCRIPTION
## What is the current behavior?
Segment view does not contains styling once at ionic theme.

## What is the new behavior?
Same default style as md should be added.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


