### PR TITLE
fix(segment): add logic to connect to segment-view in `componentDidLoad()` callback

### DIFF
--- a/core/src/components/segment/segment.tsx
+++ b/core/src/components/segment/segment.tsx
@@ -175,8 +175,6 @@ export class Segment implements ComponentInterface {
 
   connectedCallback() {
     this.emitStyle();
-
-    this.segmentViewEl = this.getSegmentView();
   }
 
   disconnectedCallback() {
@@ -188,6 +186,8 @@ export class Segment implements ComponentInterface {
   }
 
   async componentDidLoad() {
+    this.segmentViewEl = this.getSegmentView();
+
     this.setCheckedClasses();
 
     /**

--- a/core/src/components/segment/segment.tsx
+++ b/core/src/components/segment/segment.tsx
@@ -175,6 +175,8 @@ export class Segment implements ComponentInterface {
 
   connectedCallback() {
     this.emitStyle();
+
+    this.segmentViewEl = this.getSegmentView();
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
Issue number: resolves #30000 

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The "swipeable segments" feature does not work correctly in an Angular environment (tested with both standalone and module architecture). The issues is that the `ion-segment-view` element is not correctly "attached" to the segment since it does not exist at the time the `connectedCallback()` is first executed.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Added the logic to connect the `ion-segment-view` to the `componentDidLoad()` callback in addition to the `connectedCallback()`. The existing logic was left in place for the case where the element is removed and reattached to the DOM.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev Build: `8.4.2-dev.11733239325.140ef7c3`
