### PR TITLE
fix(modal): allow sheet modals to skip focus trap

### DIFF
--- a/core/src/components/modal/test/sheet/index.html
+++ b/core/src/components/modal/test/sheet/index.html
@@ -151,6 +151,53 @@
           >
             Backdrop is inactive
           </button>
+          <button id="present-inline-sheet-modal">Present Inline Sheet Modal</button>
+
+          <div id="inline-sheet-modal-container">
+            <ion-modal id="inline-sheet-modal" mode="md">
+              <ion-content>
+                <ion-searchbar id="inline-sheet-searchbar" placeholder="Search"></ion-searchbar>
+                <ion-list>
+                  <ion-item>
+                    <ion-avatar slot="start">
+                      <ion-img src="https://i.pravatar.cc/300?u=b"></ion-img>
+                    </ion-avatar>
+                    <ion-label>
+                      <h2>Connor Smith</h2>
+                      <p>Sales Rep</p>
+                    </ion-label>
+                  </ion-item>
+                  <ion-item>
+                    <ion-avatar slot="start">
+                      <ion-img src="https://i.pravatar.cc/300?u=a"></ion-img>
+                    </ion-avatar>
+                    <ion-label>
+                      <h2>Daniel Smith</h2>
+                      <p>Product Designer</p>
+                    </ion-label>
+                  </ion-item>
+                  <ion-item>
+                    <ion-avatar slot="start">
+                      <ion-img src="https://i.pravatar.cc/300?u=d"></ion-img>
+                    </ion-avatar>
+                    <ion-label>
+                      <h2>Greg Smith</h2>
+                      <p>Director of Operations</p>
+                    </ion-label>
+                  </ion-item>
+                  <ion-item>
+                    <ion-avatar slot="start">
+                      <ion-img src="https://i.pravatar.cc/300?u=e"></ion-img>
+                    </ion-avatar>
+                    <ion-label>
+                      <h2>Zoey Smith</h2>
+                      <p>CEO</p>
+                    </ion-label>
+                  </ion-item>
+                </ion-list>
+              </ion-content>
+            </ion-modal>
+          </div>
 
           <div class="grid">
             <div class="grid-item red"></div>
@@ -172,6 +219,36 @@
       window.addEventListener('ionModalWillDismiss', function (e) {
         console.log('WillDismiss', e);
       });
+
+      const inlineSheetModal = document.querySelector('#inline-sheet-modal');
+      const inlineSheetTrigger = document.querySelector('#present-inline-sheet-modal');
+      const inlineSheetSearchbar = document.querySelector('#inline-sheet-searchbar');
+
+      if (inlineSheetModal) {
+        inlineSheetModal.initialBreakpoint = 0.2;
+        inlineSheetModal.breakpoints = [0, 0.2, 0.75, 1];
+        inlineSheetModal.backdropDismiss = false;
+        inlineSheetModal.backdropBreakpoint = 0.5;
+        inlineSheetModal.focusTrap = false;
+        inlineSheetModal.handleBehavior = 'cycle';
+        inlineSheetModal.presentingElement = document.querySelector('.ion-page');
+
+        inlineSheetModal.addEventListener('ionModalDidDismiss', () => {
+          inlineSheetModal.isOpen = false;
+        });
+
+        if (inlineSheetTrigger) {
+          inlineSheetTrigger.addEventListener('click', () => {
+            inlineSheetModal.isOpen = true;
+          });
+        }
+
+        if (inlineSheetSearchbar) {
+          inlineSheetSearchbar.addEventListener('click', () => {
+            inlineSheetModal.setCurrentBreakpoint(0.75);
+          });
+        }
+      }
 
       function createModal(options) {
         let items = '';

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -664,7 +664,9 @@ export const dismiss = async <OverlayDismissOptions>(
    * from the root element when the last focus-trapping overlay
    * is dismissed.
    */
-  const overlaysTrappingFocus = presentedOverlays.filter((o) => o.tagName !== 'ION-TOAST' && (o as any).focusTrap !== false);
+  const overlaysTrappingFocus = presentedOverlays.filter(
+    (o) => o.tagName !== 'ION-TOAST' && (o as any).focusTrap !== false
+  );
   const overlayEl = overlay.el as HTMLIonOverlayElement & { focusTrap?: boolean };
   const trapsFocus = overlayEl.tagName !== 'ION-TOAST' && overlayEl.focusTrap !== false;
 

--- a/packages/angular/test/base/e2e/src/lazy/modal-sheet-inline.spec.ts
+++ b/packages/angular/test/base/e2e/src/lazy/modal-sheet-inline.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Modals: Inline Sheet', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/lazy/modal-sheet-inline');
+  });
+
+  test('should open inline sheet modal', async ({ page }) => {
+    await page.locator('#present-inline-sheet-modal').click();
+
+    await expect(page.locator('ion-modal')).toBeVisible();
+    await expect(page.locator('#current-breakpoint')).toHaveText('0.2');
+    await expect(page.locator('ion-modal ion-item')).toHaveCount(4);
+  });
+
+  test('should expand to 0.75 breakpoint when searchbar is clicked', async ({ page }) => {
+    await page.locator('#present-inline-sheet-modal').click();
+    await expect(page.locator('#current-breakpoint')).toHaveText('0.2');
+
+    await page.locator('ion-modal ion-searchbar').click();
+
+    await expect(page.locator('#current-breakpoint')).toHaveText('0.75');
+  });
+
+  test('should allow interacting with background content while sheet is open', async ({ page }) => {
+    await page.locator('#present-inline-sheet-modal').click();
+
+    await expect(page.locator('ion-modal')).toBeVisible();
+
+    await page.locator('#background-action').click();
+
+    await expect(page.locator('#background-action-count')).toHaveText('1');
+  });
+});

