### PR TITLE
fix(select-modal): hide focus option's border for ionic theme

### DIFF
--- a/core/src/components/select-modal/select-modal.ionic.scss
+++ b/core/src/components/select-modal/select-modal.ionic.scss
@@ -11,6 +11,11 @@ ion-item {
   --border-width: 0;
 }
 
+ion-item.ion-focused::part(native)::after {
+  // Your styles for the ::after pseudo element when ion-item is focused
+  border: none;
+}
+
 // Toolbar
 // ----------------------------------------------------------------
 


### PR DESCRIPTION
Issue number: resolves internal

---------
## What is the current behavior?
When opening a ion-select with a modal interface, the first option is focused and, as such, has a border.
This happens because an ion-item is being rendered, which has a specific styling for focused stated.

## What is the new behavior?
When inside a `ion-select-modal`, we don't want this specific `ion-item` styling.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No