### PR TITLE
fix(modal): consider scrollable content while dragging when expandToScroll is false

### DIFF
--- a/core/src/components/modal/gestures/sheet.ts
+++ b/core/src/components/modal/gestures/sheet.ts
@@ -265,10 +265,14 @@ export const createSheetGesture = (
   const onMove = (detail: GestureDetail) => {
     /**
      * If `expandToScroll` is disabled, we should not allow the swipe gesture
-     * to continue if the gesture is not pulling down.
+     * to continue if the gesture is not pulling down within scrollable content.
      */
     if (!expandToScroll && detail.deltaY <= 0) {
-      return;
+      const contentEl = findClosestIonContent(detail.event.target! as HTMLElement)
+      const scrollEl = contentEl && isIonContent(contentEl) ? getElementRoot(contentEl).querySelector('.inner-scroll') : contentEl;
+      if (scrollEl) {
+        return;
+      }
     }
 
     /**

--- a/core/src/components/modal/gestures/sheet.ts
+++ b/core/src/components/modal/gestures/sheet.ts
@@ -340,6 +340,19 @@ export const createSheetGesture = (
       return Math.abs(b - diff) < Math.abs(a - diff) ? b : a;
     });
 
+    /**
+     * If expandToScroll is disabled, we should not allow the moveSheetToBreakpoint
+     * function to be called if the user is trying to swipe upwards and the content
+     * is not scrolled to the top.
+     */
+    if (!expandToScroll && detail.deltaY <= 0 && findClosestIonContent(detail.event.target! as HTMLElement)) {
+      const contentEl = findClosestIonContent(detail.event.target! as HTMLElement)!;
+      const scrollEl = isIonContent(contentEl) ? getElementRoot(contentEl).querySelector('.inner-scroll') : contentEl;
+      if (scrollEl!.scrollTop > 0) {
+        return;
+      }
+    }
+
     moveSheetToBreakpoint({
       breakpoint: closest,
       breakpointOffset: offset,


### PR DESCRIPTION
Issue number: **no error submited yet**

---------
## What is the current behavior?
Changes introduced by #30235 caused two major issues:
- Animations were not being played when increasing breakpoints.
- When the scrollable content was at the top, and a big scroll down the list was made, the modal would jump to another breakpoint. 

## What is the new behavior?
- When `expandToScroll` is false, the swipe gesture is allowed unless it's a pull down within scrollable content.
- When `expandToScroll` is false, we cancel the `moveSheetToBreakpoint` when a scroll to top is being done within the scrollable content

## Does this introduce a breaking change?

- [ ] Yes
- [ x] No

## Other information
| Before | After |
|--------|-------|
| https://github.com/user-attachments/assets/e1c22f48-f990-45cf-a6c4-1aec0d019c6d     |  https://github.com/user-attachments/assets/f01e0480-748f-40af-ac11-94f790f0e197     |


