### PR TITLE
fix(input-password-toggle, button): force update aria attributes

### DIFF
--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -1,5 +1,5 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
-import { Component, Element, Event, Host, Prop, Watch, State, h } from '@stencil/core';
+import { Component, Element, Event, Host, Prop, Watch, State, forceUpdate, h } from '@stencil/core';
 import type { AnchorInterface, ButtonInterface } from '@utils/element-interface';
 import type { Attributes } from '@utils/helpers';
 import { inheritAriaAttributes, hasShadowDom } from '@utils/helpers';
@@ -157,6 +157,26 @@ export class Button implements ComponentInterface, AnchorInterface, ButtonInterf
    * Emitted when the button loses focus.
    */
   @Event() ionBlur!: EventEmitter<void>;
+
+  /**
+   * This component is used within the `ion-input-password-toggle` component
+   * to toggle the visibility of the password input.
+   * These attributes need to update based on the state of the password input.
+   * Otherwise, the values will be stale.
+   *
+   * @param newValue
+   * @param _oldValue
+   * @param propName
+   */
+  @Watch('aria-checked')
+  @Watch('aria-label')
+  onAriaChanged(newValue: string, _oldValue: string, propName: string) {
+    this.inheritedAttributes = {
+      ...this.inheritedAttributes,
+      [propName]: newValue,
+    };
+    forceUpdate(this);
+  }
 
   /**
    * This is responsible for rendering a hidden native

--- a/core/src/components/input-password-toggle/input-password-toggle.tsx
+++ b/core/src/components/input-password-toggle/input-password-toggle.tsx
@@ -127,7 +127,7 @@ export class InputPasswordToggle implements ComponentInterface {
           fill="clear"
           shape="round"
           aria-checked={isPasswordVisible ? 'true' : 'false'}
-          aria-label="show password"
+          aria-label={isPasswordVisible ? 'Hide password' : 'Show password'}
           role="switch"
           type="button"
           onPointerDown={(ev) => {

--- a/core/src/components/input-password-toggle/test/a11y/input-password-toggle.e2e.ts
+++ b/core/src/components/input-password-toggle/test/a11y/input-password-toggle.e2e.ts
@@ -20,4 +20,38 @@ configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
       expect(results.violations).toEqual([]);
     });
   });
+
+  test.describe(title('input password toggle: aria attributes'), () => {
+    test('should inherit aria attributes to inner button on load', async ({ page }) => {
+      await page.setContent(
+        `
+        <ion-input label="input" type="password">
+          <ion-input-password-toggle slot="end"></ion-input-password-toggle>
+        </ion-input>
+      `,
+        config
+      );
+
+      const nativeButton = page.locator('ion-input-password-toggle button');
+
+      await expect(nativeButton).toHaveAttribute('aria-label', 'Show password');
+      await expect(nativeButton).toHaveAttribute('aria-checked', 'false');
+    });
+    test('should inherit aria attributes to inner button after toggle', async ({ page }) => {
+      await page.setContent(
+        `
+        <ion-input label="input" type="password">
+          <ion-input-password-toggle slot="end"></ion-input-password-toggle>
+        </ion-input>
+      `,
+        config
+      );
+
+      const nativeButton = page.locator('ion-input-password-toggle button');
+      await nativeButton.click();
+
+      await expect(nativeButton).toHaveAttribute('aria-label', 'Hide password');
+      await expect(nativeButton).toHaveAttribute('aria-checked', 'true');
+    });
+  });
 });


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The `ion-input-password-toggle` has aria attributes that are updated based on the value visibility. However, those values do not reflect on the native button. This leads to the screen readers to not announce correctly.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The aria attributes now reflects correctly within the native button.
- The `aria-label` has been updated to indicate the state of visibility.
- Added tests.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Preview
