### PR TITLE
fix(accordion): move padding to inner element to use proper animation

### DIFF
--- a/core/src/components/accordion/accordion.ionic.scss
+++ b/core/src/components/accordion/accordion.ionic.scss
@@ -58,7 +58,7 @@
 // Accordion Content
 // --------------------------------------------------
 
-#content {
+#content-wrapper {
   @include globals.padding(null, globals.$ion-space-400, globals.$ion-space-300, globals.$ion-space-400);
   @include globals.typography(globals.$ion-body-md-regular);
 

--- a/core/src/components/accordion/test/shape/index.html
+++ b/core/src/components/accordion/test/shape/index.html
@@ -11,7 +11,7 @@
     <style>
       .grid {
         display: grid;
-        grid-template-columns: repeat(4, 1fr);
+        grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
         grid-row-gap: 20px;
         grid-column-gap: 20px;
       }

--- a/core/src/components/accordion/test/shape/index.html
+++ b/core/src/components/accordion/test/shape/index.html
@@ -11,7 +11,7 @@
     <style>
       .grid {
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
         grid-row-gap: 20px;
         grid-column-gap: 20px;
       }


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?
The animation is off for the `ionic` theme when using an accordion with text content.

## What is the new behavior?
- Moves the padding to the inner content element so the `offsetHeight` will be calculated properly and the animation will be smooth

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

[Preview](https://ionic-framework-git-rou-11362-ionic1.vercel.app/src/components/accordion/test/shape?ionic:theme=ionic)