### PR TITLE
test(handlePageTransition): add tests for undefined enteringEl scenario

### DIFF
--- a/packages/vue/test/base/tests/unit/router-outlet.spec.ts
+++ b/packages/vue/test/base/tests/unit/router-outlet.spec.ts
@@ -148,3 +148,115 @@ describe('Routing', () => {
     )
   });
 });
+
+/**
+ * These tests verify that handlePageTransition does not
+ * throw when enteringViewItem.ionPageElement is undefined.
+ * This can happen when a page component is missing the
+ * required <ion-page> wrapper.
+ */
+describe('handlePageTransition - undefined enteringEl', () => {
+  const enteringViewItem = {
+    ionPageElement: undefined,
+    vueComponent: {},
+    vueComponentRef: {},
+    routerAnimation: undefined,
+    mount: true,
+    matchedRoute: { path: '/' },
+    pathname: '/',
+  };
+
+  const leavingViewItem = {
+    ionPageElement: document.createElement('div'),
+    vueComponent: {},
+    vueComponentRef: {},
+    routerAnimation: undefined,
+    mount: true,
+    matchedRoute: { path: '/page2' },
+    pathname: '/page2',
+  };
+
+  const mockViewStacks = {
+    getViewStack: vi.fn().mockReturnValue([enteringViewItem, leavingViewItem]),
+    findViewItemByRouteInfo: vi.fn().mockReturnValue(enteringViewItem),
+    findLeavingViewItemByRouteInfo: vi.fn().mockReturnValue(leavingViewItem),
+    getChildrenToRender: vi.fn().mockReturnValue([]),
+    createViewItem: vi.fn().mockReturnValue(enteringViewItem),
+    add: vi.fn(),
+    clear: vi.fn(),
+    registerIonPage: vi.fn(),
+    size: vi.fn().mockReturnValue(1),
+    findViewItemByPathname: vi.fn(),
+    unmountLeavingViews: vi.fn(),
+    mountIntermediaryViews: vi.fn(),
+  };
+
+  const mockNavManager = {
+    getLeavingRouteInfo: vi.fn().mockReturnValue({
+      pathname: '/page2',
+      pushedByRoute: '/',
+      routerAnimation: undefined,
+    }),
+    getCurrentRouteInfo: vi.fn().mockReturnValue({
+      pathname: '/',
+      pushedByRoute: '/',
+      routerDirection: 'forward',
+      routerAction: 'push',
+      routerAnimation: undefined,
+      prevRouteLastPathname: '/page2',
+      delta: 1,
+    }),
+    canGoBack: vi.fn().mockReturnValue(false),
+    handleNavigateBack: vi.fn(),
+  };
+
+  const mountOutlet = async () => {
+    const router = createRouter({
+      history: createWebHistory(process.env.BASE_URL),
+      routes: [
+        { path: '/', component: BasePage },
+        { path: '/page2', component: BasePage }
+      ]
+    });
+
+    router.push('/');
+    await router.isReady();
+
+    return mount(IonRouterOutlet, {
+      global: {
+        plugins: [router, IonicVue],
+        provide: {
+          navManager: mockNavManager,
+          viewStacks: mockViewStacks,
+        }
+      }
+    });
+  };
+
+  it('should warn when enteringEl is undefined', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+
+    await mountOutlet();
+    await waitForRouter();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('does not have the required <ion-page> component')
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('should not call transition when enteringEl is undefined', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => { });
+
+    const commitFn = vi.fn();
+    const wrapper = await mountOutlet();
+    wrapper.findComponent(IonRouterOutlet).vm.$el.commit = commitFn;
+
+    await waitForRouter();
+
+    expect(commitFn).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+});


### PR DESCRIPTION
Issue number: resolves https://github.com/ionic-team/ionic-framework/issues/30081

---

## What is the current behavior?

In `handlePageTransition`, when a page component is missing the required `<ion-page>` wrapper, `enteringEl` (`enteringViewItem.ionPageElement`) is `undefined`. The code correctly detects this and logs a warning, but **does not return early**. Execution continues to `isViewVisible(enteringEl)`, which calls `enteringEl.classList.contains(...)` on `undefined`, causing an unhandled TypeError.

This crash prevents the router outlet from completing the transition and can leave it in a broken state where subsequent navigations no longer work.

## What is the new behavior?

- Add `return` after the `console.warn` in `handlePageTransition` when `enteringEl` is `undefined`, so the function exits gracefully instead of crashing.
- Update `isViewVisible` to accept `HTMLElement | undefined` and return `false` for `undefined`, as a defensive measure.
- Add unit tests to verify that `handlePageTransition` warns and returns early when `enteringEl` is `undefined`, and does not call `commit` (transition).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The existing `console.warn` at this location indicates the team already anticipated this scenario — a page without `<ion-page>` — but the missing `return` means the warning is immediately followed by a crash. This fix simply completes the intended error handling.

Without the fix, `isViewVisible(undefined)` throws `TypeError: Cannot read properties of undefined (reading 'classList')`. This unhandled error breaks the router outlet's internal state, causing all subsequent page transitions to silently fail. The user sees a frozen UI with no error feedback, which is significantly worse than the degraded-but-functional behavior the warning was designed to allow.