### PR TITLE
fix(overlays): restore presented state after a DOM move

### DIFF
--- a/core/src/components/action-sheet/action-sheet.tsx
+++ b/core/src/components/action-sheet/action-sheet.tsx
@@ -14,6 +14,7 @@ import {
   isCancel,
   prepareOverlay,
   present,
+  restoreRootFocusTrapAccessibility,
   safeCall,
   setOverlayId,
 } from '@utils/overlays';
@@ -455,6 +456,15 @@ export class ActionSheet implements ComponentInterface, OverlayInterface {
   connectedCallback() {
     prepareOverlay(this.el);
     this.triggerChanged();
+
+    // `componentDidLoad` only fires once per instance, so a reconnect has to
+    // rebuild the gesture its disconnect destroyed.
+    this.setupButtonActiveGesture();
+
+    // Re-apply the root lock if moved without dismiss() being called
+    if (this.presented) {
+      restoreRootFocusTrapAccessibility(this.el);
+    }
   }
 
   disconnectedCallback() {
@@ -478,26 +488,35 @@ export class ActionSheet implements ComponentInterface, OverlayInterface {
     this.buttonsChanged();
   }
 
-  componentDidLoad() {
-    /**
-     * Only create gesture if:
-     * 1. A gesture does not already exist
-     * 2. App is running in iOS mode
-     * 3. A wrapper ref exists
-     * 4. A group ref exists
-     */
+  /**
+   * Only create gesture if:
+   * 1. A gesture does not already exist
+   * 2. App is running in iOS mode
+   * 3. A wrapper ref exists
+   * 4. A group ref exists
+   * 5. The host is still connected, since a reconnect can schedule this and
+   *    disconnect again before the task runs
+   */
+  private setupButtonActiveGesture() {
     const { groupEl, wrapperEl } = this;
-    if (!this.gesture && getIonMode(this) === 'ios' && wrapperEl && groupEl) {
-      readTask(() => {
-        const isScrollable = groupEl.scrollHeight > groupEl.clientHeight;
-        if (!isScrollable) {
-          this.gesture = createButtonActiveGesture(wrapperEl, (refEl: HTMLElement) =>
-            refEl.classList.contains('action-sheet-button')
-          );
-          this.gesture.enable(true);
-        }
-      });
+    if (getIonMode(this) !== 'ios' || !wrapperEl || !groupEl) {
+      return;
     }
+    readTask(() => {
+      // Two calls before the first flushes would otherwise both create a
+      // gesture, orphaning the first with its listeners still bound.
+      if (this.gesture || !this.el.isConnected || groupEl.scrollHeight > groupEl.clientHeight) {
+        return;
+      }
+      this.gesture = createButtonActiveGesture(wrapperEl, (refEl: HTMLElement) =>
+        refEl.classList.contains('action-sheet-button')
+      );
+      this.gesture.enable(true);
+    });
+  }
+
+  componentDidLoad() {
+    this.setupButtonActiveGesture();
 
     /**
      * If action sheet was rendered with isOpen="true"

--- a/core/src/components/action-sheet/action-sheet.tsx
+++ b/core/src/components/action-sheet/action-sheet.tsx
@@ -503,8 +503,9 @@ export class ActionSheet implements ComponentInterface, OverlayInterface {
       return;
     }
     readTask(() => {
-      // Two calls before the first flushes would otherwise both create a
-      // gesture, orphaning the first with its listeners still bound.
+      // Bail if a call queued ahead of this one already built the gesture
+      // (a second would orphan the first with its listeners still bound), if
+      // the host disconnected while this task waited, or if the group scrolls.
       if (this.gesture || !this.el.isConnected || groupEl.scrollHeight > groupEl.clientHeight) {
         return;
       }

--- a/core/src/components/action-sheet/test/basic/action-sheet.e2e.ts
+++ b/core/src/components/action-sheet/test/basic/action-sheet.e2e.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { configs, test } from '@utils/test/playwright';
+import { configs, detachAndReattach, test } from '@utils/test/playwright';
 
 import { ActionSheetFixture } from './fixture';
 
@@ -163,6 +163,59 @@ configs({ directions: ['ltr'] }).forEach(({ title, screenshot, config }) => {
 
         await expect(actionSheet).toHaveScreenshot(screenshot(`action-sheet-safe-area`));
       });
+    });
+  });
+});
+
+/**
+ * The button gesture only exists in iOS mode, so these run there.
+ */
+configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ config, title }) => {
+  test.describe(title('action sheet: moved while presented'), () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/src/components/action-sheet/test/basic', config);
+    });
+
+    test('should keep the app root locked', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31389',
+      });
+
+      const ionActionSheetDidPresent = await page.spyOnEvent('ionActionSheetDidPresent');
+
+      await page.click('#basic');
+      await ionActionSheetDidPresent.next();
+
+      await expect(page.locator('body')).toHaveClass(/backdrop-no-scroll/);
+
+      await detachAndReattach(page.locator('ion-action-sheet'));
+
+      await expect(page.locator('body')).toHaveClass(/backdrop-no-scroll/);
+    });
+
+    test('should keep activating buttons on press', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31389',
+      });
+
+      const ionActionSheetDidPresent = await page.spyOnEvent('ionActionSheetDidPresent');
+
+      await page.click('#basic');
+      await ionActionSheetDidPresent.next();
+
+      await detachAndReattach(page.locator('ion-action-sheet'));
+
+      const button = page.locator('ion-action-sheet .action-sheet-button').first();
+      const box = (await button.boundingBox())!;
+
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+      await page.mouse.down();
+
+      await expect(button).toHaveClass(/ion-activated/);
+
+      await page.mouse.up();
     });
   });
 });

--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -17,6 +17,7 @@ import {
   isCancel,
   prepareOverlay,
   present,
+  restoreRootFocusTrapAccessibility,
   safeCall,
   setOverlayId,
 } from '@utils/overlays';
@@ -363,10 +364,16 @@ export class Alert implements ComponentInterface, OverlayInterface {
     this.triggerChanged();
     /**
      * If the alert was previously connected and is being reattached, the
-     * ResizeObserver was disconnected. componentDidLoad only fires once per
-     * instance, so re-establish the observer here on reconnect.
+     * `ResizeObserver` and the button gesture were torn down. `componentDidLoad`
+     * only fires once per instance, so re-establish both here on reconnect.
      */
     this.setupButtonGroupResizeObserver();
+    this.setupButtonActiveGesture();
+
+    // Re-apply the root lock if moved without dismiss() being called
+    if (this.presented) {
+      restoreRootFocusTrapAccessibility(this.el);
+    }
   }
 
   componentWillLoad() {
@@ -394,20 +401,23 @@ export class Alert implements ComponentInterface, OverlayInterface {
     this.buttonGroupResizeObserver = undefined;
   }
 
-  componentDidLoad() {
-    /**
-     * Only create gesture if:
-     * 1. A gesture does not already exist
-     * 2. App is running in iOS mode
-     * 3. A wrapper ref exists
-     */
+  /**
+   * Only create gesture if:
+   * 1. A gesture does not already exist
+   * 2. App is running in iOS mode
+   * 3. A wrapper ref exists
+   */
+  private setupButtonActiveGesture() {
     if (!this.gesture && getIonMode(this) === 'ios' && this.wrapperEl) {
       this.gesture = createButtonActiveGesture(this.wrapperEl, (refEl: HTMLElement) =>
         refEl.classList.contains('alert-button')
       );
       this.gesture.enable(true);
     }
+  }
 
+  componentDidLoad() {
+    this.setupButtonActiveGesture();
     this.setupButtonGroupResizeObserver();
 
     /**

--- a/core/src/components/alert/test/basic/alert.e2e.ts
+++ b/core/src/components/alert/test/basic/alert.e2e.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import type { Locator } from '@playwright/test';
 import type { E2EPage } from '@utils/test/playwright';
-import { configs, test } from '@utils/test/playwright';
+import { configs, detachAndReattach, test } from '@utils/test/playwright';
 
 configs({ directions: ['ltr'] }).forEach(({ config, screenshot, title }) => {
   test.describe(title('alert: basic'), () => {
@@ -203,3 +203,56 @@ class AlertFixture {
     await expect(this.alert).toHaveScreenshot(screenshotFn(`alert-${modifier}`));
   }
 }
+
+/**
+ * The button gesture only exists in iOS mode, so these run there.
+ */
+configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ config, title }) => {
+  test.describe(title('alert: moved while presented'), () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/src/components/alert/test/basic', config);
+    });
+
+    test('should keep the app root locked', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31389',
+      });
+
+      const ionAlertDidPresent = await page.spyOnEvent('ionAlertDidPresent');
+
+      await page.click('#basic');
+      await ionAlertDidPresent.next();
+
+      await expect(page.locator('body')).toHaveClass(/backdrop-no-scroll/);
+
+      await detachAndReattach(page.locator('ion-alert'));
+
+      await expect(page.locator('body')).toHaveClass(/backdrop-no-scroll/);
+    });
+
+    test('should keep activating buttons on press', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31389',
+      });
+
+      const ionAlertDidPresent = await page.spyOnEvent('ionAlertDidPresent');
+
+      await page.click('#multipleButtons');
+      await ionAlertDidPresent.next();
+
+      await detachAndReattach(page.locator('ion-alert'));
+
+      const button = page.locator('ion-alert .alert-button').first();
+      const box = (await button.boundingBox())!;
+
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+      await page.mouse.down();
+
+      await expect(button).toHaveClass(/ion-activated/);
+
+      await page.mouse.up();
+    });
+  });
+});

--- a/core/src/components/loading/loading.tsx
+++ b/core/src/components/loading/loading.tsx
@@ -12,6 +12,7 @@ import {
   eventMethod,
   prepareOverlay,
   present,
+  restoreRootFocusTrapAccessibility,
   setOverlayId,
 } from '@utils/overlays';
 import { sanitizeDOMString } from '@utils/sanitization';
@@ -208,6 +209,11 @@ export class Loading implements ComponentInterface, OverlayInterface {
   connectedCallback() {
     prepareOverlay(this.el);
     this.triggerChanged();
+
+    // Re-apply the root lock if moved without dismiss() being called
+    if (this.presented) {
+      restoreRootFocusTrapAccessibility(this.el);
+    }
   }
 
   componentWillLoad() {

--- a/core/src/components/loading/test/basic/loading.e2e.ts
+++ b/core/src/components/loading/test/basic/loading.e2e.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import type { E2EPage, ScreenshotFn } from '@utils/test/playwright';
-import { configs, test } from '@utils/test/playwright';
+import { configs, detachAndReattach, test } from '@utils/test/playwright';
 
 const runVisualTest = async (page: E2EPage, selector: string, screenshot: ScreenshotFn, screenshotModifier: string) => {
   const ionLoadingDidPresent = await page.spyOnEvent('ionLoadingDidPresent');
@@ -97,6 +97,33 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, screenshot, c
       }
 
       await expect(button).toBeFocused();
+    });
+  });
+});
+
+/**
+ * This behavior does not vary across modes/directions.
+ */
+configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ config, title }) => {
+  test.describe(title('loading: moved while presented'), () => {
+    test('should keep the app root locked', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31389',
+      });
+
+      await page.goto('/src/components/loading/test/basic', config);
+      const ionLoadingDidPresent = await page.spyOnEvent('ionLoadingDidPresent');
+
+      // This one carries no duration, so it can't auto-dismiss mid-move.
+      await page.click('#backdrop-loading');
+      await ionLoadingDidPresent.next();
+
+      await expect(page.locator('body')).toHaveClass(/backdrop-no-scroll/);
+
+      await detachAndReattach(page.locator('ion-loading'));
+
+      await expect(page.locator('body')).toHaveClass(/backdrop-no-scroll/);
     });
   });
 });

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -17,6 +17,7 @@ import {
   GESTURE,
   prepareOverlay,
   present,
+  restoreRootFocusTrapAccessibility,
   setOverlayId,
 } from '@utils/overlays';
 import { getClassMap } from '@utils/theme';
