### PR TITLE
fix(toggle): trigger focus and blur on click

### DIFF
--- a/core/src/components/toggle/toggle.tsx
+++ b/core/src/components/toggle/toggle.tsx
@@ -138,6 +138,7 @@ export class Toggle implements ComponentInterface {
     const isNowChecked = !checked;
     this.checked = isNowChecked;
 
+    this.setFocus();
     this.ionChange.emit({
       checked: isNowChecked,
       value,


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The blur and focus events do not trigger when clicking even though the value changes. Those events are only triggered when dragged.

This leads to Angular validation to not work accurately when clicking so the `ion-touched` is never added to the toggle since it relies on the blur event. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The blur and focus events also trigger on click. This follows the same logic as `ion-checkbox`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

How to test:

Recommendation to use `toggle/test/basic/index.html`: [Preview](https://ionic-framework-git-toggle-focus-ionic1.vercel.app/src/components/toggle/test/basic)

Add the following script:
```js
<script>
  document.addEventListener('ionChange', () => {
    console.log('toggle: ionChange')
  });

  document.addEventListener('ionFocus', () => {
    console.log('toggle: ionFocus')
  });

  document.addEventListener('ionBlur', () => {
    console.log('toggle: ionBlur')
  });
</script>
```

Verify that the focus and blur events trigger when clicking and dragging.
