### PR TITLE
chore(deps): update outsystems design tokens package

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -44,7 +44,7 @@
         "fs-extra": "^9.0.1",
         "jest": "^29.7.0",
         "jest-cli": "^29.7.0",
-        "outsystems-design-tokens": "^1.2.6",
+        "outsystems-design-tokens": "^1.3.0",
         "prettier": "^2.8.8",
         "rollup": "^2.26.4",
         "sass": "^1.33.0",
@@ -9206,17 +9206,28 @@
       }
     },
     "node_modules/outsystems-design-tokens": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/outsystems-design-tokens/-/outsystems-design-tokens-1.2.6.tgz",
-      "integrity": "sha512-Wqv7vR1nB6G8WfwKVMqpifhugT+iz5dh25QMWW/XFkblIm2e+mQcUqQw0W9lPSihWKH8wgJfe7zY0mT5G5h3VA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/outsystems-design-tokens/-/outsystems-design-tokens-1.3.0.tgz",
+      "integrity": "sha512-VEYce0sdh9EfqH3NIBlyIZ6d2AtNRSj6ZjufHar2nsJTi+6LXxCogCXOZoFY3FRZ3Mf3fW0wUDrzi9772p4F7Q==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "glob": "^11.0.0",
         "minimist": "^1.2.8",
-        "style-dictionary": "^4.3.0"
+        "style-dictionary": "^5.0.0"
       },
       "bin": {
         "build.tokens": "scripts/index.js"
+      }
+    },
+    "node_modules/outsystems-design-tokens/node_modules/@types/node": {
+      "version": "22.17.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.0.tgz",
+      "integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/outsystems-design-tokens/node_modules/balanced-match": {
@@ -9240,6 +9251,16 @@
         "node": ">= 18"
       }
     },
+    "node_modules/outsystems-design-tokens/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/outsystems-design-tokens/node_modules/glob": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
@@ -9261,6 +9282,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/outsystems-design-tokens/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/outsystems-design-tokens/node_modules/jackspeak": {
@@ -9317,6 +9351,59 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/outsystems-design-tokens/node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/outsystems-design-tokens/node_modules/style-dictionary": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-5.0.1.tgz",
+      "integrity": "sha512-j+yQ4hM7a52iUQg5LVC8bnRkem4sU+unIY2qsyjoikPVzaxjkHd4ER7bnK+znW/Rhha69t4Fi5O46UHg6w8jFQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bundled-es-modules/deepmerge": "^4.3.1",
+        "@bundled-es-modules/glob": "^10.4.2",
+        "@bundled-es-modules/memfs": "^4.9.4",
+        "@types/node": "^22.10.5",
+        "@zip.js/zip.js": "^2.7.44",
+        "chalk": "^5.3.0",
+        "change-case": "^5.3.0",
+        "commander": "^12.1.0",
+        "is-plain-obj": "^4.1.0",
+        "json5": "^2.2.2",
+        "patch-package": "^8.0.0",
+        "path-unified": "^0.2.0",
+        "prettier": "^3.3.3",
+        "tinycolor2": "^1.6.0"
+      },
+      "bin": {
+        "style-dictionary": "bin/style-dictionary.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/outsystems-design-tokens/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "2.3.0",

--- a/core/package.json
+++ b/core/package.json
@@ -66,7 +66,7 @@
     "fs-extra": "^9.0.1",
     "jest": "^29.7.0",
     "jest-cli": "^29.7.0",
-    "outsystems-design-tokens": "^1.2.6",
+    "outsystems-design-tokens": "^1.3.0",
     "prettier": "^2.8.8",
     "rollup": "^2.26.4",
     "sass": "^1.33.0",


### PR DESCRIPTION
Updating outsystems-design-tokens reference. This package removes the Inter font from being the default font, and replaced it with the respective system fonts.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
The default font was Inter, that had to be loaded from Google CDN, causing CSP problems with default rules.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Update to latest version of `outsystems-design-tokens` that no longer uses the Inter font.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
