### PR TITLE
fix(select): avoid invalid radio group structure

### DIFF
--- a/core/src/components/select-modal/select-modal.md.scss
+++ b/core/src/components/select-modal/select-modal.md.scss
@@ -2,13 +2,20 @@
 @import "./select-modal";
 @import "../../themes/ionic.mixins.scss";
 @import "../item/item.md.vars";
+@import "../list/list.md.vars";
 
-ion-list ion-radio::part(container) {
+ion-radio::part(container) {
   display: none;
 }
 
-ion-list ion-radio::part(label) {
+ion-radio::part(label) {
   @include margin(0);
+}
+
+ion-radio-group {
+  @include padding($list-md-padding-top, null, $list-md-padding-bottom, null);
+
+  display: block;
 }
 
 ion-item {

--- a/core/src/components/select-modal/select-modal.md.scss
+++ b/core/src/components/select-modal/select-modal.md.scss
@@ -16,6 +16,8 @@ ion-radio-group {
   @include padding($list-md-padding-top, null, $list-md-padding-bottom, null);
 
   display: block;
+
+  background: $item-md-background;
 }
 
 ion-item {

--- a/core/src/components/select-modal/select-modal.tsx
+++ b/core/src/components/select-modal/select-modal.tsx
@@ -226,7 +226,7 @@ export class SelectModal implements ComponentInterface {
           </ion-toolbar>
         </ion-header>
         <ion-content>
-          <ion-list>{this.multiple === true ? this.renderCheckboxOptions() : this.renderRadioOptions()}</ion-list>
+          {this.multiple === true ? <ion-list>{this.renderCheckboxOptions()}</ion-list> : this.renderRadioOptions()}
         </ion-content>
       </Host>
     );

--- a/core/src/components/select-modal/test/basic/select-modal.e2e.ts
+++ b/core/src/components/select-modal/test/basic/select-modal.e2e.ts
@@ -101,6 +101,38 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
         await selectModalPage.ionModalDidDismiss.next();
         await expect(selectModalPage.modal).not.toBeVisible();
       });
+
+      test('should render a radio group without a wrapping ion-list', async () => {
+        await selectModalPage.setup(config, options, false);
+
+        const radioGroup = selectModalPage.selectModal.locator('ion-radio-group');
+        await expect(radioGroup).toHaveAttribute('role', 'radiogroup');
+
+        const list = selectModalPage.selectModal.locator('ion-list');
+        await expect(list).toHaveCount(0);
+      });
+    });
+
+    test.describe('multiple selection', () => {
+      let selectModalPage: SelectModalPage;
+
+      test.beforeEach(async ({ page }) => {
+        selectModalPage = new SelectModalPage(page);
+      });
+
+      test('should render checkboxes inside an ion-list', async () => {
+        await selectModalPage.setup(config, options, true);
+
+        const list = selectModalPage.selectModal.locator('ion-list');
+        await expect(list).toBeVisible();
+        await expect(list).toHaveAttribute('role', 'list');
+
+        const checkboxes = selectModalPage.selectModal.locator('ion-checkbox');
+        await expect(checkboxes).toHaveCount(options.length);
+
+        const radioGroup = selectModalPage.selectModal.locator('ion-radio-group');
+        await expect(radioGroup).toHaveCount(0);
+      });
     });
   });
 });

--- a/core/src/components/select-modal/test/basic/select-modal.e2e.ts
+++ b/core/src/components/select-modal/test/basic/select-modal.e2e.ts
@@ -1,3 +1,4 @@
+import AxeBuilder from '@axe-core/playwright';
 import { expect } from '@playwright/test';
 import { configs, test } from '@utils/test/playwright';
 
@@ -102,8 +103,13 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
         await expect(selectModalPage.modal).not.toBeVisible();
       });
 
-      test('should render a radio group without a wrapping ion-list', async () => {
+      test('should render a radio group without a wrapping ion-list', async ({ page }, testInfo) => {
+        testInfo.annotations.push({ type: 'issue', description: '#31074' });
+
         await selectModalPage.setup(config, options, false);
+
+        const results = await new AxeBuilder({ page }).include('ion-select-modal').analyze();
+        expect(results.violations).toEqual([]);
 
         const radioGroup = selectModalPage.selectModal.locator('ion-radio-group');
         await expect(radioGroup).toHaveAttribute('role', 'radiogroup');
@@ -120,8 +126,13 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
         selectModalPage = new SelectModalPage(page);
       });
 
-      test('should render checkboxes inside an ion-list', async () => {
+      test('should render checkboxes inside an ion-list', async ({ page }, testInfo) => {
+        testInfo.annotations.push({ type: 'issue', description: '#31074' });
+
         await selectModalPage.setup(config, options, true);
+
+        const results = await new AxeBuilder({ page }).include('ion-select-modal').analyze();
+        expect(results.violations).toEqual([]);
 
         const list = selectModalPage.selectModal.locator('ion-list');
         await expect(list).toBeVisible();

--- a/core/src/components/select-modal/test/basic/select-modal.e2e.ts
+++ b/core/src/components/select-modal/test/basic/select-modal.e2e.ts
@@ -125,7 +125,6 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
 
         const list = selectModalPage.selectModal.locator('ion-list');
         await expect(list).toBeVisible();
-        await expect(list).toHaveAttribute('role', 'list');
 
         const checkboxes = selectModalPage.selectModal.locator('ion-checkbox');
         await expect(checkboxes).toHaveCount(options.length);


### PR DESCRIPTION
Issue number: resolves #31074

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When `ion-select` uses `interface="modal"` in single-select mode, the modal renders an `ion-list` containing an `ion-radio-group`.

The `ion-list` has `role="list"` while the nested `ion-radio-group` has `role="radiogroup"`, resulting in an invalid ARIA structure for the radio options.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Single-select modal options are now rendered directly inside the `ion-radio-group` without the wrapping `ion-list`.

- Removes the conflicting `role="list"` wrapper from the single-select radio options.
- Preserves the existing `ion-list` structure for multiple-select mode.
- Preserves the existing MD spacing and radio option styling after removing the list wrapper.
- Adds regression coverage for the single-select and multiple-select DOM structures.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

The change is limited to the select modal rendering, its existing MD styles, and regression tests.

Multiple-select behavior is unchanged.

The relevant select modal tests, linting, Stylelint, Prettier, and build checks pass.