### PR TITLE
fix(overlay): prevent detached DOM nodes during React inline overlay dismiss

### DIFF
--- a/packages/react/src/components/createInlineOverlayComponent.tsx
+++ b/packages/react/src/components/createInlineOverlayComponent.tsx
@@ -199,8 +199,10 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
        * that removes the item.)
        */
       if (wrapper && el) {
+        // The delegate's removeViewFromDom call handles unmounting the React component.
+        // Setting state here can cause race conditions.
+        // Restore the wrapper to the element before the delegate removes it.
         el.append(wrapper);
-        this.setState({ isOpen: false });
       }
 
       this.props.onDidDismiss && this.props.onDidDismiss(evt);


### PR DESCRIPTION
Issue number: resolves internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently, the inline overlay component calls setState on dismiss that can cause the component to rerender when it's otherwise trying to be removed from the DOM, preventing elements that should be removed from the DOM from being removed from memory and leading to detached nodes.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

We no longer call setState on dismiss. It shouldn't really be necessary anyway, because after dismiss in this case the entire component should be destroyed ultimately. This prevents things that were removed from the DOM from being re-rendered by React and hanging around in memory, preventing detached nodes.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
