### PR TITLE
fix(modal): dismiss modal when parent element is removed from DOM

### DIFF
--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -96,6 +96,11 @@ export class Modal implements ComponentInterface, OverlayInterface {
   private viewTransitionAnimation?: Animation;
   private resizeTimeout?: any;
 
+  // Mutation observer to watch for parent removal
+  private parentRemovalObserver?: MutationObserver;
+  // Cached original parent from before modal is moved to body during presentation
+  private cachedOriginalParent?: HTMLElement;
+
   lastFocus?: HTMLElement;
   animation?: Animation;
 
@@ -398,6 +403,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
   disconnectedCallback() {
     this.triggerController.removeClickListener();
     this.cleanupViewTransitionListener();
+    this.cleanupParentRemovalObserver();
   }
 
   componentWillLoad() {
@@ -406,6 +412,11 @@ export class Modal implements ComponentInterface, OverlayInterface {
 
     const attributesToInherit = ['aria-label', 'role'];
     this.inheritedAttributes = inheritAttributes(el, attributesToInherit);
+
+    // Cache original parent before modal gets moved to body during presentation
+    if (el.parentNode) {
+      this.cachedOriginalParent = el.parentNode as HTMLElement;
+    }
 
     /**
      * When using a controller modal you can set attributes
@@ -642,6 +653,9 @@ export class Modal implements ComponentInterface, OverlayInterface {
     // Initialize view transition listener for iOS card modals
     this.initViewTransitionListener();
 
+    // Initialize parent removal observer
+    this.initParentRemovalObserver();
+
     unlock();
   }
 
@@ -847,6 +861,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
         this.gesture.destroy();
       }
       this.cleanupViewTransitionListener();
+      this.cleanupParentRemovalObserver();
     }
     this.currentBreakpoint = undefined;
     this.animation = undefined;
@@ -1148,6 +1163,58 @@ export class Modal implements ComponentInterface, OverlayInterface {
     nestedModals?.forEach(async (modal) => {
       await (modal as HTMLIonModalElement).dismiss(undefined, 'parent-dismissed');
     });
+  }
+
+  private initParentRemovalObserver() {
+    // Only observe if we have a cached parent and are in browser environment
+    if (typeof window === 'undefined' || !this.cachedOriginalParent) {
+      return;
+    }
+
+    // Don't observe document or fragment nodes as they can't be "removed"
+    if (this.cachedOriginalParent.nodeType === Node.DOCUMENT_NODE || this.cachedOriginalParent.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+      return;
+    }
+
+    const grandParent = this.cachedOriginalParent.parentNode;
+    if (!grandParent) {
+      return;
+    }
+
+    this.parentRemovalObserver = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === 'childList' && mutation.removedNodes.length > 0) {
+          // Check if our cached original parent was removed
+          const cachedParentWasRemoved = Array.from(mutation.removedNodes).some(
+            (node) => {
+              const isDirectMatch = node === this.cachedOriginalParent;
+              const isContainedMatch = this.cachedOriginalParent ? (node as HTMLElement).contains?.(this.cachedOriginalParent) : false;
+              return isDirectMatch || isContainedMatch;
+            }
+          );
+
+          // Also check if parent is no longer connected to DOM
+          const cachedParentDisconnected = this.cachedOriginalParent && !this.cachedOriginalParent.isConnected;
+
+          if (cachedParentWasRemoved || cachedParentDisconnected) {
+            this.dismiss(undefined, 'parent-removed');
+          }
+        }
+      });
+    });
+
+    // Observe with subtree to catch nested removals
+    this.parentRemovalObserver.observe(grandParent, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  private cleanupParentRemovalObserver() {
+    if (this.parentRemovalObserver) {
+      this.parentRemovalObserver.disconnect();
+      this.parentRemovalObserver = undefined;
+    }
   }
 
   render() {

--- a/core/src/components/modal/test/inline/index.html
+++ b/core/src/components/modal/test/inline/index.html
@@ -22,9 +22,8 @@
         </ion-header>
 
         <ion-content class="ion-padding">
-          <button id="open-inline-modal" onclick="openModal(event)">Open Modal</button>
-
           <div id="modal-container">
+            <button id="open-inline-modal" onclick="openModal(event)">Open Modal</button>
             <ion-modal swipe-to-close="true">
               <ion-header>
                 <ion-toolbar>
@@ -34,6 +33,7 @@
               <ion-content class="ion-padding">
                 <p>This is my inline modal content!</p>
                 <button id="open-child-modal" onclick="openChildModal(event)">Open Child Modal</button>
+                <button id="remove-modal-container" onclick="removeModalContainer(event)">Remove Modal Container</button>
 
                 <ion-modal id="child-modal" swipe-to-close="true">
                   <ion-header>
@@ -46,6 +46,7 @@
                     <p>When the parent modal is dismissed, this child modal should also be dismissed automatically.</p>
                     <button id="dismiss-parent" onclick="dismissParent(event)">Dismiss Parent Modal</button>
                     <button id="dismiss-child" onclick="dismissChild(event)">Dismiss Child Modal</button>
+                    <button id="child-remove-modal-container" onclick="removeModalContainer(event)">Remove Modal Container</button>
                   </ion-content>
                 </ion-modal>
               </ion-content>
@@ -76,6 +77,14 @@
 
       const dismissChild = () => {
         childModal.isOpen = false;
+      };
+
+      const removeModalContainer = () => {
+        const container = document.querySelector('#modal-container');
+        if (container) {
+          container.remove();
+          console.log('Modal container removed from DOM');
+        }
       };
 
       modal.addEventListener('didDismiss', () => {


### PR DESCRIPTION
Issue number: resolves #30389

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Currently, when the element an ion-modal was presented from is removed, the modal stays presented and can be broken depending on the framework. This is unlike #30540, where children of open modals were being kept open. In this case, specifically the DOM element is being removed for whatever reason and the modal is staying open.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

We're now identifying our parent component on load and watching it with a mutation observer to determine if it gets removed from the DOM. If it does, we trigger a dismiss. This, conveniently, works nicely with #30540 and will dismiss all children and grandchildren as well. 

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The issue this resolves was already marked closed, but on closer inspection I determined that was a mistake. I believed this issue was related to another one I was dealing with and it is, but it wasn't quite the same.

After this issue is merged, I believe we will have handled all avenues of possibly ending up with broken modals because of parent elements or modals being removed.