### PR TITLE
[Optimization] The useXXX method can be directly called in the vue component, and it can be automatically uninstalled

### DIFF
--- a/packages/vue/src/hooks/back-button.ts
+++ b/packages/vue/src/hooks/back-button.ts
@@ -1,4 +1,5 @@
 import type { BackButtonEvent } from "@ionic/core/components";
+import { onBeforeUnmount, getCurrentInstance } from 'vue'
 
 type Handler = (processNextHandler: () => void) => Promise<any> | void | null;
 export interface UseBackButtonResult {
@@ -15,6 +16,12 @@ export const useBackButton = (
     document.removeEventListener("ionBackButton", callback);
 
   document.addEventListener("ionBackButton", callback);
+  
+  if (getCurrentInstance()){
+    onBeforeUnmount(() => {
+      unregister()
+    });
+  }
 
   return { unregister };
 };

--- a/packages/vue/src/hooks/keyboard.ts
+++ b/packages/vue/src/hooks/keyboard.ts
@@ -1,5 +1,5 @@
 import type { Ref } from "vue";
-import { ref } from "vue";
+import { ref, onBeforeUnmount, getCurrentInstance } from "vue";
 
 export interface UseKeyboardResult {
   isOpen: Ref<boolean>;
@@ -31,6 +31,12 @@ export const useKeyboard = (): UseKeyboardResult => {
   if (typeof (window as any) !== "undefined") {
     window.addEventListener("ionKeyboardDidShow", showCallback);
     window.addEventListener("ionKeyboardDidHide", hideCallback);
+  }
+
+  if (getCurrentInstance()){
+    onBeforeUnmount(() => {
+      unregister()
+    });
   }
 
   return {


### PR DESCRIPTION

## What is the current behavior?
Optimized useBackButton and useKeyboard, now direct reference in vue component will support auto uninstall.

## What is the new behavior?

- Added automatic uninstallation for useBackButton.
- Added automatic uninstallation for useKeyboard.

## Does this introduce a breaking change?

- [ ] Yes
- [ + ] No

## Other information

This is a default specification for vue users that the useXXX function should be called directly from within the vue component and not subsequently care about uninstallation.