@@ -113,6 +114,9 @@ export class Modal implements ComponentInterface, OverlayInterface {
   private viewTransitionAnimation?: Animation;
   private resizeTimeout?: any;
   private unsubscribeRootSafeAreaTop?: () => void;
+  // True from the first safe-area write in `present()` until the enter
+  // animation settles. A position-based read in that window is not the rest position.
+  private isPresenting = false;
 
   // Mutation observer to watch for parent removal
   private parentRemovalObserver?: MutationObserver;
@@ -460,6 +464,18 @@ export class Modal implements ComponentInterface, OverlayInterface {
     const { el } = this;
     prepareOverlay(el);
     this.triggerChanged();
+
+    // A disconnect tears down state this presentation still needs and cannot
+    // tell a re-insert from a removal, so put it back.
+    if (this.presented || this.isPresenting) {
+      this.restoreSafeAreaOverrides();
+    }
+    // A relocation from `willPresent` reaches these before `present()` has
+    // applied the lock, so they apply it instead. Both are idempotent.
+    if (this.presented) {
+      restoreRootFocusTrapAccessibility(el);
+      this.initParentRemovalObserver();
+    }
   }
 
   disconnectedCallback() {
@@ -666,28 +682,36 @@ export class Modal implements ComponentInterface, OverlayInterface {
     // bindings (e.g., Angular) may not have been applied when componentWillLoad ran.
     this.isSheetModal = this.breakpoints !== undefined && this.initialBreakpoint !== undefined;
 
-    // Set initial safe-area overrides before animation
-    this.setInitialSafeAreaOverrides();
+    this.isPresenting = true;
 
     const hasCardModal = presentingElement !== undefined;
 
-    /**
-     * We need to change the status bar at the
-     * start of the animation so that it completes
-     * by the time the card animation is done.
-     */
-    if (hasCardModal && getIonMode(this) === 'ios') {
-      // Cache the original status bar color before the modal is presented
-      this.statusBarStyle = await StatusBar.getStyle();
-      setCardStatusBarDark();
-    }
+    // Wrapped so a throw cannot strand `isPresenting`, which would suppress
+    // the position-based correction for the life of this instance.
+    try {
+      // Set initial safe-area overrides before animation
+      this.setInitialSafeAreaOverrides();
 
-    await present<ModalPresentOptions>(this, 'modalEnter', iosEnterAnimation, mdEnterAnimation, {
-      presentingEl: presentingElement,
-      currentBreakpoint: this.initialBreakpoint,
-      backdropBreakpoint: this.backdropBreakpoint,
-      expandToScroll: this.expandToScroll,
-    });
+      /**
+       * We need to change the status bar at the
+       * start of the animation so that it completes
+       * by the time the card animation is done.
+       */
+      if (hasCardModal && getIonMode(this) === 'ios') {
+        // Cache the original status bar color before the modal is presented
+        this.statusBarStyle = await StatusBar.getStyle();
+        setCardStatusBarDark();
+      }
+
+      await present<ModalPresentOptions>(this, 'modalEnter', iosEnterAnimation, mdEnterAnimation, {
+        presentingEl: presentingElement,
+        currentBreakpoint: this.initialBreakpoint,
+        backdropBreakpoint: this.backdropBreakpoint,
+        expandToScroll: this.expandToScroll,
+      });
+    } finally {
+      this.isPresenting = false;
+    }
 
     // Update safe-area based on actual position after animation
     this.updateSafeAreaOverrides();
@@ -1407,6 +1431,10 @@ export class Modal implements ComponentInterface, OverlayInterface {
       return;
     }
 
+    // Both `present()` and a reconnect call this, so drop any existing
+    // observer. Below the guards, so a call that bails cannot leave none.
+    this.cleanupParentRemovalObserver();
+
     this.parentRemovalObserver = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
         if (mutation.type === 'childList' && mutation.removedNodes.length > 0) {
@@ -1495,6 +1523,9 @@ export class Modal implements ComponentInterface, OverlayInterface {
     // Set the internal offset property with the resolved root safe-area-top value
     if (context.isSheetModal) {
       this.updateSheetOffsetTop();
+      // A restore after a DOM move runs this a second time for the same
+      // modal, so drop the previous subscription rather than stacking one.
+      this.unsubscribeRootSafeAreaTop?.();
       this.unsubscribeRootSafeAreaTop = onRootSafeAreaTopChange((safeAreaTop) =>
         this.updateSheetOffsetTop(safeAreaTop)
       );
@@ -1620,6 +1651,33 @@ export class Modal implements ComponentInterface, OverlayInterface {
 
     const { contentEl } = this.findContentAndFooter();
     this.clearContentSafeAreaPadding(contentEl);
+  }
+
+  /**
+   * Re-applies what `cleanupSafeAreaOverrides()` removed for a modal moved
+   * while presented. Anything needing no measurement goes on synchronously so
+   * the modal is never painted without safe-area. The position-based
+   * correction waits a frame for the layout pass it reads.
+   */
+  private restoreSafeAreaOverrides(): void {
+    this.setInitialSafeAreaOverrides();
+    this.applyFullscreenSafeArea();
+
+    raf(() => {
+      // A dismiss or another move can land first, and a read before the enter
+      // animation settles is not the rest position. `present()` redoes it.
+      if (!this.presented || !this.el.isConnected || this.isPresenting) {
+        return;
+      }
+      // A hidden subtree carries `display: none`, so there is no box and the
+      // read would write the safe-area for a modal touching no edge. The
+      // prediction applied above holds until the modal is shown again.
+      const { width, height } = this.el.getBoundingClientRect();
+      if (width === 0 && height === 0) {
+        return;
+      }
+      this.updateSafeAreaOverrides();
+    });
   }
 
   render() {

--- a/core/src/components/modal/test/inline/modal.e2e.ts
+++ b/core/src/components/modal/test/inline/modal.e2e.ts
@@ -152,6 +152,43 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       await expect(modalContainer).not.toBeAttached();
     });
 
+    test('it should still dismiss on parent removal after the modal was moved', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31389',
+      });
+
+      // Moving a presented modal is a disconnect plus a connect, so the
+      // observer built at the end of `present()` has to be rebuilt.
+      await page.goto('/src/components/modal/test/inline', config);
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+      const ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
+
+      const modal = page.locator('ion-modal').first();
+      const modalContainer = page.locator('#modal-container');
+
+      await page.click('#open-inline-modal');
+      await ionModalDidPresent.next();
+      await expect(modal).toBeVisible();
+
+      // Relocate the way a framework binding does: detached and re-inserted
+      // across a task, not a single synchronous appendChild.
+      await modal.evaluate(async (el: HTMLIonModalElement) => {
+        const holder = document.createElement('div');
+        document.body.appendChild(holder);
+        el.remove();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        holder.appendChild(el);
+      });
+
+      await page.click('#remove-modal-container');
+
+      const dismissEvent = await ionModalDidDismiss.next();
+
+      expect(dismissEvent.detail.role).toBe('parent-removed');
+      await expect(modalContainer).not.toBeAttached();
+    });
+
     test('it should dismiss both parent and child modals when parent container is removed from DOM', async ({
       page,
     }) => {

--- a/core/src/components/modal/test/inline/modal.e2e.ts
+++ b/core/src/components/modal/test/inline/modal.e2e.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { configs, test } from '@utils/test/playwright';
+import { configs, detachAndReattach, test } from '@utils/test/playwright';
 
 configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('modal: inline'), () => {
@@ -171,15 +171,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       await ionModalDidPresent.next();
       await expect(modal).toBeVisible();
 
-      // Relocate the way a framework binding does: detached and re-inserted
-      // across a task, not a single synchronous appendChild.
-      await modal.evaluate(async (el: HTMLIonModalElement) => {
-        const holder = document.createElement('div');
-        document.body.appendChild(holder);
-        el.remove();
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        holder.appendChild(el);
-      });
+      await detachAndReattach(modal);
 
       await page.click('#remove-modal-container');
 

--- a/core/src/components/modal/test/safe-area/modal.e2e.ts
+++ b/core/src/components/modal/test/safe-area/modal.e2e.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test';
+import type { Locator } from '@playwright/test';
 import { configs, test, Viewports } from '@utils/test/playwright';
 
 /**
@@ -442,6 +443,187 @@ configs({ modes: ['ios', 'md'], directions: ['ltr'] }).forEach(({ title, config 
 
       // Clean up
       await modal.evaluate((el: HTMLIonModalElement) => el.remove());
+    });
+
+    test.describe('moving a presented modal', () => {
+      // A single `appendChild` leaves the element connected as far as
+      // `disconnectedCallback` is concerned, so detach across a task instead.
+      const moveModal = (modal: Locator) =>
+        modal.evaluate(async (el: HTMLIonModalElement) => {
+          const holder = document.createElement('div');
+          document.querySelector('ion-app')!.appendChild(holder);
+          el.remove();
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          holder.appendChild(el);
+        });
+
+      test('should keep the safe-area overrides', async ({ page }, testInfo) => {
+        testInfo.annotations.push({
+          type: 'issue',
+          description: 'https://github.com/ionic-team/ionic-framework/issues/31389',
+        });
+
+        const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+
+        await page.click('#fullscreen-modal');
+        await ionModalDidPresent.next();
+
+        const modal = page.locator('ion-modal');
+        await moveModal(modal);
+
+        const overrides = await modal.evaluate((el: HTMLIonModalElement) => ({
+          top: el.style.getPropertyValue('--ion-safe-area-top'),
+          bottom: el.style.getPropertyValue('--ion-safe-area-bottom'),
+        }));
+
+        expect(overrides.top).toBe('inherit');
+        expect(overrides.bottom).toBe('inherit');
+        // The detach releases the root lock, so the re-insert has to put it back.
+        await expect(page.locator('body')).toHaveClass(/backdrop-no-scroll/);
+      });
+
+      test('should not measure the modal while it has no layout box', async ({ page }, testInfo) => {
+        testInfo.annotations.push({
+          type: 'issue',
+          description: 'https://github.com/ionic-team/ionic-framework/issues/31389',
+        });
+
+        // A hidden subtree carries `display: none`, so a move inside that
+        // window reconnects the modal with no box to measure.
+        const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+
+        await page.click('#fullscreen-modal');
+        await ionModalDidPresent.next();
+
+        const modal = page.locator('ion-modal');
+
+        await modal.evaluate((el: HTMLIonModalElement) => el.style.setProperty('display', 'none', 'important'));
+        await moveModal(modal);
+        // The reconnect's read is deferred a frame, so let that frame land
+        // while there is still no box. Clearing `display` from a separate
+        // round trip races it and the test stops guarding anything.
+        await modal.evaluate(async (el: HTMLIonModalElement) => {
+          await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+          el.style.removeProperty('display');
+        });
+
+        const overrides = await modal.evaluate((el: HTMLIonModalElement) => ({
+          bottom: el.style.getPropertyValue('--ion-safe-area-bottom'),
+          right: el.style.getPropertyValue('--ion-safe-area-right'),
+        }));
+
+        expect(overrides.bottom).toBe('inherit');
+        expect(overrides.right).toBe('inherit');
+      });
+
+      test('should keep the sheet offset for a sheet modal', async ({ page }, testInfo) => {
+        testInfo.annotations.push({
+          type: 'issue',
+          description: 'https://github.com/ionic-team/ionic-framework/issues/31389',
+        });
+
+        const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+
+        await page.click('#sheet-modal');
+        await ionModalDidPresent.next();
+
+        const modal = page.locator('ion-modal');
+        await moveModal(modal);
+
+        // The sheet's `--height` formula reads `--ion-modal-offset-top`, so
+        // losing it grows the sheet by the safe-area-top amount.
+        const offsetTop = await modal.evaluate((el: HTMLIonModalElement) =>
+          el.style.getPropertyValue('--ion-modal-offset-top')
+        );
+        const safeAreaTop = await modal.evaluate((el: HTMLIonModalElement) =>
+          el.style.getPropertyValue('--ion-safe-area-top')
+        );
+
+        expect(offsetTop).toBe(`${TEST_SAFE_AREA_TOP}px`);
+        expect(safeAreaTop).toBe('0px');
+      });
+
+      test('should not read a mid-animation position when moved during willPresent', async ({ page }, testInfo) => {
+        testInfo.annotations.push({
+          type: 'issue',
+          description: 'https://github.com/ionic-team/ionic-framework/issues/31389',
+        });
+
+        /**
+         * Relocating from `willPresent` reconnects the overlay just before the
+         * enter animation starts, where a position-based read measures a
+         * mid-animation box. So animations stay on and the value is sampled
+         * every frame: `present()` fixes the end state either way, so only
+         * samples taken during the animation can catch the regression.
+         */
+        await page.goto('/src/components/modal/test/safe-area?ionic:_testing=false', config);
+
+        const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+
+        await page.evaluate(() => {
+          const samples: string[] = [];
+          (window as any).safeAreaTopSamples = samples;
+
+          document.addEventListener(
+            'ionModalWillPresent',
+            (ev) => {
+              const modal = ev.target as HTMLElement;
+              const holder = document.createElement('div');
+              document.querySelector('ion-app')!.appendChild(holder);
+              holder.appendChild(modal);
+
+              const start = performance.now();
+              const sample = () => {
+                samples.push(modal.style.getPropertyValue('--ion-safe-area-top'));
+                (window as any).samplingSpanMs = performance.now() - start;
+                if (!(window as any).stopSampling) {
+                  requestAnimationFrame(sample);
+                }
+              };
+              requestAnimationFrame(sample);
+            },
+            { once: true }
+          );
+
+          document.addEventListener('ionModalDidPresent', () => ((window as any).stopSampling = true), {
+            once: true,
+          });
+        });
+
+        await page.click('#fullscreen-modal');
+        await ionModalDidPresent.next();
+
+        const samples = await page.evaluate(() => (window as any).safeAreaTopSamples as string[]);
+        const samplingSpanMs = await page.evaluate(() => (window as any).samplingSpanMs as number);
+
+        // Elapsed time rather than a frame count, which throttles under CI
+        // load. A starved queue would otherwise leave only samples that pass.
+        expect(samplingSpanMs).toBeGreaterThan(100);
+        // Assert the positive value: an unset override is as wrong as `0px`.
+        expect(samples.every((sample) => sample === 'inherit')).toBe(true);
+      });
+
+      test('should keep the ion-content scroll padding', async ({ page }, testInfo) => {
+        testInfo.annotations.push({
+          type: 'issue',
+          description: 'https://github.com/ionic-team/ionic-framework/issues/31389',
+        });
+
+        const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+
+        await page.click('#fullscreen-modal-no-footer');
+        await ionModalDidPresent.next();
+
+        const modal = page.locator('ion-modal');
+        await moveModal(modal);
+
+        const innerScroll = modal.locator('ion-content .inner-scroll');
+        const scrollPaddingBottom = await innerScroll.evaluate((el: Element) =>
+          parseFloat(getComputedStyle(el).paddingBottom)
+        );
+
+        expect(scrollPaddingBottom).toBe(TEST_ION_PADDING + TEST_SAFE_AREA_BOTTOM);
+      });
     });
   });
 });

--- a/core/src/components/modal/test/safe-area/modal.e2e.ts
+++ b/core/src/components/modal/test/safe-area/modal.e2e.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import type { Locator } from '@playwright/test';
-import { configs, test, Viewports } from '@utils/test/playwright';
+import { configs, detachAndReattach, test, Viewports } from '@utils/test/playwright';
 
 /**
  * These tests verify that safe-area CSS custom properties are correctly
@@ -446,16 +446,7 @@ configs({ modes: ['ios', 'md'], directions: ['ltr'] }).forEach(({ title, config 
     });
 
     test.describe('moving a presented modal', () => {
-      // A single `appendChild` leaves the element connected as far as
-      // `disconnectedCallback` is concerned, so detach across a task instead.
-      const moveModal = (modal: Locator) =>
-        modal.evaluate(async (el: HTMLIonModalElement) => {
-          const holder = document.createElement('div');
-          document.querySelector('ion-app')!.appendChild(holder);
-          el.remove();
-          await new Promise((resolve) => setTimeout(resolve, 0));
-          holder.appendChild(el);
-        });
+      const moveModal = (modal: Locator) => detachAndReattach(modal, 'ion-app');
 
       test('should keep the safe-area overrides', async ({ page }, testInfo) => {
         testInfo.annotations.push({

--- a/core/src/components/popover/popover.tsx
+++ b/core/src/components/popover/popover.tsx
@@ -585,7 +585,10 @@ export class Popover implements ComponentInterface, PopoverInterface {
 
     // Both `present()` and a reconnect call this, so drop any existing
     // observer. Below the guards, so a call that bails cannot leave none.
-    this.headerResizeObserver?.disconnect();
+    if (this.headerResizeObserver) {
+      this.headerResizeObserver.disconnect();
+      this.headerResizeObserver = undefined;
+    }
 
     this.headerResizeObserver = new ResizeObserver(async () => {
       if (header.offsetHeight > 0) {

--- a/core/src/components/popover/popover.tsx
+++ b/core/src/components/popover/popover.tsx
@@ -13,6 +13,7 @@ import {
   FOCUS_TRAP_DISABLE_CLASS,
   prepareOverlay,
   present,
+  restoreRootFocusTrapAccessibility,
   setOverlayId,
 } from '@utils/overlays';
 import { isPlatform } from '@utils/platform';
@@ -355,6 +356,14 @@ export class Popover implements ComponentInterface, PopoverInterface {
 
     prepareOverlay(el);
     configureTriggerInteraction();
+
+    // Re-apply the root lock if moved without dismiss() being called
+    if (this.presented) {
+      restoreRootFocusTrapAccessibility(el);
+      // The disconnect tore down the header observer, and `present()` is its
+      // only other caller, so a move mid-layout would lose the recalculation.
+      this.recalculateContentOnHeaderReady();
+    }
   }
 
   disconnectedCallback() {
@@ -573,6 +582,10 @@ export class Popover implements ComponentInterface, PopoverInterface {
     if (!header || contentElements.length === 0) {
       return;
     }
+
+    // Both `present()` and a reconnect call this, so drop any existing
+    // observer. Below the guards, so a call that bails cannot leave none.
+    this.headerResizeObserver?.disconnect();
 
     this.headerResizeObserver = new ResizeObserver(async () => {
       if (header.offsetHeight > 0) {

--- a/core/src/components/popover/test/basic/popover.e2e.ts
+++ b/core/src/components/popover/test/basic/popover.e2e.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { configs, test } from '@utils/test/playwright';
+import { configs, detachAndReattach, test } from '@utils/test/playwright';
 
 import { PopoverFixture } from '../fixture';
 
@@ -258,6 +258,32 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       await page.keyboard.press('End');
 
       await expect(vanillaTextarea).toBeFocused();
+    });
+  });
+});
+
+/**
+ * This behavior does not vary across modes/directions.
+ */
+configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ config, title }) => {
+  test.describe(title('popover: moved while presented'), () => {
+    test('should keep the app root locked', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31389',
+      });
+
+      await page.goto('/src/components/popover/test/basic', config);
+      const ionPopoverDidPresent = await page.spyOnEvent('ionPopoverDidPresent');
+
+      await page.click('#basic-popover');
+      await ionPopoverDidPresent.next();
+
+      await expect(page.locator('body')).toHaveClass(/backdrop-no-scroll/);
+
+      await detachAndReattach(page.locator('ion-popover'));
+
+      await expect(page.locator('body')).toHaveClass(/backdrop-no-scroll/);
     });
   });
 });

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -51,6 +51,16 @@ const isBackdropAlwaysBlocking = (el: OverlayWithFocusTrapProps): boolean => {
   return el.showBackdrop !== false && !((el.backdropBreakpoint ?? 0) > 0);
 };
 
