### PR TITLE
fix(input,searchbar): keep clear button clickable when input blurs

### DIFF
--- a/core/src/components/input/input.ionic.scss
+++ b/core/src/components/input/input.ionic.scss
@@ -236,11 +236,14 @@
  * only looked at the native input, tabbing to the clear
  * button would immediately hide it.
  *
+ * The pressed class keeps it visible mid-press
+ * so the click still lands on the button.
+ *
  * Note that the clear button also requires the native input
  * to have any value, but this is not specific to the ionic
  * theme, so it is handled elsewhere.
  */
-:host(:not(:focus-within)) .input-clear-icon {
+:host(:not(:focus-within)) .input-clear-icon:not(.input-clear-button-pressed) {
   display: none;
 }
 

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -90,6 +90,12 @@ export class Input implements ComponentInterface {
    */
   @State() isInvalid = false;
 
+  /**
+   * Keeps the clear button in the layout while it is being pressed, so a blur
+   * landing mid-press cannot hide it before the click resolves.
+   */
+  @State() isClearButtonPressed = false;
+
   @Element() el!: HTMLIonInputElement;
 
   private validationObserver?: MutationObserver;
@@ -497,6 +503,8 @@ export class Input implements ComponentInterface {
       );
     }
 
+    document.removeEventListener('click', this.releaseClearButtonPress);
+
     if (this.slotMutationController) {
       this.slotMutationController.destroy();
       this.slotMutationController = undefined;
@@ -728,7 +736,13 @@ export class Input implements ComponentInterface {
     this.isComposing = false;
   };
 
+  private releaseClearButtonPress = () => {
+    this.isClearButtonPressed = false;
+  };
+
   private clearTextInput = (ev?: Event) => {
+    this.isClearButtonPressed = false;
+
     if (this.clearInput && !this.readonly && !this.disabled && ev) {
       ev.preventDefault();
       ev.stopPropagation();
@@ -1075,15 +1089,29 @@ export class Input implements ComponentInterface {
               <button
                 aria-label="reset"
                 type="button"
-                class="input-clear-icon"
+                class={{
+                  'input-clear-icon': true,
+                  'input-clear-button-pressed': this.isClearButtonPressed,
+                }}
                 onPointerDown={(ev) => {
                   /**
                    * This prevents mobile browsers from
                    * blurring the input when the clear
-                   * button is activated.
+                   * button is activated. Not all browsers
+                   * honor it, so the press is tracked too.
                    */
                   ev.preventDefault();
+
+                  // Only a primary press produces a click.
+                  if (ev.button !== 0) {
+                    return;
+                  }
+
+                  this.isClearButtonPressed = true;
+                  // Cleared on click, not pointerup, so the button survives until the click dispatches.
+                  document.addEventListener('click', this.releaseClearButtonPress, { once: true });
                 }}
+                onPointerCancel={this.releaseClearButtonPress}
                 onClick={this.clearTextInput}
               >
                 <ion-icon aria-hidden="true" icon={inputClearIcon}></ion-icon>

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -15,7 +15,7 @@ import {
   h,
 } from '@stencil/core';
 import type { NotchController } from '@utils/forms';
-import { createNotchController, checkInvalidState } from '@utils/forms';
+import { createClearButtonPressController, createNotchController, checkInvalidState } from '@utils/forms';
 import type { Attributes } from '@utils/helpers';
 import { inheritAriaAttributes, debounceEvent, inheritAttributes, componentOnReady } from '@utils/helpers';
 import { printIonWarning } from '@utils/logging';
@@ -90,11 +90,12 @@ export class Input implements ComponentInterface {
    */
   @State() isInvalid = false;
 
-  /**
-   * Keeps the clear button in the layout while it is being pressed, so a blur
-   * landing mid-press cannot hide it before the click resolves.
-   */
+  /** Keeps the clear button visible for the duration of a press. */
   @State() isClearButtonPressed = false;
+
+  private readonly clearButtonPressController = createClearButtonPressController(
+    (isPressed) => (this.isClearButtonPressed = isPressed)
+  );
 
   @Element() el!: HTMLIonInputElement;
 
@@ -503,7 +504,7 @@ export class Input implements ComponentInterface {
       );
     }
 
-    document.removeEventListener('click', this.releaseClearButtonPress);
+    this.clearButtonPressController.destroy();
 
     if (this.slotMutationController) {
       this.slotMutationController.destroy();
@@ -736,12 +737,8 @@ export class Input implements ComponentInterface {
     this.isComposing = false;
   };
 
-  private releaseClearButtonPress = () => {
-    this.isClearButtonPressed = false;
-  };
-
   private clearTextInput = (ev?: Event) => {
-    this.isClearButtonPressed = false;
+    this.clearButtonPressController.release();
 
     if (this.clearInput && !this.readonly && !this.disabled && ev) {
       ev.preventDefault();
@@ -1093,25 +1090,8 @@ export class Input implements ComponentInterface {
                   'input-clear-icon': true,
                   'input-clear-button-pressed': this.isClearButtonPressed,
                 }}
-                onPointerDown={(ev) => {
-                  /**
-                   * This prevents mobile browsers from
-                   * blurring the input when the clear
-                   * button is activated. Not all browsers
-                   * honor it, so the press is tracked too.
-                   */
-                  ev.preventDefault();
-
-                  // Only a primary press produces a click.
-                  if (ev.button !== 0) {
-                    return;
-                  }
-
-                  this.isClearButtonPressed = true;
-                  // Cleared on click, not pointerup, so the button survives until the click dispatches.
-                  document.addEventListener('click', this.releaseClearButtonPress, { once: true });
-                }}
-                onPointerCancel={this.releaseClearButtonPress}
+                onPointerDown={this.clearButtonPressController.onPointerDown}
+                onPointerCancel={this.clearButtonPressController.release}
                 onClick={this.clearTextInput}
               >
                 <ion-icon aria-hidden="true" icon={inputClearIcon}></ion-icon>

--- a/core/src/components/input/test/basic/input.e2e.ts
+++ b/core/src/components/input/test/basic/input.e2e.ts
@@ -372,7 +372,7 @@ configs({ modes: ['ionic-md'], directions: ['ltr'] }).forEach(({ title, config }
       await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
       await page.mouse.down();
 
-      // Some browsers blur anyway, despite the preventDefault on pointerdown.
+      // Some browsers blur anyway, despite the `preventDefault` on `pointerdown`.
       await nativeInput.evaluate((el: HTMLInputElement) => el.blur());
       await page.waitForChanges();
 
@@ -381,6 +381,16 @@ configs({ modes: ['ionic-md'], directions: ['ltr'] }).forEach(({ title, config }
 
       await expect(input).toHaveJSProperty('value', '');
       await expect(nativeInput).toBeFocused();
+
+      // Clearing stops the click from bubbling, so it has to end the press itself.
+      await input.evaluate((el: HTMLIonInputElement) => (el.value = 'abc'));
+      await page.waitForChanges();
+      await expect(clearButton).toBeVisible();
+
+      await nativeInput.evaluate((el: HTMLInputElement) => el.blur());
+      await page.waitForChanges();
+
+      await expect(clearButton).not.toBeVisible();
     });
 
     test('should hide the clear button when the press is abandoned', async ({ page }) => {

--- a/core/src/components/input/test/basic/input.e2e.ts
+++ b/core/src/components/input/test/basic/input.e2e.ts
@@ -347,5 +347,75 @@ configs({ modes: ['ionic-md'], directions: ['ltr'] }).forEach(({ title, config }
       await expect(clearButton).toBeFocused();
       await expect(clearButton).toBeVisible();
     });
+
+    test('should clear the value when the input blurs between pointerdown and click', async ({ page }) => {
+      await page.setContent(
+        `
+          <ion-input
+            label="Label"
+            label-placement="stacked"
+            clear-input="true"
+            value="abc"
+          ></ion-input>
+        `,
+        config
+      );
+
+      const input = page.locator('ion-input');
+      const nativeInput = input.locator('input');
+      const clearButton = input.locator('.input-clear-icon');
+
+      await input.evaluate((el: HTMLIonInputElement) => el.setFocus());
+      await expect(clearButton).toBeVisible();
+
+      const box = (await clearButton.boundingBox())!;
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+      await page.mouse.down();
+
+      // Some browsers blur anyway, despite the preventDefault on pointerdown.
+      await nativeInput.evaluate((el: HTMLInputElement) => el.blur());
+      await page.waitForChanges();
+
+      await page.mouse.up();
+      await page.waitForChanges();
+
+      await expect(input).toHaveJSProperty('value', '');
+      await expect(nativeInput).toBeFocused();
+    });
+
+    test('should hide the clear button when the press is abandoned', async ({ page }) => {
+      await page.setContent(
+        `
+          <ion-input
+            label="Label"
+            label-placement="stacked"
+            clear-input="true"
+            value="abc"
+          ></ion-input>
+        `,
+        config
+      );
+
+      const input = page.locator('ion-input');
+      const nativeInput = input.locator('input');
+      const clearButton = input.locator('.input-clear-icon');
+
+      await input.evaluate((el: HTMLIonInputElement) => el.setFocus());
+      await expect(clearButton).toBeVisible();
+
+      const box = (await clearButton.boundingBox())!;
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+      await page.mouse.down();
+      await nativeInput.evaluate((el: HTMLInputElement) => el.blur());
+      await page.waitForChanges();
+
+      // Releasing off the button sends the click to an ancestor, not the button.
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + 200);
+      await page.mouse.up();
+      await page.waitForChanges();
+
+      await expect(input).toHaveJSProperty('value', 'abc');
+      await expect(clearButton).not.toBeVisible();
+    });
   });
 });

--- a/core/src/components/searchbar/searchbar.tsx
+++ b/core/src/components/searchbar/searchbar.tsx
@@ -3,6 +3,7 @@ import magnifyingGlassRegular from '@phosphor-icons/core/assets/regular/magnifyi
 import xRegular from '@phosphor-icons/core/assets/regular/x.svg';
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, forceUpdate, h } from '@stencil/core';
+import { createClearButtonPressController } from '@utils/forms';
 import { debounceEvent, raf, componentOnReady, inheritAttributes } from '@utils/helpers';
 import type { Attributes } from '@utils/helpers';
 import { isRTL } from '@utils/rtl';
@@ -49,11 +50,12 @@ export class Searchbar implements ComponentInterface {
   @State() focused = false;
   @State() noAnimate = true;
 
-  /**
-   * Keeps the clear button mounted while it is being pressed, so a blur
-   * landing mid-press cannot unmount it before the click resolves.
-   */
+  /** Keeps the clear button mounted for the duration of a press. */
   @State() isClearButtonPressed = false;
+
+  private readonly clearButtonPressController = createClearButtonPressController(
+    (isPressed) => (this.isClearButtonPressed = isPressed)
+  );
 
   /**
    * lang and dir are globally enumerated attributes.
@@ -326,7 +328,7 @@ export class Searchbar implements ComponentInterface {
   }
 
   disconnectedCallback() {
-    document.removeEventListener('click', this.releaseClearButtonPress);
+    this.clearButtonPressController.destroy();
 
     if (this.loadTimeout) {
       clearTimeout(this.loadTimeout);
@@ -398,15 +400,11 @@ export class Searchbar implements ComponentInterface {
     this.ionInput.emit({ value, event });
   }
 
-  private releaseClearButtonPress = () => {
-    this.isClearButtonPressed = false;
-  };
-
   /**
    * Clears the input field and triggers the control change.
    */
   private onClearInput = async (shouldFocus?: boolean) => {
-    this.isClearButtonPressed = false;
+    this.clearButtonPressController.release();
 
     if (this.clearTimeout) {
       clearTimeout(this.clearTimeout);
@@ -901,25 +899,8 @@ export class Searchbar implements ComponentInterface {
               type="button"
               no-blur
               class="searchbar-clear-button"
-              onPointerDown={(ev) => {
-                /**
-                 * This prevents mobile browsers from
-                 * blurring the input when the clear
-                 * button is activated. Not all browsers
-                 * honor it, so the press is tracked too.
-                 */
-                ev.preventDefault();
-
-                // Only a primary press produces a click.
-                if (ev.button !== 0) {
-                  return;
-                }
-
-                this.isClearButtonPressed = true;
-                // Cleared on click, not pointerup, so the button survives until the click dispatches.
-                document.addEventListener('click', this.releaseClearButtonPress, { once: true });
-              }}
-              onPointerCancel={this.releaseClearButtonPress}
+              onPointerDown={this.clearButtonPressController.onPointerDown}
+              onPointerCancel={this.clearButtonPressController.release}
               onClick={() => this.onClearInput(true)}
             >
               <ion-icon

--- a/core/src/components/searchbar/searchbar.tsx
+++ b/core/src/components/searchbar/searchbar.tsx
@@ -50,6 +50,12 @@ export class Searchbar implements ComponentInterface {
   @State() noAnimate = true;
 
   /**
+   * Keeps the clear button mounted while it is being pressed, so a blur
+   * landing mid-press cannot unmount it before the click resolves.
+   */
+  @State() isClearButtonPressed = false;
+
+  /**
    * lang and dir are globally enumerated attributes.
    * As a result, creating these as properties
    * can have unintended side effects. Instead, we
@@ -320,6 +326,8 @@ export class Searchbar implements ComponentInterface {
   }
 
   disconnectedCallback() {
+    document.removeEventListener('click', this.releaseClearButtonPress);
+
     if (this.loadTimeout) {
       clearTimeout(this.loadTimeout);
     }
@@ -390,10 +398,16 @@ export class Searchbar implements ComponentInterface {
     this.ionInput.emit({ value, event });
   }
 
+  private releaseClearButtonPress = () => {
+    this.isClearButtonPressed = false;
+  };
+
   /**
    * Clears the input field and triggers the control change.
    */
   private onClearInput = async (shouldFocus?: boolean) => {
+    this.isClearButtonPressed = false;
+
     if (this.clearTimeout) {
       clearTimeout(this.clearTimeout);
     }
@@ -661,13 +675,17 @@ export class Searchbar implements ComponentInterface {
    * Determines whether or not the clear button should be visible onscreen.
    * Clear button should be shown if one of two conditions applies:
    * 1. `showClearButton` is set to `always`.
-   * 2. `showClearButton` is set to `focus`, and the searchbar has been focused.
+   * 2. `showClearButton` is set to `focus`, and the searchbar has been
+   *    focused or a clear button press is still in flight.
    * Unless the `theme` is `ionic` and the searchbar is disabled.
    */
   private shouldShowClearButton(): boolean {
     const theme = getIonTheme(this);
 
-    if (this.showClearButton === 'never' || (this.showClearButton === 'focus' && !this.focused)) {
+    if (
+      this.showClearButton === 'never' ||
+      (this.showClearButton === 'focus' && !this.focused && !this.isClearButtonPressed)
+    ) {
       return false;
     }
 
@@ -887,10 +905,21 @@ export class Searchbar implements ComponentInterface {
                 /**
                  * This prevents mobile browsers from
                  * blurring the input when the clear
-                 * button is activated.
+                 * button is activated. Not all browsers
+                 * honor it, so the press is tracked too.
                  */
                 ev.preventDefault();
+
+                // Only a primary press produces a click.
+                if (ev.button !== 0) {
+                  return;
+                }
+
+                this.isClearButtonPressed = true;
+                // Cleared on click, not pointerup, so the button survives until the click dispatches.
+                document.addEventListener('click', this.releaseClearButtonPress, { once: true });
               }}
+              onPointerCancel={this.releaseClearButtonPress}
               onClick={() => this.onClearInput(true)}
             >
               <ion-icon

--- a/core/src/components/searchbar/test/basic/searchbar.e2e.ts
+++ b/core/src/components/searchbar/test/basic/searchbar.e2e.ts
@@ -93,7 +93,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
       await page.mouse.down();
 
-      // Some browsers blur anyway, despite the preventDefault on pointerdown.
+      // Some browsers blur anyway, despite the `preventDefault` on `pointerdown`.
       await nativeInput.evaluate((el: HTMLInputElement) => el.blur());
       await page.waitForChanges();
 

--- a/core/src/components/searchbar/test/basic/searchbar.e2e.ts
+++ b/core/src/components/searchbar/test/basic/searchbar.e2e.ts
@@ -78,6 +78,56 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
 
       await expect(nativeInput).toBeFocused();
     });
+
+    test('should clear the value when the searchbar blurs between pointerdown and click', async ({ page }) => {
+      await page.setContent(`<ion-searchbar value="abc" show-clear-button="focus"></ion-searchbar>`, config);
+
+      const searchbar = page.locator('ion-searchbar');
+      const nativeInput = searchbar.locator('input');
+      const clearButton = searchbar.locator('.searchbar-clear-button');
+
+      await searchbar.evaluate((el: HTMLIonSearchbarElement) => el.setFocus());
+      await expect(clearButton).toBeVisible();
+
+      const box = (await clearButton.boundingBox())!;
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+      await page.mouse.down();
+
+      // Some browsers blur anyway, despite the preventDefault on pointerdown.
+      await nativeInput.evaluate((el: HTMLInputElement) => el.blur());
+      await page.waitForChanges();
+
+      await page.mouse.up();
+      await page.waitForChanges();
+
+      await expect(searchbar).toHaveJSProperty('value', '');
+    });
+
+    test('should hide the clear button when the press is abandoned', async ({ page }) => {
+      await page.setContent(`<ion-searchbar value="abc" show-clear-button="focus"></ion-searchbar>`, config);
+
+      const searchbar = page.locator('ion-searchbar');
+      const nativeInput = searchbar.locator('input');
+      const clearButton = searchbar.locator('.searchbar-clear-button');
+
+      await searchbar.evaluate((el: HTMLIonSearchbarElement) => el.setFocus());
+      await expect(clearButton).toBeVisible();
+
+      const box = (await clearButton.boundingBox())!;
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+      await page.mouse.down();
+      await nativeInput.evaluate((el: HTMLInputElement) => el.blur());
+      await page.waitForChanges();
+
+      // Releasing off the button sends the click to an ancestor, not the button.
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + 200);
+      await page.mouse.up();
+      // A regression would clear via onClearInput's 64ms timer; outlast it.
+      await page.waitForTimeout(100);
+
+      await expect(searchbar).toHaveJSProperty('value', 'abc');
+      await expect(clearButton).not.toBeVisible();
+    });
   });
 
   test.describe(title('searchbar: placeholder'), () => {

--- a/core/src/utils/forms/clear-button-press-controller.ts
+++ b/core/src/utils/forms/clear-button-press-controller.ts
@@ -1,0 +1,55 @@
+import { doc } from '@utils/browser';
+
+/**
+ * Tracks an in-flight press on a clear button so a blur landing mid-press can't
+ * hide or unmount the button before the press produces its click.
+ *
+ * Calling `preventDefault()` on `pointerdown` is meant to stop the field
+ * blurring, but not every browser honors it (iOS Safari blurs anyway). The
+ * press is released on `click` rather than `pointerup` because touch
+ * dispatches the click after the finger lifts.
+ *
+ * @internal
+ * @param onPressChange Receives the press state.
+ */
+export const createClearButtonPressController = (
+  onPressChange: (isPressed: boolean) => void
+): ClearButtonPressController => {
+  const release = () => {
+    doc?.removeEventListener('click', release);
+
+    onPressChange(false);
+  };
+
+  const onPointerDown = (ev: PointerEvent) => {
+    ev.preventDefault();
+
+    // Only a primary press produces a click.
+    if (ev.button !== 0) {
+      return;
+    }
+
+    onPressChange(true);
+
+    doc?.addEventListener('click', release, { once: true });
+  };
+
+  // Teardown also clears the press, so a disconnect mid-press can't leave the button stuck visible.
+  const destroy = () => {
+    release();
+  };
+
+  return {
+    onPointerDown,
+    release,
+    destroy,
+  };
+};
+
+export type ClearButtonPressController = {
+  onPointerDown: (ev: PointerEvent) => void;
+  /** Ends the press without waiting for a click. */
+  release: () => void;
+  /** Ends any in-flight press. The controller stays usable if the host reconnects. */
+  destroy: () => void;
+};

--- a/core/src/utils/forms/index.ts
+++ b/core/src/utils/forms/index.ts
@@ -2,3 +2,4 @@ export * from './notch-controller';
 export * from './compare-with-utils';
 export * from './item-multiple-inputs';
 export * from './validity';
+export * from './clear-button-press-controller';

--- a/core/src/utils/forms/test/clear-button-press-controller.spec.ts
+++ b/core/src/utils/forms/test/clear-button-press-controller.spec.ts
@@ -1,0 +1,113 @@
+import { createClearButtonPressController } from '../clear-button-press-controller';
+
+/**
+ * jsdom does not implement `PointerEvent`, but the controller only reads
+ * `button` and calls `preventDefault`, both of which `MouseEvent` provides.
+ */
+const pointerEvent = (type: string, button = 0) =>
+  new MouseEvent(type, { button, bubbles: true, cancelable: true }) as unknown as PointerEvent;
+
+describe('Clear Button Press Controller', () => {
+  it('should mark a primary press as in flight', () => {
+    const onPressChange = jest.fn();
+    const controller = createClearButtonPressController(onPressChange);
+
+    controller.onPointerDown(pointerEvent('pointerdown'));
+
+    expect(onPressChange).toHaveBeenCalledWith(true);
+  });
+
+  it('should prevent the default press behavior that blurs the field', () => {
+    const controller = createClearButtonPressController(jest.fn());
+    const ev = pointerEvent('pointerdown');
+
+    controller.onPointerDown(ev);
+
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it('should ignore a non-primary press, which produces no click', () => {
+    const onPressChange = jest.fn();
+    const controller = createClearButtonPressController(onPressChange);
+
+    controller.onPointerDown(pointerEvent('pointerdown', 2));
+    document.dispatchEvent(pointerEvent('click'));
+
+    expect(onPressChange).not.toHaveBeenCalled();
+  });
+
+  it('should release the press once the click it produced has dispatched', () => {
+    const onPressChange = jest.fn();
+    const controller = createClearButtonPressController(onPressChange);
+
+    controller.onPointerDown(pointerEvent('pointerdown'));
+    document.dispatchEvent(pointerEvent('click'));
+
+    expect(onPressChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('should release an abandoned press', () => {
+    const onPressChange = jest.fn();
+    const controller = createClearButtonPressController(onPressChange);
+
+    controller.onPointerDown(pointerEvent('pointerdown'));
+    controller.release();
+
+    expect(onPressChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('should not react to clicks elsewhere once the press has been released', () => {
+    const onPressChange = jest.fn();
+    const controller = createClearButtonPressController(onPressChange);
+
+    controller.onPointerDown(pointerEvent('pointerdown'));
+    controller.release();
+    onPressChange.mockClear();
+
+    document.dispatchEvent(pointerEvent('click'));
+
+    expect(onPressChange).not.toHaveBeenCalled();
+  });
+
+  it('should track a second press on the same controller', () => {
+    const onPressChange = jest.fn();
+    const controller = createClearButtonPressController(onPressChange);
+
+    controller.onPointerDown(pointerEvent('pointerdown'));
+    controller.release();
+
+    controller.onPointerDown(pointerEvent('pointerdown'));
+    expect(onPressChange).toHaveBeenLastCalledWith(true);
+
+    document.dispatchEvent(pointerEvent('click'));
+    expect(onPressChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('should stop tracking a pending press when destroyed', () => {
+    const onPressChange = jest.fn();
+    const controller = createClearButtonPressController(onPressChange);
+
+    controller.onPointerDown(pointerEvent('pointerdown'));
+    controller.destroy();
+
+    expect(onPressChange).toHaveBeenLastCalledWith(false);
+
+    onPressChange.mockClear();
+    document.dispatchEvent(pointerEvent('click'));
+
+    expect(onPressChange).not.toHaveBeenCalled();
+  });
+
+  it('should stay usable after being destroyed, since the host can reconnect', () => {
+    const onPressChange = jest.fn();
+    const controller = createClearButtonPressController(onPressChange);
+
+    controller.destroy();
+
+    controller.onPointerDown(pointerEvent('pointerdown'));
+    expect(onPressChange).toHaveBeenLastCalledWith(true);
+
+    document.dispatchEvent(pointerEvent('click'));
+    expect(onPressChange).toHaveBeenLastCalledWith(false);
+  });
+});


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?

Currently, on iOS 26.5, tapping the clear button on an `ion-input` in the ionic theme does nothing. The button calls `preventDefault()` on `pointerdown` to stop the native input from blurring, but 26.5 blurs it anyway. `input.ionic.scss` hides the clear button with `display: none` whenever the host doesn't match `:focus-within`, so the blur removes the button from the layout between `pointerup` and `click`, the click retargets to the input underneath, and the value is never cleared. The user sees the text caret move and the text stay put.

`ion-searchbar` has the same gap with `showClearButton="focus"`, where `shouldShowClearButton()` unmounts the button once `focused` goes false. It doesn't reproduce on 26.5 today because the searchbar doesn't blur during that gesture, but any blur landing mid-press loses the click the same way (unlikely to happen, but worth fixing while we're here).

## What is the new behavior?

Both components now track an in-flight press on the clear button and keep it available until the click that press produces has been dispatched, so activation no longer depends on when the blur arrives. Input gates a class on the button that the ionic theme's hide rule ignores, and searchbar widens the `focus` branch of `shouldShowClearButton()`. The press is released on `click` rather than `pointerup`, because touch dispatches the click after the release, and clearing the flag any earlier puts the button back into the original race.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

Only the ionic theme is affected for input. The `ios`, `md`, and `native` themes gate the clear button on `.has-value` rather than focus, so a mid-press blur was never a problem there.

I verified the fix on an iOS 26.5 simulator against a Capacitor build of this branch, with 26.2 and 26.3.1 as controls - the same tap clears on all three now, and reproduced reliably on 26.5 before the change. The 26.5 blur ordering can't be reproduced in CI, so the e2e tests force the blur between `pointerdown` and `click` instead. That fails on every engine without this fix, which makes it a regression guard for the invariant rather than for the specific WebKit behavior. There's a second test per component covering an abandoned press, so the tracking flag can't leak and leave the button visible on a blurred field.

You can only reproduce/test this in a capacitor app, unfortunately.

- [Input - ionic theme](https://ionic-framework-git-fix-next-blur-clear-ionic1.vercel.app/src/components/input/test/basic?ionic:theme=ionic)
- [Searchbar - ionic theme](https://ionic-framework-git-fix-next-blur-clear-ionic1.vercel.app/src/components/searchbar/test/basic?ionic:theme=ionic)