### PR TITLE
chore(migrate): add the migrate package to the deploy orchestrator

### DIFF
--- a/.github/workflows/release-migrate.yml
+++ b/.github/workflows/release-migrate.yml
@@ -1,0 +1,72 @@
+name: 'Release @ionic/migrate'
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Which npm tag should this be published to?'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  release-migrate:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./packages/migrate
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: 🟢 Configure Node for Publish
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@ionic'
+          cache: 'npm'
+          cache-dependency-path: packages/migrate/package-lock.json
+      - name: 📦 Install latest npm
+        run: npm install -g npm@latest
+        shell: bash
+      - name: 🕸️ Install Dependencies
+        run: npm ci
+        shell: bash
+      - name: 🔎 Resolve Version
+        id: resolve-version
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Releasing @ionic/migrate@$version to the '${{ inputs.tag }}' tag"
+        shell: bash
+      - name: 🚧 Ensure Version Is Unpublished
+        run: |
+          set -euo pipefail
+          version="${{ steps.resolve-version.outputs.version }}"
+          # `npm view` exits non-zero both for an unpublished version and for a
+          # package that does not exist yet, and the latter is the expected state
+          # on the very first release. So inspect stdout rather than the exit
+          # code: empty output means the version is free to publish.
+          if [ -n "$(npm view "@ionic/migrate@$version" version 2>/dev/null || true)" ]; then
+            echo "::error::@ionic/migrate@$version is already published. Bump the version in packages/migrate/package.json."
+            exit 1
+          fi
+        shell: bash
+      - name: 🔍 Lint
+        run: npm run lint
+        shell: bash
+      - name: 🧪 Test
+        run: npm test
+        shell: bash
+      - name: 🏗️ Run Build
+        run: npm run build
+        shell: bash
+      # `--access public` is not passed here because publishConfig.access in
+      # package.json already sets it; a scoped package would otherwise default to
+      # restricted on its first publish.
+      - name: 🚀 Publish to NPM
+        run: npm publish --tag ${{ inputs.tag }} --provenance
+        shell: bash

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -15,6 +15,7 @@ on:
         options:
           - dev
           - production
+          - migrate
       version:
         description: 'Which version should be published? (Only for production releases)'
         required: false
@@ -28,7 +29,7 @@ on:
           - premajor
           - prerelease
       tag:
-        description: 'Which npm tag should this be published to? (Only for production releases)'
+        description: 'Which npm tag should this be published to? (Only for production and migrate releases)'
         required: false
         type: choice
         default: latest
@@ -67,6 +68,16 @@ jobs:
       id-token: write
     uses: ./.github/workflows/dev-build.yml
     secrets: inherit
+
+  run-migrate:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.release-type == 'migrate' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/release-migrate.yml
+    secrets: inherit
+    with:
+      tag: ${{ inputs.tag }}
 
   run-production:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.release-type == 'production' }}

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,14 @@
 {
+  "//": "packages/migrate is deliberately omitted: @ionic/migrate is versioned independently of the framework and is published by .github/workflows/release-migrate.yml, so `lerna version` must not rewrite it. Listing the packages explicitly is what keeps it out -- lerna 5 ignores negated globs like \"!packages/migrate\". Add new publishable packages here.",
   "packages": [
     "core",
-    "packages/*"
+    "packages/angular",
+    "packages/angular-server",
+    "packages/docs",
+    "packages/react",
+    "packages/react-router",
+    "packages/vue",
+    "packages/vue-router"
   ],
   "version": "8.8.17"
 }

--- a/packages/migrate/package-lock.json
+++ b/packages/migrate/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ionic/migrate",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ionic/migrate",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "ts-morph": "^25.0.0"
@@ -18,6 +18,9 @@
         "@types/node": "^24.13.3",
         "typescript": "^5.7.3",
         "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1071,9 +1074,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1394,9 +1397,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1455,9 +1458,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -1475,7 +1478,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -1,18 +1,41 @@
 {
   "name": "@ionic/migrate",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.1.0",
   "description": "Migration tool to automate and report on breaking changes across Ionic Framework major versions.",
+  "keywords": [
+    "ionic",
+    "framework",
+    "migrate",
+    "migration",
+    "codemod",
+    "upgrade",
+    "angular",
+    "react",
+    "vue",
+    "cli"
+  ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ionic-team/ionic-framework.git",
+    "directory": "packages/migrate"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "bin": {
-    "ionic-migrate": "./dist/cli.js"
+    "ionic-migrate": "dist/cli.js"
   },
   "files": [
     "dist"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "prepack": "npm run build",
     "test": "vitest run",
     "test.watch": "vitest",
     "lint": "tsc --noEmit"


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?

Currently, `packages/migrate` not able to be published because it's marked private, and the lerna config would overwrite its version

## What is the new behavior?

Migrate is now publishable and lerna ignores it. Also adding migrate to the orchestrator.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


## Other information