### PR TITLE
fix(input): improve clear button focus contrast

### DIFF
--- a/core/src/components/input/input.scss
+++ b/core/src/components/input/input.scss
@@ -225,7 +225,7 @@
  * being activated, so we never get to that state.
  */
 .input-clear-icon:focus {
-  opacity: 0.5;
+  opacity: 1;
 }
 
 :host(.has-value) .input-clear-icon {

--- a/core/src/components/input/test/basic/input.e2e.ts
+++ b/core/src/components/input/test/basic/input.e2e.ts
@@ -129,6 +129,27 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, screenshot, c
       const item = page.locator('ion-item');
       await expect(item).toHaveScreenshot(screenshot(`input-with-clear-button-item-color`));
     });
+
+    test('should retain opacity: 1 when the clear button receives keyboard focus', async ({ page, browserName }) => {
+      const tabKey = browserName === 'webkit' ? 'Alt+Tab' : 'Tab';
+
+      await page.setContent(
+        `
+        <ion-input label="my label" value="abc" clear-input="true"></ion-input>
+      `,
+        config
+      );
+
+      const input = page.locator('ion-input');
+      const nativeInput = input.locator('input');
+      const clearButton = input.locator('.input-clear-icon');
+
+      await nativeInput.focus();
+      await page.keyboard.press(tabKey);
+
+      await expect(clearButton).toBeFocused();
+      await expect(clearButton).toHaveCSS('opacity', '1');
+    });
   });
 
   test.describe(title('input: click'), () => {


### PR DESCRIPTION
Issue number: resolves #31141

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?

When an `ion-input` has `clear-input` enabled and the clear button receives keyboard focus, the clear button opacity is reduced to `0.5`.

This makes the enabled clear button appear visually disabled when navigating to it using the keyboard. The reduced opacity also results in insufficient contrast for the clear button in its focused state.

The behavior comes from the `.input-clear-icon:focus` style in `core/src/components/input/input.scss`, which explicitly sets the opacity to `0.5`.

## What is the new behavior?

The clear button now retains full opacity when it receives keyboard focus.

The focused clear button opacity has been changed from `0.5` to `1`, keeping the control visually consistent with its enabled state and improving its contrast when keyboard-focused.

A regression test has also been added to verify that:

- The clear button can receive keyboard focus.
- The clear button remains focused after keyboard navigation.
- The clear button has an opacity of `1` when focused.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

This is a visual and accessibility-related bug fix only. No component APIs, properties, events, or existing interaction behavior have been changed.

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->

## Other information

The fix is limited to the existing focused-state opacity rule and a corresponding regression test.

No dependencies, configuration, component behavior, ARIA attributes, or other styles were changed.

The regression test passes across Mobile Chrome, Mobile Safari, and Mobile Firefox.