### PR TITLE
fix(radio): keep non-string values when reflecting

### DIFF
--- a/core/src/components/radio/radio.tsx
+++ b/core/src/components/radio/radio.tsx
@@ -1,5 +1,17 @@
 import type { ComponentInterface, EventEmitter } from '@stencil/core';
-import { Component, Element, Event, Host, Method, Prop, State, Watch, forceUpdate, h } from '@stencil/core';
+import {
+  AttrDeserialize,
+  Component,
+  Element,
+  Event,
+  Host,
+  Method,
+  Prop,
+  State,
+  Watch,
+  forceUpdate,
+  h,
+} from '@stencil/core';
 import { createItemMultipleInputsObserver, isOptionSelected } from '@utils/forms';
 import { addEventListener, removeEventListener } from '@utils/helpers';
 import { createColorClasses, hostContext } from '@utils/theme';
@@ -63,6 +75,26 @@ export class Radio implements ComponentInterface {
    * the value of the radio.
    */
   @Prop({ reflect: true }) value?: any | null;
+
+  /**
+   * The runtime reflects `value` and then feeds the attribute back here. The
+   * attribute is lossy, so taking it verbatim turns `true` into `""` and the
+   * radio group reports the wrong value.
+   */
+  @AttrDeserialize('value')
+  deserializeValue(newValue: string | null) {
+    const { value } = this;
+
+    if (value === undefined) {
+      /**
+       * Removing the attribute reports `null`, which would defeat the
+       * auto-generated value in `connectedCallback`.
+       */
+      return newValue === null ? undefined : newValue;
+    }
+
+    return reflectedValue(value) === newValue ? value : newValue;
+  }
 
   @Watch('value')
   valueChanged() {
@@ -265,5 +297,25 @@ export class Radio implements ComponentInterface {
     );
   }
 }
+
+/**
+ * How the runtime writes `value` to the attribute. Values it cannot write return
+ * `undefined`, which no incoming attribute can match.
+ */
+const reflectedValue = (value: any) => {
+  if (value === true) {
+    return '';
+  }
+
+  if (value === false) {
+    return null;
+  }
+
+  if (typeof value === 'object' || typeof value === 'function') {
+    return undefined;
+  }
+
+  return String(value);
+};
 
 let radioButtonIds = 0;

--- a/core/src/components/radio/test/radio.spec.ts
+++ b/core/src/components/radio/test/radio.spec.ts
@@ -50,6 +50,190 @@ describe('ion-radio', () => {
   });
 });
 
