### PR TITLE
feat(angular): add DestroyRef support to subscribeWithPriority

### DIFF
--- a/packages/angular/common/src/providers/platform.ts
+++ b/packages/angular/common/src/providers/platform.ts
@@ -1,7 +1,6 @@
 import { DOCUMENT } from '@angular/common';
 import { NgZone, Inject, Injectable } from '@angular/core';
 import type { DestroyRef } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { getPlatforms, isPlatform } from '@ionic/core/components';
 import type { BackButtonEventDetail, KeyboardEventDetail, Platforms } from '@ionic/core/components';
 import { Subscription, Subject } from 'rxjs';
@@ -12,11 +11,6 @@ export interface BackButtonEmitter extends Subject<BackButtonEventDetail> {
   subscribeWithPriority(
     priority: number,
     callback: (processNextHandler: () => void) => Promise<any> | void,
-    /**
-     * Pass a component's `DestroyRef` to have the subscription torn down with that
-     * component. Without it the subscription lives for the lifetime of the injector,
-     * which for a root-provided `Platform` means the lifetime of the application.
-     */
     destroyRef?: DestroyRef
   ): Subscription;
 }
@@ -71,11 +65,13 @@ export class Platform {
     zone.run(() => {
       this.win = doc.defaultView;
       this.backButton.subscribeWithPriority = function (priority, callback, destroyRef) {
-        const source$ = destroyRef ? this.pipe(takeUntilDestroyed(destroyRef)) : this;
-
-        return source$.subscribe((ev) => {
+        const subscription = this.subscribe((ev) => {
           return ev.register(priority, (processNextHandler) => zone.run(() => callback(processNextHandler)));
         });
+
+        destroyRef?.onDestroy(() => subscription.unsubscribe());
+
+        return subscription;
       };
 
       proxyEvent(this.pause, doc, 'pause', zone);

--- a/packages/angular/common/src/providers/platform.ts
+++ b/packages/angular/common/src/providers/platform.ts
@@ -1,5 +1,7 @@
 import { DOCUMENT } from '@angular/common';
 import { NgZone, Inject, Injectable } from '@angular/core';
+import type { DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { getPlatforms, isPlatform } from '@ionic/core/components';
 import type { BackButtonEventDetail, KeyboardEventDetail, Platforms } from '@ionic/core/components';
 import { Subscription, Subject } from 'rxjs';
@@ -9,7 +11,13 @@ import { Subscription, Subject } from 'rxjs';
 export interface BackButtonEmitter extends Subject<BackButtonEventDetail> {
   subscribeWithPriority(
     priority: number,
-    callback: (processNextHandler: () => void) => Promise<any> | void
+    callback: (processNextHandler: () => void) => Promise<any> | void,
+    /**
+     * Pass a component's `DestroyRef` to have the subscription torn down with that
+     * component. Without it the subscription lives for the lifetime of the injector,
+     * which for a root-provided `Platform` means the lifetime of the application.
+     */
+    destroyRef?: DestroyRef
   ): Subscription;
 }
 
@@ -62,8 +70,10 @@ export class Platform {
   constructor(@Inject(DOCUMENT) private doc: any, zone: NgZone) {
     zone.run(() => {
       this.win = doc.defaultView;
-      this.backButton.subscribeWithPriority = function (priority, callback) {
-        return this.subscribe((ev) => {
+      this.backButton.subscribeWithPriority = function (priority, callback, destroyRef) {
+        const source$ = destroyRef ? this.pipe(takeUntilDestroyed(destroyRef)) : this;
+
+        return source$.subscribe((ev) => {
           return ev.register(priority, (processNextHandler) => zone.run(() => callback(processNextHandler)));
         });
       };

--- a/packages/angular/common/src/providers/platform.ts
+++ b/packages/angular/common/src/providers/platform.ts
@@ -8,6 +8,14 @@ import { Subscription, Subject } from 'rxjs';
 // TODO(FW-2827): types
 
 export interface BackButtonEmitter extends Subject<BackButtonEventDetail> {
+  /**
+   * @param priority  Handlers with a higher priority run first.
+   * @param callback  Called with a function that passes control to the next handler.
+   * @param [destroyRef]  Optionally unsubscribe when this `DestroyRef` is destroyed. For a page
+   * in an `ion-router-outlet` that is when the page is popped off the stack, not when it is
+   * navigated away from.
+   * @returns the subscription, which can also be unsubscribed by hand.
+   */
   subscribeWithPriority(
     priority: number,
     callback: (processNextHandler: () => void) => Promise<any> | void,


### PR DESCRIPTION
Issue number: resolves #31366

---------

## What is the current behavior?

`BackButtonEmitter.subscribeWithPriority` gives you no declarative way to stop listening, and the documented examples never do it by hand.

`Platform` is `providedIn: 'root'`, so `backButton` is a single application-lifetime `Subject`. A page that registers a handler:

```ts
this.platform.backButton.subscribeWithPriority(10, (processNext) => {
  this.closeMyThing();
  processNext();
});
```

keeps it registered after the page is destroyed. Each visit that constructs the page again adds another one — which happens after the page has been popped, or after a root navigation; a page still in the stack is reattached rather than rebuilt.

The consequence is not a duplicate call. Only one handler runs per press, and a tie goes to whichever was registered last, so after pushing to a page and popping back, the press is won by the handler belonging to the page that is gone, and the on-screen page's handler never runs. Measured with `@ionic/core`'s own `startHardwareBackButton` and a real `backbutton` event:

```
A on screen, destroyed B still subscribed        -> B (destroyed)
same, but B was given a DestroyRef               -> A (on screen)
destroyed page at priority 20, live page at 10   -> destroyed page (20)
same, with a DestroyRef on the destroyed one     -> live page (10)
control -- B unsubscribed by hand instead        -> A (on screen)
```

The control row is the workaround available today: hold the `Subscription` and unsubscribe in `ngOnDestroy`. It works, so this is about ergonomics and about what the documentation teaches — [#31366](https://github.com/ionic-team/ionic-framework/issues/31366) has the full case, including the counts on the docs page.

## What is the new behavior?

- `subscribeWithPriority` takes an optional third argument, a `DestroyRef`, and registers the teardown on it directly:

  ```ts
  this.platform.backButton.subscribeWithPriority(10, (processNext) => { ... }, inject(DestroyRef));
  ```

- Omit it and the path is unchanged, so nothing existing changes.
- **Which lifetime this is.** A `DestroyRef` fires with `ngOnDestroy`, and under `ion-router-outlet` that is when a page is popped off the stack, not when it is navigated away from. So this ends handlers that outlive their page. It does not silence a page that is still in the stack while another is on screen; that needs the enter and leave lifecycle hooks, and no lifetime-based API can do it. Raised in #31366 as a design question, since a visibility-aware mechanism would be a different feature.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

The parameter is optional and the no-argument path is unchanged. `DestroyRef` has been `@publicApi` since Angular 16, and this package declares `@angular/core: >=16.0.0`, so it is within the supported range.

One behavioural note that is new rather than breaking: `subscribeWithPriority` can now throw, where before it never did. Either implementation of `DestroyRef` throws if it is already destroyed — `VIEW_ALREADY_DESTROYED` for a component's, `INJECTOR_ALREADY_DESTROYED` for one taken from an environment injector.

## Other information

Two commits: the maintainer's suggested form applied on top of the original change, then the `@param` block on its own.

**On testing.** A Playwright spec belongs in `packages/angular/test/base/e2e/src/standalone/`, beside the existing `back-button.spec.ts`, and it is coming: a page that registers a handler with and without a `DestroyRef`, popped, then a `backbutton` event dispatched on `document` — the way `core/src/utils/test/hardware-back-button.spec.ts` does it, since hand-dispatching `ionBackButton` supplies a fake `detail.register` and proves nothing. An earlier version of this description said there was nowhere in the package to put a test, which was simply wrong.

A docs pull request is also needed and is not written yet: the hardware back button page shows this API in six constructor examples and mentions cleanup in none of them, which is arguably the more useful half of the change.
