### PR TITLE
fix(range): initialize ratios before first render

### DIFF
--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -401,6 +401,8 @@ export class Range implements ComponentInterface {
     this.min = isSafeNumber(this.min) ? this.min : 0;
     this.max = isSafeNumber(this.max) ? this.max : 100;
     this.step = isSafeNumber(this.step) ? this.step : 1;
+
+    this.updateRatio();
   }
 
   componentDidLoad() {

--- a/core/src/components/range/test/modal/index.html
+++ b/core/src/components/range/test/modal/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Range - Modal</title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
+    <link href="../../../../../css/ionic.bundle.css" rel="stylesheet" />
+    <script src="../../../../../scripts/testing/scripts.js"></script>
+    <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+    <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content class="ion-padding">
+        <ion-button id="open-modal">Open Modal</ion-button>
+      </ion-content>
+    </ion-app>
+
+    <script>
+      const openModal = document.querySelector('#open-modal');
+
+      openModal.addEventListener('click', async () => {
+        const content = document.createElement('div');
+        content.innerHTML = `
+          <ion-content class="ion-padding">
+            <ion-range aria-label="Dual Knobs Range"></ion-range>
+          </ion-content>
+        `;
+
+        const range = content.querySelector('ion-range');
+        range.dualKnobs = true;
+        range.value = { lower: 20, upper: 80 };
+
+        const modal = Object.assign(document.createElement('ion-modal'), {
+          breakpoints: [0, 1],
+          component: content,
+          handle: true,
+          initialBreakpoint: 1,
+        });
+
+        document.body.appendChild(modal);
+        await modal.present();
+      });
+    </script>
+  </body>
+</html>

--- a/core/src/components/range/test/modal/range.e2e.ts
+++ b/core/src/components/range/test/modal/range.e2e.ts
@@ -1,0 +1,31 @@
+import { expect } from '@playwright/test';
+import { configs, test } from '@utils/test/playwright';
+
+configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
+  test.describe(title('range: modal'), () => {
+    test('should render dual knob value when presented in a modal', async ({ page }) => {
+      await page.goto('/src/components/range/test/modal', config);
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+
+      await page.click('#open-modal');
+      await ionModalDidPresent.next();
+
+      const range = page.locator('ion-modal ion-range');
+      await expect(range).toBeVisible();
+
+      const knobPositions = await range.evaluate((el: HTMLIonRangeElement) => {
+        const shadowRoot = el.shadowRoot!;
+
+        return {
+          lower: (shadowRoot.querySelector('[part~="knob-handle-lower"]') as HTMLElement).style.left,
+          upper: (shadowRoot.querySelector('[part~="knob-handle-upper"]') as HTMLElement).style.left,
+        };
+      });
+
+      expect(knobPositions).toEqual({
+        lower: '20%',
+        upper: '80%',
+      });
+    });
+  });
+});


### PR DESCRIPTION
Issue number: resolves #31026

## What is the current behavior?

`ion-range` can render from its default knob ratios on the first render when it is created with an initial object value inside a modal. The issue report's dual-knob range starts with `{ lower: 20, upper: 80 }`, but both knobs are initially painted at the default positions.

## What is the new behavior?

- Initialize the range ratios during `componentWillLoad` after min/max/step are normalized.
- Preserve the existing `componentDidLoad` ratio update for layout-dependent work.
- Add a modal e2e regression fixture that presents a dual-knob range and verifies the lower and upper knob handle positions are `20%` and `80%`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Testing:
- `npm run build.css`
- `npx stencil build --dev`
- `git diff --check`
- `npx prettier --check src/components/range/range.tsx src/components/range/test/modal/index.html src/components/range/test/modal/range.e2e.ts`
- Manual Playwright verification with system Chrome against `src/components/range/test/modal?ionic:_testing=true&ionic:mode=ios`, observed `{"lower":"20%","upper":"80%","a":"20%","b":"80%","value":{"lower":20,"upper":80}}`

I also tried `npx playwright test src/components/range/test/modal/range.e2e.ts --project="Mobile Chrome"`, but this machine is missing Playwright's managed Chromium binary (`chromium_headless_shell-1217`), so the test could not start here.
