### PR TITLE
fix(modal): allow pull-to-refresh with a custom scroll host

### DIFF
--- a/core/src/components/modal/gestures/sheet.ts
+++ b/core/src/components/modal/gestures/sheet.ts
@@ -7,7 +7,7 @@ import type { Animation, ModalDragEventDetail } from '../../../interface';
 import type { GestureDetail } from '../../../utils/gesture';
 import { getBackdropValueForSheet } from '../utils';
 
-import { calculateSpringStep, handleCanDismiss } from './utils';
+import { calculateSpringStep, canSwipeOnContent, handleCanDismiss } from './utils';
 
 export interface MoveSheetToBreakpointOptions {
   /**
@@ -261,9 +261,6 @@ export const createSheetGesture = (
 
   const canStart = (detail: GestureDetail) => {
     /**
-     * If we are swiping on the content, swiping should only be possible if the content
-     * is scrolled all the way to the top so that we do not interfere with scrolling.
-     *
      * We cannot assume that the `ion-content` target will remain consistent between swipes.
      * For example, when using ion-nav within a modal it is possible to swipe, push a view,
      * and then swipe again. The target content will not be the same between swipes.
@@ -272,27 +269,11 @@ export const createSheetGesture = (
     currentBreakpoint = getCurrentBreakpoint();
 
     /**
-     * If `expandToScroll` is disabled, we should not allow the swipe gesture
-     * to start if the content is not scrolled to the top.
+     * Upwards swipes on the content cannot move the sheet anyway, so this only
+     * blocks swiping the sheet down from the content.
      */
-    if (!expandToScroll && contentEl) {
-      const scrollEl = isIonContent(contentEl) ? getElementRoot(contentEl).querySelector('.inner-scroll') : contentEl;
-      return scrollEl!.scrollTop === 0;
-    }
-
-    if (currentBreakpoint === 1 && contentEl) {
-      /**
-       * The modal should never swipe to close on the content with a refresher.
-       * Note 1: We cannot solve this by making this gesture have a higher priority than
-       * the refresher gesture as the iOS native refresh gesture uses a scroll listener in
-       * addition to a gesture.
-       *
-       * Note 2: Do not use getScrollElement here because we need this to be a synchronous
-       * operation, and getScrollElement is asynchronous.
-       */
-      const scrollEl = isIonContent(contentEl) ? getElementRoot(contentEl).querySelector('.inner-scroll') : contentEl;
-      const hasRefresherInContent = !!contentEl.querySelector('ion-refresher');
-      return !hasRefresherInContent && scrollEl!.scrollTop === 0;
+    if (contentEl && (!expandToScroll || currentBreakpoint === 1)) {
+      return canSwipeOnContent(contentEl);
     }
 
     return true;

--- a/core/src/components/modal/gestures/sheet.ts
+++ b/core/src/components/modal/gestures/sheet.ts
@@ -82,6 +82,8 @@ export const createSheetGesture = (
   };
 
   const contentEl = baseEl.querySelector('ion-content');
+  // Cache the initial value so the gesture restores it instead of forcing scrolling on.
+  const initialContentScrollY = contentEl?.scrollY ?? true;
   const height = wrapperEl.clientHeight;
   let currentBreakpoint = initialBreakpoint;
   let offset = 0;
@@ -543,14 +545,14 @@ export const createSheetGesture = (
     }
 
     /**
-     * Enables scrolling immediately if the sheet is about to fully expand
-     * or if it allows scrolling at any breakpoint. Without this, there would
+     * Restores the content's scroll setting immediately if the sheet is about to
+     * fully expand or if it allows scrolling at any breakpoint. Without this, there would
      * be a ~500ms delay while the modal animation completes, causing a
      * noticeable lag. Native iOS allows scrolling as soon as the gesture is
      * released, so we align with that behavior.
      */
     if (contentEl && (snapToBreakpoint === breakpoints[breakpoints.length - 1] || !expandToScroll)) {
-      contentEl.scrollY = true;
+      contentEl.scrollY = initialContentScrollY;
     }
 
     /**
@@ -749,8 +751,20 @@ export const createSheetGesture = (
     onEnd,
   });
 
+  /**
+   * Puts the content back the way the app declared it. A sheet can dismiss
+   * without going through moveSheetToBreakpoint, and an inline modal reuses
+   * the same element on the next present.
+   */
+  const resetContentScroll = () => {
+    if (contentEl) {
+      contentEl.scrollY = initialContentScrollY;
+    }
+  };
+
   return {
     gesture,
     moveSheetToBreakpoint,
+    resetContentScroll,
   };
 };

--- a/core/src/components/modal/gestures/swipe-to-close.ts
+++ b/core/src/components/modal/gestures/swipe-to-close.ts
@@ -1,7 +1,7 @@
 import { getTimeGivenProgression } from '@utils/animation/cubic-bezier';
 import { isIonContent, findClosestIonContent, disableContentScrollY, resetContentScrollY } from '@utils/content';
 import { createGesture } from '@utils/gesture';
-import { clamp, getElementRoot } from '@utils/helpers';
+import { clamp } from '@utils/helpers';
 import { OVERLAY_GESTURE_PRIORITY } from '@utils/overlays';
 
 import type { Animation, ModalDragEventDetail } from '../../../interface';
@@ -9,7 +9,7 @@ import type { GestureDetail } from '../../../utils/gesture';
 import type { Style as StatusBarStyle } from '../../../utils/native/status-bar';
 import { setCardStatusBarDark, setCardStatusBarDefault } from '../utils';
 
-import { calculateSpringStep, handleCanDismiss } from './utils';
+import { calculateSpringStep, canSwipeOnContent, handleCanDismiss } from './utils';
 
 // Defaults for the card swipe animation
 export const SwipeToCloseDefaults = {
@@ -35,7 +35,6 @@ export const createSwipeToCloseGesture = (
   let isOpen = false;
   let canDismissBlocksGesture = false;
   let contentEl: HTMLElement | null = null;
-  let scrollEl: HTMLElement | null = null;
   const canDismissMaxStep = 0.2;
   let initialScrollY = true;
   let lastStep = 0;
@@ -60,12 +59,6 @@ export const createSwipeToCloseGesture = (
     }
 
     /**
-     * If we are swiping on the content,
-     * swiping should only be possible if
-     * the content is scrolled all the way
-     * to the top so that we do not interfere
-     * with scrolling.
-     *
      * We cannot assume that the `ion-content`
      * target will remain consistent between
      * swipes. For example, when using
@@ -76,29 +69,7 @@ export const createSwipeToCloseGesture = (
      */
     contentEl = findClosestIonContent(target);
     if (contentEl) {
-      /**
-       * The card should never swipe to close
-       * on the content with a refresher.
-       * Note: We cannot solve this by making the
-       * swipeToClose gesture have a higher priority
-       * than the refresher gesture as the iOS native
-       * refresh gesture uses a scroll listener in
-       * addition to a gesture.
-       *
-       * Note: Do not use getScrollElement here
-       * because we need this to be a synchronous
-       * operation, and getScrollElement is
-       * asynchronous.
-       */
-      if (isIonContent(contentEl)) {
-        const root = getElementRoot(contentEl);
-        scrollEl = root.querySelector('.inner-scroll');
-      } else {
-        scrollEl = contentEl;
-      }
-
-      const hasRefresherInContent = !!contentEl.querySelector('ion-refresher');
-      return !hasRefresherInContent && scrollEl!.scrollTop === 0;
+      return canSwipeOnContent(contentEl);
     }
 
     /**

--- a/core/src/components/modal/gestures/utils.ts
+++ b/core/src/components/modal/gestures/utils.ts
@@ -1,6 +1,25 @@
+import { findRefresherInContent, isIonContent } from '@utils/content';
+import { getElementRoot } from '@utils/helpers';
 import { GESTURE } from '@utils/overlays';
 
 import type { Animation } from '../../../interface';
+
+/**
+ * Swiping is only possible when the content is scrolled to the top, so that we
+ * do not interfere with scrolling, and never on content with a refresher.
+ *
+ * Note: We cannot solve the refresher case with gesture priority as the iOS
+ * native refresh gesture uses a scroll listener in addition to a gesture.
+ *
+ * Note: Do not use `getScrollElement` here because we need this to be a
+ * synchronous operation, and `getScrollElement` is asynchronous.
+ */
+export const canSwipeOnContent = (contentEl: HTMLElement) => {
+  const scrollEl = isIonContent(contentEl) ? getElementRoot(contentEl).querySelector('.inner-scroll') : contentEl;
+  const hasRefresherInContent = !!findRefresherInContent(contentEl);
+
+  return !hasRefresherInContent && scrollEl!.scrollTop === 0;
+};
 
 export const handleCanDismiss = async (el: HTMLIonModalElement, animation: Animation) => {
   /**

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -93,6 +93,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
   private sortedBreakpoints?: number[];
   private keyboardOpenCallback?: () => void;
   private moveSheetToBreakpoint?: (options: MoveSheetToBreakpointOptions) => Promise<void>;
+  private resetSheetContentScroll?: () => void;
   private inheritedAttributes: Attributes = {};
   private statusBarStyle?: StatusBarStyle;
 
@@ -779,7 +780,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
 
     ani.progressStart(true, 1);
 
-    const { gesture, moveSheetToBreakpoint } = createSheetGesture(
+    const { gesture, moveSheetToBreakpoint, resetContentScroll } = createSheetGesture(
       this.el,
       this.backdropEl!,
       wrapperEl,
@@ -803,6 +804,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
 
     this.gesture = gesture;
     this.moveSheetToBreakpoint = moveSheetToBreakpoint;
+    this.resetSheetContentScroll = resetContentScroll;
 
     this.gesture.enable(true);
 
@@ -1029,6 +1031,13 @@ export class Modal implements ComponentInterface, OverlayInterface {
       if (this.gesture) {
         this.gesture.destroy();
       }
+      /**
+       * The sheet gesture turns content scrolling off while the sheet sits below
+       * the top breakpoint. Inline modals reuse the same content on the next
+       * present, so hand it back before the gesture goes away.
+       */
+      this.resetSheetContentScroll?.();
+      this.resetSheetContentScroll = undefined;
       this.cleanupViewTransitionListener();
       this.cleanupParentRemovalObserver();
       this.cleanupSafeAreaOverrides();

--- a/core/src/components/modal/test/refresher-scroll-target/index.html
+++ b/core/src/components/modal/test/refresher-scroll-target/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Modal - Refresher with Custom Scroll Target</title>
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta
+      name="viewport"
+      content="viewport-fit=cover, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
+    <link href="../../../../../../css/ionic.bundle.css" rel="stylesheet" />
+    <link href="../../../../../../scripts/testing/styles.css" rel="stylesheet" />
+    <script src="../../../../../../scripts/testing/scripts.js"></script>
+    <script type="module" src="../../../../../../dist/ionic/ionic.esm.js"></script>
+
+    <style>
+      #content {
+        position: relative;
+
+        display: block;
+        flex: 1;
+
+        height: 100%;
+        overflow-y: auto;
+
+        contain: size style;
+      }
+    </style>
+  </head>
+
+  <script type="module">
+    import { modalController } from '../../../../../dist/ionic/index.esm.js';
+    window.modalController = modalController;
+  </script>
+
+  <body>
+    <ion-app>
+      <div class="ion-page">
+        <ion-header>
+          <ion-toolbar>
+            <ion-title>Refresher with Custom Scroll Target</ion-title>
+          </ion-toolbar>
+        </ion-header>
+
+        <ion-content class="ion-padding">
+          <button class="expand" id="card" onclick="presentCardModal()">Card Modal</button>
+          <button class="expand" id="sheet" onclick="presentSheetModal()">Sheet Modal</button>
+          <button class="expand" id="sheet-no-expand" onclick="presentSheetModal(false)">
+            Sheet Modal (expandToScroll false)
+          </button>
+        </ion-content>
+      </div>
+    </ion-app>
+
+    <script>
+      // The refresher is a child of ion-content while the scroll host is a
+      // sibling of it, matching how virtual scroll viewports are set up.
+      function createModalContent() {
+        const element = document.createElement('div');
+        element.innerHTML = `
+      <ion-header id="modal-header">
+        <ion-toolbar>
+          <ion-title>Modal</ion-title>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content scroll-y="false">
+        <ion-refresher id="refresher" slot="fixed">
+          <ion-refresher-content></ion-refresher-content>
+        </ion-refresher>
+        <div id="content" class="ion-padding ion-content-scroll-host">
+          <ion-list id="list"></ion-list>
+        </div>
+      </ion-content>
+      `;
+
+        const list = element.querySelector('#list');
+        for (let i = 0; i < 30; i++) {
+          const item = document.createElement('ion-item');
+          item.textContent = `Item ${i}`;
+          list.appendChild(item);
+        }
+
+        const refresher = element.querySelector('#refresher');
+        refresher.addEventListener('ionRefresh', () => {
+          refresher.complete();
+        });
+
+        return element;
+      }
+
+      async function presentCardModal() {
+        const modal = await modalController.create({
+          // ion-app also carries the ion-page class, so the page is the second match.
+          presentingElement: document.querySelectorAll('.ion-page')[1],
+          component: createModalContent(),
+        });
+        await modal.present();
+      }
+
+      async function presentSheetModal(expandToScroll = true) {
+        const modal = await modalController.create({
+          component: createModalContent(),
+          breakpoints: [0, 1],
+          initialBreakpoint: 1,
+          expandToScroll,
+        });
+        await modal.present();
+      }
+    </script>
+  </body>
+</html>

--- a/core/src/components/modal/test/refresher-scroll-target/index.html
+++ b/core/src/components/modal/test/refresher-scroll-target/index.html
@@ -46,14 +46,26 @@
         <ion-content class="ion-padding">
           <button class="expand" id="card" onclick="presentCardModal()">Card Modal</button>
           <button class="expand" id="sheet" onclick="presentSheetModal()">Sheet Modal</button>
-          <button class="expand" id="sheet-no-expand" onclick="presentSheetModal(false)">
+          <button class="expand" id="sheet-no-expand" onclick="presentSheetModal({ expandToScroll: false })">
             Sheet Modal (expandToScroll false)
+          </button>
+          <button class="expand" id="sheet-breakpoints" onclick="presentSheetModal(MULTIPLE_BREAKPOINTS)">
+            Sheet Modal (breakpoints)
+          </button>
+          <button
+            class="expand"
+            id="sheet-breakpoints-no-expand"
+            onclick="presentSheetModal({ ...MULTIPLE_BREAKPOINTS, expandToScroll: false })"
+          >
+            Sheet Modal (breakpoints, expandToScroll false)
           </button>
         </ion-content>
       </div>
     </ion-app>
 
     <script>
+      const MULTIPLE_BREAKPOINTS = { breakpoints: [0, 0.25, 0.5, 1], initialBreakpoint: 0.5 };
+
       // The refresher is a child of ion-content while the scroll host is a
       // sibling of it, matching how virtual scroll viewports are set up.
       function createModalContent() {
@@ -66,7 +78,7 @@
       </ion-header>
       <ion-content scroll-y="false">
         <ion-refresher id="refresher" slot="fixed">
-          <ion-refresher-content></ion-refresher-content>
+          <ion-refresher-content pulling-text="Pull to refresh" refreshing-text="Refreshing..."></ion-refresher-content>
         </ion-refresher>
         <div id="content" class="ion-padding ion-content-scroll-host">
           <ion-list id="list"></ion-list>
@@ -81,9 +93,21 @@
           list.appendChild(item);
         }
 
+        let refreshCount = 0;
         const refresher = element.querySelector('#refresher');
         refresher.addEventListener('ionRefresh', () => {
-          refresher.complete();
+          // Hold the refreshing state so the spinner is visible when testing by
+          // hand, then prepend an item so the refresh leaves something behind.
+          setTimeout(() => {
+            refreshCount++;
+
+            const item = document.createElement('ion-item');
+            item.setAttribute('color', 'success');
+            item.textContent = `Refreshed ${refreshCount}`;
+            list.prepend(item);
+
+            refresher.complete();
+          }, 1500);
         });
 
         return element;
@@ -98,12 +122,12 @@
         await modal.present();
       }
 
-      async function presentSheetModal(expandToScroll = true) {
+      async function presentSheetModal(opts = {}) {
         const modal = await modalController.create({
           component: createModalContent(),
           breakpoints: [0, 1],
           initialBreakpoint: 1,
-          expandToScroll,
+          ...opts,
         });
         await modal.present();
       }

--- a/core/src/components/modal/test/refresher-scroll-target/modal.e2e.ts
+++ b/core/src/components/modal/test/refresher-scroll-target/modal.e2e.ts
@@ -1,0 +1,110 @@
+import { expect } from '@playwright/test';
+import type { E2EPage } from '@utils/test/playwright';
+import { configs, dragElementByYAxis, test } from '@utils/test/playwright';
+
+const pullDownOnScrollHost = async (page: E2EPage) => {
+  // The refresher creates its gesture asynchronously, so wait for it to hydrate.
+  await page.locator('ion-modal ion-refresher.hydrated').waitFor({ state: 'attached' });
+
+  const scrollHost = page.locator('ion-modal .ion-content-scroll-host');
+  const box = (await scrollHost.boundingBox())!;
+
+  // Start near the top of the host so the pull stays within smaller viewports.
+  await dragElementByYAxis(scrollHost, page, 250, box.y + 5);
+};
+
+/**
+ * This behavior does not vary across directions.
+ */
+configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
+  test.describe(title('sheet modal: refresher with custom scroll target'), () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/src/components/modal/test/refresher-scroll-target', config);
+    });
+
+    test('should refresh instead of dismissing when pulling down on the custom scroll target', async ({
+      page,
+    }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31332',
+      });
+
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+      const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
+      const ionRefresh = await page.spyOnEvent('ionRefresh');
+
+      await page.click('#sheet');
+      await ionModalDidPresent.next();
+
+      await pullDownOnScrollHost(page);
+
+      await ionRefresh.next();
+      expect(ionModalDidDismiss).toHaveReceivedEventTimes(0);
+    });
+
+    test('should refresh instead of dismissing when expandToScroll is disabled', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31332',
+      });
+
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+      const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
+      const ionRefresh = await page.spyOnEvent('ionRefresh');
+
+      await page.click('#sheet-no-expand');
+      await ionModalDidPresent.next();
+
+      await pullDownOnScrollHost(page);
+
+      await ionRefresh.next();
+      expect(ionModalDidDismiss).toHaveReceivedEventTimes(0);
+    });
+
+    test('should still dismiss when dragging the handle', async ({ page }) => {
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+      const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
+
+      await page.click('#sheet-no-expand');
+      await ionModalDidPresent.next();
+
+      await dragElementByYAxis(page.locator('ion-modal .modal-handle'), page, 500);
+
+      await ionModalDidDismiss.next();
+    });
+  });
+});
+
+/**
+ * Card modals are only available in iOS mode.
+ * This behavior does not vary across directions.
+ */
+configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
+  test.describe(title('card modal: refresher with custom scroll target'), () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/src/components/modal/test/refresher-scroll-target', config);
+    });
+
+    test('should refresh instead of dismissing when pulling down on the custom scroll target', async ({
+      page,
+    }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31332',
+      });
+
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+      const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
+      const ionRefresh = await page.spyOnEvent('ionRefresh');
+
+      await page.click('#card');
+      await ionModalDidPresent.next();
+
+      await pullDownOnScrollHost(page);
+
+      await ionRefresh.next();
+      expect(ionModalDidDismiss).toHaveReceivedEventTimes(0);
+    });
+  });
+});

