### PR TITLE
fix(modal): add expandToScroll property to ModalOptions

### DIFF
--- a/core/src/components/modal/modal-interface.ts
+++ b/core/src/components/modal/modal-interface.ts
@@ -25,6 +25,7 @@ export interface ModalOptions<T extends ComponentRef = ComponentRef> {
   backdropBreakpoint?: number;
   handle?: boolean;
   handleBehavior?: ModalHandleBehavior;
+  expandToScroll?: boolean;
 }
 
 export interface ModalAnimationOptions {


### PR DESCRIPTION
Issue number: resolves #30356

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
Cannot use expandToScroll property in ModalController.create

## What is the new behavior?
ExpandToScroll can be added without syntax problems

## Does this introduce a breaking change?

- [ ] Yes
- [x] No