### PR TITLE
fix(labels): prevent clicking a label from triggering onClick twice on several components

### DIFF
--- a/core/src/components/checkbox/checkbox.tsx
+++ b/core/src/components/checkbox/checkbox.tsx
@@ -205,7 +205,7 @@ export class Checkbox implements ComponentInterface {
    */
   private onDivLabelClick = (ev: MouseEvent) => {
     ev.stopPropagation();
-  }
+  };
 
   private getHintTextID(): string | undefined {
     const { el, helperText, errorText, helperTextId, errorTextId } = this;

--- a/core/src/components/checkbox/checkbox.tsx
+++ b/core/src/components/checkbox/checkbox.tsx
@@ -199,6 +199,14 @@ export class Checkbox implements ComponentInterface {
     this.toggleChecked(ev);
   };
 
+  /**
+   * Stops propagation when the display label is clicked,
+   * otherwise, two clicks will be triggered.
+   */
+  private onDivLabelClick = (ev: MouseEvent) => {
+    ev.stopPropagation();
+  }
+
   private getHintTextID(): string | undefined {
     const { el, helperText, errorText, helperTextId, errorTextId } = this;
 
@@ -314,6 +322,7 @@ export class Checkbox implements ComponentInterface {
             }}
             part="label"
             id={this.inputLabelId}
+            onClick={this.onDivLabelClick}
           >
             <slot></slot>
             {this.renderHintText()}

--- a/core/src/components/checkbox/test/basic/checkbox.e2e.ts
+++ b/core/src/components/checkbox/test/basic/checkbox.e2e.ts
@@ -101,7 +101,12 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
   });
 
   test.describe(title('checkbox: click'), () => {
-    test('clicking a checkbox label should only trigger onclick once', async ({ page }) => {
+    test('clicking a checkbox label should only trigger onclick once', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/30165',
+      });
+
       // Create a spy function in page context
       await page.setContent(`<ion-checkbox onclick="console.log('click called')">Test Checkbox</ion-checkbox>`, config);
 

--- a/core/src/components/checkbox/test/basic/checkbox.e2e.ts
+++ b/core/src/components/checkbox/test/basic/checkbox.e2e.ts
@@ -101,7 +101,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
   });
 
   test.describe(title('checkbox: click'), () => {
-    test('clicking a checkbox label should only trigger onclick once', async ({ page }, testInfo) => {
+    test('should trigger onclick only once when clicking the label', async ({ page }, testInfo) => {
       testInfo.annotations.push({
         type: 'issue',
         description: 'https://github.com/ionic-team/ionic-framework/issues/30165',

--- a/core/src/components/checkbox/test/basic/checkbox.e2e.ts
+++ b/core/src/components/checkbox/test/basic/checkbox.e2e.ts
@@ -122,4 +122,33 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       expect(ionChange).toHaveReceivedEvent();
     });
   });
+
+  test.describe(title('checkbox: click'), () => {
+    test('clicking a checkbox label should only trigger onclick once', async ({ page }) => {
+      // Create a spy function in page context
+      await page.setContent(`<ion-checkbox onclick="console.log('click called')">Test Checkbox</ion-checkbox>`, config);
+
+      // Track calls to the exposed function
+      let clickCount = 0;
+      page.on('console', (msg) => {
+        if (msg.text().includes('click called')) {
+          clickCount++;
+        }
+      });
+
+      const input = page.locator('div.label-text-wrapper');
+
+      // Use position to make sure we click into the label enough to trigger
+      // what would be the double click
+      await input.click({
+        position: {
+          x: 5,
+          y: 5,
+        },
+      });
+
+      // Verify the click was triggered exactly once
+      expect(clickCount).toBe(1);
+    });
+  });
 });

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -695,6 +695,18 @@ export class Input implements ComponentInterface {
   }
 
   /**
+   * Stops propagation when the label is clicked,
+   * otherwise, two clicks will be triggered.
+   */
+  private onLabelClick = (ev: MouseEvent) => {
+    // Only stop propagation if the click was directly on the label
+    // and not on the input or other child elements
+    if (ev.target === ev.currentTarget) {
+      ev.stopPropagation();
+    }
+  }
+
+  /**
    * Renders the border container
    * when fill="outline".
    */
@@ -789,7 +801,7 @@ export class Input implements ComponentInterface {
          * interactable, clicking the label would focus that instead
          * since it comes before the input in the DOM.
          */}
-        <label class="input-wrapper" htmlFor={inputId}>
+        <label class="input-wrapper" htmlFor={inputId} onClick={this.onLabelClick}>
           {this.renderLabelContainer()}
           <div class="native-wrapper">
             <slot name="start"></slot>

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -829,7 +829,7 @@ export class Input implements ComponentInterface {
          */}
         <label class="input-wrapper" htmlFor={inputId} onClick={this.onLabelClick}>
           {this.renderLabelContainer()}
-          <div class="native-wrapper">
+          <div class="native-wrapper" onClick={this.onLabelClick}>
             <slot name="start"></slot>
             <input
               class="native-input"

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -730,7 +730,7 @@ export class Input implements ComponentInterface {
     if (ev.target === ev.currentTarget) {
       ev.stopPropagation();
     }
-  }
+  };
 
   /**
    * Renders the border container

--- a/core/src/components/input/test/basic/input.e2e.ts
+++ b/core/src/components/input/test/basic/input.e2e.ts
@@ -164,5 +164,38 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, screenshot, c
       const event = clickEvent.events[0];
       expect((event.target as HTMLElement).tagName.toLowerCase()).toBe('ion-input');
     });
+
+    test('should trigger onclick only once when clicking the wrapper', async ({ page }) => {
+      // Create a spy function in page context
+      await page.setContent(
+        `
+        <ion-input
+          label="Click Me"
+          value="Test Value"
+        ></ion-input>
+      `,
+        config
+      );
+
+      // Track calls to the exposed function
+      const clickEvent = await page.spyOnEvent('click');
+      const input = page.locator('div.native-wrapper');
+
+      // Use position to make sure we click into the label enough to trigger
+      // what would be the double click
+      await input.click({
+        position: {
+          x: 5,
+          y: 5,
+        },
+      });
+
+      // Verify the click was triggered exactly once
+      expect(clickEvent).toHaveReceivedEventTimes(1);
+
+      // Verify that the event target is the checkbox and not the item
+      const event = clickEvent.events[0];
+      expect((event.target as HTMLElement).tagName.toLowerCase()).toBe('ion-input');
+    });
   });
 });

--- a/core/src/components/input/test/basic/input.e2e.ts
+++ b/core/src/components/input/test/basic/input.e2e.ts
@@ -133,6 +133,10 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, screenshot, c
 
   test.describe(title('input: click'), () => {
     test('should trigger onclick only once when clicking the label', async ({ page }) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/30165',
+      });
       // Create a spy function in page context
       await page.setContent(
         `

--- a/core/src/components/input/test/basic/input.e2e.ts
+++ b/core/src/components/input/test/basic/input.e2e.ts
@@ -130,4 +130,39 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, screenshot, c
       await expect(item).toHaveScreenshot(screenshot(`input-with-clear-button-item-color`));
     });
   });
+
+  test.describe(title('input: click'), () => {
+    test('should trigger onclick only once when clicking the label', async ({ page }) => {
+      // Create a spy function in page context
+      await page.setContent(
+        `
+        <ion-input
+          label="Click Me"
+          value="Test Value"
+        ></ion-input>
+      `,
+        config
+      );
+
+      // Track calls to the exposed function
+      const clickEvent = await page.spyOnEvent('click');
+      const input = page.locator('label.input-wrapper');
+
+      // Use position to make sure we click into the label enough to trigger
+      // what would be the double click
+      await input.click({
+        position: {
+          x: 5,
+          y: 5,
+        },
+      });
+
+      // Verify the click was triggered exactly once
+      expect(clickEvent).toHaveReceivedEventTimes(1);
+
+      // Verify that the event target is the checkbox and not the item
+      const event = clickEvent.events[0];
+      expect((event.target as HTMLElement).tagName.toLowerCase()).toBe('input');
+    });
+  });
 });

--- a/core/src/components/input/test/basic/input.e2e.ts
+++ b/core/src/components/input/test/basic/input.e2e.ts
@@ -132,7 +132,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, screenshot, c
   });
 
   test.describe(title('input: click'), () => {
-    test('should trigger onclick only once when clicking the label', async ({ page }) => {
+    test('should trigger onclick only once when clicking the label', async ({ page }, testInfo) => {
       testInfo.annotations.push({
         type: 'issue',
         description: 'https://github.com/ionic-team/ionic-framework/issues/30165',
@@ -169,13 +169,18 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, screenshot, c
       expect((event.target as HTMLElement).tagName.toLowerCase()).toBe('ion-input');
     });
 
-    test('should trigger onclick only once when clicking the wrapper', async ({ page }) => {
+    test('should trigger onclick only once when clicking the wrapper', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/30165',
+      });
       // Create a spy function in page context
       await page.setContent(
         `
         <ion-input
           label="Click Me"
           value="Test Value"
+          label-placement="floating"
         ></ion-input>
       `,
         config
@@ -189,8 +194,8 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, screenshot, c
       // what would be the double click
       await input.click({
         position: {
-          x: 5,
-          y: 5,
+          x: 1,
+          y: 1,
         },
       });
 

--- a/core/src/components/input/test/basic/input.e2e.ts
+++ b/core/src/components/input/test/basic/input.e2e.ts
@@ -162,7 +162,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, screenshot, c
 
       // Verify that the event target is the checkbox and not the item
       const event = clickEvent.events[0];
-      expect((event.target as HTMLElement).tagName.toLowerCase()).toBe('input');
+      expect((event.target as HTMLElement).tagName.toLowerCase()).toBe('ion-input');
     });
   });
 });

--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -921,7 +921,7 @@ export class Select implements ComponentInterface {
     if (ev.target === ev.currentTarget) {
       ev.stopPropagation();
     }
-  }
+  };
 
   /**
    * Renders the border container

--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -912,6 +912,18 @@ export class Select implements ComponentInterface {
   }
 
   /**
+   * Stops propagation when the label is clicked,
+   * otherwise, two clicks will be triggered.
+   */
+  private onLabelClick = (ev: MouseEvent) => {
+    // Only stop propagation if the click was directly on the label
+    // and not on the input or other child elements
+    if (ev.target === ev.currentTarget) {
+      ev.stopPropagation();
+    }
+  }
+
+  /**
    * Renders the border container
    * when fill="outline".
    */
@@ -1173,7 +1185,7 @@ export class Select implements ComponentInterface {
           [`select-label-placement-${labelPlacement}`]: true,
         })}
       >