+describe('ion-radio: value', () => {
+  const createRadio = async (markup = '<ion-radio></ion-radio>') => {
+    const page = await newSpecPage({
+      components: [Radio, RadioGroup],
+      html: `
+        <ion-radio-group>
+          ${markup}
+        </ion-radio-group>
+      `,
+    });
+
+    return {
+      page,
+      radio: page.body.querySelector('ion-radio')!,
+      radioGroup: page.body.querySelector('ion-radio-group')!,
+    };
+  };
+
+  it('should keep a true value on the property', async () => {
+    const { page, radio } = await createRadio();
+
+    radio.value = true;
+
+    await page.waitForChanges();
+
+    expect(radio.value).toBe(true);
+    expect(radio.getAttribute('value')).toBe('');
+  });
+
+  it('should report a non-string value to the radio group when selected', async () => {
+    const { page, radio, radioGroup } = await createRadio();
+
+    radio.value = true;
+
+    await page.waitForChanges();
+
+    radio.click();
+
+    await page.waitForChanges();
+
+    expect(radioGroup.value).toBe(true);
+  });
+
+  it('should keep a false value on the property', async () => {
+    const { page, radio, radioGroup } = await createRadio();
+
+    radio.value = false;
+
+    await page.waitForChanges();
+
+    expect(radio.value).toBe(false);
+    expect(radio.hasAttribute('value')).toBe(false);
+
+    radio.click();
+
+    await page.waitForChanges();
+
+    expect(radioGroup.value).toBe(false);
+  });
+
+  it('should not replace an undefined value with null', async () => {
+    const { page, radio } = await createRadio();
+
+    radio.value = undefined;
+
+    await page.waitForChanges();
+
+    expect(radio.value).toBe(undefined);
+  });
+
+  it('should check the radio when the group is given a matching non-string value', async () => {
+    const { page, radio, radioGroup } = await createRadio();
+
+    radio.value = true;
+
+    await page.waitForChanges();
+
+    radioGroup.value = true;
+
+    await page.waitForChanges();
+
+    expect(radio.classList.contains('radio-checked')).toBe(true);
+  });
+
+  it('should keep an object value on the property', async () => {
+    const { page, radio } = await createRadio();
+    const value = { id: 1 };
+
+    radio.value = value;
+
+    await page.waitForChanges();
+
+    expect(radio.value).toBe(value);
+  });
+
+  it('should clear an object value when it is set back to null', async () => {
+    const { page, radio } = await createRadio();
+
+    radio.value = { id: 1 };
+
+    await page.waitForChanges();
+
+    radio.value = null;
+
+    await page.waitForChanges();
+
+    expect(radio.value).toBe(null);
+    expect(radio.hasAttribute('value')).toBe(false);
+  });
+
+  it('should replace a non-string value with its string form', async () => {
+    const { page, radio } = await createRadio();
+
+    radio.value = 1;
+
+    await page.waitForChanges();
+
+    radio.value = '1';
+
+    await page.waitForChanges();
+
+    expect(radio.value).toBe('1');
+  });
+
+  it('should reflect a string value to the attribute', async () => {
+    const { page, radio } = await createRadio();
+
+    radio.value = 'a';
+
+    await page.waitForChanges();
+
+    expect(radio.getAttribute('value')).toBe('a');
+  });
+
+  it('should reflect a number value to the attribute', async () => {
+    const { page, radio } = await createRadio();
+
+    radio.value = 42;
+
+    await page.waitForChanges();
+
+    expect(radio.value).toBe(42);
+    expect(radio.getAttribute('value')).toBe('42');
+  });
+
+  it('should clear an object value when the attribute is removed', async () => {
+    const { page, radio } = await createRadio('<ion-radio value="a"></ion-radio>');
+
+    radio.value = { id: 1 };
+
+    await page.waitForChanges();
+
+    radio.removeAttribute('value');
+
+    await page.waitForChanges();
+
+    expect(radio.value).toBe(null);
+  });
+
+  it('should update the property when the attribute changes on a non-string value', async () => {
+    const { page, radio } = await createRadio();
+
+    radio.value = true;
+
+    await page.waitForChanges();
+
+    radio.setAttribute('value', 'b');
+
+    await page.waitForChanges();
+
+    expect(radio.value).toBe('b');
+  });
+
+  it('should update the property when the attribute changes', async () => {
+    const { page, radio } = await createRadio('<ion-radio value="a"></ion-radio>');
+
+    radio.setAttribute('value', 'b');
+
+    await page.waitForChanges();
+
+    expect(radio.value).toBe('b');
+  });
+});
+
 describe('ion-radio: disabled', () => {
   it('clicking disabled radio should not set checked state', async () => {
     const page = await newSpecPage({

--- a/core/src/components/radio/test/value/radio.e2e.ts
+++ b/core/src/components/radio/test/value/radio.e2e.ts
@@ -1,0 +1,78 @@
+import { expect } from '@playwright/test';
+import { configs, test } from '@utils/test/playwright';
+
+/**
+ * This behavior does not vary across modes/directions.
+ */
+configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
+  test.describe(title('radio: value'), () => {
+    test('should report a non-string value to the radio group when selected', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31394',
+      });
+
+      await page.setContent(
+        `
+        <ion-radio-group>
+          <ion-radio>Restricted</ion-radio>
+        </ion-radio-group>
+      `,
+        config
+      );
+
+      const radio = page.locator('ion-radio');
+
+      await radio.evaluate((el: HTMLIonRadioElement) => (el.value = true));
+      await page.waitForChanges();
+
+      await radio.click();
+      await page.waitForChanges();
+
+      const groupValue = await page.locator('ion-radio-group').evaluate((el: HTMLIonRadioGroupElement) => el.value);
+
+      expect(groupValue).toBe(true);
+    });
+
+    test('should clear an object value when it is set back to null', async ({ page }) => {
+      await page.setContent(
+        `
+        <ion-radio-group>
+          <ion-radio>Restricted</ion-radio>
+        </ion-radio-group>
+      `,
+        config
+      );
+
+      const radio = page.locator('ion-radio');
+
+      await radio.evaluate((el: HTMLIonRadioElement) => (el.value = { id: 1 }));
+      await page.waitForChanges();
+
+      await radio.evaluate((el: HTMLIonRadioElement) => (el.value = null));
+      await page.waitForChanges();
+
+      const value = await radio.evaluate((el: HTMLIonRadioElement) => el.value);
+
+      expect(value).toBe(null);
+    });
+
+    test('should reflect a string value to the attribute', async ({ page }) => {
+      await page.setContent(
+        `
+        <ion-radio-group>
+          <ion-radio>Public</ion-radio>
+        </ion-radio-group>
+      `,
+        config
+      );
+
+      const radio = page.locator('ion-radio');
+
+      await radio.evaluate((el: HTMLIonRadioElement) => (el.value = 'public'));
+      await page.waitForChanges();
+
+      await expect(radio).toHaveAttribute('value', 'public');
+    });
+  });
+});


### PR DESCRIPTION
Issue number: resolves #31394

---------

## What is the current behavior?

Currently, `ion-radio` reflects `value` to the attribute, and since the prop is typed `any`, the runtime parses that attribute straight back into the property. A boolean `true` reflects as an empty attribute and returns as `""`, so `ion-radio-group` reports `""` while the radio still renders as checked. Setting `false` overwrites the property with `null` the same way.

## What is the new behavior?

We now use `@AttrDeserialize` on `value` to keep the property when the incoming attribute is only the runtime's echo of it. A local `reflectedValue()` helper mirrors how the runtime writes the attribute, so a genuine external change is still taken. Booleans survive in both directions and the attribute is still written for strings.

Worth noting why the reflect can't just come off, despite it being the simplest way to actually fix this. It was added in #31063 to hold a DOM contract that broke once already: @stencil/react-output-target@0.6.0 stopped reflecting props without `reflect: true`, which surfaced as stenciljs/output-targets#476 when `<IonRadio value="de">` stopped rendering `value="de"`. We reverted the output target in v8.2.9 and v8.3.1 over that report, and when v9 finally took the upgrade, `reflect: true` on `ion-radio`'s `value` is what kept the attribute. Removing it now re-breaks the same thing for the same users, in a patch.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

`@PropSerialize` looks like the tool for this, but it installs a guard in Stencil's `setValue` that skips any property write matching the last serialized string, so after an object value the next `value = null` is silently ignored. `@AttrDeserialize` doesn't install that guard. I'll file the `setValue` behavior upstream.

This isn't visible on the preview pages since the bug only shows when the property is assigned. Set `radio.value = true` from the console, click the radio, then read the group's value: `true` here, `""` on main.

[Radio basic (iOS)](https://ionic-framework-git-fw-7717-ionic1.vercel.app/src/components/radio/test/basic?ionic:mode=ios)
[Radio basic (MD)](https://ionic-framework-git-fw-7717-ionic1.vercel.app/src/components/radio/test/basic?ionic:mode=md)