### PR TITLE
fix(capacitor): replace deprecated platform check method

### DIFF
--- a/core/src/utils/platform.ts
+++ b/core/src/utils/platform.ts
@@ -99,8 +99,8 @@ const isCordova = (win: any): boolean => !!(win['cordova'] || win['phonegap'] ||
 
 const isCapacitorNative = (win: any): boolean => {
   const capacitor = win['Capacitor'];
-  // TODO: Remove when we no longer support Capacitor 2, which does not have isNativePlatform
-  return !!capacitor?.isNative || (capacitor?.isNativePlatform && !!capacitor.isNativePlatform());
+  // TODO(ROU-11693): Remove when we no longer support Capacitor 2, which does not have isNativePlatform
+  return !!(capacitor?.isNative || (capacitor?.isNativePlatform && !!capacitor.isNativePlatform()));
 };
 
 const isElectron = (win: Window): boolean => testUserAgent(win, /electron/i);

--- a/core/src/utils/platform.ts
+++ b/core/src/utils/platform.ts
@@ -99,7 +99,7 @@ const isCordova = (win: any): boolean => !!(win['cordova'] || win['phonegap'] ||
 
 const isCapacitorNative = (win: any): boolean => {
   const capacitor = win['Capacitor'];
-  return !!capacitor?.isNative;
+  return !!capacitor?.isNativePlatform();
 };
 
 const isElectron = (win: Window): boolean => testUserAgent(win, /electron/i);

--- a/core/src/utils/platform.ts
+++ b/core/src/utils/platform.ts
@@ -99,7 +99,8 @@ const isCordova = (win: any): boolean => !!(win['cordova'] || win['phonegap'] ||
 
 const isCapacitorNative = (win: any): boolean => {
   const capacitor = win['Capacitor'];
-  return !!capacitor?.isNativePlatform();
+  // TODO: Remove when we no longer support Capacitor 2, which does not have isNativePlatform
+  return !!capacitor?.isNative || (capacitor?.isNativePlatform && !!capacitor.isNativePlatform());
 };
 
 const isElectron = (win: Window): boolean => testUserAgent(win, /electron/i);

--- a/core/src/utils/test/platform.utils.ts
+++ b/core/src/utils/test/platform.utils.ts
@@ -29,7 +29,7 @@ export const PlatformConfiguration = {
   },
   Capacitor: {
     Capacitor: {
-      isNative: true,
+      isNativePlatform: () => true,
     },
   },
   PWA: {


### PR DESCRIPTION
Issue number: resolves internal

ref: https://github.com/ionic-team/capacitor/issues/7884

---------

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
`this.platform.is('capacitor')` returns `false` in Capacitor App.

## What is the new behavior?
`this.platform.is('capacitor')` returns as expected.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
It might also need to be fixed.

https://github.com/ionic-team/ionic-framework/blob/14b6538d98303cb753d881ec6978fb98f53ed54c/core/src/utils/test/platform.utils.ts#L32
