### PR TITLE
fix(config): properly export LogLevel

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -8,6 +8,7 @@ export { getTimeGivenProgression } from './utils/animation/cubic-bezier';
 export { createGesture } from './utils/gesture';
 export { initialize } from './global/ionic-global';
 export { componentOnReady } from './utils/helpers';
+export { LogLevel } from './utils/logging';
 export { isPlatform, Platforms, PlatformConfig, getPlatforms } from './utils/platform';
 export { IonicSafeString } from './utils/sanitization';
 export { IonicConfig, getMode, setupConfig } from './utils/config';

--- a/core/src/utils/logging/test/logging.spec.ts
+++ b/core/src/utils/logging/test/logging.spec.ts
@@ -1,5 +1,5 @@
 import { config } from '@global/config';
-import { LogLevel } from '../index';
+import { LogLevel } from '../../../index';
 
 import { printIonError, printIonWarning } from '../index';
 


### PR DESCRIPTION
Issue number: resolves #30255

---------

## What is the current behavior?
`LogLevel` is not properly exported

## What is the new behavior?
Exports `LogLevel` in core

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Dev build: `8.5.4-dev.11743715474.1eadbd25`