--- a/packages/angular/test/base/src/app/lazy/app-lazy/app.routes.ts
+++ b/packages/angular/test/base/src/app/lazy/app-lazy/app.routes.ts
@@ -37,6 +37,7 @@ export const routes: Routes = [
       { path: 'template-form', component: TemplateFormComponent },
       { path: 'modals', component: ModalComponent },
       { path: 'modal-inline', loadChildren: () => import('../modal-inline').then(m => m.ModalInlineModule) },
+      { path: 'modal-sheet-inline', loadChildren: () => import('../modal-sheet-inline').then(m => m.ModalSheetInlineModule) },
       { path: 'view-child', component: ViewChildComponent },
       { path: 'keep-contents-mounted', loadChildren: () => import('../keep-contents-mounted').then(m => m.OverlayAutoMountModule) },
       { path: 'overlays-inline', loadChildren: () => import('../overlays-inline').then(m => m.OverlaysInlineModule) },
@@ -90,4 +91,3 @@ export const routes: Routes = [
     ]
   },
 ];
-

--- a/packages/angular/test/base/src/app/lazy/modal-sheet-inline/index.ts
+++ b/packages/angular/test/base/src/app/lazy/modal-sheet-inline/index.ts
@@ -1,0 +1,2 @@
+export * from './modal-sheet-inline.component';
+export * from './modal-sheet-inline.module';

--- a/packages/angular/test/base/src/app/lazy/modal-sheet-inline/modal-sheet-inline-routing.module.ts
+++ b/packages/angular/test/base/src/app/lazy/modal-sheet-inline/modal-sheet-inline-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from "@angular/core";
+import { RouterModule } from "@angular/router";
+import { ModalSheetInlineComponent } from ".";
+
+@NgModule({
+  imports: [
+    RouterModule.forChild([
+      {
+        path: '',
+        component: ModalSheetInlineComponent
+      }
+    ])
+  ],
+  exports: [RouterModule]
+})
+export class ModalSheetInlineRoutingModule { }

--- a/packages/angular/test/base/src/app/lazy/modal-sheet-inline/modal-sheet-inline.component.html
+++ b/packages/angular/test/base/src/app/lazy/modal-sheet-inline/modal-sheet-inline.component.html
@@ -1,0 +1,46 @@
+<ion-button id="present-inline-sheet-modal" (click)="presentInlineSheetModal()">
+  Present Inline Sheet Modal
+</ion-button>
+
+<p>
+  Current breakpoint: <span id="current-breakpoint">{{ currentBreakpoint }}</span>
+</p>
+
+<ion-button id="background-action" (click)="onBackgroundActionClick()">
+  Background Action
+</ion-button>
+
+<p>
+  Background action count: <span id="background-action-count">{{ backgroundActionCount }}</span>
+</p>
+
+<ion-modal
+  #inlineSheetModal
+  mode="md"
+  [isOpen]="isSheetOpen"
+  [initialBreakpoint]="0.2"
+  [breakpoints]="breakpoints"
+  [backdropDismiss]="false"
+  [backdropBreakpoint]="0.5"
+  [focusTrap]="false"
+  handleBehavior="cycle"
+  (ionBreakpointDidChange)="onSheetBreakpointDidChange($event)"
+  (didDismiss)="onSheetDidDismiss()"
+>
+  <ng-template>
+    <ion-content>
+      <ion-searchbar placeholder="Search" (click)="expandInlineSheet()"></ion-searchbar>
+      <ion-list>
+        <ion-item *ngFor="let contact of contacts">
+          <ion-avatar slot="start">
+            <ion-img [src]="contact.avatar"></ion-img>
+          </ion-avatar>
+          <ion-label>
+            <h2>{{ contact.name }}</h2>
+            <p>{{ contact.title }}</p>
+          </ion-label>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ng-template>
+</ion-modal>

