### PR TITLE
fix(focusVisibleElement): set focus on custom appRootSelector

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -333,7 +333,8 @@ export namespace Components {
          */
         "mode"?: "ios" | "md";
         /**
-          * Used to set focus on an element that uses `ion-focusable`. Do not use this if focusing the element as a result of a keyboard event as the focus utility should handle this for us. This method should be used when we want to programmatically focus an element as a result of another user action. (Ex: We focus the first element inside of a popover when the user presents it, but the popover is not always presented as a result of keyboard action.)
+          * Sets focus on elements that use `ion-focusable`.
+          * @param elements - The elements to set focus on.
          */
         "setFocus": (elements: HTMLElement[]) => Promise<void>;
         /**

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -333,7 +333,7 @@ export namespace Components {
          */
         "mode"?: "ios" | "md";
         /**
-          * Sets focus on elements that use `ion-focusable`.
+          * Used to set focus on an element that uses `ion-focusable`. Do not use this if focusing the element as a result of a keyboard event as the focus utility should handle this for us. This method should be used when we want to programmatically focus an element as a result of another user action. (Ex: We focus the first element inside of a popover when the user presents it, but the popover is not always presented as a result of keyboard action.)
           * @param elements - The elements to set focus on.
          */
         "setFocus": (elements: HTMLElement[]) => Promise<void>;

--- a/core/src/components/app/app.tsx
+++ b/core/src/components/app/app.tsx
@@ -17,7 +17,13 @@ export class App implements ComponentInterface {
   @Element() el!: HTMLElement;
 
   /**
-   * Sets focus on elements that use `ion-focusable`.
+   * Used to set focus on an element that uses `ion-focusable`.
+   * Do not use this if focusing the element as a result of a keyboard
+   * event as the focus utility should handle this for us. This method
+   * should be used when we want to programmatically focus an element as
+   * a result of another user action. (Ex: We focus the first element
+   * inside of a popover when the user presents it, but the popover is not always
+   * presented as a result of keyboard action.)
    *
    * @param elements - The elements to set focus on.
    */

--- a/core/src/components/app/app.tsx
+++ b/core/src/components/app/app.tsx
@@ -1,6 +1,6 @@
 import type { ComponentInterface } from '@stencil/core';
 import { Component, Element, Host, Method, h } from '@stencil/core';
-import { getOrInitFocusVisibleUtility } from '@utils/focus-visible';
+import { focusElements } from '@utils/focus-visible';
 
 import { config } from '../../global/config';
 import { getIonTheme } from '../../global/ionic-global';
@@ -27,8 +27,7 @@ export class App implements ComponentInterface {
    */
   @Method()
   async setFocus(elements: HTMLElement[]) {
-    const focusVisible = getOrInitFocusVisibleUtility();
-    focusVisible.setFocus(elements);
+    focusElements(elements);
   }
 
   render() {

--- a/core/src/components/app/app.tsx
+++ b/core/src/components/app/app.tsx
@@ -17,16 +17,16 @@ export class App implements ComponentInterface {
   @Element() el!: HTMLElement;
 
   /**
-   * Used to set focus on an element that uses `ion-focusable`.
-   * Do not use this if focusing the element as a result of a keyboard
-   * event as the focus utility should handle this for us. This method
-   * should be used when we want to programmatically focus an element as
-   * a result of another user action. (Ex: We focus the first element
-   * inside of a popover when the user presents it, but the popover is not always
-   * presented as a result of keyboard action.)
+   * Sets focus on elements that use `ion-focusable`.
+   *
+   * @param elements - The elements to set focus on.
    */
   @Method()
   async setFocus(elements: HTMLElement[]) {
+    /**
+     * The focus-visible utility is used to set focus on an
+     * element that uses `ion-focusable`.
+     */
     focusElements(elements);
   }
 

--- a/core/src/utils/focus-visible.ts
+++ b/core/src/utils/focus-visible.ts
@@ -30,6 +30,20 @@ export const getOrInitFocusVisibleUtility = () => {
   return focusVisibleUtility;
 };
 
+/**
+ * Used to set focus on an element that uses `ion-focusable`.
+ * Do not use this if focusing the element as a result of a keyboard
+ * event as the focus utility should handle this for us. This method
+ * should be used when we want to programmatically focus an element as
+ * a result of another user action. (Ex: We focus the first element
+ * inside of a popover when the user presents it, but the popover is not always
+ * presented as a result of keyboard action.)
+ */
+export const focusElements = (elements: Element[]) => {
+  const focusVisible = getOrInitFocusVisibleUtility();
+  focusVisible.setFocus(elements);
+};
+
 export const startFocusVisible = (rootEl?: HTMLElement): FocusVisibleUtility => {
   let currentFocus: Element[] = [];
   let keyboardMode = true;

--- a/core/src/utils/focus-visible.ts
+++ b/core/src/utils/focus-visible.ts
@@ -38,6 +38,8 @@ export const getOrInitFocusVisibleUtility = () => {
  * a result of another user action. (Ex: We focus the first element
  * inside of a popover when the user presents it, but the popover is not always
  * presented as a result of keyboard action.)
+ *
+ * @param elements - The elements to set focus on.
  */
 export const focusElements = (elements: Element[]) => {
   const focusVisible = getOrInitFocusVisibleUtility();

--- a/core/src/utils/helpers.ts
+++ b/core/src/utils/helpers.ts
@@ -256,6 +256,17 @@ export const hasShadowDom = (el: HTMLElement) => {
   return !!el.shadowRoot && !!(el as any).attachShadow;
 };
 
+/**
+ * Focuses a given element while ensuring proper focus management
+ * within the Ionic framework. If the element is marked as `ion-focusable`,
+ * this function will delegate focus handling to `ion-app` or manually
+ * apply focus when a custom app root is used.
+ *
+ * This function helps maintain accessibility and expected focus behavior
+ * in both standard and custom root environments.
+ *
+ * @param el - The element to focus.
+ */
 export const focusVisibleElement = (el: HTMLElement) => {
   el.focus();
 
@@ -281,15 +292,21 @@ export const focusVisibleElement = (el: HTMLElement) => {
         app.setFocus([el]);
       } else {
         /**
-         * If the user has provided a custom app root selector,
-         * then we need to manually set focus on the element
-         * since the focus-visible utility will not be available
-         * on the custom app root.
-         *
-         * The focus-visible utility is used to set focus on an
-         * element that uses `ion-focusable`.
+         * When using a custom app root selector, the focus-visible
+         * utility is not available to manage focus automatically.
+         * If we set focus immediately, the element may not be fully
+         * rendered or interactive, especially if it was just added
+         * to the DOM. Using requestAnimationFrame ensures that focus
+         * is applied on the next frame, allowing the DOM to settle
+         * before changing focus.
          */
-        focusElements([el]);
+        requestAnimationFrame(() => {
+          /**
+           * The focus-visible utility is used to set focus on an
+           * element that uses `ion-focusable`.
+           */
+          focusElements([el]);
+        });
       }
     }
   }

--- a/core/src/utils/helpers.ts
+++ b/core/src/utils/helpers.ts
@@ -1,4 +1,5 @@
 import type { EventEmitter } from '@stencil/core';
+import { focusElements } from '@utils/focus-visible';
 
 import type { Side } from '../components/menu/menu-interface';
 import { config } from '../global/config';
@@ -267,10 +268,29 @@ export const focusVisibleElement = (el: HTMLElement) => {
    * which will let us explicitly set the elements to focus.
    */
   if (el.classList.contains('ion-focusable')) {
-    const appRootSelector = config.get('appRootSelector', 'ion-app');
+    const appRootSelector: string = config.get('appRootSelector', 'ion-app');
     const app = el.closest(appRootSelector) as HTMLIonAppElement | null;
     if (app) {
-      app.setFocus([el]);
+      if (appRootSelector === 'ion-app') {
+        /**
+         * If the app root is the default, then it will be
+         * in charge of setting focus. This is because the
+         * focus-visible utility is attached to the app root
+         * and will handle setting focus on the correct element.
+         */
+        app.setFocus([el]);
+      } else {
+        /**
+         * If the user has provided a custom app root selector,
+         * then we need to manually set focus on the element
+         * since the focus-visible utility will not be available
+         * on the custom app root.
+         *
+         * The focus-visible utility is used to set focus on an
+         * element that uses `ion-focusable`.
+         */
+        focusElements([el]);
+      }
     }
   }
 };


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The `focusVisibleElement` function does not take into account that a user might use a custom `appRootSelector`. If they do, the the `setFocus` function will throw an error that it does not exist leading to focus not being established on the elements.

This error can be seen when opening a `ion-select` with a modal interface.

![Screenshot 2025-02-26 at 1 24 18 PM](https://github.com/user-attachments/assets/6318175f-f816-4baa-b41b-a2e02d3d566f)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Created a new function to reuse the focus logic within `ion-app` and for the custom app root selector. This will make sure that there will be consistency between both if that logic needs to change in the future.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
