### PR TITLE
fix(refresher): validate slot after frameworks assign it

### DIFF
--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -513,10 +513,10 @@ export class Refresher implements ComponentInterface {
   }
 
   /**
-   * Checked here rather than in `connectedCallback`, which with the custom elements
-   * build runs while the element is being inserted, before frameworks like React
-   * assign the slot. Rendering puts `slot="fixed"` on the host, so this is also the
-   * last point where the developer's own markup is still visible.
+   * Validate the slot attribute before rendering, while the host still reflects the
+   * developer's original markup. `connectedCallback` is too early: in the custom
+   * elements build it runs during insertion, before frameworks such as React assign
+   * the slot.
    */
   componentWillLoad() {
     if (this.el.getAttribute('slot') !== 'fixed') {

--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -512,11 +512,19 @@ export class Refresher implements ComponentInterface {
     this.checkNativeRefresher();
   }
 
-  async connectedCallback() {
+  /**
+   * Checked here rather than in `connectedCallback`, which with the custom elements
+   * build runs while the element is being inserted, before frameworks like React
+   * assign the slot. Rendering puts `slot="fixed"` on the host, so this is also the
+   * last point where the developer's own markup is still visible.
+   */
+  componentWillLoad() {
     if (this.el.getAttribute('slot') !== 'fixed') {
       printIonError('[ion-refresher] - Make sure you use: <ion-refresher slot="fixed">');
-      return;
     }
+  }
+
+  async connectedCallback() {
     const contentEl = this.el.closest(ION_CONTENT_ELEMENT_SELECTOR);
     if (!contentEl) {
       printIonContentErrorMsg(this.el);

--- a/core/src/components/refresher/test/missing-slot/refresher.e2e.ts
+++ b/core/src/components/refresher/test/missing-slot/refresher.e2e.ts
@@ -1,0 +1,69 @@
+import { expect } from '@playwright/test';
+import { configs, dragElementByYAxis, test } from '@utils/test/playwright';
+
+/**
+ * Rendering puts `slot="fixed"` on the host, so a refresher whose markup omits the
+ * slot still ends up in the right place and has to work. Frameworks that assign the
+ * slot after inserting the element start out the same way.
+ *
+ * This behavior does not vary across directions.
+ */
+configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
+  test.describe(title('refresher: missing slot'), () => {
+    test('should still set up the pull-to-refresh gesture', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31376',
+      });
+
+      await page.setContent(
+        `
+        <ion-content>
+          <ion-refresher>
+            <ion-refresher-content></ion-refresher-content>
+          </ion-refresher>
+
+          <div style="height: 200vh"></div>
+        </ion-content>
+      `,
+        config
+      );
+      /**
+       * Gesture setup runs behind a dynamic import, so dragging straight after
+       * setContent can land before the refresher is listening.
+       */
+      await page.locator('ion-refresher.hydrated').waitFor({ state: 'attached' });
+
+      const ionRefresh = await page.spyOnEvent('ionRefresh');
+
+      await dragElementByYAxis(page.locator('body'), page, 320);
+
+      await expect.poll(() => ionRefresh.events.length).toBe(1);
+    });
+
+    test('should report an error telling the developer to add the slot', async ({ page }) => {
+      const logs: string[] = [];
+
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') {
+          logs.push(msg.text());
+        }
+      });
+
+      await page.setContent(
+        `
+        <ion-content>
+          <ion-refresher>
+            <ion-refresher-content></ion-refresher-content>
+          </ion-refresher>
+        </ion-content>
+      `,
+        config
+      );
+      await page.locator('ion-refresher.hydrated').waitFor({ state: 'attached' });
+
+      expect(logs.length).toBe(1);
+      expect(logs[0]).toContain('[Ionic Error]: [ion-refresher] - Make sure you use: <ion-refresher slot="fixed">');
+    });
+  });
+});

--- a/core/src/components/refresher/test/slot-validation/refresher.e2e.ts
+++ b/core/src/components/refresher/test/slot-validation/refresher.e2e.ts
@@ -1,5 +1,20 @@
 import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import { configs, dragElementByYAxis, test } from '@utils/test/playwright';
+
+const collectConsoleErrors = (page: Page) => {
+  const logs: string[] = [];
+
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      logs.push(msg.text());
+    }
+  });
+
+  return logs;
+};
+
+const SLOT_ERROR = '[Ionic Error]: [ion-refresher] - Make sure you use: <ion-refresher slot="fixed">';
 
 /**
  * Rendering puts `slot="fixed"` on the host, so a refresher whose markup omits the
@@ -9,8 +24,8 @@ import { configs, dragElementByYAxis, test } from '@utils/test/playwright';
  * This behavior does not vary across directions.
  */
 configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
-  test.describe(title('refresher: missing slot'), () => {
-    test('should still set up the pull-to-refresh gesture', async ({ page }, testInfo) => {
+  test.describe(title('refresher: slot validation'), () => {
+    test('should still set up the pull-to-refresh gesture when the slot is missing', async ({ page }, testInfo) => {
       testInfo.annotations.push({
         type: 'issue',
         description: 'https://github.com/ionic-team/ionic-framework/issues/31376',
@@ -42,13 +57,7 @@ configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
     });
 
     test('should report an error telling the developer to add the slot', async ({ page }) => {
-      const logs: string[] = [];
-
-      page.on('console', (msg) => {
-        if (msg.type() === 'error') {
-          logs.push(msg.text());
-        }
-      });
+      const logs = collectConsoleErrors(page);
 
       await page.setContent(
         `
@@ -63,7 +72,25 @@ configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
       await page.locator('ion-refresher.hydrated').waitFor({ state: 'attached' });
 
       expect(logs.length).toBe(1);
-      expect(logs[0]).toContain('[Ionic Error]: [ion-refresher] - Make sure you use: <ion-refresher slot="fixed">');
+      expect(logs[0]).toContain(SLOT_ERROR);
+    });
+
+    test('should not report an error when the slot is set', async ({ page }) => {
+      const logs = collectConsoleErrors(page);
+
+      await page.setContent(
+        `
+        <ion-content>
+          <ion-refresher slot="fixed">
+            <ion-refresher-content></ion-refresher-content>
+          </ion-refresher>
+        </ion-content>
+      `,
+        config
+      );
+      await page.locator('ion-refresher.hydrated').waitFor({ state: 'attached' });
+
+      expect(logs).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
Issue number: resolves #31376

---------

## What is the current behavior?

Currently, `ion-refresher` reads its `slot` attribute in `connectedCallback` and gives up if it isn't `fixed`. In v9 `@ionic/react` uses the custom elements build, so `connectedCallback` runs while the element is still being inserted, which is before React assigns the slot. The check fails on perfectly correct markup, logs the "Make sure you use" error, and the pull-to-refresh gesture never gets created. This affects React 18 and 19.

## What is the new behavior?

The check now runs in `componentWillLoad`, which is late enough that frameworks have assigned the slot, but still before rendering puts `slot="fixed"` on the host. Gesture setup no longer bails, so the refresher works whether the slot is in the markup or arrives later, and correctly written React apps stop logging the error. Markup that genuinely omits the slot still gets it.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

Current dev build:
```
9.0.1-dev.11787177893.1979eb13
```