### PR TITLE
fix(web-types): fix web types for `@ionic/vue`

### DIFF
--- a/packages/vue/scripts/build-web-types.js
+++ b/packages/vue/scripts/build-web-types.js
@@ -75,12 +75,8 @@ for (const component of filteredComponents) {
     "doc-url": docUrl,
     description: component.docs,
     source: {
-      module:
-        "@ionic/core/" +
-        component.filePath
-          .replace("./src/", "dist/types/")
-          .replace(".tsx", ".d.ts"),
-      symbol: componentName.substr(3),
+      module: "@ionic/vue",
+      symbol: componentName,
     },
     attributes,
     slots,


### PR DESCRIPTION
## What is the current behavior?
1. Missed code completion for imported Ionic Vue components in WebStorm
  a. Reason - invalid Web Types for `@ionic/vue`
  b. Related issue - [WEB-53833](https://youtrack.jetbrains.com/issue/WEB-53833)

## What is the new behavior?
1. Fine code completion for imported Ionic Vue components in WebStorm

## Does this introduce a breaking change?

- [ ] Yes
- [x] No