### PR TITLE
fix(modal): dismiss keyboard on drag card modal

### DIFF
--- a/core/src/components/modal/gestures/swipe-to-close.ts
+++ b/core/src/components/modal/gestures/swipe-to-close.ts
@@ -1,7 +1,7 @@
 import { getTimeGivenProgression } from '@utils/animation/cubic-bezier';
 import { isIonContent, findClosestIonContent, disableContentScrollY, resetContentScrollY } from '@utils/content';
 import { createGesture } from '@utils/gesture';
-import { clamp, getElementRoot } from '@utils/helpers';
+import { clamp, getElementRoot, raf } from '@utils/helpers';
 import { OVERLAY_GESTURE_PRIORITY } from '@utils/overlays';
 
 import type { Animation } from '../../../interface';
@@ -140,6 +140,14 @@ export const createSwipeToCloseGesture = (
     if (deltaY > 0 && contentEl) {
       disableContentScrollY(contentEl);
     }
+
+    raf(() => {
+      /**
+       * Dismisses the open keyboard when the card drag gesture is started.
+       * Sets the focus onto the modal element.
+       */
+      el.focus();
+    });
 
     animation.progressStart(true, isOpen ? 1 : 0);
   };


### PR DESCRIPTION
Issue number: resolves https://github.com/ionic-team/ionic-framework/issues/30019

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
Dragging a card modal on iOS while the keyboard is open does not close the keyboard.

## What is the new behavior?
Dragging a card modal closes the keyboard.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

|Before|After|
|------|------|
| <video src="https://github.com/user-attachments/assets/7f6071dc-dfd2-4f38-97fa-a757b971e1d3"/>|<video src="https://github.com/user-attachments/assets/2f63a6c2-8268-40cd-8cde-fa621a8f030b" />|


