### PR TITLE
perf(sheet): fixing performance regression on modal sheets when expandToScroll is false

### DIFF
--- a/core/src/components/modal/gestures/sheet.ts
+++ b/core/src/components/modal/gestures/sheet.ts
@@ -239,9 +239,11 @@ export const createSheetGesture = (
      * this allows us to avoid querying the DOM for the target in onMove,
      * which would impact performance significantly.
      */
-    const targetEl = findClosestIonContent(detail.event.target! as HTMLElement);
-    cachedScrollEl =
-      targetEl && isIonContent(targetEl) ? getElementRoot(targetEl).querySelector('.inner-scroll') : targetEl;
+    if (!expandToScroll) {
+      const targetEl = findClosestIonContent(detail.event.target! as HTMLElement);
+      cachedScrollEl =
+        targetEl && isIonContent(targetEl) ? getElementRoot(targetEl).querySelector('.inner-scroll') : targetEl;
+    }
 
     /**
      * If expandToScroll is disabled, we need to swap

--- a/core/src/components/modal/gestures/sheet.ts
+++ b/core/src/components/modal/gestures/sheet.ts
@@ -240,7 +240,8 @@ export const createSheetGesture = (
      * which would impact performance significantly.
      */
     const targetEl = findClosestIonContent(detail.event.target! as HTMLElement);
-    cachedScrollEl = targetEl && isIonContent(targetEl) ? getElementRoot(targetEl).querySelector('.inner-scroll') : targetEl;
+    cachedScrollEl =
+      targetEl && isIonContent(targetEl) ? getElementRoot(targetEl).querySelector('.inner-scroll') : targetEl;
 
     /**
      * If expandToScroll is disabled, we need to swap


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->
Currently, when a sheet is moved while `expandToScroll` is disabled, the DOM is queried excessively causing performance degradation.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

We now cache the targeted element in `onStart` and refer to it in `onMove` and `onEnd`, preventing over-querying the DOM

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
This regression was introduced in #30257 and quickly highlighted by a member of the community
