### PR TITLE
fix(stencil-version): Revert stencil to version `4.33.1`

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@phosphor-icons/core": "^2.1.1",
-        "@stencil/core": "4.36.2",
+        "@stencil/core": "4.33.1",
         "ionicons": "^8.0.13",
         "tslib": "^2.1.0"
       },
@@ -2552,9 +2552,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.36.2",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.36.2.tgz",
-      "integrity": "sha512-PRFSpxNzX9Oi0Wfh02asztN9Sgev/MacfZwmd+VVyE6ZxW+a/kEpAYZhzGAmE+/aKVOGYuug7R9SulanYGxiDQ==",
+      "version": "4.33.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.33.1.tgz",
+      "integrity": "sha512-12k9xhAJBkpg598it+NRmaYIdEe6TSnsL/v6/KRXDcUyTK11VYwZQej2eHnMWtqot+znJ+GNTqb5YbiXi+5Low==",
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"
@@ -6747,6 +6747,29 @@
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^4.35.3"
+      }
+    },
+    "node_modules/ionicons/node_modules/@stencil/core": {
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.38.0.tgz",
+      "integrity": "sha512-oC3QFKO0X1yXVvETgc8OLY525MNKhn9vISBrbtKnGoPlokJ6rI8Vk1RK22TevnNrHLI4SExNLbcDnqilKR35JQ==",
+      "license": "MIT",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-darwin-arm64": "4.34.9",
+        "@rollup/rollup-darwin-x64": "4.34.9",
+        "@rollup/rollup-linux-arm64-gnu": "4.34.9",
+        "@rollup/rollup-linux-arm64-musl": "4.34.9",
+        "@rollup/rollup-linux-x64-gnu": "4.34.9",
+        "@rollup/rollup-linux-x64-musl": "4.34.9",
+        "@rollup/rollup-win32-arm64-msvc": "4.34.9",
+        "@rollup/rollup-win32-x64-msvc": "4.34.9"
       }
     },
     "node_modules/is-alphabetical": {

--- a/core/package.json
+++ b/core/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "@phosphor-icons/core": "^2.1.1",
-    "@stencil/core": "4.36.2",
+    "@stencil/core": "4.33.1",
     "ionicons": "^8.0.13",
     "tslib": "^2.1.0"
   },


### PR DESCRIPTION
Issue number: resolves #

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
The current version in use of stencil (`4.36.2`), as well as, a more recent version (`4.38.0`) are breaking the tests for several of the components (e.g. accordion, datepicker, modal)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Reverting the version of stencil to the last known stable version `4.33.1`

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
N/A