### PR TITLE
test(angular): register Ionic components on the landing page

### DIFF
--- a/packages/angular/test/base/src/app/app-landing/app-landing.component.ts
+++ b/packages/angular/test/base/src/app/app-landing/app-landing.component.ts
@@ -1,9 +1,16 @@
 import { Component, VERSION } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { IonContent, IonHeader, IonItem, IonLabel, IonList, IonRouterLink, IonTitle, IonToolbar } from '@ionic/angular';
 
+/**
+ * Only the standalone bootstrap renders this page, so it can't rely on
+ * AppModule's IonicModule scope. These imports register the custom elements.
+ */
 @Component({
   selector: 'app-landing',
   templateUrl: './app-landing.component.html',
-  standalone: false
+  standalone: true,
+  imports: [RouterLink, IonRouterLink, IonContent, IonHeader, IonItem, IonLabel, IonList, IonTitle, IonToolbar],
 })
 export class AppLandingComponent {
   angularVersion = VERSION;

--- a/packages/angular/test/base/src/app/app.module.ts
+++ b/packages/angular/test/base/src/app/app.module.ts
@@ -4,7 +4,6 @@ import { RouteReuseStrategy } from '@angular/router';
 import { IonicModule, IonicRouteStrategy } from '@ionic/angular/lazy';
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
-import { AppLandingComponent } from './app-landing/app-landing.component';
 import { ModeSwitcherComponent } from './mode-switcher.component';
 
 const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined';
@@ -15,7 +14,7 @@ export function ionicConfigFactory(): any {
 }
 
 @NgModule({
-  declarations: [AppComponent, AppLandingComponent],
+  declarations: [AppComponent],
   imports: [
     BrowserModule,
     AppRoutingModule,

--- a/packages/angular/test/base/src/app/app.routes.ts
+++ b/packages/angular/test/base/src/app/app.routes.ts
@@ -1,11 +1,15 @@
 import { Routes } from '@angular/router';
-import { AppLandingComponent } from './app-landing/app-landing.component';
 
 export const routes: Routes = [
+  /**
+   * Has to load lazily. The lazy app bootstraps from this same route table, and
+   * eagerly pulling in a standalone component races its custom element
+   * registration against the lazy loader's.
+   */
   {
     path: '',
     pathMatch: 'full',
-    component: AppLandingComponent
+    loadComponent: () => import('./app-landing/app-landing.component').then(c => c.AppLandingComponent)
   },
   {
     path: 'lazy',


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?

Currently, the Angular test app's landing page renders as unstyled inline text on the Vercel preview. It relied on `AppModule`'s `IonicModule` scope for its `ion-*` directives, but `/` is only rendered by the standalone bootstrap, so `IonicModule.forRoot()`'s `defineCustomElements()` initializer never runs, and nothing registers those elements once a build tree-shakes the unused standalone proxies.

## What is the new behavior?

The landing page is now standalone and imports the components it renders, so it registers its own custom elements. The route uses `loadComponent` instead of `component` to keep that standalone build out of the lazy app's eager graph.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

[Major 9.0's Angular Landing Page](https://ionic-framework-git-major-90-ionic1.vercel.app/angular/)

[This PR's Angular Landing page link](https://ionic-framework-git-fix-angular-landing-ionic1.vercel.app/angular/)