### PR TITLE
fix(item): allow nested content to be conditionally interactive

### DIFF
--- a/core/src/components/item/test/inputs/item.e2e.ts
+++ b/core/src/components/item/test/inputs/item.e2e.ts
@@ -252,5 +252,46 @@ configs({ directions: ['ltr'] }).forEach(({ title, screenshot, config }) => {
 
       await expect(list).toHaveScreenshot(screenshot(`item-inputs-div-with-inputs`));
     });
+
+    test('should update interactivity state when elements are conditionally rendered', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/29763',
+      });
+
+      await page.setContent(
+        `
+        <ion-list>
+          <ion-item>
+            <ion-label>Conditional Checkbox</ion-label>
+          </ion-item>
+        </ion-list>
+        `,
+        config
+      );
+
+      const item = page.locator('ion-item');
+
+      await page.evaluate(() => {
+        const item = document.querySelector('ion-item');
+        const checkbox = document.createElement('ion-checkbox');
+        item?.appendChild(checkbox);
+      });
+
+      await page.waitForChanges();
+
+      const checkbox = page.locator('ion-checkbox');
+      await expect(checkbox).not.toBeChecked();
+
+      // Test that clicking on the left edge of the item toggles the checkbox
+      await item.click({
+        position: {
+          x: 5,
+          y: 5,
+        },
+      });
+
+      await expect(checkbox).toBeChecked();
+    });
   });
 });


### PR DESCRIPTION
Issue number: resolves #29763 

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
If the nested content of an ion-item is conditionally rendered and goes from containing zero interactive elements to one or more, a render is not triggered in Angular and the item does not behave correctly for one or more nested inputs.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- A mutation observer is created in `connectedCallback()` to watch for changes in item's child list.  When the `childList` changes, two pieces of state that track whether the item needs to be interactive and whether there are multiple interactive elements are updated.
- Add `disconnectedCallback()` and logic to disconnect Mutation Observer.
- Create new function `totalNestedInputs()` with logic from existing `setMultipleInputs` function to be used for both `setMultipleInputs` and new function `setIsInteractive`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

 I opted for the MutationObserver over a `slotchange` listener because the `slotchange` fires synchronously on any slot within the shadowRoot, and the MutationObserver fires once on the item element itself. I attempted to add the minimum amount of logic to achieve this but there may be a more elegant solution that combines what `multipleInputs` and `isInteractive` are doing but requires more changes to existing code.