### PR TITLE
feat(reorder-group): add ionReorderStart, ionReorderMove, ionReorderEnd events

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -1508,6 +1508,9 @@ ion-reorder-group,none
 ion-reorder-group,prop,disabled,boolean,true,false,false
 ion-reorder-group,method,complete,complete(listOrReorder?: boolean | any[]) => Promise<any>
 ion-reorder-group,event,ionItemReorder,ItemReorderEventDetail,true
+ion-reorder-group,event,ionReorderEnd,ReorderEndEventDetail,true
+ion-reorder-group,event,ionReorderMove,ReorderMoveEventDetail,true
+ion-reorder-group,event,ionReorderStart,void,true
 
 ion-ripple-effect,shadow
 ion-ripple-effect,prop,type,"bounded" | "unbounded",'bounded',false,false

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -30,7 +30,7 @@ import { PopoverSize, PositionAlign, PositionReference, PositionSide, TriggerAct
 import { RadioGroupChangeEventDetail, RadioGroupCompareFn } from "./components/radio-group/radio-group-interface";
 import { PinFormatter, RangeChangeEventDetail, RangeKnobMoveEndEventDetail, RangeKnobMoveStartEventDetail, RangeValue } from "./components/range/range-interface";
 import { RefresherEventDetail } from "./components/refresher/refresher-interface";
-import { ItemReorderEventDetail } from "./components/reorder-group/reorder-group-interface";
+import { ItemReorderEventDetail, ReorderEndEventDetail, ReorderMoveEventDetail } from "./components/reorder-group/reorder-group-interface";
 import { NavigationHookCallback } from "./components/route/route-interface";
 import { SearchbarChangeEventDetail, SearchbarInputEventDetail } from "./components/searchbar/searchbar-interface";
 import { SegmentChangeEventDetail, SegmentValue } from "./components/segment/segment-interface";
@@ -68,7 +68,7 @@ export { PopoverSize, PositionAlign, PositionReference, PositionSide, TriggerAct
 export { RadioGroupChangeEventDetail, RadioGroupCompareFn } from "./components/radio-group/radio-group-interface";
 export { PinFormatter, RangeChangeEventDetail, RangeKnobMoveEndEventDetail, RangeKnobMoveStartEventDetail, RangeValue } from "./components/range/range-interface";
 export { RefresherEventDetail } from "./components/refresher/refresher-interface";
-export { ItemReorderEventDetail } from "./components/reorder-group/reorder-group-interface";
+export { ItemReorderEventDetail, ReorderEndEventDetail, ReorderMoveEventDetail } from "./components/reorder-group/reorder-group-interface";
 export { NavigationHookCallback } from "./components/route/route-interface";
 export { SearchbarChangeEventDetail, SearchbarInputEventDetail } from "./components/searchbar/searchbar-interface";
 export { SegmentChangeEventDetail, SegmentValue } from "./components/segment/segment-interface";
@@ -2770,7 +2770,7 @@ export namespace Components {
     }
     interface IonReorderGroup {
         /**
-          * Completes the reorder operation. Must be called by the `ionItemReorder` event.  If a list of items is passed, the list will be reordered and returned in the proper order.  If no parameters are passed or if `true` is passed in, the reorder will complete and the item will remain in the position it was dragged to. If `false` is passed, the reorder will complete and the item will bounce back to its original position.
+          * Completes the reorder operation. Must be called by the `ionReorderEnd` event.  If a list of items is passed, the list will be reordered and returned in the proper order.  If no parameters are passed or if `true` is passed in, the reorder will complete and the item will remain in the position it was dragged to. If `false` is passed, the reorder will complete and the item will bounce back to its original position.
           * @param listOrReorder A list of items to be sorted and returned in the new order or a boolean of whether or not the reorder should reposition the item.
          */
         "complete": (listOrReorder?: boolean | any[]) => Promise<any>;
@@ -4755,6 +4755,9 @@ declare global {
     };
     interface HTMLIonReorderGroupElementEventMap {
         "ionItemReorder": ItemReorderEventDetail;
+        "ionReorderStart": void;
+        "ionReorderMove": ReorderMoveEventDetail;
+        "ionReorderEnd": ReorderEndEventDetail;
     }
     interface HTMLIonReorderGroupElement extends Components.IonReorderGroup, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIonReorderGroupElementEventMap>(type: K, listener: (this: HTMLIonReorderGroupElement, ev: IonReorderGroupCustomEvent<HTMLIonReorderGroupElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -8039,9 +8042,22 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * Event that needs to be listened to in order to complete the reorder action. Once the event has been emitted, the `complete()` method then needs to be called in order to finalize the reorder action.
+          * TODO(FW-6590): Remove this in a major release.
+          * @deprecated Use `ionReorderEnd` instead. The new event is emitted at the end of every reorder gesture, even if the positions do not change. If you were accessing `event.detail.from` or `event.detail.to`, you should now add `undefined` checks as they can be `undefined` in `ionReorderEnd`.
          */
         "onIonItemReorder"?: (event: IonReorderGroupCustomEvent<ItemReorderEventDetail>) => void;
+        /**
+          * Event that is emitted when the reorder gesture ends. The from and to properties are only available if the reorder gesture moved the item. If the item did not move, the from and to properties will be undefined. Once the event has been emitted, the `complete()` method then needs to be called in order to finalize the reorder action.
+         */
+        "onIonReorderEnd"?: (event: IonReorderGroupCustomEvent<ReorderEndEventDetail>) => void;
+        /**
+          * Event that is emitted as the reorder gesture moves.
+         */
+        "onIonReorderMove"?: (event: IonReorderGroupCustomEvent<ReorderMoveEventDetail>) => void;
+        /**
+          * Event that is emitted when the reorder gesture starts.
+         */
+        "onIonReorderStart"?: (event: IonReorderGroupCustomEvent<void>) => void;
     }
     interface IonRippleEffect {
         /**

--- a/core/src/components/item/test/reorder/index.html
+++ b/core/src/components/item/test/reorder/index.html
@@ -84,7 +84,7 @@
       }
       function initGroup(group) {
         var groupEl = document.getElementById(group.id);
-        groupEl.addEventListener('ionItemReorder', function (ev) {
+        groupEl.addEventListener('ionReorderEnd', function (ev) {
           ev.detail.complete();
         });
         var groupItems = [];

--- a/core/src/components/reorder-group/reorder-group-interface.ts
+++ b/core/src/components/reorder-group/reorder-group-interface.ts
@@ -1,10 +1,33 @@
+// TODO(FW-6590): Remove this once the deprecated event is removed
 export interface ItemReorderEventDetail {
   from: number;
   to: number;
   complete: (data?: boolean | any[]) => any;
 }
 
+// TODO(FW-6590): Remove this once the deprecated event is removed
 export interface ItemReorderCustomEvent extends CustomEvent {
   detail: ItemReorderEventDetail;
+  target: HTMLIonReorderGroupElement;
+}
+
+export interface ReorderMoveEventDetail {
+  from: number;
+  to: number;
+}
+
+export interface ReorderEndEventDetail {
+  from?: number;
+  to?: number;
+  complete: (data?: boolean | any[]) => any;
+}
+
+export interface ReorderMoveCustomEvent extends CustomEvent {
+  detail: ReorderMoveEventDetail;
+  target: HTMLIonReorderGroupElement;
+}
+
+export interface ReorderEndCustomEvent extends CustomEvent {
+  detail: ReorderEndEventDetail;
   target: HTMLIonReorderGroupElement;
 }

--- a/core/src/components/reorder-group/test/basic/index.html
+++ b/core/src/components/reorder-group/test/basic/index.html
@@ -122,8 +122,25 @@
         const reorderGroup = document.getElementById('reorder');
         reorderGroup.disabled = !reorderGroup.disabled;
 
+        // TODO(FW-6590): Remove this once the deprecated event is removed
         reorderGroup.addEventListener('ionItemReorder', ({ detail }) => {
-          console.log('Dragged from index', detail.from, 'to', detail.to);
+          console.log('ionItemReorder: Dragged from index', detail.from, 'to', detail.to);
+        });
+
+        reorderGroup.addEventListener('ionReorderStart', () => {
+          console.log('ionReorderStart');
+        });
+
+        reorderGroup.addEventListener('ionReorderMove', ({ detail }) => {
+          console.log('ionReorderMove: Dragged from index', detail.from, 'to', detail.to);
+        });
+
+        reorderGroup.addEventListener('ionReorderEnd', ({ detail }) => {
+          if (detail.from !== undefined && detail.to !== undefined) {
+            console.log('ionReorderEnd: Dragged from index', detail.from, 'to', detail.to);
+          } else {
+            console.log('ionReorderEnd: No position change occurred');
+          }
 
           detail.complete();
         });

--- a/core/src/components/reorder-group/test/data/index.html
+++ b/core/src/components/reorder-group/test/data/index.html
@@ -50,7 +50,7 @@
         reorderGroup.innerHTML = html;
       }
 
-      reorderGroup.addEventListener('ionItemReorder', ({ detail }) => {
+      reorderGroup.addEventListener('ionReorderEnd', ({ detail }) => {
         console.log('Dragged from index', detail.from, 'to', detail.to);
 
         console.log('Before complete', items);

--- a/core/src/components/reorder-group/test/interactive/index.html
+++ b/core/src/components/reorder-group/test/interactive/index.html
@@ -37,9 +37,9 @@
     </ion-reorder-group>
     <script>
       const group = document.querySelector('ion-reorder-group');
-      group.addEventListener('ionItemReorder', (ev) => {
+      group.addEventListener('ionReorderEnd', (ev) => {
         ev.detail.complete();
-        window.dispatchEvent(new CustomEvent('ionItemReorderComplete'));
+        window.dispatchEvent(new CustomEvent('ionReorderComplete'));
       });
     </script>
   </body>

--- a/core/src/components/reorder-group/test/interactive/reorder-group.e2e.ts
+++ b/core/src/components/reorder-group/test/interactive/reorder-group.e2e.ts
@@ -11,24 +11,24 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
     });
     test('should drag and drop when ion-reorder wraps ion-item', async ({ page }) => {
       const items = page.locator('ion-item');
-      const ionItemReorderComplete = await page.spyOnEvent('ionItemReorderComplete');
+      const ionReorderComplete = await page.spyOnEvent('ionReorderComplete');
 
       await expect(items).toContainText(['Item 1', 'Item 2', 'Item 3', 'Item 4']);
 
       await dragElementBy(items.nth(1), page, 0, 300);
-      await ionItemReorderComplete.next();
+      await ionReorderComplete.next();
 
       await expect(items).toContainText(['Item 1', 'Item 3', 'Item 4', 'Item 2']);
     });
     test('should drag and drop when ion-item wraps ion-reorder', async ({ page }) => {
       const reorderHandle = page.locator('ion-reorder');
       const items = page.locator('ion-item');
-      const ionItemReorderComplete = await page.spyOnEvent('ionItemReorderComplete');
+      const ionReorderComplete = await page.spyOnEvent('ionReorderComplete');
 
       await expect(items).toContainText(['Item 1', 'Item 2', 'Item 3', 'Item 4']);
 
       await dragElementBy(reorderHandle.nth(0), page, 0, 300);
-      await ionItemReorderComplete.next();
+      await ionReorderComplete.next();
 
       await expect(items).toContainText(['Item 2', 'Item 3', 'Item 4', 'Item 1']);
     });

--- a/core/src/components/reorder-group/test/nested/index.html
+++ b/core/src/components/reorder-group/test/nested/index.html
@@ -68,9 +68,9 @@
         customElements.define('app-reorder', AppReorder);
 
         const group = document.querySelector('ion-reorder-group');
-        group.addEventListener('ionItemReorder', (ev) => {
+        group.addEventListener('ionReorderEnd', (ev) => {
           ev.detail.complete();
-          window.dispatchEvent(new CustomEvent('ionItemReorderComplete'));
+          window.dispatchEvent(new CustomEvent('ionReorderComplete'));
         });
       </script>
     </ion-app>

--- a/core/src/components/reorder-group/test/nested/reorder-group.e2e.ts
+++ b/core/src/components/reorder-group/test/nested/reorder-group.e2e.ts
@@ -11,24 +11,24 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
     });
     test('should drag and drop when ion-reorder wraps ion-item', async ({ page }) => {
       const items = page.locator('app-reorder');
-      const ionItemReorderComplete = await page.spyOnEvent('ionItemReorderComplete');
+      const ionReorderComplete = await page.spyOnEvent('ionReorderComplete');
 
       await expect(items).toContainText(['Item 1', 'Item 2', 'Item 3', 'Item 4']);
 
       await dragElementBy(items.nth(1), page, 0, 300);
-      await ionItemReorderComplete.next();
+      await ionReorderComplete.next();
 
       await expect(items).toContainText(['Item 1', 'Item 3', 'Item 4', 'Item 2']);
     });
     test('should drag and drop when ion-item wraps ion-reorder', async ({ page }) => {
       const reorderHandle = page.locator('app-reorder ion-reorder');
       const items = page.locator('app-reorder');
-      const ionItemReorderComplete = await page.spyOnEvent('ionItemReorderComplete');
+      const ionReorderComplete = await page.spyOnEvent('ionReorderComplete');
 
       await expect(items).toContainText(['Item 1', 'Item 2', 'Item 3', 'Item 4']);
 
       await dragElementBy(reorderHandle.nth(0), page, 0, 300);
-      await ionItemReorderComplete.next();
+      await ionReorderComplete.next();
 
       await expect(items).toContainText(['Item 2', 'Item 3', 'Item 4', 'Item 1']);
     });

--- a/core/src/components/reorder-group/test/reorder-group-events.e2e.ts
+++ b/core/src/components/reorder-group/test/reorder-group-events.e2e.ts
@@ -1,0 +1,289 @@
+import { expect } from '@playwright/test';
+import { configs, dragElementBy, test } from '@utils/test/playwright';
+
+/**
+ * This behavior does not vary across modes/directions.
+ */
+configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
+  test.describe(title('reorder-group: events:'), () => {
+    test.describe('ionReorderStart', () => {
+      test('should emit when the reorder operation starts', async ({ page }) => {
+        await page.setContent(
+          `
+          <ion-reorder-group disabled="false">
+            <ion-item>
+              <ion-label>Item 1</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+            <ion-item>
+              <ion-label>Item 2</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+            <ion-item>
+              <ion-label>Item 3</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+          </ion-reorder-group>
+        `,
+          config
+        );
+
+        const reorderGroup = page.locator('ion-reorder-group');
+        const ionReorderStart = await page.spyOnEvent('ionReorderStart');
+
+        await expect(ionReorderStart).toHaveReceivedEventTimes(0);
+
+        // Start the drag to verify it emits the event without having to
+        // actually move the item. Do not release the drag here.
+        await dragElementBy(reorderGroup.locator('ion-reorder').first(), page, 0, 0, undefined, undefined, false);
+
+        await page.waitForChanges();
+
+        await expect(ionReorderStart).toHaveReceivedEventTimes(1);
+
+        // Drag the reorder item further to verify it does
+        // not emit the event again
+        await dragElementBy(reorderGroup.locator('ion-reorder').first(), page, 0, 300);
+
+        await page.waitForChanges();
+
+        await expect(ionReorderStart).toHaveReceivedEventTimes(1);
+      });
+    });
+
+    test.describe('ionReorderMove', () => {
+      test('should emit when the reorder operation does not move the item position', async ({ page }) => {
+        await page.setContent(
+          `
+          <ion-reorder-group disabled="false">
+            <ion-item>
+              <ion-label>Item 1</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+            <ion-item>
+              <ion-label>Item 2</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+            <ion-item>
+              <ion-label>Item 3</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+          </ion-reorder-group>
+        `,
+          config
+        );
+
+        const reorderGroup = page.locator('ion-reorder-group');
+        const ionReorderMove = await page.spyOnEvent('ionReorderMove');
+
+        await dragElementBy(reorderGroup.locator('ion-reorder').first(), page, 0, 0);
+
+        await page.waitForChanges();
+
+        expect(ionReorderMove.events.length).toBeGreaterThan(0);
+
+        // Grab the last event to verify that it is emitting
+        // the correct from and to positions
+        const lastEvent = ionReorderMove.events[ionReorderMove.events.length - 1];
+        expect(lastEvent?.detail.from).toBe(0);
+        expect(lastEvent?.detail.to).toBe(0);
+      });
+
+      test('should emit when the reorder operation moves the item by multiple positions', async ({ page }) => {
+        await page.setContent(
+          `
+          <ion-reorder-group disabled="false">
+            <ion-item>
+              <ion-label>Item 1</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+            <ion-item>
+              <ion-label>Item 2</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+            <ion-item>
+              <ion-label>Item 3</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+          </ion-reorder-group>
+        `,
+          config
+        );
+
+        const reorderGroup = page.locator('ion-reorder-group');
+        const ionReorderMove = await page.spyOnEvent('ionReorderMove');
+
+        // Drag the reorder item by a lot to verify it emits the event
+        await dragElementBy(reorderGroup.locator('ion-reorder').first(), page, 0, 300);
+
+        await page.waitForChanges();
+
+        expect(ionReorderMove.events.length).toBeGreaterThan(0);
+
+        // Grab the last event where the from and to are different to
+        // verify that it is not using the gesture start position as the from
+        const lastDifferentEvent = ionReorderMove.events
+          .reverse()
+          .find((event) => event.detail.from !== event.detail.to);
+        expect(lastDifferentEvent?.detail.from).toBe(1);
+        expect(lastDifferentEvent?.detail.to).toBe(2);
+      });
+    });
+
+    test.describe('ionReorderEnd', () => {
+      test('should emit without details when the reorder operation ends without moving the item position', async ({
+        page,
+      }) => {
+        await page.setContent(
+          `
+          <ion-reorder-group disabled="false">
+            <ion-item>
+              <ion-label>Item 1</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+            <ion-item>
+              <ion-label>Item 2</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+            <ion-item>
+              <ion-label>Item 3</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+          </ion-reorder-group>
+        `,
+          config
+        );
+
+        const reorderGroup = page.locator('ion-reorder-group');
+        const ionReorderEnd = await page.spyOnEvent('ionReorderEnd');
+
+        // Drag the reorder item a little bit but not enough to
+        // make it switch to a different position
+        await dragElementBy(reorderGroup.locator('ion-reorder').first(), page, 0, 20);
+
+        await page.waitForChanges();
+
+        await expect(ionReorderEnd).toHaveReceivedEventTimes(1);
+        await expect(ionReorderEnd).toHaveReceivedEventDetail({ complete: undefined });
+      });
+
+      test('should emit with details when the reorder operation ends and the item has moved', async ({ page }) => {
+        await page.setContent(
+          `
+          <ion-reorder-group disabled="false">
+            <ion-item>
+              <ion-label>Item 1</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+            <ion-item>
+              <ion-label>Item 2</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+            <ion-item>
+              <ion-label>Item 3</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+          </ion-reorder-group>
+        `,
+          config
+        );
+
+        const reorderGroup = page.locator('ion-reorder-group');
+        const ionReorderEnd = await page.spyOnEvent('ionReorderEnd');
+
+        // Start the drag to verify it does not emit the event at the start
+        // of the drag or during the drag. Do not release the drag here.
+        await dragElementBy(reorderGroup.locator('ion-reorder').first(), page, 0, 100, undefined, undefined, false);
+
+        await page.waitForChanges();
+
+        await expect(ionReorderEnd).toHaveReceivedEventTimes(0);
+
+        // Drag the reorder item further and release the drag to verify it emits the event
+        await dragElementBy(reorderGroup.locator('ion-reorder').first(), page, 0, 300);
+
+        await page.waitForChanges();
+
+        await expect(ionReorderEnd).toHaveReceivedEventTimes(1);
+        await expect(ionReorderEnd).toHaveReceivedEventDetail({ from: 0, to: 2, complete: undefined });
+      });
+    });
+
+    // TODO(FW-6590): Remove this once the deprecated event is removed
+    test.describe('ionItemReorder', () => {
+      test('should not emit when the reorder operation ends without moving the item position', async ({ page }) => {
+        await page.setContent(
+          `
+          <ion-reorder-group disabled="false">
+            <ion-item>
+              <ion-label>Item 1</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+            <ion-item>
+              <ion-label>Item 2</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+            <ion-item>
+              <ion-label>Item 3</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+          </ion-reorder-group>
+        `,
+          config
+        );
+
+        const reorderGroup = page.locator('ion-reorder-group');
+        const ionItemReorder = await page.spyOnEvent('ionItemReorder');
+
+        // Drag the reorder item a little bit but not enough to
+        // make it switch to a different position
+        await dragElementBy(reorderGroup.locator('ion-reorder').first(), page, 0, 20);
+
+        await page.waitForChanges();
+
+        await expect(ionItemReorder).toHaveReceivedEventTimes(0);
+      });
+
+      test('should emit when the reorder operation ends and the item has moved', async ({ page }) => {
+        await page.setContent(
+          `
+          <ion-reorder-group disabled="false">
+            <ion-item>
+              <ion-label>Item 1</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+            <ion-item>
+              <ion-label>Item 2</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+            <ion-item>
+              <ion-label>Item 3</ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+          </ion-reorder-group>
+        `,
+          config
+        );
+
+        const reorderGroup = page.locator('ion-reorder-group');
+        const ionItemReorder = await page.spyOnEvent('ionItemReorder');
+
+        // Start the drag to verify it does not emit the event at the start
+        // of the drag or during the drag. Do not release the drag here.
+        await dragElementBy(reorderGroup.locator('ion-reorder').first(), page, 0, 100, undefined, undefined, false);
+
+        await page.waitForChanges();
+
+        await expect(ionItemReorder).toHaveReceivedEventTimes(0);
+
+        // Drag the reorder item further and release the drag to verify it emits the event
+        await dragElementBy(reorderGroup.locator('ion-reorder').first(), page, 0, 300);
+
+        await page.waitForChanges();
+
+        await expect(ionItemReorder).toHaveReceivedEventTimes(1);
+        await expect(ionItemReorder).toHaveReceivedEventDetail({ from: 0, to: 2, complete: undefined });
+      });
+    });
+  });
+});

--- a/core/src/components/reorder-group/test/scroll-target/index.html
+++ b/core/src/components/reorder-group/test/scroll-target/index.html
@@ -57,9 +57,9 @@
 
     <script>
       const group = document.querySelector('ion-reorder-group');
-      group.addEventListener('ionItemReorder', (ev) => {
+      group.addEventListener('ionReorderEnd', (ev) => {
         ev.detail.complete();
-        window.dispatchEvent(new CustomEvent('ionItemReorderComplete'));
+        window.dispatchEvent(new CustomEvent('ionReorderComplete'));
       });
     </script>
   </body>

--- a/core/src/components/reorder-group/test/scroll-target/reorder-group.e2e.ts
+++ b/core/src/components/reorder-group/test/scroll-target/reorder-group.e2e.ts
@@ -11,24 +11,24 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
     });
     test('should drag and drop when ion-reorder wraps ion-item', async ({ page }) => {
       const items = page.locator('ion-item');
-      const ionItemReorderComplete = await page.spyOnEvent('ionItemReorderComplete');
+      const ionReorderComplete = await page.spyOnEvent('ionReorderComplete');
 
       await expect(items).toContainText(['Item 1', 'Item 2', 'Item 3', 'Item 4']);
 
       await dragElementBy(items.nth(1), page, 0, 300);
-      await ionItemReorderComplete.next();
+      await ionReorderComplete.next();
 
       await expect(items).toContainText(['Item 1', 'Item 3', 'Item 4', 'Item 2']);
     });
     test('should drag and drop when ion-item wraps ion-reorder', async ({ page }) => {
       const reorderHandle = page.locator('ion-reorder');
       const items = page.locator('ion-item');
-      const ionItemReorderComplete = await page.spyOnEvent('ionItemReorderComplete');
+      const ionReorderComplete = await page.spyOnEvent('ionReorderComplete');
 
       await expect(items).toContainText(['Item 1', 'Item 2', 'Item 3', 'Item 4']);
 
       await dragElementBy(reorderHandle.nth(0), page, 0, 300);
-      await ionItemReorderComplete.next();
+      await ionReorderComplete.next();
 
       await expect(items).toContainText(['Item 2', 'Item 3', 'Item 4', 'Item 1']);
     });

--- a/packages/angular/src/directives/proxies.ts
+++ b/packages/angular/src/directives/proxies.ts
@@ -1895,20 +1895,41 @@ export class IonReorderGroup {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionItemReorder']);
+    proxyOutputs(this, this.el, ['ionItemReorder', 'ionReorderStart', 'ionReorderMove', 'ionReorderEnd']);
   }
 }
 
 
 import type { ItemReorderEventDetail as IIonReorderGroupItemReorderEventDetail } from '@ionic/core';
+import type { ReorderMoveEventDetail as IIonReorderGroupReorderMoveEventDetail } from '@ionic/core';
+import type { ReorderEndEventDetail as IIonReorderGroupReorderEndEventDetail } from '@ionic/core';
 
 export declare interface IonReorderGroup extends Components.IonReorderGroup {
   /**
-   * Event that needs to be listened to in order to complete the reorder action.
+   * TODO(FW-6590): Remove this in a major release. @deprecated Use `ionReorderEnd` instead. The new event is emitted
+at the end of every reorder gesture, even if the positions do not
+change. If you were accessing `event.detail.from` or `event.detail.to`,
+you should now add `undefined` checks as they can be `undefined` in
+`ionReorderEnd`.
+   */
+  ionItemReorder: EventEmitter<CustomEvent<IIonReorderGroupItemReorderEventDetail>>;
+  /**
+   * Event that is emitted when the reorder gesture starts.
+   */
+  ionReorderStart: EventEmitter<CustomEvent<void>>;
+  /**
+   * Event that is emitted as the reorder gesture moves.
+   */
+  ionReorderMove: EventEmitter<CustomEvent<IIonReorderGroupReorderMoveEventDetail>>;
+  /**
+   * Event that is emitted when the reorder gesture ends.
+The from and to properties are only available if the reorder gesture
+moved the item. If the item did not move, the from and to properties
+will be undefined.
 Once the event has been emitted, the `complete()` method then needs
 to be called in order to finalize the reorder action.
    */
-  ionItemReorder: EventEmitter<CustomEvent<IIonReorderGroupItemReorderEventDetail>>;
+  ionReorderEnd: EventEmitter<CustomEvent<IIonReorderGroupReorderEndEventDetail>>;
 }
 
 

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -90,6 +90,7 @@ export {
   InputOtpChangeEventDetail,
   InputOtpCompleteEventDetail,
   InputOtpInputEventDetail,
+  // TODO(FW-6590): Remove the next two lines once the deprecated event is removed
   ItemReorderEventDetail,
   ItemReorderCustomEvent,
   ItemSlidingCustomEvent,
@@ -112,6 +113,10 @@ export {
   RangeKnobMoveEndEventDetail,
   RefresherCustomEvent,
   RefresherEventDetail,
+  ReorderMoveCustomEvent,
+  ReorderMoveEventDetail,
+  ReorderEndCustomEvent,
+  ReorderEndEventDetail,
   RouterEventDetail,
   RouterCustomEvent,
   ScrollBaseCustomEvent,

--- a/packages/angular/standalone/src/directives/proxies.ts
+++ b/packages/angular/standalone/src/directives/proxies.ts
@@ -1755,20 +1755,41 @@ export class IonReorderGroup {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ionItemReorder']);
+    proxyOutputs(this, this.el, ['ionItemReorder', 'ionReorderStart', 'ionReorderMove', 'ionReorderEnd']);
   }
 }
 
 
 import type { ItemReorderEventDetail as IIonReorderGroupItemReorderEventDetail } from '@ionic/core/components';
+import type { ReorderMoveEventDetail as IIonReorderGroupReorderMoveEventDetail } from '@ionic/core/components';
+import type { ReorderEndEventDetail as IIonReorderGroupReorderEndEventDetail } from '@ionic/core/components';
 
 export declare interface IonReorderGroup extends Components.IonReorderGroup {
   /**
-   * Event that needs to be listened to in order to complete the reorder action.
+   * TODO(FW-6590): Remove this in a major release. @deprecated Use `ionReorderEnd` instead. The new event is emitted
+at the end of every reorder gesture, even if the positions do not
+change. If you were accessing `event.detail.from` or `event.detail.to`,
+you should now add `undefined` checks as they can be `undefined` in
+`ionReorderEnd`.
+   */
+  ionItemReorder: EventEmitter<CustomEvent<IIonReorderGroupItemReorderEventDetail>>;
+  /**
+   * Event that is emitted when the reorder gesture starts.
+   */
+  ionReorderStart: EventEmitter<CustomEvent<void>>;
+  /**
+   * Event that is emitted as the reorder gesture moves.
+   */
+  ionReorderMove: EventEmitter<CustomEvent<IIonReorderGroupReorderMoveEventDetail>>;
+  /**
+   * Event that is emitted when the reorder gesture ends.
+The from and to properties are only available if the reorder gesture
+moved the item. If the item did not move, the from and to properties
+will be undefined.
 Once the event has been emitted, the `complete()` method then needs
 to be called in order to finalize the reorder action.
    */
-  ionItemReorder: EventEmitter<CustomEvent<IIonReorderGroupItemReorderEventDetail>>;
+  ionReorderEnd: EventEmitter<CustomEvent<IIonReorderGroupReorderEndEventDetail>>;
 }
 
 

--- a/packages/angular/standalone/src/index.ts
+++ b/packages/angular/standalone/src/index.ts
@@ -88,6 +88,7 @@ export {
   InputOtpChangeEventDetail,
   InputOtpCompleteEventDetail,
   InputOtpInputEventDetail,
+  // TODO(FW-6590): Remove the next two lines once the deprecated event is removed
   ItemReorderEventDetail,
   ItemReorderCustomEvent,
   ItemSlidingCustomEvent,
@@ -110,6 +111,10 @@ export {
   RangeKnobMoveEndEventDetail,
   RefresherCustomEvent,
   RefresherEventDetail,
+  ReorderMoveCustomEvent,
+  ReorderMoveEventDetail,
+  ReorderEndCustomEvent,
+  ReorderEndEventDetail,
   RouterEventDetail,
   RouterCustomEvent,
   ScrollBaseCustomEvent,

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -47,6 +47,7 @@ export {
   InputOtpChangeEventDetail,
   InputOtpCompleteEventDetail,
   InputOtpInputEventDetail,
+  // TODO(FW-6590): Remove the next two lines once the deprecated event is removed
   ItemReorderEventDetail,
   ItemReorderCustomEvent,
   ItemSlidingCustomEvent,
@@ -68,6 +69,10 @@ export {
   RangeKnobMoveEndEventDetail,
   RefresherCustomEvent,
   RefresherEventDetail,
+  ReorderMoveCustomEvent,
+  ReorderMoveEventDetail,
+  ReorderEndCustomEvent,
+  ReorderEndEventDetail,
   RouterEventDetail,
   RouterCustomEvent,
   ScrollBaseCustomEvent,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -84,6 +84,7 @@ export {
   InputOtpChangeEventDetail,
   InputOtpCompleteEventDetail,
   InputOtpInputEventDetail,
+  // TODO(FW-6590): Remove the next two lines once the deprecated event is removed
   ItemReorderEventDetail,
   ItemReorderCustomEvent,
   ItemSlidingCustomEvent,
@@ -107,6 +108,10 @@ export {
   RangeKnobMoveEndEventDetail,
   RefresherCustomEvent,
   RefresherEventDetail,
+  ReorderMoveCustomEvent,
+  ReorderMoveEventDetail,
+  ReorderEndCustomEvent,
+  ReorderEndEventDetail,
   RouterEventDetail,
   RouterCustomEvent,
   ScrollBaseCustomEvent,

--- a/packages/vue/src/proxies.ts
+++ b/packages/vue/src/proxies.ts
@@ -804,9 +804,15 @@ export const IonReorder: StencilVueComponent<JSX.IonReorder> = /*@__PURE__*/ def
 
 export const IonReorderGroup: StencilVueComponent<JSX.IonReorderGroup> = /*@__PURE__*/ defineContainer<JSX.IonReorderGroup>('ion-reorder-group', defineIonReorderGroup, [
   'disabled',
-  'ionItemReorder'
+  'ionItemReorder',
+  'ionReorderStart',
+  'ionReorderMove',
+  'ionReorderEnd'
 ], [
-  'ionItemReorder'
+  'ionItemReorder',
+  'ionReorderStart',
+  'ionReorderMove',
+  'ionReorderEnd'
 ]);
 
 


### PR DESCRIPTION
Issue number: resolves #23148 resolves #27614

---------

## What is the current behavior?
The `ion-reorder-group` only emits an `ionItemReorder` event when the reorder gesture ends AND the item position has changed. There is no way to listen for when the gesture starts, is actively moving, or ends without the item changing position.

## What is the new behavior?
- Adds an `ionReorderStart` event which is fired without any details on the start of the gesture.
- Adds an `ionReorderMove` event which is fired on gesture move and includes the `from` and `to` detail. 
- Adds an `ionReorderEnd` event which is fired on gesture end and includes the `from` and `to` detail ONLY if they are different, otherwise they are `undefined`.
- Deprecates the `ionItemReorder` event, recommending to use the `ionReorderEnd` instead.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

While this does not introduce a breaking change, it does deprecate the `ionItemReorder` event in favor of the `ionReorderEnd` event. This event behaves a bit differently since it is always emitted on end, but if the `to` and `from` are the same then it won't emit them, so it is possible to check if they are `undefined` to determine if the `ionReorderEnd` fired without moving item positions.

## Other information

[Preview](https://ionic-framework-git-fw-6539-ionic1.vercel.app/src/components/reorder-group/test/basic)