### PR TITLE
chore(deps): downgrade Stencil to v4.33.1

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.6.6",
       "license": "MIT",
       "dependencies": {
-        "@stencil/core": "4.36.2",
+        "@stencil/core": "4.33.1",
         "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       },
@@ -1914,9 +1914,10 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.36.2",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.36.2.tgz",
-      "integrity": "sha512-PRFSpxNzX9Oi0Wfh02asztN9Sgev/MacfZwmd+VVyE6ZxW+a/kEpAYZhzGAmE+/aKVOGYuug7R9SulanYGxiDQ==",
+      "version": "4.33.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.33.1.tgz",
+      "integrity": "sha512-12k9xhAJBkpg598it+NRmaYIdEe6TSnsL/v6/KRXDcUyTK11VYwZQej2eHnMWtqot+znJ+GNTqb5YbiXi+5Low==",
+      "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -11982,9 +11983,9 @@
       "requires": {}
     },
     "@stencil/core": {
-      "version": "4.36.2",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.36.2.tgz",
-      "integrity": "sha512-PRFSpxNzX9Oi0Wfh02asztN9Sgev/MacfZwmd+VVyE6ZxW+a/kEpAYZhzGAmE+/aKVOGYuug7R9SulanYGxiDQ==",
+      "version": "4.33.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.33.1.tgz",
+      "integrity": "sha512-12k9xhAJBkpg598it+NRmaYIdEe6TSnsL/v6/KRXDcUyTK11VYwZQej2eHnMWtqot+znJ+GNTqb5YbiXi+5Low==",
       "requires": {
         "@rollup/rollup-darwin-arm64": "4.34.9",
         "@rollup/rollup-darwin-x64": "4.34.9",

--- a/core/package.json
+++ b/core/package.json
@@ -31,7 +31,7 @@
     "loader/"
   ],
   "dependencies": {
-    "@stencil/core": "4.36.2",
+    "@stencil/core": "4.33.1",
     "ionicons": "^7.2.2",
     "tslib": "^2.1.0"
   },


### PR DESCRIPTION
A major regression related to Reorder was found in Stencil v4.36. Downgrade Stencil until this can be resolved.