### PR TITLE
test(angular): fixing over-import of RouterModule in the standalone router-link test

### DIFF
--- a/packages/angular/test/base/src/app/standalone/app-standalone/app.component.ts
+++ b/packages/angular/test/base/src/app/standalone/app-standalone/app.component.ts
@@ -1,12 +1,11 @@
 import { Component } from '@angular/core';
-import { RouterModule } from '@angular/router';
-import { IonRouterOutlet, IonApp } from '@ionic/angular/standalone';
+import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-root-standalone',
   templateUrl: './app.component.html',
   standalone: true,
-  imports: [RouterModule, IonRouterOutlet, IonApp]
+  imports: [IonRouterOutlet, IonApp]
 })
 export class AppComponent {
 }

--- a/packages/angular/test/base/src/app/standalone/router-link/router-link.component.ts
+++ b/packages/angular/test/base/src/app/standalone/router-link/router-link.component.ts
@@ -1,11 +1,11 @@
 import { Component } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { RouterLink } from '@angular/router';
 import { IonRouterLink, IonRouterLinkWithHref } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-router-link',
   templateUrl: './router-link.component.html',
   standalone: true,
-  imports: [RouterModule, IonRouterLink, IonRouterLinkWithHref],
+  imports: [RouterLink, IonRouterLink, IonRouterLinkWithHref],
 })
 export class RouterLinkComponent {}

--- a/packages/angular/test/base/src/app/standalone/standalone.component.ts
+++ b/packages/angular/test/base/src/app/standalone/standalone.component.ts
@@ -1,5 +1,4 @@
 import { Component } from "@angular/core";
-import { RouterModule } from "@angular/router";
 
 import { IonicModule } from '@ionic/angular';
 
@@ -7,6 +6,6 @@ import { IonicModule } from '@ionic/angular';
   selector: 'app-standalone',
   templateUrl: './standalone.component.html',
   standalone: true,
-  imports: [IonicModule, RouterModule]
+  imports: [IonicModule]
 })
 export class StandaloneComponent { }


### PR DESCRIPTION
Issue number: resolves internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently the standalone test app for router-link in Angular imports all of `RouterModule` when it only needs to import `RouterLink` from `@angular/router`

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Now, the Angular test app will import only what it needs from router instead of over-importing.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This PR helps align our Angular test apps with a more real-world implementation expectation