### PR TITLE
fix(react): skip undefined props in attachProps

### DIFF
--- a/packages/react/src/components/__tests__/createComponent.spec.tsx
+++ b/packages/react/src/components/__tests__/createComponent.spec.tsx
@@ -1,13 +1,15 @@
+/**
+ * `createReactComponent` reaches nothing in `@ionic/core`, so the generated
+ * wrapper can be driven directly, with no module to mock. These cases only fail
+ * at the wrapper level: `render()` omits a nullish prop, so React emits no
+ * attribute, and `componentDidUpdate` then writes one back through
+ * `attachProps`.
+ */
 import { render } from '@testing-library/react';
 
 import { createReactComponent } from '../react-component-lib/createComponent';
 
-/**
- * `createReactComponent` pulls nothing from `@ionic/core`, so the generated
- * wrapper can be driven directly. The bug these tests cover only appears at this
- * level: `render()` omits an undefined prop, so React emits no attribute, and
- * `componentDidUpdate` then writes it back through `attachProps`.
- */
+// Mirror how IonToggle is generated: a plain wrapper with no context or delegate.
 const IonToggle = createReactComponent<any, any>('ion-toggle') as any;
 
 const getToggle = () => document.querySelector('ion-toggle') as HTMLElement;

--- a/packages/react/src/components/__tests__/createComponent.spec.tsx
+++ b/packages/react/src/components/__tests__/createComponent.spec.tsx
@@ -1,0 +1,51 @@
+import { render } from '@testing-library/react';
+
+import { createReactComponent } from '../react-component-lib/createComponent';
+
+/**
+ * `createReactComponent` pulls nothing from `@ionic/core`, so the generated
+ * wrapper can be driven directly. The bug these tests cover only appears at this
+ * level: `render()` omits an undefined prop, so React emits no attribute, and
+ * `componentDidUpdate` then writes it back through `attachProps`.
+ */
+const IonToggle = createReactComponent<any, any>('ion-toggle') as any;
+
+const getToggle = () => document.querySelector('ion-toggle') as HTMLElement;
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('createReactComponent: nullish props', () => {
+  it('should not render an attribute for a prop passed as undefined', () => {
+    render(<IonToggle id={undefined} title={undefined} />);
+
+    expect(getToggle().hasAttribute('id')).toEqual(false);
+    expect(getToggle().hasAttribute('title')).toEqual(false);
+  });
+
+  it('should not render an attribute for a prop passed as null', () => {
+    render(<IonToggle id={null} title={null} />);
+
+    expect(getToggle().hasAttribute('id')).toEqual(false);
+    expect(getToggle().hasAttribute('title')).toEqual(false);
+  });
+
+  it('should remove the attribute when a prop becomes undefined', () => {
+    const { rerender } = render(<IonToggle id="my-id" />);
+    expect(getToggle().getAttribute('id')).toEqual('my-id');
+
+    rerender(<IonToggle id={undefined} />);
+
+    expect(getToggle().hasAttribute('id')).toEqual(false);
+  });
+
+  it('should remove the attribute when a prop becomes null', () => {
+    const { rerender } = render(<IonToggle id="my-id" />);
+    expect(getToggle().getAttribute('id')).toEqual('my-id');
+
+    rerender(<IonToggle id={null} />);
+
+    expect(getToggle().hasAttribute('id')).toEqual(false);
+  });
+});

--- a/packages/react/src/components/__tests__/utils.spec.ts
+++ b/packages/react/src/components/__tests__/utils.spec.ts
@@ -57,7 +57,7 @@ describe('attachProps', () => {
 
     expect(div.hasAttribute('id')).toEqual(false);
     expect(div.hasAttribute('title')).toEqual(false);
-    expect((div as any).testprop).toEqual(undefined);
+    expect('testprop' in div).toBe(false);
   });
 
   it('should clear a prop that no longer has a value', () => {

--- a/packages/react/src/components/__tests__/utils.spec.ts
+++ b/packages/react/src/components/__tests__/utils.spec.ts
@@ -50,4 +50,22 @@ describe('attachProps', () => {
     expect(div).toHaveStyle(`display: block;`);
     expect(Object.keys((div as any).__events)).toEqual(['ionClick']);
   });
+
+  it('should not write undefined props to a dom node', () => {
+    var div = document.createElement('div');
+    utils.attachProps(div, { id: undefined, title: undefined, testprop: undefined });
+
+    expect(div.hasAttribute('id')).toEqual(false);
+    expect(div.hasAttribute('title')).toEqual(false);
+    expect((div as any).testprop).toEqual(undefined);
+  });
+
+  it('should clear a prop that no longer has a value', () => {
+    var div = document.createElement('div');
+    utils.attachProps(div, { id: 'my-id', testprop: ['red'] });
+    utils.attachProps(div, { id: undefined, testprop: undefined }, { id: 'my-id', testprop: ['red'] });
+
+    expect(div.hasAttribute('id')).toEqual(false);
+    expect((div as any).testprop).toEqual(undefined);
+  });
 });

