### PR TITLE
fix(overlays): ensure overlayIndex is greater than any existing overlay in DOM

### DIFF
--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -97,7 +97,24 @@ export const prepareOverlay = <T extends HTMLIonOverlayElement>(el: T) => {
      */
     connectListeners(document);
   }
-  const overlayIndex = lastOverlayIndex++;
+  let maxIndex = 0;
+
+  if (typeof document !== 'undefined') {
+    const overlays = Array.from(
+      document.querySelectorAll(
+        'ion-alert,ion-action-sheet,ion-loading,ion-modal,ion-picker-legacy,ion-popover,ion-toast'
+      )
+    ) as HTMLIonOverlayElement[];
+
+    for (const o of overlays) {
+      if (o !== el && o.overlayIndex !== undefined) {
+        maxIndex = Math.max(maxIndex, o.overlayIndex);
+      }
+    }
+  }
+
+  const overlayIndex = Math.max(lastOverlayIndex, maxIndex + 1);
+  lastOverlayIndex = overlayIndex + 1;
   /**
    * overlayIndex is used in the overlay components to set a zIndex.
    * This ensures that the most recently presented overlay will be


### PR DESCRIPTION

Issue number: resolves #31247

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
When a dynamically generated overlay (such as an `ion-alert` triggered by an `ion-select` with `interface="alert"`) is opened inside an already active overlay (like an `ion-modal`), it can sometimes be rendered behind the active modal. This is caused by the internal `lastOverlayIndex` falling out of sync across different module boundaries (common in microfrontends or Angular Standalone Component architectures), causing the newer overlay to receive a lower or equal `overlayIndex` (and consequently a lower CSS `z-index`) than the active modal.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Modified `prepareOverlay` in `core/src/utils/overlays.ts` to actively query the DOM for all existing Ionic overlays.
- The function now calculates the true maximum `overlayIndex` currently present in the DOM.
- New overlays are guaranteed a mathematically higher `overlayIndex` by assigning the maximum between the module's `lastOverlayIndex` and the DOM's `maxIndex + 1`, ensuring the most recently presented overlay is always stacked on top.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
This fix natively relies on `document.querySelectorAll` to serve as a robust Single Source of Truth for the stacking order, which effectively bridges the gap in complex environments where `@ionic/core` modules might be duplicated or heavily code-split.
