### PR TITLE
fix(core): restore prop defaults when consumers downlevel

### DIFF
--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -9,6 +9,10 @@
       "dom.iterable",
       "es2022"
     ],
+    // Must stay false. At target es2022 TypeScript defaults it to true, emitting @Prop
+    // defaults as class fields. Consumers that downlevel those hoist the initializers
+    // above Stencil's registerInstance(), so its prop setter drops every default.
+    "useDefineForClassFields": false,
     "jsx": "react",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment",


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?

Currently, core builds with `target: es2022` and no `useDefineForClassFields` setting, so TypeScript defaults it to `true` and emits every `@Prop` default as a class field instead of a constructor assignment. Stencil proxies props onto the component prototype as getter/setter pairs, and its setter returns early when the host ref isn't registered yet. An app that downlevels those class fields hoists the initializers above `registerInstance()`, so the setter drops every default.

That happens in any Stencil app importing `@ionic/core` with a target below es2022, since the app re-transpiles core.

## What is the new behavior?

Setting `useDefineForClassFields: false` restores the emit v8 shipped: `registerInstance()` runs first, then the defaults assign through Stencil's setter. There's nothing left for a downstream bundler to hoist, so the defaults survive whatever target the app uses. Every output target picks it up.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

Regression from #31280, which moved core to `target: es2022` and flipped the TypeScript default.

Brandy hit it on [the docs-demo v9 update](https://github.com/ionic-team/docs-demo/pull/179), where the Input OTP page renders an empty group. I packed this build into that branch with no docs-demo changes and the boxes come back.

I put the flag in `core/tsconfig.json` rather than the shared `tsconfig.base.json`, so the six packages extending the base emit the same bytes as before.

I didn't add a test. It only breaks in a downstream build, so covering it means asserting on the shape of core's emitted output, which we don't do anywhere. Happy to add something if you'd rather have one.