### PR TITLE
chore(ci): update PR title check to exclude chore and release titles

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -9,24 +9,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
-        uses:  amannn/action-semantic-pull-request@v5
+        if: |
+          !contains(github.event.pull_request.title, 'release') &&
+          !contains(github.event.pull_request.title, 'chore')
+        uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # Configure that a scope must always be provided.
           requireScope: true
+          # Configure allowed commit types
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            revert
+            release
+            chore
           # Configure additional validation for the subject based on a regex.
           # This example ensures the subject doesn't start with an uppercase character.
           subjectPattern: ^(?![A-Z]).+$
-          # If `subjectPattern` is configured, you can use this property to 
-          # override the default error message that is shown when the pattern 
-          # doesn't match. The variables `subject` and `title` can be used 
+          # If `subjectPattern` is configured, you can use this property to
+          # override the default error message that is shown when the pattern
+          # doesn't match. The variables `subject` and `title` can be used
           # within the message.
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}" didn't match the configured pattern. Please ensure that the subject doesn't start with an uppercase character.
-          # If the PR contains one of these newline-delimited labels, the
-          # validation is skipped. If you want to rerun the validation when
-          # labels change, you might want to use the `labeled` and `unlabeled`
-          # event triggers in your workflow.
-          ignoreLabels: |
-            release


### PR DESCRIPTION
Updates our PR title check to ignore titles with `chore` or `release` in them, eliminating the need for a `release` label on release PRs & allowing us to write commits like `chore: update dependency`. 

I also specified which commit types are allowed and included `chore` and `release` here even though they are skipped in case we ever remove the if skipping them. 