+/**
+ * Whether the overlay takes the app root out of the accessibility tree and
+ * blocks body scroll while presented. Toasts never do, modal and popover can
+ * opt out with `focusTrap={false}`, and a backdrop that does not block
+ * (`showBackdrop={false}`, or a `backdropBreakpoint` above 0) is excluded.
+ */
+const locksAppRoot = (el: OverlayWithFocusTrapProps): boolean => {
+  return el.tagName !== 'ION-TOAST' && el.focusTrap !== false && isBackdropAlwaysBlocking(el);
+};
+
 const createController = <Opts extends object, HTMLElm>(tagName: string) => {
   return {
     create(options: Opts): Promise<HTMLElm> {
@@ -468,6 +478,14 @@ export const getPresentedOverlay = (
 };
 
 /**
+ * The element an app nests its views under. Overlays hide this rather than the
+ * whole root, so the overlay itself (a sibling) stays reachable.
+ */
+const getViewContainer = () => {
+  return getAppRoot(document).querySelector('ion-router-outlet, #ion-view-container-root');
+};
+
+/**
  * When an overlay is presented, the main
  * focus is the overlay not the page content.
  * We need to remove the page content from the
@@ -490,8 +508,7 @@ export const getPresentedOverlay = (
  * for main content.
  */
 export const setRootAriaHidden = (hidden = false) => {
-  const root = getAppRoot(document);
-  const viewContainer = root.querySelector('ion-router-outlet, #ion-view-container-root');
+  const viewContainer = getViewContainer();
 
   if (!viewContainer) {
     return;
@@ -519,15 +536,44 @@ export const cleanupRootFocusTrapAccessibility = () => {
   }
 
   const remainingOverlays = getPresentedOverlays(document);
-  const hasRemainingLocking = remainingOverlays.some((o) => {
-    const el = o as OverlayWithFocusTrapProps;
-    return el.tagName !== 'ION-TOAST' && el.focusTrap !== false && isBackdropAlwaysBlocking(el);
-  });
+  const hasRemainingLocking = remainingOverlays.some((o) => locksAppRoot(o as OverlayWithFocusTrapProps));
 
   if (!hasRemainingLocking) {
     setRootAriaHidden(false);
     document.body.classList.remove(BACKDROP_NO_SCROLL);
   }
+};
+
+/**
+ * Shared by `present()` and the restore below, which have to stay in lockstep.
+ */
+const applyRootLock = (el: OverlayWithFocusTrapProps) => {
+  // Hiding the container the overlay now sits in would hide the overlay too.
+  if (!getViewContainer()?.contains(el)) {
+    setRootAriaHidden(true);
+  }
+  document.body.classList.add(BACKDROP_NO_SCROLL);
+};
+
+/**
+ * Re-applies the root lock that `cleanupRootFocusTrapAccessibility()` released.
+ * Call from `connectedCallback` when the overlay is still presented.
+ *
+ * A synchronous move keeps the overlay connected, so the lock survives. A
+ * detach with a re-insert in a later task releases it, which is the shape a
+ * framework produces when it takes a subtree out and puts it back.
+ */
+export const restoreRootFocusTrapAccessibility = (overlayEl: HTMLIonOverlayElement) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const el = overlayEl as OverlayWithFocusTrapProps;
+  if (!locksAppRoot(el)) {
+    return;
+  }
+
+  applyRootLock(el);
 };
 
 export const present = async <OverlayPresentOptions>(
@@ -554,15 +600,7 @@ export const present = async <OverlayPresentOptions>(
   }
 
   /**
-   * Due to accessibility guidelines, toasts do not have
-   * focus traps.
-   *
-   * All other overlays should have focus traps to prevent
-   * the keyboard focus from leaving the overlay unless
-   * developers explicitly opt out (for example, sheet
-   * modals that should permit background interaction).
-   *
-   * Note: Some apps move inline overlays to a specific container
+   * Some apps move inline overlays to a specific container
    * during the willPresent lifecycle (e.g., React portals via
    * onWillPresent). Defer applying aria-hidden/inert to the app
    * root until after willPresent so we can detect where the
@@ -571,21 +609,13 @@ export const present = async <OverlayPresentOptions>(
    * to avoid disabling the overlay.
    */
   const overlayEl = overlay.el as OverlayWithFocusTrapProps;
-  const shouldTrapFocus = overlayEl.tagName !== 'ION-TOAST' && overlayEl.focusTrap !== false;
-  const shouldLockRoot = shouldTrapFocus && isBackdropAlwaysBlocking(overlayEl);
+  const shouldLockRoot = locksAppRoot(overlayEl);
 
   overlay.presented = true;
   overlay.willPresent.emit();
 
   if (shouldLockRoot) {
-    const root = getAppRoot(document);
-    const viewContainer = root.querySelector('ion-router-outlet, #ion-view-container-root');
-    const overlayInsideViewContainer = viewContainer ? viewContainer.contains(overlayEl) : false;
-
-    if (!overlayInsideViewContainer) {
-      setRootAriaHidden(true);
-    }
-    document.body.classList.add(BACKDROP_NO_SCROLL);
+    applyRootLock(overlayEl);
   }
   overlay.willPresentShorthand?.emit();
 
@@ -730,13 +760,9 @@ export const dismiss = async <OverlayDismissOptions>(
    * from the root element when the last focus-trapping overlay
    * is dismissed.
    */
-  const overlaysLockingRoot = presentedOverlays.filter((o) => {
-    const el = o as OverlayWithFocusTrapProps;
-    return el.tagName !== 'ION-TOAST' && el.focusTrap !== false && isBackdropAlwaysBlocking(el);
-  });
+  const overlaysLockingRoot = presentedOverlays.filter((o) => locksAppRoot(o as OverlayWithFocusTrapProps));
   const overlayEl = overlay.el as OverlayWithFocusTrapProps;
-  const locksRoot =
-    overlayEl.tagName !== 'ION-TOAST' && overlayEl.focusTrap !== false && isBackdropAlwaysBlocking(overlayEl);
+  const locksRoot = locksAppRoot(overlayEl);
 
   /**
    * If this is the last visible overlay that is trapping focus

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -545,7 +545,9 @@ export const cleanupRootFocusTrapAccessibility = () => {
 };
 
 /**
- * Shared by `present()` and the restore below, which have to stay in lockstep.
+ * Applies the root lock itself: `aria-hidden` on the view container, and
+ * `backdrop-no-scroll` on the body. Shared by `present()` and the restore
+ * below, which have to stay in lockstep.
  */
 const applyRootLock = (el: OverlayWithFocusTrapProps) => {
   // Hiding the container the overlay now sits in would hide the overlay too.

--- a/core/src/utils/test/overlays/overlays-root-locking.spec.ts
+++ b/core/src/utils/test/overlays/overlays-root-locking.spec.ts
@@ -1,0 +1,180 @@
+import { newSpecPage } from '@stencil/core/testing';
+
+import type { HTMLIonOverlayElement } from '../../overlays-interface';
+
+import { ActionSheet } from '../../../components/action-sheet/action-sheet';
+import { Alert } from '../../../components/alert/alert';
+import { Loading } from '../../../components/loading/loading';
+import { Modal } from '../../../components/modal/modal';
+import { Popover } from '../../../components/popover/popover';
+
+// A presented overlay locks the app root with `aria-hidden` on the view
+// container and `backdrop-no-scroll` on the body, and being taken out and put
+// back must not drop it. mock-doc's `appendChild` removes before it inserts, so
+// the disconnect fires while detached, which a browser only does across tasks.
+// Fixes https://github.com/ionic-team/ionic-framework/issues/31389
+describe('overlays: root locking across a move', () => {
+  const overlays = [
+    { tag: 'ion-modal', component: Modal },
+    { tag: 'ion-popover', component: Popover },
+    { tag: 'ion-alert', component: Alert },
+    { tag: 'ion-action-sheet', component: ActionSheet },
+    { tag: 'ion-loading', component: Loading },
+  ];
+
+  overlays.forEach(({ tag, component }) => {
+    it(`should keep the app root locked when a presented ${tag} is moved`, async () => {
+      const page = await newSpecPage({
+        components: [component],
+        html: `
+          <div id="ion-view-container-root"></div>
+          <div id="destination"></div>
+          <${tag}></${tag}>
+        `,
+      });
+
+      const overlay = page.body.querySelector(tag) as HTMLIonOverlayElement;
+      const viewContainer = page.body.querySelector('#ion-view-container-root')!;
+      const destination = page.body.querySelector('#destination')!;
+      const body = page.doc.querySelector('body')!;
+
+      await overlay.present();
+
+      expect(viewContainer.getAttribute('aria-hidden')).toBe('true');
+      expect(body).toHaveClass('backdrop-no-scroll');
+
+      destination.appendChild(overlay);
+      await page.waitForChanges();
+
+      expect(viewContainer.getAttribute('aria-hidden')).toBe('true');
+      expect(body).toHaveClass('backdrop-no-scroll');
+    });
+  });
+
+  it('should release the app root when a moved overlay is later dismissed', async () => {
+    const page = await newSpecPage({
+      components: [Modal],
+      html: `
+        <div id="ion-view-container-root"></div>
+        <div id="destination"></div>
+        <ion-modal></ion-modal>
+      `,
+    });
+
+    const modal = page.body.querySelector('ion-modal')!;
+    const viewContainer = page.body.querySelector('#ion-view-container-root')!;
+    const destination = page.body.querySelector('#destination')!;
+    const body = page.doc.querySelector('body')!;
+
+    await modal.present();
+
+    destination.appendChild(modal);
+    await page.waitForChanges();
+
+    await modal.dismiss();
+
+    expect(viewContainer.hasAttribute('aria-hidden')).toBe(false);
+    expect(body).not.toHaveClass('backdrop-no-scroll');
+  });
+
+  it('should not lock the app root for a moved overlay that opted out of the focus trap', async () => {
+    // The overlay never locked the root, so a move must not start locking it.
+    const page = await newSpecPage({
+      components: [Modal],
+      html: `
+        <div id="ion-view-container-root"></div>
+        <div id="destination"></div>
+        <ion-modal></ion-modal>
+      `,
+    });
+
+    const modal = page.body.querySelector('ion-modal')!;
+    modal.focusTrap = false;
+    const viewContainer = page.body.querySelector('#ion-view-container-root')!;
+    const destination = page.body.querySelector('#destination')!;
+    const body = page.doc.querySelector('body')!;
+
+    await modal.present();
+
+    expect(viewContainer.hasAttribute('aria-hidden')).toBe(false);
+
+    destination.appendChild(modal);
+    await page.waitForChanges();
+
+    expect(viewContainer.hasAttribute('aria-hidden')).toBe(false);
+    expect(body).not.toHaveClass('backdrop-no-scroll');
+  });
+
+  it('should not aria-hide the view container an overlay was re-inserted into', async () => {
+    /**
+     * Presenting skips `aria-hidden` when the overlay ends up inside the view
+     * container, since hiding it would hide the overlay too. A re-insert has to
+     * reach the same conclusion while still restoring the scroll block.
+     */
+    const page = await newSpecPage({
+      components: [Modal],
+      html: `
+        <div id="ion-view-container-root"></div>
+        <ion-modal></ion-modal>
+      `,
+    });
+
+    const modal = page.body.querySelector('ion-modal')!;
+    const viewContainer = page.body.querySelector('#ion-view-container-root')!;
+    const body = page.doc.querySelector('body')!;
+
+    await modal.present();
+    expect(viewContainer.getAttribute('aria-hidden')).toBe('true');
+
+    viewContainer.appendChild(modal);
+    await page.waitForChanges();
+
+    expect(viewContainer.hasAttribute('aria-hidden')).toBe(false);
+    // The scroll block still has to come back, or this would pass on the
+    // teardown alone and never see the restore run.
+    expect(body).toHaveClass('backdrop-no-scroll');
+  });
+
+  it('should not stack parent-removal observers when a modal is moved while presenting', async () => {
+    // Both `present()` and the reconnect init the observer, so a move between
+    // the two must not leave an orphan that nothing ever disconnects.
+    const NativeMutationObserver = (global as any).MutationObserver;
+    const live = new Set<unknown>();
+    (global as any).MutationObserver = class {
+      constructor() {
+        live.add(this);
+      }
+      observe() {}
+      disconnect() {
+        live.delete(this);
+      }
+    };
+
+    try {
+      const page = await newSpecPage({
+        components: [Modal],
+        html: `
+          <div id="parent"><ion-modal></ion-modal></div>
+          <div id="destination"></div>
+        `,
+      });
+
+      const modal = page.body.querySelector('ion-modal')!;
+      const destination = page.body.querySelector('#destination')!;
+
+      modal.addEventListener('ionModalWillPresent', () => destination.appendChild(modal), { once: true });
+
+      await modal.present();
+      await page.waitForChanges();
+
+      expect(live.size).toBe(1);
+
+      await modal.dismiss();
+      await page.waitForChanges();
+
+      expect(live.size).toBe(0);
+    } finally {
+      (global as any).MutationObserver = NativeMutationObserver;
+    }
+  });
+});

--- a/core/src/utils/test/playwright/detach-reattach.ts
+++ b/core/src/utils/test/playwright/detach-reattach.ts
@@ -1,0 +1,22 @@
+import type { Locator } from '@playwright/test';
+
+/**
+ * Detaches an element and puts it back in a later task, the way a framework
+ * binding relocates a subtree it owns.
+ *
+ * A single `appendChild` won't do it. Custom element reactions run at the end
+ * of the same task, so `disconnectedCallback` fires with the element already
+ * back and nothing tears down. The detach has to survive a task before the
+ * disconnect is observable.
+ *
+ * Pass `containerSelector` to hold the element somewhere other than the body.
+ */
+export const detachAndReattach = async (locator: Locator, containerSelector = 'body') => {
+  await locator.evaluate(async (el: HTMLElement, selector: string) => {
+    const holder = document.createElement('div');
+    document.querySelector(selector)!.appendChild(holder);
+    el.remove();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    holder.appendChild(el);
+  }, containerSelector);
+};

--- a/core/src/utils/test/playwright/index.ts
+++ b/core/src/utils/test/playwright/index.ts
@@ -7,3 +7,4 @@ export * from './apply-keyboard-focus';
 export * from './matchers';
 export * from './viewports';
 export * from './generator';
+export * from './detach-reattach';

--- a/packages/react/src/components/__tests__/createInlineOverlayComponent.spec.tsx
+++ b/packages/react/src/components/__tests__/createInlineOverlayComponent.spec.tsx
@@ -40,9 +40,144 @@ const teleport = (el: HTMLElement) => {
   dest.appendChild(el);
 };
 
-afterEach(() => {
+/**
+ * The unmount teardown is deferred by a microtask so it can check whether
+ * React removed the DOM or only hid it. Let that microtask run.
+ */
+const flushTeardown = () => act(async () => {});
+
+/**
+ * Track `MutationObserver` use. `jest.spyOn` cannot wrap a class constructor
+ * (its mock is called without `new`), so swap in a subclass. `observersLive`
+ * counts observing-minus-disconnected, which is what a missing `disconnect`
+ * shows up in; `observersCreated` cannot see that.
+ */
+const countMutationObservers = () => {
+  const Original = global.MutationObserver;
+  let created = 0;
+  let live = 0;
+  global.MutationObserver = class extends Original {
+    private isObserving = false;
+
+    constructor(callback: MutationCallback) {
+      super(callback);
+      created++;
+    }
+
+    observe(target: Node, options?: MutationObserverInit) {
+      if (!this.isObserving) {
+        this.isObserving = true;
+        live++;
+      }
+      return super.observe(target, options);
+    }
+
+    disconnect() {
+      if (this.isObserving) {
+        this.isObserving = false;
+        live--;
+      }
+      return super.disconnect();
+    }
+  };
+
+  return {
+    observersCreated: () => created,
+    observersLive: () => live,
+    restore: () => {
+      global.MutationObserver = Original;
+    },
+  };
+};
+
+/**
+ * A component that suspends while it holds a pending promise. Rendering it
+ * inside a Suspense boundary hides that boundary's content: React runs
+ * `componentWillUnmount` on everything in it without unmounting, and brings
+ * the same instances back with `componentDidMount` on the reveal.
+ */
+const Suspender = ({ pending }: { pending: Promise<void> | null }) => {
+  if (pending) {
+    throw pending;
+  }
+  return null;
+};
+
+/**
+ * Render `children` in a Suspense boundary next to a sibling that suspends on
+ * demand. `hide()` is the reported trigger: the overlay renders fine, another
+ * child of the boundary does not, and React hides the whole boundary. Each
+ * `hide()` takes a fresh promise so a test can drive more than one cycle.
+ */
+const renderWithBoundary = (children: React.ReactNode) => {
+  let setPending!: (pending: Promise<void> | null) => void;
+  let resolvePending: (() => void) | null = null;
+
+  const Boundary = () => {
+    const [pending, setPendingState] = React.useState<Promise<void> | null>(null);
+    setPending = setPendingState;
+
+    return (
+      <React.Suspense fallback={<div>loading</div>}>
+        {children}
+        <Suspender pending={pending} />
+      </React.Suspense>
+    );
+  };
+
+  const result = render(<Boundary />);
+
+  return {
+    ...result,
+    hide: async () => {
+      const pending = new Promise<void>((resolve) => {
+        resolvePending = resolve as () => void;
+      });
+      act(() => {
+        setPending(pending);
+      });
+      await flushTeardown();
+    },
+    reveal: async () => {
+      await act(async () => {
+        setPending(null);
+        resolvePending?.();
+        resolvePending = null;
+      });
+      await flushTeardown();
+    },
+  };
+};
+
+afterEach(async () => {
   document.body.innerHTML = '';
   mockComponentOnReady = defaultComponentOnReady;
+  jest.restoreAllMocks();
+  // Clearing the body disconnects any marker still being watched. Let the
+  // shared destroy observer drain so it does not carry into the next test.
+  await flushTeardown();
+});
+
+describe('createInlineOverlayComponent: cachedOriginalParent', () => {
+  it('redirects cachedOriginalParent for a portaled overlay but not a nested one', () => {
+    /**
+     * Core walks up from `cachedOriginalParent` to find the enclosing
+     * `.ion-page`. A portaled host is cached against the portal container, so
+     * it has to be pointed back at its JSX position. A nested host already
+     * renders at that position, so the wrapper must leave it alone.
+     */
+    const { container } = render(
+      <IonModal keepContentsMounted={true}>
+        <IonPopover />
+      </IonModal>
+    );
+
+    const modal = document.body.querySelector('ion-modal') as any;
+    const popover = document.body.querySelector('ion-popover') as any;
+
+    expect(modal.cachedOriginalParent).toBe(container);
+    expect(popover.cachedOriginalParent).toBeUndefined();
+  });
 });
 
 describe('createInlineOverlayComponent: unmount cleanup', () => {
@@ -111,7 +246,7 @@ describe('createInlineOverlayComponent: unmount cleanup', () => {
     expect(document.querySelectorAll('ion-modal')).toHaveLength(1);
   });
 
-  it('removes a relocated nested overlay on unmount even when it never opened', () => {
+  it('removes a relocated nested overlay on unmount even when it never opened', async () => {
     // keepContentsMounted renders the children (and the nested popover) while
     // the outer modal is closed, so the popover observes the nested context.
     const { unmount } = render(
@@ -127,11 +262,12 @@ describe('createInlineOverlayComponent: unmount cleanup', () => {
     teleport(popover);
 
     unmount();
+    await flushTeardown();
 
     expect(document.querySelector('ion-popover')).toBeNull();
   });
 
-  it('removes an open, relocated nested overlay on unmount', () => {
+  it('removes an open, relocated nested overlay on unmount', async () => {
     const { unmount } = render(
       <IonModal keepContentsMounted={true}>
         <IonPopover />
@@ -149,7 +285,651 @@ describe('createInlineOverlayComponent: unmount cleanup', () => {
     teleport(popover);
 
     expect(() => unmount()).not.toThrow();
+    await flushTeardown();
 
     expect(document.querySelector('ion-popover')).toBeNull();
+  });
+});
+
+// Fixes https://github.com/ionic-team/ionic-framework/issues/31389
+describe('createInlineOverlayComponent: hidden subtree', () => {
+  it('leaves a relocated nested overlay alone while a Suspense boundary hides it', async () => {
+    // A hide must leave the host exactly where it is: React did not remove it,
+    // so React will not put it back on the reveal.
+    const { hide, reveal } = renderWithBoundary(
+      <IonModal keepContentsMounted={true}>
+        <IonPopover />
+      </IonModal>
+    );
+
+    const popover = document.body.querySelector('ion-popover') as HTMLElement;
+
+    // CoreDelegate teleports the host out of its `<template>` as `present()`
+    // starts, before the events that flip `isOpen` have fired.
+    teleport(popover);
+    const teleportDestination = popover.parentElement;
+
+    await hide();
+
+    // The host is untouched while hidden: same node, same position, still
+    // connected, so nothing has to be restored on the reveal.
+    expect(popover.isConnected).toBe(true);
+    expect(popover.parentElement).toBe(teleportDestination);
+
+    await reveal();
+
+    expect(popover.isConnected).toBe(true);
+    expect(popover.parentElement).toBe(teleportDestination);
+  });
+
+  it('keeps a hidden overlay wired up to the app for the rest of that open', async () => {
+    // `present()` was in flight when the hide landed and core finishes it
+    // regardless, so the app's handlers still have to fire while hidden.
+    const onDidPresent = jest.fn();
+    const onDidDismiss = jest.fn();
+
+    const { hide, reveal } = renderWithBoundary(
+      <IonModal keepContentsMounted={true}>
+        <IonPopover onIonPopoverDidPresent={onDidPresent} onDidDismiss={onDidDismiss}>
+          <span data-testid="popover-content">content</span>
+        </IonPopover>
+      </IonModal>
+    );
+
+    const popover = document.body.querySelector('ion-popover') as HTMLElement;
+
+    // `present()` has started, so the wrapper counts the overlay as open.
+    act(() => {
+      popover.dispatchEvent(new CustomEvent('willPresent'));
+    });
+    teleport(popover);
+
+    await hide();
+
+    // Core finishes presenting, then the overlay is dismissed, both while the
+    // subtree is still hidden.
+    act(() => {
+      popover.dispatchEvent(new CustomEvent('ionPopoverDidPresent'));
+      popover.dispatchEvent(new CustomEvent('didDismiss'));
+    });
+
+    expect(onDidPresent).toHaveBeenCalledTimes(1);
+    expect(onDidDismiss).toHaveBeenCalledTimes(1);
+
+    await reveal();
+
+    // The dismiss also has to close the wrapper. React nulls the refs for the
+    // whole hidden window, so a close that only runs when they are present
+    // would leave the contents mounted against a dismissed overlay.
+    expect(document.querySelector('[data-testid="popover-content"]')).toBeNull();
+  });
+
+  it('keeps a portaled overlay wired up to the app across a hide', async () => {
+    // Same coverage for a top-level overlay: a hide must not detach its event
+    // bindings either, so `didPresent` still reaches the app.
+    const onDidPresent = jest.fn();
+
+    const { hide, reveal } = renderWithBoundary(<IonModal onIonModalDidPresent={onDidPresent} />);
+
+    const modal = document.body.querySelector('ion-modal') as HTMLElement;
+
+    act(() => {
+      modal.dispatchEvent(new CustomEvent('willPresent'));
+    });
+
+    await hide();
+
+    act(() => {
+      modal.dispatchEvent(new CustomEvent('ionModalDidPresent'));
+    });
+
+    expect(onDidPresent).toHaveBeenCalledTimes(1);
+
+    await reveal();
+
+    expect(modal.isConnected).toBe(true);
+  });
+
+  it('puts a relocated portaled host back where it was after a hide', async () => {
+    /**
+     * A portaled host that user code moved out of `portalTarget` has to go
+     * back into it synchronously, before a hide can be told from a destroy,
+     * or React's portal removal would not find it. That move is wrong for a
+     * hide, so the reveal has to undo it, back to the exact position: the real
+     * destination is ion-app, which holds other overlays whose order matters.
+     */
+    const { hide, reveal } = renderWithBoundary(<IonModal />);
+
+    const modal = document.body.querySelector('ion-modal') as HTMLElement;
+
+    act(() => {
+      modal.dispatchEvent(new CustomEvent('willPresent'));
+    });
+    teleport(modal);
+    const teleportDestination = modal.parentElement as HTMLElement;
+    // Give the host a following sibling, or appending and restoring in place
+    // are indistinguishable.
+    const followingSibling = document.createElement('div');
+    teleportDestination.appendChild(followingSibling);
+
+    await hide();
+    await reveal();
+
+    expect(modal.parentElement).toBe(teleportDestination);
+    expect(modal.nextElementSibling).toBe(followingSibling);
+  });
+
+  it('presents and dismisses a nested overlay after the reveal', async () => {
+    // The other tests only assert the node survived; this one drives a full
+    // open and close after the reveal.
+    const onWillPresent = jest.fn();
+    const onDidPresent = jest.fn();
+    const onDidDismiss = jest.fn();
+
+    const { hide, reveal } = renderWithBoundary(
+      <IonModal keepContentsMounted={true}>
+        <IonPopover onWillPresent={onWillPresent} onIonPopoverDidPresent={onDidPresent} onDidDismiss={onDidDismiss}>
+          <span data-testid="popover-content">content</span>
+        </IonPopover>
+      </IonModal>
+    );
+
+    const popover = document.body.querySelector('ion-popover') as HTMLElement;
+    teleport(popover);
+
+    await hide();
+    await reveal();
+
+    act(() => {
+      popover.dispatchEvent(new CustomEvent('willPresent'));
+      popover.dispatchEvent(new CustomEvent('ionPopoverDidPresent'));
+    });
+
+    // One call each: the reveal re-adds the same lifecycle listener
+    // references, and `syncEvent` swaps rather than stacks the prop handlers.
+    expect(onWillPresent).toHaveBeenCalledTimes(1);
+    expect(onDidPresent).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('[data-testid="popover-content"]')).toBeTruthy();
+
+    act(() => {
+      popover.dispatchEvent(new CustomEvent('didDismiss'));
+    });
+
+    expect(onDidDismiss).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('[data-testid="popover-content"]')).toBeNull();
+  });
+
+  it('survives a hide of a nested overlay whose own contents suspended while presenting', async () => {
+    /**
+     * The reported flow. Core emits `ionMount` from the middle of `present()`,
+     * which is what first mounts the overlay's children, so a suspension in
+     * those children always lands while `present()` is in flight and the host
+     * has just been teleported out of its `<template>`.
+     */
+    const onDidPresent = jest.fn();
+
+    /**
+     * The latch has to sit outside React here. This suspender is the component
+     * that throws, so React discards its state and re-renders it from scratch
+     * on the retry, unlike the sibling `<Suspender pending>` above.
+     */
+    let contentsReady = false;
+    let resolveContents!: () => void;
+    const contents = new Promise<void>((resolve) => {
+      resolveContents = () => {
+        contentsReady = true;
+        resolve();
+      };
+    });
+    const SuspendingContents = () => {
+      if (!contentsReady) {
+        throw contents;
+      }
+      return null;
+    };
+
+    render(
+      <React.Suspense fallback={<div>loading</div>}>
+        <IonModal keepContentsMounted={true}>
+          <IonPopover id="nested-popover" onIonPopoverDidPresent={onDidPresent}>
+            <SuspendingContents />
+          </IonPopover>
+        </IonModal>
+      </React.Suspense>
+    );
+
+    const popover = document.querySelector('#nested-popover') as HTMLElement;
+    teleport(popover);
+    const teleportDestination = popover.parentElement;
+
+    // `present()`: the host is already teleported when `ionMount` mounts the
+    // contents, and the contents suspend as they render.
+    await act(async () => {
+      popover.dispatchEvent(new CustomEvent('ionMount'));
+    });
+
+    expect(popover.isConnected).toBe(true);
+
+    await act(async () => {
+      resolveContents();
+      await contents;
+    });
+
+    expect(popover.isConnected).toBe(true);
+    expect(popover.parentElement).toBe(teleportDestination);
+
+    // `present()` runs to completion against a host that never moved.
+    act(() => {
+      popover.dispatchEvent(new CustomEvent('ionPopoverDidPresent'));
+    });
+
+    expect(onDidPresent).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes a relocated nested overlay destroyed while it was hidden', async () => {
+    /**
+     * React does not call `componentWillUnmount` a second time when it
+     * destroys a subtree it had already hidden, so the overlay still has to
+     * be cleaned up when it is destroyed straight out of the hidden state.
+     */
+    const { hide, unmount } = renderWithBoundary(
+      <IonModal keepContentsMounted={true}>
+        <IonPopover />
+      </IonModal>
+    );
+
+    const popover = document.body.querySelector('ion-popover') as HTMLElement;
+    teleport(popover);
+
+    await hide();
+    expect(popover.isConnected).toBe(true);
+
+    unmount();
+    await flushTeardown();
+
+    expect(popover.isConnected).toBe(false);
+    expect(document.querySelector('ion-popover')).toBeNull();
+  });
+
+  it('detaches an open portaled overlay destroyed while it was hidden', async () => {
+    /**
+     * React's portal removal takes the host, but the listeners and the props
+     * synced onto it are the wrapper's to detach, and the destroy arrives
+     * with no second `componentWillUnmount` to do it in.
+     */
+    const onDidDismiss = jest.fn();
+
+    const { hide, unmount } = renderWithBoundary(<IonModal onDidDismiss={onDidDismiss} />);
+
+    const modal = document.body.querySelector('ion-modal') as HTMLElement;
+
+    act(() => {
+      modal.dispatchEvent(new CustomEvent('willPresent'));
+    });
+
+    await hide();
+
+    unmount();
+    await flushTeardown();
+
+    act(() => {
+      modal.dispatchEvent(new CustomEvent('didDismiss'));
+    });
+
+    expect(onDidDismiss).not.toHaveBeenCalled();
+  });
+
+  it('detaches an overlay that only started presenting after the hide', async () => {
+    /**
+     * The overlay can open while hidden, since core keeps running. Deciding at
+     * hide time whether a destroy will have anything to detach reads an
+     * `isOpen` that is still false, and then the destroy has no second
+     * `componentWillUnmount` to detach in.
+     */
+    const onDidDismiss = jest.fn();
+
+    const { hide, unmount } = renderWithBoundary(<IonModal onDidDismiss={onDidDismiss} />);
+
+    const modal = document.body.querySelector('ion-modal') as HTMLElement;
+
+    await hide();
+
+    // `present()` starts while the subtree is still hidden.
+    await act(async () => {
+      modal.dispatchEvent(new CustomEvent('willPresent'));
+    });
+
+    unmount();
+    await flushTeardown();
+
+    act(() => {
+      modal.dispatchEvent(new CustomEvent('didDismiss'));
+    });
+
+    expect(onDidDismiss).not.toHaveBeenCalled();
+  });
+
+  it('moves the wrapper back under the host when a dismiss lands while hidden', async () => {
+    /**
+     * The wrapper has to be a direct child of the host before flipping
+     * `isOpen` makes React remove it, and Stencil's scoped-slot relocation can
+     * nest it deeper. React nulls the refs for the whole hidden window, so a
+     * dismiss that lands there has to recover the nodes some other way or the
+     * removal throws and takes the tree down with it.
+     */
+    const { hide, reveal } = renderWithBoundary(
+      <IonModal>
+        <span data-testid="modal-content">content</span>
+      </IonModal>
+    );
+
+    const modal = document.body.querySelector('ion-modal') as HTMLElement;
+
+    act(() => {
+      modal.dispatchEvent(new CustomEvent('willPresent'));
+    });
+
+    const wrapper = modal.querySelector('.ion-delegate-host') as HTMLElement;
+    expect(wrapper).toBeTruthy();
+
+    // Stand in for a scoped overlay relocating its slotted content, which
+    // leaves React's wrapper nested one level deeper than React thinks.
+    const coreWrapper = document.createElement('div');
+    coreWrapper.append(...Array.from(modal.children));
+    modal.appendChild(coreWrapper);
+    expect(wrapper.parentElement).toBe(coreWrapper);
+
+    await hide();
+
+    act(() => {
+      modal.dispatchEvent(new CustomEvent('didDismiss'));
+    });
+
+    // Recovered without the refs, so React's removal finds it where it left it.
+    expect(wrapper.parentElement).toBe(modal);
+
+    await expect(reveal()).resolves.not.toThrow();
+
+    expect(document.querySelector('[data-testid="modal-content"]')).toBeNull();
+    expect(modal.isConnected).toBe(true);
+  });
+
+  it('redirects cachedOriginalParent once across repeated hide/reveal cycles', async () => {
+    // Core clears `cachedOriginalParent` on parent removal, so a repeatedly
+    // suspending subtree must not keep putting the reference back.
+    let readyCallbacks = 0;
+    mockComponentOnReady = (_el, cb) => {
+      readyCallbacks++;
+      cb();
+    };
+
+    const { hide, reveal } = renderWithBoundary(<IonModal />);
+    expect(readyCallbacks).toBe(1);
+
+    const modal = document.body.querySelector('ion-modal') as HTMLElement;
+
+    for (let cycle = 0; cycle < 2; cycle++) {
+      await hide();
+      // React hides portal children too, so this is the observable hide.
+      expect(modal.style.display).toBe('none');
+      await reveal();
+      expect(modal.style.display).toBe('');
+    }
+
+    expect(readyCallbacks).toBe(1);
+  });
+
+  it('leaves the cachedOriginalParent redirect to the reveal when the host is ready while hidden', async () => {
+    /**
+     * `componentOnReady` is async in the real builds, so it can resolve during
+     * the hidden window, where React has nulled the marker ref and there is no
+     * JSX parent to read. That callback has to bail without latching, or the
+     * reveal never gets to redirect.
+     */
+    let fireReady: (() => void) | null = null;
+    mockComponentOnReady = (_el, cb) => {
+      fireReady = cb;
+    };
+
+    const { container, hide, reveal } = renderWithBoundary(<IonModal />);
+    const modal = document.body.querySelector('ion-modal') as any;
+
+    await hide();
+
+    // The host comes online while the subtree is hidden.
+    act(() => {
+      fireReady?.();
+    });
+    expect(modal.cachedOriginalParent).toBeUndefined();
+
+    // The reveal registers again and gets the JSX parent this time.
+    mockComponentOnReady = defaultComponentOnReady;
+    await reveal();
+
+    expect(modal.cachedOriginalParent).toBe(container);
+  });
+
+  it('leaves a wrapper that is already a direct child in place', async () => {
+    const { hide } = renderWithBoundary(
+      <IonModal>
+        <span data-testid="modal-content">content</span>
+      </IonModal>
+    );
+
+    const modal = document.body.querySelector('ion-modal') as HTMLElement;
+
+    act(() => {
+      modal.dispatchEvent(new CustomEvent('willPresent'));
+    });
+
+    const wrapper = modal.querySelector('.ion-delegate-host') as HTMLElement;
+    // Core renders its own nodes after the wrapper, so re-appending a wrapper
+    // that is already in place would reorder it past them.
+    const coreNode = document.createElement('div');
+    modal.appendChild(coreNode);
+
+    await hide();
+
+    act(() => {
+      modal.dispatchEvent(new CustomEvent('didDismiss'));
+    });
+
+    expect(wrapper.nextElementSibling).toBe(coreNode);
+  });
+
+  it('releases the destroy watch on a reveal', async () => {
+    const { observersCreated, restore } = countMutationObservers();
+
+    try {
+      const { hide, reveal } = renderWithBoundary(<IonModal keepContentsMounted={true} />);
+
+      await hide();
+      await reveal();
+      // The reveal drained the last watch, so the shared observer was
+      // disconnected and the next hide has to build a new one. Without that
+      // release every cycle would add a watch that never leaves the set.
+      await hide();
+
+      expect(observersCreated()).toBe(2);
+
+      await reveal();
+    } finally {
+      restore();
+    }
+  });
+
+  it('leaves no destroy watch behind after a StrictMode mount/unmount cycle', async () => {
+    /**
+     * The discarded first mount's deferred teardown runs after the remount has
+     * already released its watch, and finds its marker still connected because
+     * StrictMode never removed the DOM. Without the mount-generation check it
+     * registers a watch nothing will ever release, holding the shared observer
+     * and the host open for the life of the page.
+     */
+    const { observersLive, restore } = countMutationObservers();
+
+    try {
+      render(
+        <React.StrictMode>
+          <IonModal />
+        </React.StrictMode>
+      );
+      await flushTeardown();
+
+      expect(observersLive()).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('cleans up when an ancestor of the marker is destroyed while hidden', async () => {
+    /**
+     * The destroy the watch exists for: React removes a node above the marker,
+     * not the marker itself, so an observer on the marker's own parent would
+     * never fire for it.
+     */
+    let removeAncestor!: () => void;
+    let suspend!: () => void;
+
+    /**
+     * The boundary sits inside the modal so only the popover is hidden and
+     * watched: an outer overlay hidden alongside it would share the observer
+     * and mask which node the registration was made against. The `<div>` is
+     * the intervening ancestor, and both pieces of state sit outside the
+     * boundary because React defers updates made inside a hidden subtree.
+     */
+    const App = () => {
+      const [isPresent, setIsPresent] = React.useState(true);
+      const [pending, setPending] = React.useState<Promise<void> | null>(null);
+      removeAncestor = () => setIsPresent(false);
+      suspend = () => setPending(new Promise<void>(() => undefined));
+
+      return (
+        <IonModal keepContentsMounted={true}>
+          {isPresent ? (
+            <div>
+              <React.Suspense fallback={<div>loading</div>}>
+                <IonPopover />
+                <Suspender pending={pending} />
+              </React.Suspense>
+            </div>
+          ) : null}
+        </IonModal>
+      );
+    };
+
+    render(<App />);
+
+    const popover = document.body.querySelector('ion-popover') as HTMLElement;
+    teleport(popover);
+
+    act(() => {
+      suspend();
+    });
+    await flushTeardown();
+    expect(popover.isConnected).toBe(true);
+
+    act(() => {
+      removeAncestor();
+    });
+    await flushTeardown();
+
+    expect(popover.isConnected).toBe(false);
+  });
+
+  it('leaves a host moved elsewhere during the hidden window where it is', async () => {
+    /**
+     * The reveal only undoes the move `componentWillUnmount` made. A host that
+     * something else moved while hidden is no longer in `portalTarget`, so
+     * putting it back at the pre-hide position would be wrong.
+     */
+    const { hide, reveal } = renderWithBoundary(<IonModal />);
+
+    const modal = document.body.querySelector('ion-modal') as HTMLElement;
+
+    act(() => {
+      modal.dispatchEvent(new CustomEvent('willPresent'));
+    });
+    teleport(modal);
+
+    await hide();
+
+    const elsewhere = document.createElement('div');
+    document.body.appendChild(elsewhere);
+    elsewhere.appendChild(modal);
+
+    await reveal();
+
+    expect(modal.parentElement).toBe(elsewhere);
+  });
+
+  it('shares one destroy observer across overlays hidden together', async () => {
+    /**
+     * Every hidden overlay asks the same question of the same tree, so they
+     * share one observer rather than each taking a `document`-wide `subtree`
+     * one. At most one construction here: none if a prior watch already built
+     * it, two if the sharing regresses to per-instance.
+     */
+    const { observersCreated, restore } = countMutationObservers();
+
+    try {
+      const { hide, unmount } = renderWithBoundary(
+        <IonModal keepContentsMounted={true}>
+          <IonPopover id="first" />
+          <IonPopover id="second" />
+        </IonModal>
+      );
+
+      const first = document.querySelector('#first') as HTMLElement;
+      const second = document.querySelector('#second') as HTMLElement;
+      teleport(first);
+      teleport(second);
+
+      await hide();
+      expect(first.isConnected).toBe(true);
+      expect(second.isConnected).toBe(true);
+      expect(observersCreated()).toBeLessThanOrEqual(1);
+
+      unmount();
+      await flushTeardown();
+
+      expect(first.isConnected).toBe(false);
+      expect(second.isConnected).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it('does not orphan a relocated nested overlay across a StrictMode mount/unmount cycle', async () => {
+    /**
+     * A relocated nested host has to survive the StrictMode dev cycle with
+     * exactly one copy of itself left in the DOM, the same one-copy guarantee
+     * the portaled StrictMode test asserts.
+     */
+    // Relocate from a layout effect: `mockComponentOnReady` never fires for a
+    // nested overlay, so the host would never leave its `<template>`.
+    const Teleporter = () => {
+      React.useLayoutEffect(() => {
+        teleport(document.querySelector('ion-popover') as HTMLElement);
+      }, []);
+      return null;
+    };
+
+    render(
+      <React.StrictMode>
+        <IonModal keepContentsMounted={true}>
+          <IonPopover id="nested-popover" keepContentsMounted={true}>
+            <Teleporter />
+          </IonPopover>
+        </IonModal>
+      </React.StrictMode>
+    );
+    await flushTeardown();
+
+    const popovers = document.querySelectorAll('ion-popover');
+    expect(popovers).toHaveLength(1);
+    expect(popovers[0].isConnected).toBe(true);
+    // The survivor is the relocated one, not a host left behind in its template.
+    expect(popovers[0].parentElement?.id).toBe('teleport-destination');
   });
 });

--- a/packages/react/src/components/__tests__/createInlineOverlayComponent.spec.tsx
+++ b/packages/react/src/components/__tests__/createInlineOverlayComponent.spec.tsx
@@ -40,17 +40,14 @@ const teleport = (el: HTMLElement) => {
   dest.appendChild(el);
 };
 
-/**
- * The unmount teardown is deferred by a microtask so it can check whether
- * React removed the DOM or only hid it. Let that microtask run.
- */
+// The unmount teardown is deferred a microtask so it can check whether React
+// removed the DOM or only hid it. Let that microtask run.
 const flushTeardown = () => act(async () => {});
 
 /**
- * Track `MutationObserver` use. `jest.spyOn` cannot wrap a class constructor
+ * Tracks `MutationObserver` use. `jest.spyOn` cannot wrap a class constructor
  * (its mock is called without `new`), so swap in a subclass. `observersLive`
- * counts observing-minus-disconnected, which is what a missing `disconnect`
- * shows up in; `observersCreated` cannot see that.
+ * counts observing-minus-disconnected, where a missing `disconnect` shows up.
  */
 const countMutationObservers = () => {
   const Original = global.MutationObserver;
@@ -91,10 +88,9 @@ const countMutationObservers = () => {
 };
 
 /**
- * A component that suspends while it holds a pending promise. Rendering it
- * inside a Suspense boundary hides that boundary's content: React runs
- * `componentWillUnmount` on everything in it without unmounting, and brings
- * the same instances back with `componentDidMount` on the reveal.
+ * Suspends while it holds a pending promise. Inside a Suspense boundary that
+ * hides the boundary's content: React runs `componentWillUnmount` on everything
+ * in it without unmounting, then remounts the same instances on the reveal.
  */
 const Suspender = ({ pending }: { pending: Promise<void> | null }) => {
   if (pending) {
@@ -104,12 +100,13 @@ const Suspender = ({ pending }: { pending: Promise<void> | null }) => {
 };
 
 /**
- * Render `children` in a Suspense boundary next to a sibling that suspends on
- * demand. `hide()` is the reported trigger: the overlay renders fine, another
- * child of the boundary does not, and React hides the whole boundary. Each
- * `hide()` takes a fresh promise so a test can drive more than one cycle.
+ * Renders `children` in a Suspense boundary next to a sibling that suspends on
+ * demand, which is the reported trigger: the overlay renders fine, another
+ * child does not, and React hides the whole boundary. Each `hide()` takes a
+ * fresh promise so a test can drive more than one cycle. `container` places
+ * the React root elsewhere, which the shadow-root case needs.
  */
-const renderWithBoundary = (children: React.ReactNode) => {
+const renderWithBoundary = (children: React.ReactNode, container?: HTMLElement) => {
   let setPending!: (pending: Promise<void> | null) => void;
   let resolvePending: (() => void) | null = null;
 
@@ -125,7 +122,7 @@ const renderWithBoundary = (children: React.ReactNode) => {
     );
   };
 
-  const result = render(<Boundary />);
+  const result = render(<Boundary />, container ? { container } : undefined);
 
   return {
     ...result,
@@ -160,12 +157,9 @@ afterEach(async () => {
 
 describe('createInlineOverlayComponent: cachedOriginalParent', () => {
   it('redirects cachedOriginalParent for a portaled overlay but not a nested one', () => {
-    /**
-     * Core walks up from `cachedOriginalParent` to find the enclosing
-     * `.ion-page`. A portaled host is cached against the portal container, so
-     * it has to be pointed back at its JSX position. A nested host already
-     * renders at that position, so the wrapper must leave it alone.
-     */
+    // Core walks up from `cachedOriginalParent` to find the `.ion-page`. A
+    // portaled host is cached against the portal container, so it has to be
+    // pointed back at its JSX position. A nested host is already there.
     const { container } = render(
       <IonModal keepContentsMounted={true}>
         <IonPopover />
@@ -294,8 +288,8 @@ describe('createInlineOverlayComponent: unmount cleanup', () => {
 // Fixes https://github.com/ionic-team/ionic-framework/issues/31389
 describe('createInlineOverlayComponent: hidden subtree', () => {
   it('leaves a relocated nested overlay alone while a Suspense boundary hides it', async () => {
-    // A hide must leave the host exactly where it is: React did not remove it,
-    // so React will not put it back on the reveal.
+    // A hide must leave the host where it is, since React did not remove it
+    // and will not put it back on the reveal.
     const { hide, reveal } = renderWithBoundary(
       <IonModal keepContentsMounted={true}>
         <IonPopover />
@@ -311,8 +305,6 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
 
     await hide();
 
-    // The host is untouched while hidden: same node, same position, still
-    // connected, so nothing has to be restored on the reveal.
     expect(popover.isConnected).toBe(true);
     expect(popover.parentElement).toBe(teleportDestination);
 
@@ -323,7 +315,7 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
   });
 
   it('keeps a hidden overlay wired up to the app for the rest of that open', async () => {
-    // `present()` was in flight when the hide landed and core finishes it
+    // Core had `present()` in flight when the hide landed and finishes it
     // regardless, so the app's handlers still have to fire while hidden.
     const onDidPresent = jest.fn();
     const onDidDismiss = jest.fn();
@@ -338,7 +330,7 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
 
     const popover = document.body.querySelector('ion-popover') as HTMLElement;
 
-    // `present()` has started, so the wrapper counts the overlay as open.
+    // Presenting has started, so the wrapper counts the overlay as open.
     act(() => {
       popover.dispatchEvent(new CustomEvent('willPresent'));
     });
@@ -346,8 +338,7 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
 
     await hide();
 
-    // Core finishes presenting, then the overlay is dismissed, both while the
-    // subtree is still hidden.
+    // Both of these land while the subtree is still hidden.
     act(() => {
       popover.dispatchEvent(new CustomEvent('ionPopoverDidPresent'));
       popover.dispatchEvent(new CustomEvent('didDismiss'));
@@ -359,8 +350,7 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
     await reveal();
 
     // The dismiss also has to close the wrapper. React nulls the refs for the
-    // whole hidden window, so a close that only runs when they are present
-    // would leave the contents mounted against a dismissed overlay.
+    // hidden window, so a close gated on them would leave the contents mounted.
     expect(document.querySelector('[data-testid="popover-content"]')).toBeNull();
   });
 
@@ -392,11 +382,10 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
 
   it('puts a relocated portaled host back where it was after a hide', async () => {
     /**
-     * A portaled host that user code moved out of `portalTarget` has to go
-     * back into it synchronously, before a hide can be told from a destroy,
-     * or React's portal removal would not find it. That move is wrong for a
-     * hide, so the reveal has to undo it, back to the exact position: the real
-     * destination is ion-app, which holds other overlays whose order matters.
+     * A host moved out of `portalTarget` has to go back synchronously, before a
+     * hide can be told from a destroy, or React's portal removal misses it. The
+     * reveal undoes that to the exact position, since the real destination is
+     * `ion-app` and the overlays in it have an order.
      */
     const { hide, reveal } = renderWithBoundary(<IonModal />);
 
@@ -420,8 +409,6 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
   });
 
   it('presents and dismisses a nested overlay after the reveal', async () => {
-    // The other tests only assert the node survived; this one drives a full
-    // open and close after the reveal.
     const onWillPresent = jest.fn();
     const onDidPresent = jest.fn();
     const onDidDismiss = jest.fn();
@@ -460,19 +447,13 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
   });
 
   it('survives a hide of a nested overlay whose own contents suspended while presenting', async () => {
-    /**
-     * The reported flow. Core emits `ionMount` from the middle of `present()`,
-     * which is what first mounts the overlay's children, so a suspension in
-     * those children always lands while `present()` is in flight and the host
-     * has just been teleported out of its `<template>`.
-     */
+    // Core emits `ionMount` from the middle of `present()`, which is what
+    // first mounts the children, so a suspension in them always lands while
+    // `present()` is in flight and the host is already teleported.
     const onDidPresent = jest.fn();
 
-    /**
-     * The latch has to sit outside React here. This suspender is the component
-     * that throws, so React discards its state and re-renders it from scratch
-     * on the retry, unlike the sibling `<Suspender pending>` above.
-     */
+    // The latch sits outside React: this suspender is the component that
+    // throws, so React discards its state and re-renders it on the retry.
     let contentsReady = false;
     let resolveContents!: () => void;
     const contents = new Promise<void>((resolve) => {
@@ -502,7 +483,7 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
     teleport(popover);
     const teleportDestination = popover.parentElement;
 
-    // `present()`: the host is already teleported when `ionMount` mounts the
+    // On `present()` the host is already teleported when `ionMount` mounts the
     // contents, and the contents suspend as they render.
     await act(async () => {
       popover.dispatchEvent(new CustomEvent('ionMount'));
@@ -518,7 +499,7 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
     expect(popover.isConnected).toBe(true);
     expect(popover.parentElement).toBe(teleportDestination);
 
-    // `present()` runs to completion against a host that never moved.
+    // Presenting runs to completion against a host that never moved.
     act(() => {
       popover.dispatchEvent(new CustomEvent('ionPopoverDidPresent'));
     });
@@ -527,11 +508,8 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
   });
 
   it('removes a relocated nested overlay destroyed while it was hidden', async () => {
-    /**
-     * React does not call `componentWillUnmount` a second time when it
-     * destroys a subtree it had already hidden, so the overlay still has to
-     * be cleaned up when it is destroyed straight out of the hidden state.
-     */
+    // React skips the second `componentWillUnmount` when it destroys an
+    // already-hidden subtree, so cleanup still has to happen.
     const { hide, unmount } = renderWithBoundary(
       <IonModal keepContentsMounted={true}>
         <IonPopover />
@@ -552,11 +530,9 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
   });
 
   it('detaches an open portaled overlay destroyed while it was hidden', async () => {
-    /**
-     * React's portal removal takes the host, but the listeners and the props
-     * synced onto it are the wrapper's to detach, and the destroy arrives
-     * with no second `componentWillUnmount` to do it in.
-     */
+    // React's portal removal takes the host, but the listeners and props
+    // synced onto it are the wrapper's to detach, with no second
+    // `componentWillUnmount` to do it in.
     const onDidDismiss = jest.fn();
 
     const { hide, unmount } = renderWithBoundary(<IonModal onDidDismiss={onDidDismiss} />);
@@ -579,13 +555,43 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
     expect(onDidDismiss).not.toHaveBeenCalled();
   });
 
+  it('detaches an open overlay when the shadow host holding the React root is destroyed', async () => {
+    // With a React root inside a shadow root, removing the shadow host
+    // disconnects the marker without mutating anything inside it, so a watch
+    // scoped to that root alone never fires.
+    const onDidDismiss = jest.fn();
+
+    const shadowHost = document.createElement('div');
+    document.body.appendChild(shadowHost);
+    const container = document.createElement('div');
+    shadowHost.attachShadow({ mode: 'open' }).appendChild(container);
+
+    const { hide } = renderWithBoundary(<IonModal onDidDismiss={onDidDismiss} />, container);
+
+    // The host portals to `document.body`, so only the marker is in the shadow root.
+    const modal = document.body.querySelector('ion-modal') as HTMLElement;
+
+    act(() => {
+      modal.dispatchEvent(new CustomEvent('willPresent'));
+    });
+
+    await hide();
+
+    // A raw DOM removal, so React runs nothing and the watch is the only
+    // mechanism left to notice the destroy.
+    shadowHost.remove();
+    await flushTeardown();
+
+    act(() => {
+      modal.dispatchEvent(new CustomEvent('didDismiss'));
+    });
+
+    expect(onDidDismiss).not.toHaveBeenCalled();
+  });
+
   it('detaches an overlay that only started presenting after the hide', async () => {
-    /**
-     * The overlay can open while hidden, since core keeps running. Deciding at
-     * hide time whether a destroy will have anything to detach reads an
-     * `isOpen` that is still false, and then the destroy has no second
-     * `componentWillUnmount` to detach in.
-     */
+    // The overlay can open while hidden, since core keeps running. Deciding at
+    // hide time what a destroy has to detach reads an `isOpen` still false.
     const onDidDismiss = jest.fn();
 
     const { hide, unmount } = renderWithBoundary(<IonModal onDidDismiss={onDidDismiss} />);
@@ -594,7 +600,7 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
 
     await hide();
 
-    // `present()` starts while the subtree is still hidden.
+    // Presenting starts while the subtree is still hidden.
     await act(async () => {
       modal.dispatchEvent(new CustomEvent('willPresent'));
     });
@@ -611,11 +617,10 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
 
   it('moves the wrapper back under the host when a dismiss lands while hidden', async () => {
     /**
-     * The wrapper has to be a direct child of the host before flipping
-     * `isOpen` makes React remove it, and Stencil's scoped-slot relocation can
-     * nest it deeper. React nulls the refs for the whole hidden window, so a
-     * dismiss that lands there has to recover the nodes some other way or the
-     * removal throws and takes the tree down with it.
+     * The wrapper has to be a direct child of the host before flipping `isOpen`
+     * makes React remove it, and a scoped overlay's slot relocation can nest it
+     * deeper. React nulls the refs for the hidden window, so a dismiss landing
+     * there has to recover the nodes or the removal throws.
      */
     const { hide, reveal } = renderWithBoundary(
       <IonModal>
@@ -680,12 +685,9 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
   });
 
   it('leaves the cachedOriginalParent redirect to the reveal when the host is ready while hidden', async () => {
-    /**
-     * `componentOnReady` is async in the real builds, so it can resolve during
-     * the hidden window, where React has nulled the marker ref and there is no
-     * JSX parent to read. That callback has to bail without latching, or the
-     * reveal never gets to redirect.
-     */
+    // The real builds resolve `componentOnReady` asynchronously, so it can land
+    // in the hidden window with the marker ref nulled and no JSX parent to
+    // read. It has to bail without latching, or the reveal cannot redirect.
     let fireReady: (() => void) | null = null;
     mockComponentOnReady = (_el, cb) => {
       fireReady = cb;
@@ -745,9 +747,8 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
 
       await hide();
       await reveal();
-      // The reveal drained the last watch, so the shared observer was
-      // disconnected and the next hide has to build a new one. Without that
-      // release every cycle would add a watch that never leaves the set.
+      // The reveal drained the last watch, so the next hide builds a new
+      // observer. Without that release every cycle would add a watch.
       await hide();
 
       expect(observersCreated()).toBe(2);
@@ -760,11 +761,10 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
 
   it('leaves no destroy watch behind after a StrictMode mount/unmount cycle', async () => {
     /**
-     * The discarded first mount's deferred teardown runs after the remount has
-     * already released its watch, and finds its marker still connected because
-     * StrictMode never removed the DOM. Without the mount-generation check it
-     * registers a watch nothing will ever release, holding the shared observer
-     * and the host open for the life of the page.
+     * The discarded first mount's deferred teardown runs after the remount
+     * released its watch, and finds its marker connected because StrictMode
+     * never removed the DOM. Without the generation check it registers a watch
+     * nothing releases, holding the observer and host for the life of the page.
      */
     const { observersLive, restore } = countMutationObservers();
 
@@ -783,20 +783,17 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
   });
 
   it('cleans up when an ancestor of the marker is destroyed while hidden', async () => {
-    /**
-     * The destroy the watch exists for: React removes a node above the marker,
-     * not the marker itself, so an observer on the marker's own parent would
-     * never fire for it.
-     */
+    // React removes a node above the marker, so an observer on the marker's
+    // own parent would never fire.
     let removeAncestor!: () => void;
     let suspend!: () => void;
 
     /**
      * The boundary sits inside the modal so only the popover is hidden and
-     * watched: an outer overlay hidden alongside it would share the observer
-     * and mask which node the registration was made against. The `<div>` is
-     * the intervening ancestor, and both pieces of state sit outside the
-     * boundary because React defers updates made inside a hidden subtree.
+     * watched, since an outer overlay hidden alongside it would share the
+     * observer and mask which node was registered. The `<div>` is the
+     * intervening ancestor, and the state sits outside the boundary because
+     * React defers updates made inside a hidden subtree.
      */
     const App = () => {
       const [isPresent, setIsPresent] = React.useState(true);
@@ -838,11 +835,9 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
   });
 
   it('leaves a host moved elsewhere during the hidden window where it is', async () => {
-    /**
-     * The reveal only undoes the move `componentWillUnmount` made. A host that
-     * something else moved while hidden is no longer in `portalTarget`, so
-     * putting it back at the pre-hide position would be wrong.
-     */
+    // The reveal only undoes the move `componentWillUnmount` made. A host that
+    // something else moved is no longer in `portalTarget`, so the pre-hide
+    // position is wrong.
     const { hide, reveal } = renderWithBoundary(<IonModal />);
 
     const modal = document.body.querySelector('ion-modal') as HTMLElement;
@@ -864,12 +859,9 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
   });
 
   it('shares one destroy observer across overlays hidden together', async () => {
-    /**
-     * Every hidden overlay asks the same question of the same tree, so they
-     * share one observer rather than each taking a `document`-wide `subtree`
-     * one. At most one construction here: none if a prior watch already built
-     * it, two if the sharing regresses to per-instance.
-     */
+    // Hidden overlays share one observer rather than each taking a
+    // `document`-wide one. At most one construction here: none if a prior
+    // watch built it, two if the sharing regresses to per-instance.
     const { observersCreated, restore } = countMutationObservers();
 
     try {
@@ -901,11 +893,8 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
   });
 
   it('does not orphan a relocated nested overlay across a StrictMode mount/unmount cycle', async () => {
-    /**
-     * A relocated nested host has to survive the StrictMode dev cycle with
-     * exactly one copy of itself left in the DOM, the same one-copy guarantee
-     * the portaled StrictMode test asserts.
-     */
+    // A relocated nested host has to survive the StrictMode cycle with exactly
+    // one copy left in the DOM, same as the portaled StrictMode test.
     // Relocate from a layout effect: `mockComponentOnReady` never fires for a
     // nested overlay, so the host would never leave its `<template>`.
     const Teleporter = () => {
@@ -929,7 +918,6 @@ describe('createInlineOverlayComponent: hidden subtree', () => {
     const popovers = document.querySelectorAll('ion-popover');
     expect(popovers).toHaveLength(1);
     expect(popovers[0].isConnected).toBe(true);
-    // The survivor is the relocated one, not a host left behind in its template.
     expect(popovers[0].parentElement?.id).toBe('teleport-destination');
   });
 });

--- a/packages/react/src/components/createInlineOverlayComponent.tsx
+++ b/packages/react/src/components/createInlineOverlayComponent.tsx
@@ -32,10 +32,12 @@ type DestroyWatch = { marker: HTMLElement; onDestroy: () => void };
 
 /**
  * React skips `componentWillUnmount` when it destroys a subtree it had already
- * hidden, so a hidden overlay watches its own marker leave the document. Every
- * watcher asks the same question of the same tree, so they share one observer:
- * a `document`-wide `subtree` observer per overlay is the change-detection cost
- * core avoids where it can (see modal's `initParentRemovalObserver`).
+ * hidden, so a hidden overlay watches its own marker leave the document. One
+ * observer serves every watcher, since each one allocates its own records for
+ * a whole root.
+ *
+ * This all assumes React hides with `display: none` rather than detaching, so
+ * the marker survives a hide. True today, but an implementation detail.
  */
 const destroyWatches = new Set<DestroyWatch>();
 let destroyObserver: MutationObserver | undefined;
@@ -48,7 +50,6 @@ const stopDestroyObserverIfIdle = () => {
 };
 
 const watchForDestroy = (marker: HTMLElement, onDestroy: () => void): DestroyWatch | undefined => {
-  // Mirrors core's guard for environments with a DOM but no MutationObserver.
   if (typeof MutationObserver === 'undefined') {
     return undefined;
   }
@@ -56,24 +57,36 @@ const watchForDestroy = (marker: HTMLElement, onDestroy: () => void): DestroyWat
   destroyWatches.add(watch);
   if (destroyObserver === undefined) {
     destroyObserver = new MutationObserver(() => {
-      for (const candidate of Array.from(destroyWatches)) {
-        if (candidate.marker.isConnected) {
-          continue;
+      try {
+        for (const candidate of Array.from(destroyWatches)) {
+          if (candidate.marker.isConnected) {
+            continue;
+          }
+          destroyWatches.delete(candidate);
+          // `detachProps` assigns arbitrary props onto a custom element, so a
+          // throwing setter would otherwise strand every remaining overlay.
+          try {
+            candidate.onDestroy();
+          } catch (error) {
+            console.error(error);
+          }
         }
-        destroyWatches.delete(candidate);
-        candidate.onDestroy();
+      } finally {
+        stopDestroyObserverIfIdle();
       }
-      stopDestroyObserverIfIdle();
     });
   }
   /**
-   * The node React removes is usually the marker's own parent, and a
-   * `childList` observer never fires for its own removal, so this watches from
-   * the marker's root down rather than from its parent. The root rather than
-   * `document.body` so a React root mounted outside the body, or inside a
-   * shadow root, is still covered.
+   * React usually removes the marker's own parent, and a `childList` observer
+   * never fires for its own removal, so watch from the root down. Removing a
+   * shadow host disconnects the marker without mutating anything inside its
+   * root, so walk up the host chain too.
    */
-  destroyObserver.observe(marker.getRootNode(), { childList: true, subtree: true });
+  for (let root: Node | null = marker.getRootNode(); root !== null; ) {
+    destroyObserver.observe(root, { childList: true, subtree: true });
+    const { host } = root as ShadowRoot;
+    root = host === undefined ? null : host.getRootNode();
+  }
   return watch;
 };
 
@@ -116,23 +129,14 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
     // Bumped on every mount, so a deferred teardown can tell it was revealed.
     private mountCount = 0;
     private hiddenDestroyWatch?: DestroyWatch;
-    /**
-     * Where a relocated portaled host sat before `componentWillUnmount` moved
-     * it back into `portalTarget`, so a reveal can put it back.
-     */
+    // Where a relocated portaled host sat before `componentWillUnmount` moved
+    // it back into `portalTarget`, so a reveal can put it back.
     private relocatedPortalHost?: { node: HTMLElement; parent: Node; nextSibling: Node | null };
-    /**
-     * The host and wrapper as of the last `componentWillUnmount`. React nulls
-     * the refs for as long as it keeps this subtree hidden, and a dismiss can
-     * land in that window, so `handleDidDismiss` falls back to these.
-     */
+    // React nulls the refs for as long as it keeps this subtree hidden, and a
+    // dismiss can land in that window, so `handleDidDismiss` falls back to these.
     private nodesAtUnmount: { host: HTMLElement; wrapper: HTMLElement | null } | null = null;
-    /**
-     * `componentDidMount` runs again on every reveal, but the redirect must
-     * not: core clears `cachedOriginalParent` when the parent is removed, and
-     * re-running would put the reference back. The JSX parent never changes,
-     * so once is enough.
-     */
+    // Core clears `cachedOriginalParent` when the parent is removed, so the
+    // redirect must not re-run on a reveal and put the reference back.
     private hasRedirectedOriginalParent = false;
 
     constructor(props: InternalProps) {
@@ -145,8 +149,6 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
       this.state = { isOpen: false };
       // Create a local ref to the inner child element.
       this.wrapperRef = React.createRef();
-      // Marker stays at the JSX location: portaled overlays recover their JSX
-      // parent from it, and it leaves the document only on a real unmount.
       this.markerRef = React.createRef();
       /**
        * Resolve the portal target to the same container CoreDelegate
@@ -161,8 +163,7 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
     componentDidMount() {
       this.mountCount++;
       this.nodesAtUnmount = null;
-      // React is showing this subtree again, so the pending teardown from the
-      // hide is off.
+      // React is showing this subtree again, so cancel the hide's teardown.
       this.stopWatchingForDestroy();
       this.restoreRelocatedPortalHost();
 
@@ -179,25 +180,20 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
        * from `cachedOriginalParent` to find the enclosing `.ion-page`,
        * so we redirect it at the marker's JSX parent.
        *
-       * Nested overlays are excluded: they never portal, so a nested modal
-       * already cached its `<template>`, which sits at the JSX position and
-       * resolves the right `.ion-page`.
+       * Nested overlays never portal, so they already cached their
+       * `<template>` at the JSX position and resolve the right `.ion-page`.
        */
       const overlay = this.ref.current;
       const generation = this.mountCount;
       if (overlay && !this.props.isNested && !this.hasRedirectedOriginalParent) {
         componentOnReady(overlay as HTMLElement, () => {
-          /**
-           * A newer mount owns this now, or React nulled the marker ref
-           * because it unmounted or hid the subtree. Either way the callback
-           * is stale, and leaving the latch open lets the reveal retry.
-           */
+          // Stale: a newer mount owns this, or React nulled the marker ref.
+          // Leave the latch open so the reveal can try again.
           const markerParent = this.markerRef.current?.parentElement ?? null;
           if (this.mountCount !== generation || markerParent === null) {
             return;
           }
-          // Latch on completion, not on success: either way this instance is
-          // done, so a later reveal must not redirect again.
+          // Reached the JSX parent, so close the latch against later reveals.
           this.hasRedirectedOriginalParent = true;
           if (markerParent !== this.portalTarget) {
             (overlay as any).cachedOriginalParent = markerParent;
@@ -227,20 +223,18 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
       /**
        * CoreDelegate (or user code in onWillPresent) can move a portaled
        * overlay out of `portalTarget`. React's portal `removeChild` runs as
-       * soon as this returns and needs the host where it left it, so this one
-       * has to stay synchronous, before we know whether this is a hide or a
-       * destroy. Record where it came from so a reveal can undo the move.
+       * soon as this returns and needs the host where it left it, so this has
+       * to stay synchronous, before we know a hide from a destroy.
        */
       if (node.isConnected && !this.props.isNested && this.portalTarget && node.parentNode !== this.portalTarget) {
         this.relocatedPortalHost = { node, parent: node.parentNode!, nextSibling: node.nextSibling };
         this.portalTarget.appendChild(node);
       }
       /**
-       * React also calls `componentWillUnmount` when it only *hides* a
-       * subtree - a Suspense boundary falling back, an Offscreen tree, the
-       * StrictMode dev cycle - and then mounts the same instance again on the
-       * reveal. Nothing here tells the two apart, so the teardown waits a
-       * microtask and runs only if the marker really left the document.
+       * React also calls this when it only *hides* a subtree - a Suspense
+       * fallback, an Offscreen tree, the StrictMode cycle - and remounts the
+       * same instance on the reveal. Nothing here tells the two apart, so the
+       * teardown waits a microtask and runs only if the marker really left.
        */
       const marker = this.markerRef.current;
       const mountCount = this.mountCount;
@@ -257,11 +251,8 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
       });
     }
 
-    /**
-     * `componentWillUnmount` has to move a relocated portaled host back into
-     * `portalTarget` before it knows a hide from a destroy. On a reveal there
-     * was no removal to prepare for, so put the host back where it was.
-     */
+    // Undoes the move `componentWillUnmount` made. Skipped if something else
+    // moved the host while hidden, since the pre-hide position is then wrong.
     private restoreRelocatedPortalHost() {
       const relocated = this.relocatedPortalHost;
       this.relocatedPortalHost = undefined;
@@ -274,15 +265,12 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
       parent.insertBefore(node, nextSibling?.parentNode === parent ? nextSibling : null);
     }
 
-    /**
-     * `cleanupAfterUnmount` decides what a destroy actually has to undo:
-     * gating here on the state at hide time would miss an overlay that only
-     * starts presenting afterwards.
-     */
+    // `cleanupAfterUnmount` decides what to undo. Gating on the state at hide
+    // time would miss an overlay that only starts presenting afterwards.
     private watchForDestroyWhileHidden(marker: HTMLElement, node: HTMLElement, mountCount: number) {
       this.hiddenDestroyWatch = watchForDestroy(marker, () => {
         this.hiddenDestroyWatch = undefined;
-        // A reveal already happened, so componentDidMount owns the teardown.
+        // A reveal already happened, so `componentDidMount` owns the teardown.
         if (this.mountCount !== mountCount) {
           return;
         }
@@ -296,14 +284,12 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
     }
 
     private cleanupAfterUnmount(node: HTMLElement) {
-      // The component is really gone, so nothing is waiting to be put back.
       this.nodesAtUnmount = null;
       this.relocatedPortalHost = undefined;
       /**
-       * Nested overlays render inline inside a `<template>`. If the host has
-       * been moved out of that template, React's unmount won't reach it, so
-       * remove it directly. A host still in its template is left for React to
-       * remove.
+       * Nested overlays render inline inside a `<template>`. React's unmount
+       * won't reach a host that has been moved out of one, so remove it here.
+       * A host still in its template is left for React.
        */
       if (this.props.isNested && node.isConnected && !(node.parentElement instanceof HTMLTemplateElement)) {
         node.remove();
@@ -390,10 +376,10 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
         )
       );
 
-      // Top-level overlays portal into `portalTarget` with a marker
-      // `<template>` at the JSX location to recover the immediate JSX
-      // parent after CoreDelegate teleports. Nested overlays and SSR
-      // fall back to a `<template>` wrapper.
+      // The marker sits at the JSX location on both branches and leaves the
+      // document only on a real unmount, which is how `componentWillUnmount`
+      // tells a hide from a destroy. Portaled overlays also recover their
+      // JSX parent from it.
       if (!isNested && this.portalTarget) {
         return createElement(
           React.Fragment,
@@ -433,27 +419,20 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
     };
 
     private handleDidDismiss = (evt: any) => {
-      // The refs are null for as long as React keeps this subtree hidden, so a
-      // dismiss that lands there falls back to the nodes recorded at hide time.
       const wrapper = this.wrapperRef.current ?? this.nodesAtUnmount?.wrapper ?? null;
       const el = this.ref.current ?? this.nodesAtUnmount?.host ?? null;
 
       /**
        * React's `removeChild` needs the wrapper as a direct child of the host,
-       * and Stencil's scoped-slot relocation (ion-alert, ion-action-sheet,
-       * ion-loading) can nest it deeper. So this has to run before the flip
-       * below, which is what triggers that removal. Already a direct child
-       * means leaving it alone: appending would only reorder it against core's
-       * own nodes.
+       * and a scoped overlay's slot relocation can nest it deeper. So this runs
+       * before the flip below, which triggers that removal. Appending one that
+       * is already a direct child would reorder it against core's own nodes.
        */
       if (wrapper && el && wrapper.parentElement !== el) {
         el.append(wrapper);
       }
-      /**
-       * Flip either way: a dismiss that lands while hidden would otherwise
-       * leave the contents mounted against a closed overlay on reveal. After a
-       * real unmount this is a no-op.
-       */
+      // Flip either way, or a dismiss landing while hidden leaves the contents
+      // mounted against a closed overlay on reveal. A no-op after a real unmount.
       this.setState({ isOpen: false });
 
       this.props.onDidDismiss && this.props.onDidDismiss(evt);

--- a/packages/react/src/components/createInlineOverlayComponent.tsx
+++ b/packages/react/src/components/createInlineOverlayComponent.tsx
@@ -28,6 +28,63 @@ type InlineOverlayState = {
  */
 const NestedOverlayContext = React.createContext(false);
 
+type DestroyWatch = { marker: HTMLElement; onDestroy: () => void };
+
+/**
+ * React skips `componentWillUnmount` when it destroys a subtree it had already
+ * hidden, so a hidden overlay watches its own marker leave the document. Every
+ * watcher asks the same question of the same tree, so they share one observer:
+ * a `document`-wide `subtree` observer per overlay is the change-detection cost
+ * core avoids where it can (see modal's `initParentRemovalObserver`).
+ */
+const destroyWatches = new Set<DestroyWatch>();
+let destroyObserver: MutationObserver | undefined;
+
+const stopDestroyObserverIfIdle = () => {
+  if (destroyWatches.size === 0) {
+    destroyObserver?.disconnect();
+    destroyObserver = undefined;
+  }
+};
+
+const watchForDestroy = (marker: HTMLElement, onDestroy: () => void): DestroyWatch | undefined => {
+  // Mirrors core's guard for environments with a DOM but no MutationObserver.
+  if (typeof MutationObserver === 'undefined') {
+    return undefined;
+  }
+  const watch: DestroyWatch = { marker, onDestroy };
+  destroyWatches.add(watch);
+  if (destroyObserver === undefined) {
+    destroyObserver = new MutationObserver(() => {
+      for (const candidate of Array.from(destroyWatches)) {
+        if (candidate.marker.isConnected) {
+          continue;
+        }
+        destroyWatches.delete(candidate);
+        candidate.onDestroy();
+      }
+      stopDestroyObserverIfIdle();
+    });
+  }
+  /**
+   * The node React removes is usually the marker's own parent, and a
+   * `childList` observer never fires for its own removal, so this watches from
+   * the marker's root down rather than from its parent. The root rather than
+   * `document.body` so a React root mounted outside the body, or inside a
+   * shadow root, is still covered.
+   */
+  destroyObserver.observe(marker.getRootNode(), { childList: true, subtree: true });
+  return watch;
+};
+
+const unwatchForDestroy = (watch: DestroyWatch | undefined) => {
+  if (watch === undefined) {
+    return;
+  }
+  destroyWatches.delete(watch);
+  stopDestroyObserverIfIdle();
+};
+
 interface IonicReactInternalProps<ElementType> extends React.HTMLAttributes<ElementType> {
   forwardedRef?: React.ForwardedRef<ElementType>;
   ref?: React.Ref<any>;
@@ -56,7 +113,27 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
     markerRef: React.RefObject<HTMLTemplateElement>;
     stableMergedRefs: React.RefCallback<HTMLElement>;
     portalTarget: HTMLElement | null;
-    isUnmounted = false;
+    // Bumped on every mount, so a deferred teardown can tell it was revealed.
+    private mountCount = 0;
+    private hiddenDestroyWatch?: DestroyWatch;
+    /**
+     * Where a relocated portaled host sat before `componentWillUnmount` moved
+     * it back into `portalTarget`, so a reveal can put it back.
+     */
+    private relocatedPortalHost?: { node: HTMLElement; parent: Node; nextSibling: Node | null };
+    /**
+     * The host and wrapper as of the last `componentWillUnmount`. React nulls
+     * the refs for as long as it keeps this subtree hidden, and a dismiss can
+     * land in that window, so `handleDidDismiss` falls back to these.
+     */
+    private nodesAtUnmount: { host: HTMLElement; wrapper: HTMLElement | null } | null = null;
+    /**
+     * `componentDidMount` runs again on every reveal, but the redirect must
+     * not: core clears `cachedOriginalParent` when the parent is removed, and
+     * re-running would put the reference back. The JSX parent never changes,
+     * so once is enough.
+     */
+    private hasRedirectedOriginalParent = false;
 
     constructor(props: InternalProps) {
       super(props);
@@ -68,8 +145,8 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
       this.state = { isOpen: false };
       // Create a local ref to the inner child element.
       this.wrapperRef = React.createRef();
-      // Marker stays at the JSX location so we can recover the immediate
-      // JSX parent after the overlay has been portaled to ion-app.
+      // Marker stays at the JSX location: portaled overlays recover their JSX
+      // parent from it, and it leaves the document only on a real unmount.
       this.markerRef = React.createRef();
       /**
        * Resolve the portal target to the same container CoreDelegate
@@ -82,10 +159,12 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
     }
 
     componentDidMount() {
-      // Reset for React 18 StrictMode: the dev-mode unmount/remount cycle
-      // re-uses this instance and leaves the flag set from the prior
-      // componentWillUnmount.
-      this.isUnmounted = false;
+      this.mountCount++;
+      this.nodesAtUnmount = null;
+      // React is showing this subtree again, so the pending teardown from the
+      // hide is off.
+      this.stopWatchingForDestroy();
+      this.restoreRelocatedPortalHost();
 
       this.componentDidUpdate(this.props);
 
@@ -99,13 +178,28 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
        * child-route passthrough, parent-removal auto-dismiss) walk up
        * from `cachedOriginalParent` to find the enclosing `.ion-page`,
        * so we redirect it at the marker's JSX parent.
+       *
+       * Nested overlays are excluded: they never portal, so a nested modal
+       * already cached its `<template>`, which sits at the JSX position and
+       * resolves the right `.ion-page`.
        */
       const overlay = this.ref.current;
-      if (overlay) {
+      const generation = this.mountCount;
+      if (overlay && !this.props.isNested && !this.hasRedirectedOriginalParent) {
         componentOnReady(overlay as HTMLElement, () => {
-          if (this.isUnmounted) return;
+          /**
+           * A newer mount owns this now, or React nulled the marker ref
+           * because it unmounted or hid the subtree. Either way the callback
+           * is stale, and leaving the latch open lets the reveal retry.
+           */
           const markerParent = this.markerRef.current?.parentElement ?? null;
-          if (markerParent && markerParent !== this.portalTarget) {
+          if (this.mountCount !== generation || markerParent === null) {
+            return;
+          }
+          // Latch on completion, not on success: either way this instance is
+          // done, so a later reveal must not redirect again.
+          this.hasRedirectedOriginalParent = true;
+          if (markerParent !== this.portalTarget) {
             (overlay as any).cachedOriginalParent = markerParent;
           }
         });
@@ -125,42 +219,94 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
     }
 
     componentWillUnmount() {
-      this.isUnmounted = true;
       const node = this.ref.current;
       if (!node) {
         return;
       }
+      this.nodesAtUnmount = { host: node, wrapper: this.wrapperRef.current };
       /**
-       * CoreDelegate (or user code in onWillPresent) can move the overlay out
-       * of where React rendered it. React's unmount only removes the node from
-       * its original React location, so we recover a relocated host here,
-       * regardless of open state.
-       *
-       * We can't gate this on `isOpen`: the overlay can be moved before it
-       * finishes presenting (e.g. the React 18 StrictMode mount/unmount cycle,
-       * where the present events that flip `isOpen` haven't fired yet), which
-       * would orphan the relocated host in the DOM. It also has to run
-       * synchronously here, since React's portal `removeChild` runs after
-       * `componentWillUnmount` returns and needs the host where it expects it.
+       * CoreDelegate (or user code in onWillPresent) can move a portaled
+       * overlay out of `portalTarget`. React's portal `removeChild` runs as
+       * soon as this returns and needs the host where it left it, so this one
+       * has to stay synchronous, before we know whether this is a hide or a
+       * destroy. Record where it came from so a reveal can undo the move.
        */
-      if (node.isConnected) {
-        if (this.props.isNested) {
-          /**
-           * Nested overlays render inline inside a `<template>`. If the host
-           * has been moved out of that template, React's unmount won't reach
-           * it, so remove it directly. A host still in its template is left
-           * for React to remove.
-           */
-          if (!(node.parentElement instanceof HTMLTemplateElement)) {
-            node.remove();
-          }
-        } else if (this.portalTarget && node.parentNode !== this.portalTarget) {
-          /**
-           * Portaled overlays: move the host back into `portalTarget` so
-           * React's portal `removeChild` can find it.
-           */
-          this.portalTarget.appendChild(node);
+      if (node.isConnected && !this.props.isNested && this.portalTarget && node.parentNode !== this.portalTarget) {
+        this.relocatedPortalHost = { node, parent: node.parentNode!, nextSibling: node.nextSibling };
+        this.portalTarget.appendChild(node);
+      }
+      /**
+       * React also calls `componentWillUnmount` when it only *hides* a
+       * subtree - a Suspense boundary falling back, an Offscreen tree, the
+       * StrictMode dev cycle - and then mounts the same instance again on the
+       * reveal. Nothing here tells the two apart, so the teardown waits a
+       * microtask and runs only if the marker really left the document.
+       */
+      const marker = this.markerRef.current;
+      const mountCount = this.mountCount;
+      queueMicrotask(() => {
+        // Already back (the StrictMode cycle remounts before this runs).
+        if (this.mountCount !== mountCount) {
+          return;
         }
+        if (marker?.isConnected) {
+          this.watchForDestroyWhileHidden(marker, node, mountCount);
+          return;
+        }
+        this.cleanupAfterUnmount(node);
+      });
+    }
+
+    /**
+     * `componentWillUnmount` has to move a relocated portaled host back into
+     * `portalTarget` before it knows a hide from a destroy. On a reveal there
+     * was no removal to prepare for, so put the host back where it was.
+     */
+    private restoreRelocatedPortalHost() {
+      const relocated = this.relocatedPortalHost;
+      this.relocatedPortalHost = undefined;
+      if (!relocated || !relocated.parent.isConnected || relocated.node.parentNode !== this.portalTarget) {
+        return;
+      }
+      const { node, parent, nextSibling } = relocated;
+      // The recorded sibling can have moved or been removed while hidden, in
+      // which case appending is the closest we can get.
+      parent.insertBefore(node, nextSibling?.parentNode === parent ? nextSibling : null);
+    }
+
+    /**
+     * `cleanupAfterUnmount` decides what a destroy actually has to undo:
+     * gating here on the state at hide time would miss an overlay that only
+     * starts presenting afterwards.
+     */
+    private watchForDestroyWhileHidden(marker: HTMLElement, node: HTMLElement, mountCount: number) {
+      this.hiddenDestroyWatch = watchForDestroy(marker, () => {
+        this.hiddenDestroyWatch = undefined;
+        // A reveal already happened, so componentDidMount owns the teardown.
+        if (this.mountCount !== mountCount) {
+          return;
+        }
+        this.cleanupAfterUnmount(node);
+      });
+    }
+
+    private stopWatchingForDestroy() {
+      unwatchForDestroy(this.hiddenDestroyWatch);
+      this.hiddenDestroyWatch = undefined;
+    }
+
+    private cleanupAfterUnmount(node: HTMLElement) {
+      // The component is really gone, so nothing is waiting to be put back.
+      this.nodesAtUnmount = null;
+      this.relocatedPortalHost = undefined;
+      /**
+       * Nested overlays render inline inside a `<template>`. If the host has
+       * been moved out of that template, React's unmount won't reach it, so
+       * remove it directly. A host still in its template is left for React to
+       * remove.
+       */
+      if (this.props.isNested && node.isConnected && !(node.parentElement instanceof HTMLTemplateElement)) {
+        node.remove();
       }
       /**
        * If the overlay is being unmounted, but is still
@@ -257,7 +403,7 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
         );
       }
 
-      return createElement('template', {}, overlayElement);
+      return createElement('template', { ref: this.markerRef }, overlayElement);
     }
 
     static get displayName() {
@@ -287,19 +433,28 @@ export const createInlineOverlayComponent = <PropType, ElementType>(
     };
 
     private handleDidDismiss = (evt: any) => {
-      const wrapper = this.wrapperRef.current;
-      const el = this.ref.current;
+      // The refs are null for as long as React keeps this subtree hidden, so a
+      // dismiss that lands there falls back to the nodes recorded at hide time.
+      const wrapper = this.wrapperRef.current ?? this.nodesAtUnmount?.wrapper ?? null;
+      const el = this.ref.current ?? this.nodesAtUnmount?.host ?? null;
 
       /**
-       * This component might be unmounted already, if the containing
-       * element was removed while the overlay was still open. (For
-       * example, if an item contains an inline overlay with a button
-       * that removes the item.)
+       * React's `removeChild` needs the wrapper as a direct child of the host,
+       * and Stencil's scoped-slot relocation (ion-alert, ion-action-sheet,
+       * ion-loading) can nest it deeper. So this has to run before the flip
+       * below, which is what triggers that removal. Already a direct child
+       * means leaving it alone: appending would only reorder it against core's
+       * own nodes.
        */
-      if (wrapper && el) {
+      if (wrapper && el && wrapper.parentElement !== el) {
         el.append(wrapper);
-        this.setState({ isOpen: false });
       }
+      /**
+       * Flip either way: a dismiss that lands while hidden would otherwise
+       * leave the contents mounted against a closed overlay on reveal. After a
+       * real unmount this is a no-op.
+       */
+      this.setState({ isOpen: false });
 
       this.props.onDidDismiss && this.props.onDidDismiss(evt);
     };


### PR DESCRIPTION
Issue number: resolves #31389

---------

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Currently, `componentWillUnmount` in `createInlineOverlayComponent` removes a nested inline overlay host that `CoreDelegate` has teleported out of its `<template>`. React also runs that hook when it only *hides* a subtree, so a Suspense fallback, an Offscreen tree, or the StrictMode cycle deletes an overlay that is still presenting. React did not remove the host, so React never puts it back. Core emits `ionMount` and then goes quiet: no `willPresent`, no `didPresent`, and no dismiss lifecycle, while the React tree still believes the overlay is open. The user sees nothing at all.

## What is the new behavior?

The wrapper now tells a React hide from a real destroy instead of treating both as an unmount. The marker `<template>` is the discriminator, since it stays at the JSX position and leaves the document only on a real unmount, so the teardown defers a microtask and runs only if the marker really left. A hide leaves the host exactly where it is, `present()` and `didDismiss` keep working while the subtree is hidden, and a destroy that hits while it is already hidden still cleans up even though React skips the second `componentWillUnmount` there. This addresses #31223's requirements by making a relocated portaled host move back into `portalTarget` synchronously, and the StrictMode cycle still leaves exactly one copy in the DOM.

Separately, the five overlays that release the app root on disconnect (`modal`, `popover`, `alert`, `action-sheet`, `loading`) now restore it on reconnect, along with the modal's safe-area overrides and parent-removal observer, and the button gesture on `alert` and `action-sheet`. A presented overlay that gets detached and re-inserted across a task previously came back with the root lock and safe-area gone.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

This supersedes #31390, which fixes the same issue by recording the removed host and re-appending it on remount. That works for the reported case, but it keeps the removal, and the removal costs more than the DOM node: the disconnect releases the root lock, clears the safe-area overrides and the sheet's `--ion-modal-offset-top`, destroys the button gesture, and drops the parent-removal observer. Putting the node back restores none of that, so the smaller fix needs the core half of this PR anyway. Not removing it in the first place avoids all of that, and also covers the portaled overlays, the destroy-while-hidden case, and a dismiss landing during the hidden window, which #31390 doesn't reach. Thanks to @ptmkenny for the report, the analysis, and the original patch, which is where the diagnosis came from.

Note that the core half is defence-in-depth rather than a requirement for #31389. Once the React wrapper stops removing the host, core no longer sees a detach and re-attach in the reported flow. It does fix a real pre-existing bug though, since a presented modal moved by anything else lost its safe-area, so it's worth keeping.

Preview:
- [Inline modal (iOS)](https://ionic-framework-git-fix-react-inline-overlay-hide-21139f-ionic1.vercel.app/src/components/modal/test/inline?ionic:mode=ios)
- [Modal safe-area (iOS)](https://ionic-framework-git-fix-react-inline-overlay-hide-21139f-ionic1.vercel.app/src/components/modal/test/safe-area?ionic:mode=ios)

## Current dev build:
```
9.0.1-dev.11787589191.1e183b55
```