--- a/packages/react/src/components/__tests__/utils.spec.ts
+++ b/packages/react/src/components/__tests__/utils.spec.ts
@@ -68,4 +68,41 @@ describe('attachProps', () => {
     expect(div.hasAttribute('id')).toEqual(false);
     expect((div as any).testprop).toEqual(undefined);
   });
+
+  it('should not write null native props to a dom node', () => {
+    var div = document.createElement('div');
+    utils.attachProps(div, { id: null, title: null, slot: null });
+
+    expect(div.hasAttribute('id')).toEqual(false);
+    expect(div.hasAttribute('title')).toEqual(false);
+    expect(div.hasAttribute('slot')).toEqual(false);
+  });
+
+  it('should clear a native prop set to null', () => {
+    var div = document.createElement('div');
+    utils.attachProps(div, { id: 'my-id' });
+    utils.attachProps(div, { id: null }, { id: 'my-id' });
+
+    expect(div.hasAttribute('id')).toEqual(false);
+  });
+
+  it('should treat null as a value for a prop the element does not natively have', () => {
+    var div = document.createElement('div');
+    utils.attachProps(div, { value: 'my-value' });
+    utils.attachProps(div, { value: null }, { value: 'my-value' });
+
+    expect((div as any).value).toEqual(null);
+  });
+
+  it('should clear both attribute spellings of a camel cased native prop', () => {
+    var div = document.createElement('div');
+    // The property write reflects to `accesskey` while the dash-cased write
+    // adds `access-key`, so both attributes end up on the element.
+    utils.attachProps(div, { accessKey: 'k', tabIndex: 2 });
+    utils.attachProps(div, { accessKey: undefined, tabIndex: undefined }, { accessKey: 'k', tabIndex: 2 });
+
+    expect(div.hasAttribute('accesskey')).toEqual(false);
+    expect(div.hasAttribute('access-key')).toEqual(false);
+    expect(div.hasAttribute('tabindex')).toEqual(false);
+  });
 });

--- a/packages/react/src/components/react-component-lib/utils/attachProps.ts
+++ b/packages/react/src/components/react-component-lib/utils/attachProps.ts
@@ -31,16 +31,14 @@ export const attachProps = (node: HTMLElement, newProps: any, oldProps: any = {}
         const value = newProps[name];
         if (value === undefined) {
           /**
-           * An undefined prop must never be assigned to the element. Reflected
-           * properties such as `id`, `title` and `slot` stringify whatever they
-           * are given, so `node.id = undefined` leaves the element with the
-           * literal attribute `id="undefined"`. `render()` already omits
-           * undefined props for the same reason.
+           * Reflected properties such as `id`, `title` and `slot` stringify
+           * whatever they are given, so `node.id = undefined` leaves the element
+           * with the literal attribute `id="undefined"`. Never assign an
+           * undefined value.
            *
-           * A prop that had a value and no longer does is a removal, so clear
-           * it the way React clears a removed attribute: reset the property
-           * first, for props with no attribute to mirror, then drop the
-           * attribute that a reflected property left behind.
+           * A prop that had a value and no longer does is a removal: reset the
+           * property, which covers props with no attribute to mirror, then drop
+           * the attribute a reflected property left behind.
            */
           if (oldProps[name] !== undefined) {
             (node as any)[name] = undefined;

--- a/packages/react/src/components/react-component-lib/utils/attachProps.ts
+++ b/packages/react/src/components/react-component-lib/utils/attachProps.ts
@@ -28,10 +28,30 @@ export const attachProps = (node: HTMLElement, newProps: any, oldProps: any = {}
           syncEvent(node, eventNameLc, newProps[name]);
         }
       } else {
-        (node as any)[name] = newProps[name];
-        const propType = typeof newProps[name];
+        const value = newProps[name];
+        if (value === undefined) {
+          /**
+           * An undefined prop must never be assigned to the element. Reflected
+           * properties such as `id`, `title` and `slot` stringify whatever they
+           * are given, so `node.id = undefined` leaves the element with the
+           * literal attribute `id="undefined"`. `render()` already omits
+           * undefined props for the same reason.
+           *
+           * A prop that had a value and no longer does is a removal, so clear
+           * it the way React clears a removed attribute: reset the property
+           * first, for props with no attribute to mirror, then drop the
+           * attribute that a reflected property left behind.
+           */
+          if (oldProps[name] !== undefined) {
+            (node as any)[name] = undefined;
+            node.removeAttribute(camelToDashCase(name));
+          }
+          return;
+        }
+        (node as any)[name] = value;
+        const propType = typeof value;
         if (propType === 'string') {
-          node.setAttribute(camelToDashCase(name), newProps[name]);
+          node.setAttribute(camelToDashCase(name), value);
         }
       }
     });

