### PR TITLE
fix(scroll-assist): allow focus on input's siblings

### DIFF
--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -868,15 +868,6 @@ export class Input implements ComponentInterface {
                    */
                   ev.preventDefault();
                 }}
-                onFocusin={(ev) => {
-                  /**
-                   * Prevent the focusin event from bubbling otherwise it will cause the focusin
-                   * event listener in scroll assist to fire. When this fires, focus will be moved
-                   * back to the input even if the clear button was never tapped. This poses issues
-                   * for screen readers as it means users would be unable to swipe past the clear button.
-                   */
-                  ev.stopPropagation();
-                }}
                 onClick={this.clearTextInput}
               >
                 <ion-icon aria-hidden="true" icon={clearIconData}></ion-icon>

--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -190,7 +190,7 @@ const setManualFocus = (el: HTMLElement) => {
    * the attribute here, screen readers would be unable to navigate to and interact
    * with these sibling elements.
    *
-   * Without this check, we would need to call `ev.stopPropagation()` on the 
+   * Without this check, we would need to call `ev.stopPropagation()` on the
    * 'focusin' event of each focusable sibling to prevent the scroll assist
    * listener from incorrectly moving focus back to the input. This approach
    * is less maintainable and more error-prone.

--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -181,6 +181,24 @@ const setManualFocus = (el: HTMLElement) => {
     return;
   }
 
+  /**
+   * Optimization for scenarios where the currently focused element is a sibling
+   * of the target element. In such cases, we avoid setting `SKIP_SCROLL_ASSIST`.
+   *
+   * This is crucial for accessibility: input elements can now contain focusable
+   * siblings (e.g., clear buttons, slotted elements). If we didn't skip setting
+   * the attribute here, screen readers would be unable to navigate to and interact
+   * with these sibling elements.
+   *
+   * Without this check, we would need to call `ev.stopPropagation()` on the 
+   * 'focusin' event of each focusable sibling to prevent the scroll assist
+   * listener from incorrectly moving focus back to the input. This approach
+   * is less maintainable and more error-prone.
+   */
+  if (document.activeElement?.parentNode === el.parentNode) {
+    return;
+  }
+
   el.setAttribute(SKIP_SCROLL_ASSIST, 'true');
   el.focus();
 };

--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -195,7 +195,13 @@ const setManualFocus = (el: HTMLElement) => {
    * listener from incorrectly moving focus back to the input. That approach
    * would be less maintainable and more error-prone.
    */
-  if (document.activeElement?.parentNode === el.parentNode) {
+  const inputId = el.getAttribute('id');
+  const label = el.closest(`label[for="${inputId}"]`);
+  const activeElLabel = document.activeElement?.closest(`label[for="${inputId}"]`);
+
+  if (label !== null && label === activeElLabel) {
+    // If the label is the same as the active element label, then
+    // we don't need to set the `SKIP_SCROLL_ASSIST` and reset focus.
     return;
   }
 

--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -192,8 +192,8 @@ const setManualFocus = (el: HTMLElement) => {
    *
    * Without this check, we would need to call `ev.stopPropagation()` on the
    * 'focusin' event of each focusable sibling to prevent the scroll assist
-   * listener from incorrectly moving focus back to the input. This approach
-   * is less maintainable and more error-prone.
+   * listener from incorrectly moving focus back to the input. That approach
+   * would be less maintainable and more error-prone.
    */
   if (document.activeElement?.parentNode === el.parentNode) {
     return;


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

If scroll assist is on (by default it is on for iOS mobile devices), then focus will be redirected to the input if a `focusIn` event fires within the component. This leads to some elements to not being accessible with screen readers.

For example: When the clear button is focused, focusin is dispatched and bubbles up to the ion-input. Our [scroll assist utility listens for focusin](https://github.com/ionic-team/ionic-framework/blob/2fc81ddc9b35d6909fd4b585079aedabbd659233/core/src/utils/input-shims/hacks/scroll-assist.ts#L135) to adjust the scroll position. It also causes the input to be re-focused. As a result, when swiping to the clear button with a screen reader, focus will be forcibly moved back to the input. This means that users cannot swipe away from the input to the right when using a screen reader.

This issue was resolved via PR https://github.com/ionic-team/ionic-framework/pull/29366. However, this only fixed the issue with the clear button. Since then, `ion-input` has implemented `start` and `end` slots. This has opened up the possibility of other focusable elements to being present within `ion-input`. The same issue applies to them. A great example of this is the `input-password-toggle`. The password toggle is required to have a `slot="end"` to render appropriately within `ion-input`. But the users can never access the toggle when using a screen reader.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Since we have no control of what is being passed within the the slots, the fix was done through the scroll assist instead of `ion-input`. It checks if any siblings of the native input have been focused, if they have then leave the focus on them instead of re-directing back to the native input.

- Updated the scroll assist logic to check for focusable siblings of the native input. If found, then allow focus on them.
- Removed the `focusIn` code from the clear button since it's being handle at the scroll assist level.

This fix will be introduced in a feature to lessen any possible issues in case of a regression.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

N/A
