### PR TITLE
fix(modal): dismiss child modals when parent is dismissed

### DIFF
--- a/core/src/components/modal/test/inline/index.html
+++ b/core/src/components/modal/test/inline/index.html
@@ -24,28 +24,75 @@
         <ion-content class="ion-padding">
           <button id="open-inline-modal" onclick="openModal(event)">Open Modal</button>
 
-          <ion-modal swipe-to-close="true">
-            <ion-header>
-              <ion-toolbar>
-                <ion-title> Modal </ion-title>
-              </ion-toolbar>
-            </ion-header>
-            <ion-content class="ion-padding"> This is my inline modal content! </ion-content>
-          </ion-modal>
+          <div id="modal-container">
+            <ion-modal swipe-to-close="true">
+              <ion-header>
+                <ion-toolbar>
+                  <ion-title> Modal </ion-title>
+                </ion-toolbar>
+              </ion-header>
+              <ion-content class="ion-padding">
+                <p>This is my inline modal content!</p>
+                <button id="open-child-modal" onclick="openChildModal(event)">Open Child Modal</button>
+
+                <ion-modal id="child-modal" swipe-to-close="true">
+                  <ion-header>
+                    <ion-toolbar>
+                      <ion-title>Child Modal</ion-title>
+                    </ion-toolbar>
+                  </ion-header>
+                  <ion-content class="ion-padding">
+                    <p>This is the child modal content!</p>
+                    <p>When the parent modal is dismissed, this child modal should also be dismissed automatically.</p>
+                    <button id="dismiss-parent" onclick="dismissParent(event)">Dismiss Parent Modal</button>
+                    <button id="dismiss-child" onclick="dismissChild(event)">Dismiss Child Modal</button>
+                  </ion-content>
+                </ion-modal>
+              </ion-content>
+            </ion-modal>
+          </div>
         </ion-content>
       </div>
     </ion-app>
 
     <script>
       const modal = document.querySelector('ion-modal');
+      const childModal = document.querySelector('#child-modal');
+
       modal.presentingElement = document.querySelector('.ion-page');
+      childModal.presentingElement = modal;
 
       const openModal = () => {
         modal.isOpen = true;
       };
 
+      const openChildModal = () => {
+        childModal.isOpen = true;
+      };
+
+      const dismissParent = () => {
+        modal.isOpen = false;
+      };
+
+      const dismissChild = () => {
+        childModal.isOpen = false;
+      };
+
       modal.addEventListener('didDismiss', () => {
         modal.isOpen = false;
+      });
+
+      childModal.addEventListener('didDismiss', () => {
+        childModal.isOpen = false;
+      });
+
+      // Add event listeners to demonstrate the new functionality
+      modal.addEventListener('ionModalDidDismiss', (event) => {
+        console.log('Parent modal dismissed with role:', event.detail.role);
+      });
+
+      childModal.addEventListener('ionModalDidDismiss', (event) => {
+        console.log('Child modal dismissed with role:', event.detail.role);
       });
     </script>
   </body>

--- a/core/src/components/modal/test/inline/modal.e2e.ts
+++ b/core/src/components/modal/test/inline/modal.e2e.ts
@@ -7,7 +7,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       await page.goto('/src/components/modal/test/inline', config);
       const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
       const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
-      const modal = page.locator('ion-modal');
+      const modal = page.locator('ion-modal').first();
 
       await page.click('#open-inline-modal');
 
@@ -20,6 +20,67 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       await ionModalDidDismiss.next();
 
       await expect(modal).toBeHidden();
+    });
+
+    test('it should dismiss child modals when parent modal is dismissed', async ({ page }) => {
+      await page.goto('/src/components/modal/test/inline', config);
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+      const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
+
+      const parentModal = page.locator('ion-modal').first();
+      const childModal = page.locator('#child-modal');
+
+      // Open the parent modal
+      await page.click('#open-inline-modal');
+      await ionModalDidPresent.next();
+      await expect(parentModal).toBeVisible();
+
+      // Open the child modal
+      await page.click('#open-child-modal');
+      await ionModalDidPresent.next();
+      await expect(childModal).toBeVisible();
+
+      // Both modals should be visible
+      await expect(parentModal).toBeVisible();
+      await expect(childModal).toBeVisible();
+
+      // Dismiss the parent modal
+      await page.click('#dismiss-parent');
+
+      // Wait for both modals to be dismissed
+      await ionModalDidDismiss.next(); // child modal dismissed
+      await ionModalDidDismiss.next(); // parent modal dismissed
+
+      // Both modals should be hidden
+      await expect(parentModal).toBeHidden();
+      await expect(childModal).toBeHidden();
+    });
+
+    test('it should only dismiss child modal when child dismiss button is clicked', async ({ page }) => {
+      await page.goto('/src/components/modal/test/inline', config);
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+      const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
+
+      const parentModal = page.locator('ion-modal').first();
+      const childModal = page.locator('#child-modal');
+
+      // Open the parent modal
+      await page.click('#open-inline-modal');
+      await ionModalDidPresent.next();
+      await expect(parentModal).toBeVisible();
+
+      // Open the child modal
+      await page.click('#open-child-modal');
+      await ionModalDidPresent.next();
+      await expect(childModal).toBeVisible();
+
+      // Dismiss only the child modal
+      await page.click('#dismiss-child');
+      await ionModalDidDismiss.next();
+
+      // Parent modal should still be visible, child modal should be hidden
+      await expect(parentModal).toBeVisible();
+      await expect(childModal).toBeHidden();
     });
 
     test('presenting should create a single root element with the ion-page class', async ({ page }, testInfo) => {


### PR DESCRIPTION
Issue number: resolves #30389

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Currently, when a child modal is present and a parent modal is somehow dismissed, the child modal stays open. This can cause issues in some frameworks like React and Angular, where this cuts the connection to the child modal and it can no longer be dismissed programmatically. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This change enables modals to identify their children and close the children when they're closed. This prevents orphaned modals that can cause a poor UX. Note: This fix is only for inline modals, which is the biggest cause of the above issue.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