--- a/packages/react/src/components/react-component-lib/utils/attachProps.ts
+++ b/packages/react/src/components/react-component-lib/utils/attachProps.ts
@@ -1,5 +1,24 @@
 import { camelToDashCase } from './case';
 
+/**
+ * A prop name that already exists on a plain element is a native property: it
+ * mirrors an attribute the element owns, and assigning to it stringifies
+ * (`node.id = undefined` leaves `id="undefined"`, `node.tabIndex = undefined`
+ * leaves `tabindex="0"`). Anything else is a component prop, where `null` can be
+ * a real value — `ion-input` declares `value?: string | number | null` — so it
+ * must still be assigned.
+ */
+let nativePropertyProbe: HTMLElement | undefined;
+const isNativeElementProperty = (name: string) => {
+  if (typeof document === 'undefined') {
+    return false;
+  }
+  if (nativePropertyProbe === undefined) {
+    nativePropertyProbe = document.createElement('div');
+  }
+  return name in nativePropertyProbe;
+};
+
 export const attachProps = (node: HTMLElement, newProps: any, oldProps: any = {}) => {
   // some test frameworks don't render DOM elements, so we test here to make sure we are dealing with DOM first
   if (node instanceof Element) {
@@ -29,20 +48,38 @@ export const attachProps = (node: HTMLElement, newProps: any, oldProps: any = {}
         }
       } else {
         const value = newProps[name];
-        if (value === undefined) {
+        const isNativeProperty = isNativeElementProperty(name);
+        if (value === undefined || (value === null && isNativeProperty)) {
           /**
            * Reflected properties such as `id`, `title` and `slot` stringify
            * whatever they are given, so `node.id = undefined` leaves the element
            * with the literal attribute `id="undefined"`. Never assign an
-           * undefined value.
+           * undefined value. `null` stringifies the same way, but only native
+           * properties are treated as empty here: a component prop may accept
+           * `null` as a value.
            *
-           * A prop that had a value and no longer does is a removal: reset the
-           * property, which covers props with no attribute to mirror, then drop
-           * the attribute a reflected property left behind.
+           * A prop that had a value and no longer does is a removal. For a
+           * native property that means dropping the attribute, never assigning,
+           * since assigning coerces again (`node.tabIndex = undefined` leaves
+           * `tabindex="0"`). Both spellings have to go: the one the property
+           * reflects to (`accesskey`) and the dash-cased one `render()` emits
+           * (`access-key`). Other props are reset on the property, which covers
+           * props with no attribute to mirror, then have the attribute the
+           * string branch set removed.
            */
-          if (oldProps[name] !== undefined) {
-            (node as any)[name] = undefined;
-            node.removeAttribute(camelToDashCase(name));
+          const oldValue = oldProps[name];
+          if (oldValue !== undefined && oldValue !== null) {
+            const dashCasedName = camelToDashCase(name);
+            if (isNativeProperty) {
+              const reflectedName = name.toLowerCase();
+              node.removeAttribute(reflectedName);
+              if (dashCasedName !== reflectedName) {
+                node.removeAttribute(dashCasedName);
+              }
+            } else {
+              (node as any)[name] = undefined;
+              node.removeAttribute(dashCasedName);
+            }
           }
           return;
         }

--- a/packages/react/src/components/react-component-lib/utils/attachProps.ts
+++ b/packages/react/src/components/react-component-lib/utils/attachProps.ts
@@ -1,23 +1,14 @@
 import { camelToDashCase } from './case';
 
 /**
- * A prop name that already exists on a plain element is a native property: it
- * mirrors an attribute the element owns, and assigning to it stringifies
- * (`node.id = undefined` leaves `id="undefined"`, `node.tabIndex = undefined`
- * leaves `tabindex="0"`). Anything else is a component prop, where `null` can be
- * a real value — `ion-input` declares `value?: string | number | null` — so it
+ * A prop that every element already has is a native property: it mirrors an
+ * attribute the element owns, and assigning to it stringifies the value, so
+ * `node.id = undefined` leaves `id="undefined"` and `node.tabIndex = undefined`
+ * leaves `tabindex="0"`. Anything else is a component prop, where `null` can be
+ * a real value (`ion-input` declares `value?: string | number | null`), so it
  * must still be assigned.
  */
-let nativePropertyProbe: HTMLElement | undefined;
-const isNativeElementProperty = (name: string) => {
-  if (typeof document === 'undefined') {
-    return false;
-  }
-  if (nativePropertyProbe === undefined) {
-    nativePropertyProbe = document.createElement('div');
-  }
-  return name in nativePropertyProbe;
-};
+const isNativeElementProperty = (name: string) => name in HTMLElement.prototype;
 
 export const attachProps = (node: HTMLElement, newProps: any, oldProps: any = {}) => {
   // some test frameworks don't render DOM elements, so we test here to make sure we are dealing with DOM first
@@ -54,18 +45,17 @@ export const attachProps = (node: HTMLElement, newProps: any, oldProps: any = {}
            * Reflected properties such as `id`, `title` and `slot` stringify
            * whatever they are given, so `node.id = undefined` leaves the element
            * with the literal attribute `id="undefined"`. Never assign an
-           * undefined value. `null` stringifies the same way, but only native
-           * properties are treated as empty here: a component prop may accept
+           * undefined value. `null` stringifies the same way, but only a native
+           * property is treated as empty here, since a component prop may take
            * `null` as a value.
            *
-           * A prop that had a value and no longer does is a removal. For a
-           * native property that means dropping the attribute, never assigning,
-           * since assigning coerces again (`node.tabIndex = undefined` leaves
-           * `tabindex="0"`). Both spellings have to go: the one the property
-           * reflects to (`accesskey`) and the dash-cased one `render()` emits
-           * (`access-key`). Other props are reset on the property, which covers
-           * props with no attribute to mirror, then have the attribute the
-           * string branch set removed.
+           * A prop that had a value and no longer does is a removal. A native
+           * property is cleared by dropping its attributes rather than by
+           * assigning, which would only coerce again, and it can carry two: the
+           * one it reflects to (`accesskey`) and the dash-cased one `render()`
+           * emits (`access-key`). Any other prop resets the property, which
+           * covers props with no attribute to mirror, then drops the attribute
+           * the string branch left behind.
            */
           const oldValue = oldProps[name];
           if (oldValue !== undefined && oldValue !== null) {


### PR DESCRIPTION
Issue number: resolves #31344

V9 version: https://github.com/ionic-team/ionic-framework/pull/31349

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When a React component forwards an optional prop to an Ionic component and the caller
leaves it unset, `@ionic/react` writes the string `"undefined"` into the corresponding DOM
attribute.

```tsx
const MyToggle: React.FC<{ id?: string }> = ({ id }) => <IonToggle id={id}>Toggle</IonToggle>;

<MyToggle />
```

renders:

```html
<ion-toggle id="undefined" role="switch" aria-checked="false" aria-labelledby="ion-tg-0-lbl" tabindex="0" class="md toggle-label-placement-start toggle-ltr hydrated">Toggle</ion-toggle>
```

There is no error and no warning. Consequences:

- Every element rendered this way carries the same id, so any page with more than one has
  duplicate ids (invalid HTML), and `document.getElementById('undefined')` resolves to
  whichever comes first.
- `id` is not special. Any prop backed by a reflected DOM property behaves the same way:
  `title={undefined}` produces a tooltip that reads "undefined", and `slot={undefined}`
  places the element in a slot named `undefined`, which moves it in the layout.
- A prop that had a value and is then set to `undefined` is not cleared: the attribute is
  overwritten with `"undefined"` rather than removed.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Skip undefined values, and treat a prop that had a value and no longer does
as a removal, which is how React handles it.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

Prepared with Claude Opus. This seems to be @ionic/react specific, as `attachProps` is React-only.

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