--- a/packages/angular/test/base/src/app/lazy/modal-sheet-inline/modal-sheet-inline.component.ts
+++ b/packages/angular/test/base/src/app/lazy/modal-sheet-inline/modal-sheet-inline.component.ts
@@ -1,0 +1,79 @@
+import { Component, ViewChild } from "@angular/core";
+import { IonModal } from "@ionic/angular";
+
+interface Contact {
+  name: string;
+  title: string;
+  avatar: string;
+}
+
+@Component({
+  selector: 'app-modal-sheet-inline',
+  templateUrl: './modal-sheet-inline.component.html',
+  standalone: false
+})
+export class ModalSheetInlineComponent {
+
+  @ViewChild('inlineSheetModal', { read: IonModal }) inlineSheetModal?: IonModal;
+
+  readonly breakpoints: number[] = [0, 0.2, 0.75, 1];
+
+  readonly contacts: Contact[] = [
+    {
+      name: 'Connor Smith',
+      title: 'Sales Rep',
+      avatar: 'https://i.pravatar.cc/300?u=b'
+    },
+    {
+      name: 'Daniel Smith',
+      title: 'Product Designer',
+      avatar: 'https://i.pravatar.cc/300?u=a'
+    },
+    {
+      name: 'Greg Smith',
+      title: 'Director of Operations',
+      avatar: 'https://i.pravatar.cc/300?u=d'
+    },
+    {
+      name: 'Zoey Smith',
+      title: 'CEO',
+      avatar: 'https://i.pravatar.cc/300?u=e'
+    }
+  ];
+
+  isSheetOpen = false;
+
+  currentBreakpoint = 'closed';
+
+  backgroundActionCount = 0;
+
+  presentInlineSheetModal() {
+    this.isSheetOpen = true;
+    this.currentBreakpoint = '0.2';
+  }
+
+  async expandInlineSheet() {
+    const modal = this.inlineSheetModal;
+
+    if (!modal) {
+      return;
+    }
+
+    await modal.setCurrentBreakpoint(0.75);
+    this.currentBreakpoint = '0.75';
+  }
+
+  onSheetDidDismiss() {
+    this.isSheetOpen = false;
+    this.currentBreakpoint = 'closed';
+  }
+
+  onSheetBreakpointDidChange(event: CustomEvent<{ breakpoint: number }>) {
+    this.currentBreakpoint = event.detail.breakpoint.toString();
+  }
+
+  onBackgroundActionClick() {
+    this.backgroundActionCount++;
+  }
+
+}

--- a/packages/angular/test/base/src/app/lazy/modal-sheet-inline/modal-sheet-inline.module.ts
+++ b/packages/angular/test/base/src/app/lazy/modal-sheet-inline/modal-sheet-inline.module.ts
@@ -1,0 +1,12 @@
+import { CommonModule } from "@angular/common";
+import { NgModule } from "@angular/core";
+import { IonicModule } from "@ionic/angular";
+import { ModalSheetInlineRoutingModule } from "./modal-sheet-inline-routing.module";
+import { ModalSheetInlineComponent } from "./modal-sheet-inline.component";
+
+@NgModule({
+  imports: [CommonModule, IonicModule, ModalSheetInlineRoutingModule],
+  declarations: [ModalSheetInlineComponent],
+  exports: [ModalSheetInlineComponent]
+})
+export class ModalSheetInlineModule { }


### PR DESCRIPTION
Issue number: resolves #30684

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Recently, we [fixed some issues with aria-hidden in modals](https://github.com/ionic-team/ionic-framework/pull/30563), unfortunately at this time we neglected modals that opt out of focus trapping. As a result, a lot of modals that disable focus trapping still have it happening and it doesn't get cleaned up properly on dismiss.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
We're now properly checking for and skipping focus traps on modals that do not want them.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

I created regression tests for Angular in this to prevent this from happening again. I tried to do this with core, but the issue doesn't seem to reproduce with core. I still kept inline modals around in the sheet modal page anyway just in case it's useful in the future.

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