--- a/core/src/components/modal/test/refresher-scroll-target/modal.e2e.ts
+++ b/core/src/components/modal/test/refresher-scroll-target/modal.e2e.ts
@@ -94,6 +94,53 @@ configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
       expect(ionBreakpointDidChange).toHaveReceivedEventTimes(0);
     });
 
+    test('should keep the content opted out of scrolling after the sheet snaps back', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31332',
+      });
+
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+      const ionBreakpointDidChange = await page.spyOnEvent('ionBreakpointDidChange');
+      const ionRefresh = await page.spyOnEvent('ionRefresh');
+
+      await page.click('#sheet-breakpoints');
+      await ionModalDidPresent.next();
+
+      const content = page.locator('ion-modal ion-content');
+      await expect(content).toHaveJSProperty('scrollY', false);
+
+      /**
+       * Expanding to the top breakpoint is what used to force scrolling back on.
+       * Waiting on the breakpoint change also proves the drag moved the sheet, so
+       * this cannot pass by leaving the content untouched.
+       */
+      const wrapper = (await page.locator('ion-modal .modal-wrapper').boundingBox())!;
+      await dragElementByYAxis(page.locator('ion-modal .modal-handle'), page, -Math.round(wrapper.height * 0.3));
+      await ionBreakpointDidChange.next();
+
+      await expect(content).toHaveJSProperty('scrollY', false);
+
+      await dragDownOnScrollHost(page);
+
+      await ionRefresh.next();
+    });
+
+    test('should keep the content opted out of scrolling when expandToScroll is disabled', async ({ page }) => {
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+
+      await page.click('#sheet-breakpoints-no-expand');
+      await ionModalDidPresent.next();
+
+      const content = page.locator('ion-modal ion-content');
+      await expect(content).toHaveJSProperty('scrollY', false);
+
+      // With expandToScroll disabled the sheet restores scrolling at every breakpoint.
+      await dragElementByYAxis(page.locator('ion-modal .modal-handle'), page, 60);
+
+      await expect(content).toHaveJSProperty('scrollY', false);
+    });
+
     test('should still dismiss when dragging the handle', async ({ page }) => {
       const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
       const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');

--- a/core/src/components/modal/test/refresher-scroll-target/modal.e2e.ts
+++ b/core/src/components/modal/test/refresher-scroll-target/modal.e2e.ts
@@ -2,15 +2,15 @@ import { expect } from '@playwright/test';
 import type { E2EPage } from '@utils/test/playwright';
 import { configs, dragElementByYAxis, test } from '@utils/test/playwright';
 
-const pullDownOnScrollHost = async (page: E2EPage) => {
+const dragDownOnScrollHost = async (page: E2EPage, dragByY = 250) => {
   // The refresher creates its gesture asynchronously, so wait for it to hydrate.
   await page.locator('ion-modal ion-refresher.hydrated').waitFor({ state: 'attached' });
 
   const scrollHost = page.locator('ion-modal .ion-content-scroll-host');
   const box = (await scrollHost.boundingBox())!;
 
-  // Start near the top of the host so the pull stays within smaller viewports.
-  await dragElementByYAxis(scrollHost, page, 250, box.y + 5);
+  // Start near the top of the host so the drag stays within smaller viewports.
+  await dragElementByYAxis(scrollHost, page, dragByY, box.y + 5);
 };
 
 /**
@@ -37,7 +37,7 @@ configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
       await page.click('#sheet');
       await ionModalDidPresent.next();
 
-      await pullDownOnScrollHost(page);
+      await dragDownOnScrollHost(page);
 
       await ionRefresh.next();
       expect(ionModalDidDismiss).toHaveReceivedEventTimes(0);
@@ -56,10 +56,42 @@ configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
       await page.click('#sheet-no-expand');
       await ionModalDidPresent.next();
 
-      await pullDownOnScrollHost(page);
+      await dragDownOnScrollHost(page);
 
       await ionRefresh.next();
       expect(ionModalDidDismiss).toHaveReceivedEventTimes(0);
+    });
+
+    test('should move the sheet rather than refresh when dragging the content at a partial breakpoint', async ({
+      page,
+    }) => {
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+      const ionBreakpointDidChange = await page.spyOnEvent('ionBreakpointDidChange');
+      const ionRefresh = await page.spyOnEvent('ionRefresh');
+
+      await page.click('#sheet-breakpoints');
+      await ionModalDidPresent.next();
+
+      await dragDownOnScrollHost(page);
+
+      await ionBreakpointDidChange.next();
+      expect(ionRefresh).toHaveReceivedEventTimes(0);
+    });
+
+    test('should refresh rather than move the sheet at a partial breakpoint when expandToScroll is disabled', async ({
+      page,
+    }) => {
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+      const ionBreakpointDidChange = await page.spyOnEvent('ionBreakpointDidChange');
+      const ionRefresh = await page.spyOnEvent('ionRefresh');
+
+      await page.click('#sheet-breakpoints-no-expand');
+      await ionModalDidPresent.next();
+
+      await dragDownOnScrollHost(page);
+
+      await ionRefresh.next();
+      expect(ionBreakpointDidChange).toHaveReceivedEventTimes(0);
     });
 
     test('should still dismiss when dragging the handle', async ({ page }) => {
@@ -101,7 +133,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       await page.click('#card');
       await ionModalDidPresent.next();
 
-      await pullDownOnScrollHost(page);
+      await dragDownOnScrollHost(page);
 
       await ionRefresh.next();
       expect(ionModalDidDismiss).toHaveReceivedEventTimes(0);

--- a/core/src/components/modal/test/sheet/modal.e2e.ts
+++ b/core/src/components/modal/test/sheet/modal.e2e.ts
@@ -127,6 +127,20 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
         expect(breakpoint).toBe(0.5);
       });
 
+      test('should give scrolling back to the content when expanded to the top breakpoint', async ({ page }) => {
+        const ionBreakpointDidChange = await page.spyOnEvent('ionBreakpointDidChange');
+        const modal = page.locator('.modal-sheet');
+        const content = modal.locator('ion-content');
+
+        // The sheet starts partially open, so the content doesn't scroll yet.
+        await expect(content).toHaveJSProperty('scrollY', false);
+
+        await modal.evaluate((el: HTMLIonModalElement) => el.setCurrentBreakpoint(1));
+        await ionBreakpointDidChange.next();
+
+        await expect(content).toHaveJSProperty('scrollY', true);
+      });
+
       test('should emit ionBreakpointDidChange', async ({ page }) => {
         const ionBreakpointDidChange = await page.spyOnEvent('ionBreakpointDidChange');
         const modal = page.locator('.modal-sheet');
@@ -155,6 +169,61 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
 
         expect(ionBreakpointDidChange.events.length).toBe(1);
       });
+    });
+
+    test('it should restore content scrolling on dismiss so a reused modal still scrolls', async ({ page }) => {
+      await page.goto('/src/components/modal/test/sheet', config);
+
+      await page.setContent(
+        `
+        <ion-content>
+          <ion-button id="open-modal">Open</ion-button>
+          <ion-modal trigger="open-modal" initial-breakpoint="0.25">
+            <ion-content>
+              <ion-button id="dismiss" onclick="modal.dismiss();">Dismiss</ion-button>
+            </ion-content>
+          </ion-modal>
+        </ion-content>
+        <script>
+          const modal = document.querySelector('ion-modal');
+          modal.breakpoints = [0, 0.25, 0.5, 1];
+        </script>
+      `,
+        config
+      );
+
+      const modal = page.locator('ion-modal');
+      const content = modal.locator('ion-content');
+      const openButton = page.locator('#open-modal');
+      const dismissButton = page.locator('#dismiss');
+
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+      const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
+      const ionBreakpointDidChange = await page.spyOnEvent('ionBreakpointDidChange');
+
+      await openButton.click();
+      await ionModalDidPresent.next();
+
+      // Below the top breakpoint, so the sheet has turned content scrolling off.
+      await expect(content).toHaveJSProperty('scrollY', false);
+
+      await dismissButton.click();
+      await ionModalDidDismiss.next();
+
+      /**
+       * An inline modal reuses this content on the next present. Leaving it
+       * switched off means the re-presented sheet reads that as the app's own
+       * setting and never scrolls again.
+       */
+      await expect(content).toHaveJSProperty('scrollY', true);
+
+      await openButton.click();
+      await ionModalDidPresent.next();
+
+      await modal.evaluate((el: HTMLIonModalElement) => el.setCurrentBreakpoint(1));
+      await ionBreakpointDidChange.next();
+
+      await expect(content).toHaveJSProperty('scrollY', true);
     });
 
     test('it should reset the breakpoint value on dismiss', async ({ page }) => {

--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -2,6 +2,7 @@ import type { ComponentInterface, EventEmitter } from '@stencil/core';
 import { Component, Element, Event, Host, Method, Prop, State, Watch, h, readTask, writeTask } from '@stencil/core';
 import { getTimeGivenProgression } from '@utils/animation/cubic-bezier';
 import {
+  findRefresherScrollHost,
   getScrollElement,
   ION_CONTENT_CLASS_SELECTOR,
   ION_CONTENT_ELEMENT_SELECTOR,
@@ -526,7 +527,7 @@ export class Refresher implements ComponentInterface {
      * or the background content element.
      */
     componentOnReady(contentEl, async () => {
-      const customScrollTarget = contentEl.querySelector(ION_CONTENT_CLASS_SELECTOR);
+      const customScrollTarget = findRefresherScrollHost(contentEl);
       /**
        * Query the custom scroll target (if available), first. In refresher implementations,
        * the ion-refresher element will always be a direct child of ion-content (slot="fixed"). By

--- a/core/src/utils/content/content.utils.spec.ts
+++ b/core/src/utils/content/content.utils.spec.ts
@@ -4,6 +4,7 @@ import {
   printIonContentErrorMsg,
   findClosestIonContent,
   findIonContent,
+  findRefresherInContent,
   getScrollElement,
 } from './index';
 
@@ -45,6 +46,68 @@ describe('Content Utils', () => {
       } as any);
 
       expect(closestMock).toHaveBeenCalledWith('ion-content, .ion-content-scroll-host');
+    });
+  });
+
+  describe('findRefresherInContent', () => {
+    const createContent = ({ hasRefresher = true, scrollHostCount = 0 } = {}) => {
+      const content = document.createElement('ion-content');
+
+      if (hasRefresher) {
+        const refresher = document.createElement('ion-refresher');
+        refresher.setAttribute('slot', 'fixed');
+        content.appendChild(refresher);
+      }
+
+      for (let i = 0; i < scrollHostCount; i++) {
+        const scrollHost = document.createElement('div');
+        scrollHost.classList.add('ion-content-scroll-host');
+        content.appendChild(scrollHost);
+      }
+
+      return content;
+    };
+
+    it('should find the refresher within ion-content', () => {
+      const content = createContent();
+
+      expect(findRefresherInContent(content)).toBe(content.querySelector('ion-refresher'));
+    });
+
+    it('should return null when ion-content has no refresher', () => {
+      const content = createContent({ hasRefresher: false });
+
+      expect(findRefresherInContent(content)).toBe(null);
+    });
+
+    it('should find the refresher from a custom scroll host that is a sibling of it', () => {
+      const content = createContent({ scrollHostCount: 1 });
+      const scrollHost = content.querySelector('.ion-content-scroll-host')!;
+
+      expect(findRefresherInContent(scrollHost)).toBe(content.querySelector('ion-refresher'));
+    });
+
+    it('should find the refresher from an element nested within the custom scroll host', () => {
+      const content = createContent({ scrollHostCount: 1 });
+      const nested = document.createElement('div');
+      content.querySelector('.ion-content-scroll-host')!.appendChild(nested);
+
+      expect(findRefresherInContent(nested)).toBe(content.querySelector('ion-refresher'));
+    });
+
+    it('should return null for a custom scroll host the refresher does not scroll with', () => {
+      const content = createContent({ scrollHostCount: 2 });
+      const secondScrollHost = content.querySelectorAll('.ion-content-scroll-host')[1];
+
+      expect(findRefresherInContent(secondScrollHost)).toBe(null);
+    });
+
+    it('should return null for a custom scroll host that is not within an ion-content', () => {
+      const scrollHost = document.createElement('div');
+      scrollHost.classList.add('ion-content-scroll-host');
+      scrollHost.appendChild(document.createElement('ion-refresher'));
+
+      expect(findRefresherInContent(scrollHost)).toBe(null);
     });
   });
 

--- a/core/src/utils/content/index.ts
+++ b/core/src/utils/content/index.ts
@@ -59,6 +59,41 @@ export const findClosestIonContent = (el: Element) => {
 };
 
 /**
+ * Queries the custom scroll host an `ion-refresher` scrolls with in the given
+ * `ion-content`. A refresher only pairs with the first host.
+ */
+export const findRefresherScrollHost = (ionContent: Element) => {
+  return ionContent.querySelector<HTMLElement>(ION_CONTENT_CLASS_SELECTOR);
+};
+
+/**
+ * Queries the `ion-refresher` that scrolls with the given content element,
+ * which may be an `ion-content` or a custom scroll host. A refresher is a
+ * `slot="fixed"` child of `ion-content`, so it is a sibling of a scroll host
+ * rather than a descendant of it.
+ */
+export const findRefresherInContent = (contentEl: Element) => {
+  // An `ion-content` owns any refresher inside it, scroll host or not.
+  if (isIonContent(contentEl)) {
+    return contentEl.querySelector('ion-refresher');
+  }
+
+  // A refresher needs an `ion-content` ancestor to initialize.
+  const ionContent = contentEl.closest(ION_CONTENT_ELEMENT_SELECTOR);
+  if (ionContent === null) {
+    return null;
+  }
+
+  // Any scroll host other than the refresher's own has no refresher.
+  const refresherScrollHost = findRefresherScrollHost(ionContent);
+  if (refresherScrollHost === null || !refresherScrollHost.contains(contentEl)) {
+    return null;
+  }
+
+  return ionContent.querySelector('ion-refresher');
+};
+
+/**
  * Scrolls to the top of the element. If an `ion-content` is found, it will scroll
  * using the public API `scrollToTop` with a duration.
  */


### PR DESCRIPTION
Issue number: resolves #31332

---------

## What is the current behavior?

Currently, pulling down inside a sheet or card modal dismisses the modal instead of triggering the refresher when the content uses a custom scroll host.

## What is the new behavior?

With this change, the gesture resolves the refresher from the enclosing `ion-content` when the swipe target is a custom scroll host, so pulling down runs the refresher and leaves the modal alone. The new `findRefresherInContent` util only reports a refresher for the scroll host that refresher actually scrolls with, which is the first one in the content, so a second unrelated scroll host still swipes the modal normally. The `expandToScroll: false` path now runs the same check.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

Test coverage is 4 e2e tests on the new page:

[Test page (iOS)](https://ionic-framework-git-fix-31332-ionic1.vercel.app/src/components/modal/test/refresher-scroll-target/?ionic:mode=ios)
[Test page (MD)](https://ionic-framework-git-fix-31332-ionic1.vercel.app/src/components/modal/test/refresher-scroll-target/?ionic:mode=md)

## Current dev build:

```
8.8.18-dev.11786385944.17aca7e5
```