-        <label class="select-wrapper" id="select-label">
+        <label class="select-wrapper" id="select-label" onClick={this.onLabelClick}>
           {this.renderLabelContainer()}
           <div class="select-wrapper-inner">
             <slot name="start"></slot>

--- a/core/src/components/select/test/basic/select.e2e.ts
+++ b/core/src/components/select/test/basic/select.e2e.ts
@@ -153,6 +153,10 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
 
   test.describe(title('select: click'), () => {
     test('clicking a select label should only trigger onclick once', async ({ page }) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/30165',
+      });
       // Create a spy function in page context
       await page.setContent(
         `

--- a/core/src/components/select/test/basic/select.e2e.ts
+++ b/core/src/components/select/test/basic/select.e2e.ts
@@ -152,7 +152,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
   });
 
   test.describe(title('select: click'), () => {
-    test('clicking a select label should only trigger onclick once', async ({ page }, testInfo) => {
+    test('should trigger onclick only once when clicking the label', async ({ page }, testInfo) => {
       testInfo.annotations.push({
         type: 'issue',
         description: 'https://github.com/ionic-team/ionic-framework/issues/30165',

--- a/core/src/components/select/test/basic/select.e2e.ts
+++ b/core/src/components/select/test/basic/select.e2e.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import { configs, test } from '@utils/test/playwright';
 import type { E2ELocator } from '@utils/test/playwright';
+import { configs, test } from '@utils/test/playwright';
 
 /**
  * This checks that certain overlays open correctly. While the
@@ -148,6 +148,41 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       const alerts = await page.$$('ion-alert');
 
       expect(alerts.length).toBe(1);
+    });
+  });
+
+  test.describe(title('select: click'), () => {
+    test('clicking a select label should only trigger onclick once', async ({ page }) => {
+      // Create a spy function in page context
+      await page.setContent(
+        `
+        <ion-select aria-label="Fruit" interface="alert">
+          <ion-select-option value="apple">Apple</ion-select-option>
+          <ion-select-option value="banana">Banana</ion-select-option>
+        </ion-select>
+      `,
+        config
+      );
+
+      // Track calls to the exposed function
+      const clickEvent = await page.spyOnEvent('click');
+      const input = page.locator('label.select-wrapper');
+
+      // Use position to make sure we click into the label enough to trigger
+      // what would be the double click
+      await input.click({
+        position: {
+          x: 5,
+          y: 5,
+        },
+      });
+
+      // Verify the click was triggered exactly once
+      expect(clickEvent).toHaveReceivedEventTimes(1);
+
+      // Verify that the event target is the checkbox and not the item
+      const event = clickEvent.events[0];
+      expect((event.target as HTMLElement).tagName.toLowerCase()).toBe('ion-select');
     });
   });
 });

--- a/core/src/components/select/test/basic/select.e2e.ts
+++ b/core/src/components/select/test/basic/select.e2e.ts
@@ -152,7 +152,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
   });
 
   test.describe(title('select: click'), () => {
-    test('clicking a select label should only trigger onclick once', async ({ page }) => {
+    test('clicking a select label should only trigger onclick once', async ({ page }, testInfo) => {
       testInfo.annotations.push({
         type: 'issue',
         description: 'https://github.com/ionic-team/ionic-framework/issues/30165',

--- a/core/src/components/textarea/test/basic/textarea.e2e.ts
+++ b/core/src/components/textarea/test/basic/textarea.e2e.ts
@@ -4,6 +4,10 @@ import { configs, test } from '@utils/test/playwright';
 configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('textarea: click'), () => {
     test('should trigger onclick only once when clicking the label', async ({ page }) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/30165',
+      });
       // Create a spy function in page context
       await page.setContent(`<ion-textarea label="Textarea"></ion-textarea>`, config);
 

--- a/core/src/components/textarea/test/basic/textarea.e2e.ts
+++ b/core/src/components/textarea/test/basic/textarea.e2e.ts
@@ -3,7 +3,7 @@ import { configs, test } from '@utils/test/playwright';
 
 configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('textarea: click'), () => {
-    test('should trigger onclick only once when clicking the label', async ({ page }) => {
+    test('should trigger onclick only once when clicking the label', async ({ page }, testInfo) => {
       testInfo.annotations.push({
         type: 'issue',
         description: 'https://github.com/ionic-team/ionic-framework/issues/30165',

--- a/core/src/components/textarea/test/basic/textarea.e2e.ts
+++ b/core/src/components/textarea/test/basic/textarea.e2e.ts
@@ -1,0 +1,31 @@
+import { expect } from '@playwright/test';
+import { configs, test } from '@utils/test/playwright';
+
+configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
+  test.describe(title('textarea: click'), () => {
+    test('should trigger onclick only once when clicking the label', async ({ page }) => {
+      // Create a spy function in page context
+      await page.setContent(`<ion-textarea label="Textarea"></ion-textarea>`, config);
+
+      // Track calls to the exposed function
+      const clickEvent = await page.spyOnEvent('click');
+      const input = page.locator('label.textarea-wrapper');
+
+      // Use position to make sure we click into the label enough to trigger
+      // what would be the double click
+      await input.click({
+        position: {
+          x: 5,
+          y: 5,
+        },
+      });
+
+      // Verify the click was triggered exactly once
+      expect(clickEvent).toHaveReceivedEventTimes(1);
+
+      // Verify that the event target is the checkbox and not the item
+      const event = clickEvent.events[0];
+      expect((event.target as HTMLElement).tagName.toLowerCase()).toBe('textarea');
+    });
+  });
+});

--- a/core/src/components/textarea/test/basic/textarea.e2e.ts
+++ b/core/src/components/textarea/test/basic/textarea.e2e.ts
@@ -25,7 +25,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
 
       // Verify that the event target is the checkbox and not the item
       const event = clickEvent.events[0];
-      expect((event.target as HTMLElement).tagName.toLowerCase()).toBe('textarea');
+      expect((event.target as HTMLElement).tagName.toLowerCase()).toBe('ion-textarea');
     });
   });
 });

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -559,6 +559,18 @@ export class Textarea implements ComponentInterface {
   }
 
   /**
+   * Stops propagation when the label is clicked,
+   * otherwise, two clicks will be triggered.
+   */
+  private onLabelClick = (ev: MouseEvent) => {
+    // Only stop propagation if the click was directly on the label
+    // and not on the input or other child elements
+    if (ev.target === ev.currentTarget) {
+      ev.stopPropagation();
+    }
+  }
+
+  /**
    * Renders the border container when fill="outline".
    */
   private renderLabelContainer() {
@@ -712,7 +724,7 @@ export class Textarea implements ComponentInterface {
          * interactable, clicking the label would focus that instead
          * since it comes before the textarea in the DOM.
          */}
-        <label class="textarea-wrapper" htmlFor={inputId}>
+        <label class="textarea-wrapper" htmlFor={inputId} onClick={this.onLabelClick}>
           {this.renderLabelContainer()}
           <div class="textarea-wrapper-inner">
             {/**

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -582,7 +582,7 @@ export class Textarea implements ComponentInterface {
     if (ev.target === ev.currentTarget) {
       ev.stopPropagation();
     }
-  }
+  };
 
   /**
    * Renders the border container when fill="outline".

--- a/core/src/components/toggle/test/basic/toggle.e2e.ts
+++ b/core/src/components/toggle/test/basic/toggle.e2e.ts
@@ -1,0 +1,33 @@
+import { expect } from '@playwright/test';
+import { configs, test } from '@utils/test/playwright';
+
+configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
+  test.describe(title('toggle: click'), () => {
+    test('should trigger onclick only once when clicking the label', async ({ page }) => {
+      // Create a spy function in page context
+      await page.setContent(`<ion-toggle onclick="console.log('click called')">my label</ion-toggle>`, config);
+
+      // Track calls to the exposed function
+      let clickCount = 0;
+      page.on('console', (msg) => {
+        if (msg.text().includes('click called')) {
+          clickCount++;
+        }
+      });
+
+      const input = page.locator('div.label-text-wrapper');
+
+      // Use position to make sure we click into the label enough to trigger
+      // what would be the double click
+      await input.click({
+        position: {
+          x: 5,
+          y: 5,
+        },
+      });
+
+      // Verify the click was triggered exactly once
+      expect(clickCount).toBe(1);
+    });
+  });
+});

--- a/core/src/components/toggle/test/basic/toggle.e2e.ts
+++ b/core/src/components/toggle/test/basic/toggle.e2e.ts
@@ -3,7 +3,12 @@ import { configs, test } from '@utils/test/playwright';
 
 configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('toggle: click'), () => {
-    test('should trigger onclick only once when clicking the label', async ({ page }) => {
+    test('should trigger onclick only once when clicking the label', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/30165',
+      });
+
       // Create a spy function in page context
       await page.setContent(`<ion-toggle onclick="console.log('click called')">my label</ion-toggle>`, config);
 

--- a/core/src/components/toggle/toggle.tsx
+++ b/core/src/components/toggle/toggle.tsx
@@ -274,7 +274,7 @@ export class Toggle implements ComponentInterface {
    */
   private onDivLabelClick = (ev: MouseEvent) => {
     ev.stopPropagation();
-  }
+  };
 
   private onFocus = () => {
     this.ionFocus.emit();

--- a/core/src/components/toggle/toggle.tsx
+++ b/core/src/components/toggle/toggle.tsx
@@ -268,6 +268,14 @@ export class Toggle implements ComponentInterface {
     }
   };
 
+  /**
+   * Stops propagation when the display label is clicked,
+   * otherwise, two clicks will be triggered.
+   */
+  private onDivLabelClick = (ev: MouseEvent) => {
+    ev.stopPropagation();
+  }
+
   private onFocus = () => {
     this.ionFocus.emit();
   };
@@ -437,6 +445,7 @@ export class Toggle implements ComponentInterface {
             }}
             part="label"
             id={inputLabelId}
+            onClick={this.onDivLabelClick}
           >
             <slot></slot>
             {this.renderHintText()}


### PR DESCRIPTION
Issue number: resolves #30165

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently, several components will trigger their `onClick` twice if you click on their labels.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
After this fix, the affected components will only trigger `onClick` once per click of their labels or click directly on the element.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The affected components are:
- Checkbox
- Select
- Textarea
- Toggle
- Input

I also tested radio and range but could not reproduce the issue for them.

Note that two of the components, checkbox and toggle, had to have special implementations for both their test and fix because of how the host component acts as the component for accessibility purposes.

Current dev build: `8.5.7-dev.11746044124.147aab6c`