### PR TITLE
fix(vue): add component-specific overlay events

### DIFF
--- a/packages/vue/src/utils/overlays.ts
+++ b/packages/vue/src/utils/overlays.ts
@@ -1,5 +1,5 @@
-import type { VNode, ComponentOptions } from "vue";
-import { defineComponent, h, ref, onMounted } from "vue";
+import type { ComponentOptions, VNode } from "vue";
+import { defineComponent, h, onMounted, ref } from "vue";
 
 // TODO(FW-2969): types
 
@@ -147,23 +147,30 @@ export const defineOverlayContainer = <Props extends object>(
       const elementRef = ref();
 
       onMounted(() => {
+        // Convert name from kebab-case to camelCase
+        const componentName = name.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
         elementRef.value.addEventListener("ionMount", (ev: Event) => {
           emit("ionMount", ev);
+          emit(componentName + "IonMount", ev);
           isOpen.value = true;
         });
         elementRef.value.addEventListener("willPresent", (ev: Event) => {
           emit("willPresent", ev);
+          emit(componentName + "WillPresent", ev);
           isOpen.value = true;
         });
         elementRef.value.addEventListener("didDismiss", (ev: Event) => {
           emit("didDismiss", ev);
+          emit(componentName + "DidDismiss", ev);
           isOpen.value = false;
         });
         elementRef.value.addEventListener("willDismiss", (ev: Event) => {
           emit("willDismiss", ev);
+          emit(componentName + "WillDismiss", ev);
         });
         elementRef.value.addEventListener("didPresent", (ev: Event) => {
           emit("didPresent", ev);
+          emit(componentName + "DidPresent", ev);
         });
       });
 


### PR DESCRIPTION
Issue number: resolves #30641

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Currently, Vue modals do not emit `ionModal...` events. This happened due to a change in the way the stencil output targets for Vue changed. Christian [updated the overlays](https://github.com/ionic-team/ionic-framework/pull/30227/files#diff-7e46aba01094c4917cd55e8eebd263fc4a297a2d62143f1ae30959ec4e023b6f) to support the base events, but not the component-specific events. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

With this change, you'll be able to bind to the events as described in the Ionic documentation.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
