### PR TITLE
chore(renovate): keep playwright Dockerfile and package.json in lockstep

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -41,18 +41,41 @@
       matchPackageNames: ["@playwright/test", "@axe-core/playwright", "playwright-core"],
       groupName: "playwright",
       matchFileNames: [
-        "core/package.json"
+        "core/package.json",
+        "core/Dockerfile"
       ],
-      "rangeStrategy": "bump"
+      "rangeStrategy": "bump",
+      /**
+       * The mcr.microsoft.com/playwright Docker image is usually published
+       * about a day after the npm release. Waiting a few days before opening
+       * the PR gives the image time to appear, so the Dockerfile bump has a
+       * valid tag to point at. Both files are driven by the npm datasource
+       * (refer to customManagers below), so they always bump together.
+       *
+       * If the Docker build still fails because the tag does not exist yet,
+       * the image has not been published for this release. To fix it, confirm
+       * the image is available, then re-run the failed CI job. No code change
+       * is needed because the tag is already correct; the registry just needs
+       * time to catch up.
+       */
+      minimumReleaseAge: "3 days"
     },
     {
+      /**
+       * The built-in Docker manager tracks the mcr.microsoft.com/playwright tag
+       * against the container registry, which lags the npm release by about a day.
+       * That lag decouples the Dockerfile from the npm bump: the update either
+       * arrives as its own PR or has to be folded into the grouped PR with a
+       * manual rebase. Disable it and drive the tag from the npm datasource
+       * instead (refer to customManagers below) so the Dockerfile and
+       * core/package.json bump together.
+       */
       matchDatasources: ["docker"],
       matchPackageNames: ["mcr.microsoft.com/playwright"],
-      groupName: "playwright",
       matchFileNames: [
         "core/Dockerfile"
       ],
-      versioning: "semver"
+      enabled: false
     },
     {
       matchPackagePatterns: ["ionicons"],
@@ -105,6 +128,22 @@
       matchDatasources: ["node-version"],
       matchPackagePatterns: ["node"],
       groupName: "node-version-updates"
+    }
+  ],
+  customManagers: [
+    {
+      /**
+       * Bump the Playwright Docker image tag in core/Dockerfile from the npm
+       * @playwright/test release instead of the container registry. The image
+       * tag mirrors the npm version (for example v1.62.0), so this keeps the
+       * Dockerfile and core/package.json in lockstep within a single PR.
+       */
+      customType: "regex",
+      managerFilePatterns: ["core/Dockerfile"],
+      matchStrings: ["mcr\\.microsoft\\.com/playwright:v(?<currentValue>\\S+)"],
+      depNameTemplate: "@playwright/test",
+      datasourceTemplate: "npm",
+      versioningTemplate: "npm"
     }
   ],
   dependencyDashboard: false,


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The Playwright npm packages and the `mcr.microsoft.com/playwright` Docker image in `core/Dockerfile` are tracked by two separate Renovate managers. The Docker image is published to the container registry about a day after the npm release, so the two updates become available at different times. Because they are on different datasources, the npm bump opens a PR before the Docker tag is ready, and getting the Dockerfile into the same PR requires a manual rebase once the image lands. This is easy to miss, and merging the npm bump alone leaves `core/package.json` and `core/Dockerfile` on mismatched Playwright versions.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- A custom manager now resolves the `core/Dockerfile` Playwright image tag from the npm `@playwright/test` release instead of the container registry, so both files bump from the same version.
- The built-in Docker manager for that image is disabled so it no longer produces a separate, lagging update.
- The Dockerfile is added to the grouped `playwright` rule, and a `minimumReleaseAge` of 3 days lets the matching image publish before the PR opens.
- Net result is a single `playwright` PR that updates `core/package.json` and `core/Dockerfile` together, with no manual rebase.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This is a Renovate config change only, so it will not take effect until the next scheduled Renovate run. If the Docker image for a given release has not been published yet when CI runs, the Dockerfile build can fail on a missing tag; the fix is to wait for the image to appear and re-run the job, with no code change needed. This is documented inline in `renovate.json5`.