### PR TITLE
fix(overlays): announce info after opening based on platform

### DIFF
--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -32,6 +32,7 @@ import {
   removeEventListener,
 } from './helpers';
 import { printIonWarning } from './logging';
+import { isPlatform } from './platform';
 
 let lastOverlayIndex = 0;
 let lastId = 0;
@@ -986,9 +987,7 @@ export const createTriggerController = () => {
 const hideAnimatingOverlayFromScreenReaders = (overlay: HTMLIonOverlayElement) => {
   if (doc === undefined) return;
 
-  const mode = getIonMode(overlay);
-
-  if (mode === 'md') {
+  if (isPlatform('android')) {
     /**
      * Once the animation is complete, this attribute will be removed.
      * This is done at the end of the `present` method.

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -524,7 +524,7 @@ export const present = async <OverlayPresentOptions>(
   document.body.classList.add(BACKDROP_NO_SCROLL);
 
   hideUnderlyingOverlaysFromScreenReaders(overlay.el);
-  hideAnimatingOverlayFromScreenReaders(overlay.el);
+  // hideAnimatingOverlayFromScreenReaders(overlay.el);
 
   overlay.presented = true;
   overlay.willPresent.emit();
@@ -677,7 +677,7 @@ export const dismiss = async <OverlayDismissOptions>(
      * the dismiss animation. This is because the overlay will be removed
      * from the DOM after the animation is complete.
      */
-    hideAnimatingOverlayFromScreenReaders(overlay.el);
+    // hideAnimatingOverlayFromScreenReaders(overlay.el);
 
     // Overlay contents should not be clickable during dismiss
     overlay.el.style.setProperty('pointer-events', 'none');
@@ -977,15 +977,15 @@ export const createTriggerController = () => {
  *
  * @param overlay - The overlay that is being animated.
  */
-const hideAnimatingOverlayFromScreenReaders = (overlay: HTMLIonOverlayElement) => {
-  if (doc === undefined) return;
+// const hideAnimatingOverlayFromScreenReaders = (overlay: HTMLIonOverlayElement) => {
+//   if (doc === undefined) return;
 
-  /**
-   * Once the animation is complete, this attribute will be removed.
-   * This is done at the end of the `present` method.
-   */
-  overlay.setAttribute('aria-hidden', 'true');
-};
+//   /**
+//    * Once the animation is complete, this attribute will be removed.
+//    * This is done at the end of the `present` method.
+//    */
+//   overlay.setAttribute('aria-hidden', 'true');
+// };
 
 /**
  * Ensure that underlying overlays have aria-hidden if necessary so that screen readers

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -677,7 +677,7 @@ export const dismiss = async <OverlayDismissOptions>(
      * the dismiss animation. This is because the overlay will be removed
      * from the DOM after the animation is complete.
      */
-    // hideAnimatingOverlayFromScreenReaders(overlay.el);
+    hideAnimatingOverlayFromScreenReaders(overlay.el);
 
     // Overlay contents should not be clickable during dismiss
     overlay.el.style.setProperty('pointer-events', 'none');
@@ -977,15 +977,15 @@ export const createTriggerController = () => {
  *
  * @param overlay - The overlay that is being animated.
  */
-// const hideAnimatingOverlayFromScreenReaders = (overlay: HTMLIonOverlayElement) => {
-//   if (doc === undefined) return;
+const hideAnimatingOverlayFromScreenReaders = (overlay: HTMLIonOverlayElement) => {
+  if (doc === undefined) return;
 
-//   /**
-//    * Once the animation is complete, this attribute will be removed.
-//    * This is done at the end of the `present` method.
-//    */
-//   overlay.setAttribute('aria-hidden', 'true');
-// };
+  /**
+   * Once the animation is complete, this attribute will be removed.
+   * This is done at the end of the `present` method.
+   */
+  overlay.setAttribute('aria-hidden', 'true');
+};
 
 /**
  * Ensure that underlying overlays have aria-hidden if necessary so that screen readers

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -754,7 +754,10 @@ const overlayAnimation = async (
 
   animation.beforeAddWrite(() => {
     console.log('beforeAddWrite');
-    baseEl.setAttribute('aria-hidden', 'true');
+    const overlayWrapper = baseEl.querySelector('.ion-overlay-wrapper');
+    if (overlayWrapper) {
+      overlayWrapper.setAttribute('aria-hidden', 'true');
+    }
 
     if (overlay.keyboardClose) {
       const activeElement = baseEl.ownerDocument!.activeElement as HTMLElement;
@@ -765,10 +768,11 @@ const overlayAnimation = async (
   });
 
   animation.afterAddWrite(() => {
-    requestAnimationFrame(() => {
-      baseEl.removeAttribute('aria-hidden');
-      console.log('afterAddWrite');
-    });
+    const overlayWrapper = baseEl.querySelector('.ion-overlay-wrapper');
+    if (overlayWrapper) {
+      overlayWrapper.removeAttribute('aria-hidden');
+    }
+    console.log('afterAddWrite');
   });
 
   const activeAni = activeAnimations.get(overlay) || [];

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -535,7 +535,7 @@ export const present = async <OverlayPresentOptions>(
     ? overlay.enterAnimation
     : config.get(name, mode === 'ios' ? iosEnterAnimation : mdEnterAnimation);
 
-  hideAnimatingOverlayFromScreenReaders(overlay.el);
+  // hideAnimatingOverlayFromScreenReaders(overlay.el);
 
   const completed = await overlayAnimation(overlay, animationBuilder, overlay.el, opts);
   if (completed) {
@@ -749,6 +749,8 @@ const overlayAnimation = async (
   const aniRoot = overlay.el;
   const animation = animationBuilder(aniRoot, opts);
 
+  aniRoot.setAttribute('aria-hidden', 'true');
+
   if (!overlay.animated || !config.getBoolean('animated', true)) {
     animation.duration(0);
   }
@@ -766,6 +768,8 @@ const overlayAnimation = async (
   activeAnimations.set(overlay, [...activeAni, animation]);
 
   await animation.play();
+
+  aniRoot.removeAttribute('aria-hidden');
 
   return true;
 };

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -524,7 +524,7 @@ export const present = async <OverlayPresentOptions>(
   document.body.classList.add(BACKDROP_NO_SCROLL);
 
   hideUnderlyingOverlaysFromScreenReaders(overlay.el);
-  hideAnimatingOverlayFromScreenReaders(overlay.el);
+  // hideAnimatingOverlayFromScreenReaders(overlay.el);
 
   overlay.presented = true;
   overlay.willPresent.emit();
@@ -677,7 +677,7 @@ export const dismiss = async <OverlayDismissOptions>(
      * the dismiss animation. This is because the overlay will be removed
      * from the DOM after the animation is complete.
      */
-    hideAnimatingOverlayFromScreenReaders(overlay.el);
+    // hideAnimatingOverlayFromScreenReaders(overlay.el);
 
     // Overlay contents should not be clickable during dismiss
     overlay.el.style.setProperty('pointer-events', 'none');
@@ -977,19 +977,19 @@ export const createTriggerController = () => {
  *
  * @param overlay - The overlay that is being animated.
  */
-const hideAnimatingOverlayFromScreenReaders = (overlay: HTMLIonOverlayElement) => {
-  if (doc === undefined) return;
+// const hideAnimatingOverlayFromScreenReaders = (overlay: HTMLIonOverlayElement) => {
+//   if (doc === undefined) return;
 
-  const mode = getIonMode(overlay);
+//   const mode = getIonMode(overlay);
 
-  if (mode === 'md') {
-    /**
-     * Once the animation is complete, this attribute will be removed.
-     * This is done at the end of the `present` method.
-     */
-    overlay.setAttribute('aria-hidden', 'true');
-  }
-};
+//   if (mode === 'md') {
+//     /**
+//      * Once the animation is complete, this attribute will be removed.
+//      * This is done at the end of the `present` method.
+//      */
+//     overlay.setAttribute('aria-hidden', 'true');
+//   }
+// };
 
 /**
  * Ensure that underlying overlays have aria-hidden if necessary so that screen readers

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -983,13 +983,14 @@ const hideAnimatingOverlayFromScreenReaders = (overlay: HTMLIonOverlayElement) =
   const mode = getIonMode(overlay);
   console.log('mode', mode);
 
-  // if (mode === 'md') {
-  //   /**
-  //    * Once the animation is complete, this attribute will be removed.
-  //    * This is done at the end of the `present` method.
-  //    */
-  //   overlay.setAttribute('aria-hidden', 'true');
-  // }
+  if (mode === 'md') {
+    console.log('in md');
+    /**
+     * Once the animation is complete, this attribute will be removed.
+     * This is done at the end of the `present` method.
+     */
+    overlay.setAttribute('aria-hidden', 'true');
+  }
 };
 
 /**

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -114,6 +114,7 @@ export const createOverlay = <T extends HTMLIonOverlayElement>(
     return window.customElements.whenDefined(tagName).then(() => {
       const element = document.createElement(tagName) as HTMLIonOverlayElement;
       element.classList.add('overlay-hidden');
+      element.setAttribute('aria-hidden', 'true');
 
       /**
        * Convert the passed in overlay options into props
@@ -744,6 +745,7 @@ const overlayAnimation = async (
 ): Promise<boolean> => {
   // Make overlay visible in case it's hidden
   baseEl.classList.remove('overlay-hidden');
+  baseEl.removeAttribute('aria-hidden');
 
   const aniRoot = overlay.el;
   const animation = animationBuilder(aniRoot, opts);
@@ -753,20 +755,12 @@ const overlayAnimation = async (
   }
 
   animation.beforeAddWrite(() => {
-    console.log('beforeAddWrite');
-    baseEl.setAttribute('aria-hidden', 'true');
-
     if (overlay.keyboardClose) {
       const activeElement = baseEl.ownerDocument!.activeElement as HTMLElement;
       if (activeElement?.matches('input,ion-input, ion-textarea')) {
         activeElement.blur();
       }
     }
-  });
-
-  animation.afterAddWrite(() => {
-    baseEl.removeAttribute('aria-hidden');
-    console.log('afterAddWrite');
   });
 
   const activeAni = activeAnimations.get(overlay) || [];

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -539,7 +539,6 @@ export const present = async <OverlayPresentOptions>(
 
   const completed = await overlayAnimation(overlay, animationBuilder, overlay.el, opts);
   if (completed) {
-    overlay.el.removeAttribute('aria-hidden');
     overlay.didPresent.emit();
     overlay.didPresentShorthand?.emit();
   }
@@ -753,6 +752,8 @@ const overlayAnimation = async (
     animation.duration(0);
   }
 
+  aniRoot.setAttribute('aria-hidden', 'true');
+
   if (overlay.keyboardClose) {
     animation.beforeAddWrite(() => {
       const activeElement = baseEl.ownerDocument!.activeElement as HTMLElement;
@@ -762,14 +763,14 @@ const overlayAnimation = async (
     });
   }
 
+  animation.afterAddWrite(() => {
+    aniRoot.removeAttribute('aria-hidden');
+  });
+
   const activeAni = activeAnimations.get(overlay) || [];
   activeAnimations.set(overlay, [...activeAni, animation]);
 
-  aniRoot.setAttribute('aria-hidden', 'true');
-
   await animation.play();
-
-  aniRoot.removeAttribute('aria-hidden');
 
   return true;
 };

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -539,6 +539,7 @@ export const present = async <OverlayPresentOptions>(
 
   const completed = await overlayAnimation(overlay, animationBuilder, overlay.el, opts);
   if (completed) {
+    overlay.el.removeAttribute('aria-hidden');
     overlay.didPresent.emit();
     overlay.didPresentShorthand?.emit();
   }

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -754,7 +754,7 @@ const overlayAnimation = async (
 
   animation.beforeAddWrite(() => {
     console.log('beforeAddWrite');
-    aniRoot.setAttribute('aria-hidden', 'true');
+    baseEl.setAttribute('aria-hidden', 'true');
 
     if (overlay.keyboardClose) {
       const activeElement = baseEl.ownerDocument!.activeElement as HTMLElement;
@@ -765,7 +765,7 @@ const overlayAnimation = async (
   });
 
   animation.afterAddWrite(() => {
-    aniRoot.removeAttribute('aria-hidden');
+    baseEl.removeAttribute('aria-hidden');
     console.log('afterAddWrite');
   });
 

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -114,7 +114,6 @@ export const createOverlay = <T extends HTMLIonOverlayElement>(
     return window.customElements.whenDefined(tagName).then(() => {
       const element = document.createElement(tagName) as HTMLIonOverlayElement;
       element.classList.add('overlay-hidden');
-      element.setAttribute('aria-hidden', 'true');
 
       /**
        * Convert the passed in overlay options into props
@@ -745,7 +744,6 @@ const overlayAnimation = async (
 ): Promise<boolean> => {
   // Make overlay visible in case it's hidden
   baseEl.classList.remove('overlay-hidden');
-  baseEl.removeAttribute('aria-hidden');
 
   const aniRoot = overlay.el;
   const animation = animationBuilder(aniRoot, opts);
@@ -755,12 +753,22 @@ const overlayAnimation = async (
   }
 
   animation.beforeAddWrite(() => {
+    console.log('beforeAddWrite');
+    baseEl.setAttribute('aria-hidden', 'true');
+
     if (overlay.keyboardClose) {
       const activeElement = baseEl.ownerDocument!.activeElement as HTMLElement;
       if (activeElement?.matches('input,ion-input, ion-textarea')) {
         activeElement.blur();
       }
     }
+  });
+
+  animation.afterAddWrite(() => {
+    requestAnimationFrame(() => {
+      baseEl.removeAttribute('aria-hidden');
+      console.log('afterAddWrite');
+    });
   });
 
   const activeAni = activeAnimations.get(overlay) || [];

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -752,19 +752,21 @@ const overlayAnimation = async (
     animation.duration(0);
   }
 
-  aniRoot.setAttribute('aria-hidden', 'true');
+  animation.beforeAddWrite(() => {
+    console.log('beforeAddWrite');
+    aniRoot.setAttribute('aria-hidden', 'true');
 
-  if (overlay.keyboardClose) {
-    animation.beforeAddWrite(() => {
+    if (overlay.keyboardClose) {
       const activeElement = baseEl.ownerDocument!.activeElement as HTMLElement;
       if (activeElement?.matches('input,ion-input, ion-textarea')) {
         activeElement.blur();
       }
-    });
-  }
+    }
+  });
 
   animation.afterAddWrite(() => {
     aniRoot.removeAttribute('aria-hidden');
+    console.log('afterAddWrite');
   });
 
   const activeAni = activeAnimations.get(overlay) || [];

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -749,8 +749,6 @@ const overlayAnimation = async (
   const aniRoot = overlay.el;
   const animation = animationBuilder(aniRoot, opts);
 
-  aniRoot.setAttribute('aria-hidden', 'true');
-
   if (!overlay.animated || !config.getBoolean('animated', true)) {
     animation.duration(0);
   }
@@ -766,6 +764,8 @@ const overlayAnimation = async (
 
   const activeAni = activeAnimations.get(overlay) || [];
   activeAnimations.set(overlay, [...activeAni, animation]);
+
+  aniRoot.setAttribute('aria-hidden', 'true');
 
   await animation.play();
 

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -524,7 +524,7 @@ export const present = async <OverlayPresentOptions>(
   document.body.classList.add(BACKDROP_NO_SCROLL);
 
   hideUnderlyingOverlaysFromScreenReaders(overlay.el);
-  // hideAnimatingOverlayFromScreenReaders(overlay.el);
+  hideAnimatingOverlayFromScreenReaders(overlay.el);
 
   overlay.presented = true;
   overlay.willPresent.emit();
@@ -677,7 +677,7 @@ export const dismiss = async <OverlayDismissOptions>(
      * the dismiss animation. This is because the overlay will be removed
      * from the DOM after the animation is complete.
      */
-    // hideAnimatingOverlayFromScreenReaders(overlay.el);
+    hideAnimatingOverlayFromScreenReaders(overlay.el);
 
     // Overlay contents should not be clickable during dismiss
     overlay.el.style.setProperty('pointer-events', 'none');
@@ -977,19 +977,20 @@ export const createTriggerController = () => {
  *
  * @param overlay - The overlay that is being animated.
  */
-// const hideAnimatingOverlayFromScreenReaders = (overlay: HTMLIonOverlayElement) => {
-//   if (doc === undefined) return;
+const hideAnimatingOverlayFromScreenReaders = (overlay: HTMLIonOverlayElement) => {
+  if (doc === undefined) return;
 
-//   const mode = getIonMode(overlay);
+  const mode = getIonMode(overlay);
+  console.log('mode', mode);
 
-//   if (mode === 'md') {
-//     /**
-//      * Once the animation is complete, this attribute will be removed.
-//      * This is done at the end of the `present` method.
-//      */
-//     overlay.setAttribute('aria-hidden', 'true');
-//   }
-// };
+  // if (mode === 'md') {
+  //   /**
+  //    * Once the animation is complete, this attribute will be removed.
+  //    * This is done at the end of the `present` method.
+  //    */
+  //   overlay.setAttribute('aria-hidden', 'true');
+  // }
+};
 
 /**
  * Ensure that underlying overlays have aria-hidden if necessary so that screen readers

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -524,7 +524,6 @@ export const present = async <OverlayPresentOptions>(
   document.body.classList.add(BACKDROP_NO_SCROLL);
 
   hideUnderlyingOverlaysFromScreenReaders(overlay.el);
-  // hideAnimatingOverlayFromScreenReaders(overlay.el);
 
   overlay.presented = true;
   overlay.willPresent.emit();
@@ -535,6 +534,8 @@ export const present = async <OverlayPresentOptions>(
   const animationBuilder = overlay.enterAnimation
     ? overlay.enterAnimation
     : config.get(name, mode === 'ios' ? iosEnterAnimation : mdEnterAnimation);
+
+  hideAnimatingOverlayFromScreenReaders(overlay.el);
 
   const completed = await overlayAnimation(overlay, animationBuilder, overlay.el, opts);
   if (completed) {


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

PR https://github.com/ionic-team/ionic-framework/pull/29951 would hide the overlays from screen readers while animating. This allows the element to navigate to its correct destination for screen readers to interact with. Otherwise, the focus rings would never appear. However, this ended up breaking the interaction for iOS.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Overlays are hidden from screen readers while animating only if the platform is `android`. Since the original issue only applied to Android devices.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `8.4.1-dev.11732033492.170e160c`

Test on iOS and Android devices.
