### PR TITLE
chore(deps): update to stencil/core 4.44.1

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
-        "@stencil/core": "^4.43.5",
+        "@stencil/core": "^4.44.1",
         "ionicons": "^8.1.0",
         "tslib": "^2.1.0"
       },
@@ -1839,9 +1839,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.43.5",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.43.5.tgz",
-      "integrity": "sha512-cgWD+GeuvJpTe1WQn40p02+BJ2j0j1YJ17GdkF2qKIQ23s2e3Zivq5yISXS3dcuV6oUJFN93jprdk+nk/sq99Q==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.44.1.tgz",
+      "integrity": "sha512-OaFtMODcDcKswPbJC6An6xAcNmeuBggxyUTVKSX1UY7bPtWgIR5mGy1jZ6JkyFGgIxZCj/9wp2r97KBQow9wOQ==",
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"

--- a/core/package.json
+++ b/core/package.json
@@ -66,7 +66,7 @@
     "loader/"
   ],
   "dependencies": {
-    "@stencil/core": "^4.43.5",
+    "@stencil/core": "^4.44.1",
     "ionicons": "^8.1.0",
     "tslib": "^2.1.0"
   },

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -5168,7 +5168,7 @@ declare global {
     }
 }
 declare namespace LocalJSX {
-    type OneOf<K extends string, PropT, AttrT = PropT> = { [P in K]: PropT } & { [P in `attr:${K}` | `prop:${K}`]?: never } | { [P in `attr:${K}`]: AttrT } & { [P in K | `prop:${K}`]?: never } | { [P in `prop:${K}`]: PropT } & { [P in K | `attr:${K}`]?: never };
+    type OneOf<K extends string, PropT, AttrT = PropT> = { [P in K]: PropT } & { [P in `attr:${K}`]?: never } | { [P in `attr:${K}`]: AttrT } & { [P in K]?: never };
 
     interface IonAccordion {
         /**


### PR DESCRIPTION
## What is the current behavior?

The latest version of `@stencil/core` changes a line in the generated `components.d.ts`, failing the nightly build.

## What is the new behavior?

Bump `@stencil/core` on the main branch and commit the new `components.d.ts`.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
