### PR TITLE
fix(vue): support attribute autocomplete in WebStorm

### DIFF
--- a/packages/vue/scripts/build-web-types.js
+++ b/packages/vue/scripts/build-web-types.js
@@ -74,6 +74,7 @@ for (const component of filteredComponents) {
     name: componentName,
     "doc-url": docUrl,
     description: component.docs,
+    priority: "highest",
     source: {
       module:
         "@ionic/core/" +

--- a/packages/vue/scripts/build-web-types.js
+++ b/packages/vue/scripts/build-web-types.js
@@ -74,7 +74,7 @@ for (const component of filteredComponents) {
     name: componentName,
     "doc-url": docUrl,
     description: component.docs,
-    priority: "highest",
+    priority: "highest", // Fixes attribute autocomplete (FW-7636)
     source: {
       module:
         "@ionic/core/" +


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?

The `web-types.json` file provides autocomplete information for Ionic-Vue component attributes to the JetBrains WebStorm IDE. The autocomplete does work, but only when the component has not been imported into the source `.vue` file. Once imported, the IDE replaces types provided by `web-types.json` with types from `@ionic/vue/dist/types/proxies.d.ts`, which it fails to understand, and ceases providing attribute autocomplete.

## What is the new behavior?

Setting `priority: "highest"` on each component in `web-types.json` tells WebStorm to keep these types over imported ones. Autocomplete information persists after importing the Ionic-Vue component.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
