### PR TITLE
fix(gesture): remove leaked optsTest listener from passive support check

### DIFF
--- a/core/src/utils/gesture/listener.ts
+++ b/core/src/utils/gesture/listener.ts
@@ -7,14 +7,10 @@ export const addEventListener = (
     capture?: boolean;
   }
 ): (() => void) => {
-  // use event listener options when supported
-  // otherwise it's just a boolean for the "capture" arg
-  const listenerOpts = supportsPassive(el)
-    ? {
-        capture: !!opts.capture,
-        passive: !!opts.passive,
-      }
-    : !!opts.capture;
+  const listenerOpts = {
+    capture: !!opts.capture,
+    passive: !!opts.passive,
+  };
 
   let add: string;
   let remove: string;
@@ -31,27 +27,3 @@ export const addEventListener = (
     el[remove](eventName, callback, listenerOpts);
   };
 };
-
-const supportsPassive = (node: Node) => {
-  if (_sPassive === undefined) {
-    try {
-      const opts = Object.defineProperty({}, 'passive', {
-        get: () => {
-          _sPassive = true;
-        },
-      });
-      node.addEventListener(
-        'optsTest',
-        () => {
-          return;
-        },
-        opts
-      );
-    } catch (e) {
-      _sPassive = false;
-    }
-  }
-  return !!_sPassive;
-};
-
-let _sPassive: boolean | undefined;


### PR DESCRIPTION
Issue number: resolves #30539

---------

## What is the current behavior?

Currently, `supportsPassive` in the gesture listener utils detects passive listener support by attaching a real `optsTest` listener to the element and reading the `passive` getter, but it never removes that listener. The result is a listener permanently attached to whichever element runs the first gesture.

There's a second failure mode in the same function. The `_sPassive === undefined` guard only clears if the getter fires or if `addEventListener` throws, so a runtime that does neither leaves `_sPassive` undefined and every subsequent call attaches another `optsTest` listener that's never cleaned up.

## What is the new behavior?

We now always pass the options object, and the detection is removed entirely. The check was already dead code, because passive options object support landed in Chrome 51, Safari 10, Firefox 49, and Edge 16, all in 2016, while our lowest supported versions are Chrome 89, Safari 15, Firefox 75, and Edge 89. The function returned `true` on every browser we support, so both branches of the removed ternary collapse to the same value and there's no behavior change.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information